### PR TITLE
fix: install protoc for Fedora CI jobs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           dnf install -y --setopt=install_weak_deps=False \
             git gcc pkg-config rustup \
+            protobuf-compiler protobuf-devel \
             gtk4-devel libadwaita-devel vte291-gtk4-devel
 
       - uses: actions/checkout@v5
@@ -88,6 +89,7 @@ jobs:
         run: |
           dnf install -y --setopt=install_weak_deps=False \
             git gcc pkg-config rustup \
+            protobuf-compiler protobuf-devel \
             gtk4-devel libadwaita-devel vte291-gtk4-devel
 
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- install Fedora protobuf compiler packages in the CI container jobs
- restore `Clippy` and `Test` after the pinned sibling `rttxd` checkout fix

## Testing
- cargo build
- cargo clippy -- -D warnings
- bash .github/scripts/run-quality-tests.sh

Fixes #139