### PR TITLE
docs: sync RFCs with monorepo reality

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -31,6 +31,11 @@ concrete code type.
 - [RFC-001-manifesto.md](./RFC-001-manifesto.md) and
   [RFC-013-persistent-host-sessions.md](./RFC-013-persistent-host-sessions.md) define the current
   product direction.
+- [RFC-010-maintainability-refactor.md](./RFC-010-maintainability-refactor.md) is the active
+  maintainability roadmap. Some slices are implemented on `mainline`, but the large file/module
+  decomposition work is still in progress.
+- [RFC-012-ci-cd-pipeline.md](./RFC-012-ci-cd-pipeline.md) now describes the live GitHub Actions
+  workflows rather than a future-only plan.
 - [RFC-007-session-recovery.md](./RFC-007-session-recovery.md) still matters for recipe-based
   recovery and retry UX, but its architecture assumptions are historical.
 - [RFC-011-flatpak-native-host-integration.md](./RFC-011-flatpak-native-host-integration.md)

--- a/designs/RFC-003-testing-strategy.md
+++ b/designs/RFC-003-testing-strategy.md
@@ -16,6 +16,21 @@ library; failures at the Rust/C boundary produce segfaults and process aborts, n
 The test suite is organized around specific crash categories and is designed to catch each class
 of GTK-Rust failure as a failing test before it reaches a user.
 
+## Current implementation snapshot (2026-03)
+
+- The project is now a monorepo, so the live test surfaces span:
+  - `clients/rttx/` for GTK/unit/integration/UI tests
+  - `services/rttx-server/` for daemon/unit/integration tests
+  - `protocols/rttx-proto/` for protocol framing/unit tests
+- The CI-equivalent local command is `bash .github/scripts/run-quality-tests.sh`, not plain
+  `cargo test --workspace`. The client's GTK-heavy tests still need the curated harness rather than
+  the default Rust test runner.
+- `run_ui_tests.sh` and the AT-SPI suite exist and run locally/in CI-style environments, but the
+  nightly GitHub job is still tracked separately.
+- The highest-value remaining testing gaps are now deterministic GTK harness behavior under plain
+  `cargo test`, deeper client+daemon end-to-end recovery coverage, and the daemon adversarial test
+  backlog now tracked in the monorepo issue set (`#144`–`#153`).
+
 ---
 
 ## Goals
@@ -104,33 +119,39 @@ violated?" Tests that can't answer that question don't belong in the suite.
 
 ### Test layers
 
-**Unit tests** (`src/session/layout.rs`, `src/config.rs`, `src/color_scheme.rs`, `src/preferences.rs`)
+**Unit tests** (`clients/rttx/src/session/layout.rs`, `clients/rttx/src/config.rs`,
+`clients/rttx/src/color_scheme.rs`, `clients/rttx/src/preferences.rs`,
+`services/rttx-server/src/session.rs`, `services/rttx-server/src/protocol.rs`)
 — data model correctness, serialization, tree invariants. No GTK required.
 
 **Property-based tests** (`proptest`) — randomized layout trees with guaranteed UUID uniqueness.
 Found a real duplicate-UUID bug in early development.
 
-**Integration tests** (`tests/session_lifecycle.rs`, `tests/color_scheme_compat.rs`) — end-to-end
-persistence, Tilix color scheme compatibility.
+**Integration tests** (`clients/rttx/tests/session_lifecycle.rs`,
+`clients/rttx/tests/color_scheme_compat.rs`, `services/rttx-server/tests/*.rs`) — end-to-end
+persistence, Tilix color scheme compatibility, daemon lifecycle, reconnect, ownership, revisions,
+and runtime policy coverage.
 
-**GTK contract tests** (`tests/gtk_boundary_contracts.rs`) — validate data-model assumptions that
-window.rs relies on. These are the C1/C6/C7 defenses: UUID uniqueness, terminal count consistency,
-split/remove invariants, serialization roundtrips, backward compatibility.
+**GTK contract tests** (`clients/rttx/tests/gtk_boundary_contracts.rs`) — validate data-model
+assumptions that `window.rs` relies on. These are the C1/C6/C7 defenses: UUID uniqueness, terminal
+count consistency, split/remove invariants, serialization roundtrips, backward compatibility.
 
-**GTK widget tests** (`tests/gtk_widget_tests.rs`, `tests/layout_widget_tests.rs`,
-`tests/terminal_lifecycle_tests.rs`) — instantiate real GTK4 widgets via broadway backend. Test
+**GTK widget tests** (`clients/rttx/tests/gtk_widget_tests.rs`,
+`clients/rttx/tests/layout_widget_tests.rs`, `clients/rttx/tests/terminal_lifecycle_tests.rs`) —
+instantiate real GTK4 widgets via broadway backend. Test
 exact Stack→Paned→unparent→rebuild sequences, GObject ref-count survival, and Paned position
 application after allocation.
 
 ### Headless execution
 
 ```bash
-GDK_BACKEND=broadway GTK_A11Y=none cargo test
+bash .github/scripts/run-quality-tests.sh
 ```
 
-`broadwayd :5` serves as a framebuffer. Tests that run on non-GTK threads are skipped via
-`std::sync::Once` + `std::panic::catch_unwind` pattern (not `OnceLock<bool>`, which would
-dispatch GTK calls from non-main threads).
+For focused local client-only runs, `GDK_BACKEND=broadway GTK_A11Y=none cargo test -p rttx`
+remains useful. Tests that run on non-GTK threads are skipped via `std::sync::Once` +
+`std::panic::catch_unwind` pattern (not `OnceLock<bool>`, which would dispatch GTK calls from
+non-main threads).
 
 ### Coverage map
 
@@ -144,16 +165,15 @@ dispatch GTK calls from non-main threads).
 | C6 — index out of bounds | partial | — | — |
 | C7 — duplicate UUID | ✓ | — | ✓ |
 
-### Missing tests (priority order)
+### Highest-value remaining gaps
 
-- **M3** — `active_session_index` out-of-bounds safety (pure data, no display)
-- **M2** — RefCell re-entrancy proof with `#[should_panic]` counterpart
-- **M1** — Signal handler doubling: split preserves existing UUID for widget reuse
-- **M7** — `disconnect_child_exited` before VTE destruction
-- **M4** — GObject weak reference invalidated after last strong ref drop
-- **M5** — Extreme ratios (0.1, 0.9) produce non-zero Paned positions
-- **M8** — `SessionColor` backward compat (add alongside that feature)
-- **M6** — Activity timer safe after session close (add alongside activity detection)
+- **GAP1** — Make the client GTK suite deterministic under the plain Rust harness, not just the
+  curated Broadway quality script
+- **GAP2** — Add more real client+daemon restart/reconcile coverage now that both live in one repo
+- **GAP3** — Expand daemon adversarial tests: malformed protocol input, persistence failure
+  injection, race-heavy ownership, stress/load, and leak-oriented lifecycle loops
+- **GAP4** — Add the deferred nightly AT-SPI job so accessibility-level UI regressions run
+  continuously in GitHub Actions
 
 ---
 
@@ -173,11 +193,12 @@ dispatch GTK calls from non-main threads).
 - [x] GTK contract tests (C1, C3, C7, C6 partial)
 - [x] GTK widget tests (C1, C3)
 - [x] Paned position regression tests (nested split goes dark)
-- [ ] **M3** — `active_session_index` bounds contract test — *tracked in todo.md — Stability, Testing & Maintenance*
-- [ ] **M2** — RefCell re-entrancy proof
-- [ ] **M1** — Signal handler doubling / widget reuse contract
-- [ ] **M7** — `child_exited` disconnect test
-- [ ] **M4** — Weak reference lifecycle test
-- [ ] **M5** — Extreme ratio Paned position test
+- [x] Active-index bounds contract coverage
+- [x] Activity indicator timer regression coverage
+- [x] Nested split ratio restore regression coverage
+- [ ] Deterministic plain-harness GTK execution
+- [ ] Deeper client+daemon restart/reconcile integration coverage
+- [ ] Expanded daemon adversarial test matrix
+- [ ] Nightly AT-SPI GitHub Actions job
 
 ---

--- a/designs/RFC-005-distribution-packaging.md
+++ b/designs/RFC-005-distribution-packaging.md
@@ -12,8 +12,18 @@
 ## Summary
 
 rttx targets Linux distributions via multiple packaging formats, prioritized by GNOME user reach.
-Fedora/COPR is the first distribution channel (already live). Flatpak/Flathub, DEB/PPA, and
-AppImage follow. A CI/CD release pipeline automates artifact generation on each tagged release.
+Fedora/COPR is the first distribution channel (already live). The repository now also contains a
+Flatpak manifest and a GitHub Actions release workflow for Flatpak, DEB, and RPM artifacts. DEB
+packaging metadata is still incomplete, and AppImage is currently deferred rather than actively
+implemented.
+
+## Current implementation snapshot (2026-03)
+
+- Packaging assets now live under `packaging/rttx/` in the monorepo.
+- The release workflow exists in `.github/workflows/release.yml`.
+- COPR and the Flatpak bundle path are wired into the repo.
+- DEB/RPM metadata in `clients/rttx/Cargo.toml` is still a follow-up item.
+- AppImage is not part of the live workflow and should be treated as deferred, not imminent.
 
 ---
 
@@ -21,7 +31,8 @@ AppImage follow. A CI/CD release pipeline automates artifact generation on each 
 
 - **G1** — Users on Fedora can install rttx with `dnf` from a native RPM repository
 - **G2** — Users on Ubuntu/Debian can install rttx without building from source
-- **G3** — Users on any Linux distro can run rttx without system-level installation (AppImage)
+- **G3** — Users on any Linux distro can install via Flatpak or build from source without distro
+  packaging lag
 - **G4** — Release artifacts are generated automatically; no manual packaging steps per release
 
 ## Non-Goals
@@ -45,7 +56,7 @@ already live (`dnf copr enable illya/rttx`), providing a reference for all other
 
 | Audience | Impact |
 | --- | --- |
-| End users | Native package management on Fedora/Ubuntu; zero-install AppImage on any distro |
+| End users | Native package management on Fedora; Flatpak bundle or source build elsewhere; DEB remains follow-up work |
 | Contributors | Release process is documented and automated; no manual fiddling per release |
 | Packagers | Each format has a dedicated config file in `packaging/`; maintainable independently |
 
@@ -93,8 +104,9 @@ that adding a format does not add per-release manual work.
 | --- | --- | --- | --- |
 | RPM | `cargo-generate-rpm` + COPR | `dnf copr enable illya/rttx` | Live |
 | DEB | `cargo-deb` | GitHub Releases / PPA | Pending |
-| Flatpak | `flatpak-builder` | Flathub | Pending |
-| AppImage | `linuxdeploy` + GTK plugin | GitHub Releases | Pending |
+| Flatpak | `flatpak-builder` | GitHub Releases / Flathub follow-up | Implemented in repo, publication pending |
+| Source install | Meson + Cargo | Manual / docs | Live |
+| AppImage | `linuxdeploy` + GTK plugin | GitHub Releases | Deferred |
 
 ### COPR repository setup
 
@@ -149,14 +161,15 @@ Build history is also visible at `https://copr.fedorainfracloud.org/coprs/illya/
 
 ### Release pipeline (GitHub Actions)
 
-On a version tag (`v*`):
+On a version tag (`v*`), the current workflow builds:
 
 1. Run `cargo test`
 2. `flatpak-builder` → bundle
 3. `cargo-deb` → `.deb`
 4. `cargo-generate-rpm` → `.rpm` → submit to COPR via `copr-cli`
-5. `linuxdeploy` → `.AppImage`
-6. Upload all artifacts to the GitHub Release
+5. Upload artifacts to the GitHub Release
+
+AppImage is not currently part of the live pipeline.
 
 ### RPM spec generation
 
@@ -171,7 +184,7 @@ On a version tag (`v*`):
 | --- | --- |
 | G1 — Fedora native install | COPR repository live at `dnf copr enable illya/rttx` |
 | G2 — Ubuntu/Debian install | `cargo-deb` → DEB + PPA (pending) |
-| G3 — Distro-agnostic AppImage | `linuxdeploy` with GTK plugin bundles all shared libs (pending) |
+| G3 — Distro-agnostic install path | Flatpak bundle plus documented source install; AppImage deferred |
 | G4 — Automated releases | GitHub Actions release workflow generates all formats on tag |
 
 ---
@@ -181,8 +194,8 @@ On a version tag (`v*`):
 - [x] COPR RPM repository live
 - [ ] **DEB packaging** — Add `[package.metadata.deb]` to `Cargo.toml`; configure `cargo-deb` — tracked in #108
 - [x] **Flatpak manifest** — `packaging/rttx/io.github.IllyaYalovyy.rttx.json`; offline Cargo dependencies via `rust-bundle` extension (implemented; see RFC-011)
-- [ ] **AppImage** — `linuxdeploy` with GTK + Rust plugins
-- [ ] **GitHub Actions release workflow** — `.github/workflows/release.yml`; all formats on version tag — designed in RFC-012
+- [ ] **AppImage** — deferred; no active implementation work on `mainline`
+- [x] **GitHub Actions release workflow** — `.github/workflows/release.yml` exists in the monorepo
 
 ---
 

--- a/designs/RFC-009-development-mode.md
+++ b/designs/RFC-009-development-mode.md
@@ -17,6 +17,17 @@ production build. Development mode uses a distinct application identity, a separ
 and an unmistakable visual indicator. This is not cosmetic. It removes day-to-day friction for
 contributors and makes the project materially easier to develop, test, and adopt.
 
+## Current implementation snapshot (2026-03)
+
+- The client uses a separate application/profile identity in dev mode:
+  - app ID: `io.github.IllyaYalovyy.rttx.Devel`
+  - config dir: `rttx-devel`
+- The daemon also uses separate runtime/cache roots in dev mode:
+  - socket root: `$XDG_RUNTIME_DIR/rttx-server-devel/v1/`
+  - state root: `$XDG_CACHE_HOME/rttx-server-devel/`
+- The monorepo docs in `README.md` and `CONTRIBUTING.md` now document both client and daemon dev
+  mode together because a safe dev run requires both sides to stay isolated from production state.
+
 ---
 
 ## Goals

--- a/designs/RFC-010-maintainability-refactor.md
+++ b/designs/RFC-010-maintainability-refactor.md
@@ -2,7 +2,7 @@
 
 | Field         | Value                   |
 |---------------|-------------------------|
-| Status        | Draft                   |
+| Status        | Accepted / In Progress  |
 | Author(s)     | Illya Yalovyy           |
 | Supersedes    | —                       |
 | Superseded by | —                       |
@@ -16,11 +16,28 @@ duplication, and restore clear boundaries between pure data, GTK wiring, and run
 This RFC is deliberately conservative. It does not propose a rewrite. It proposes small structural
 moves that make the code easier to reason about and harder to accidentally bloat.
 
+## Current implementation snapshot (2026-03)
+
+Several slices of this RFC are already on `mainline`:
+
+- the repository was consolidated into a monorepo, which removed the cross-repo protocol/daemon
+  coordination overhead that had made structural cleanup harder
+- `clients/rttx/src/runtime.rs` now holds pure connection-state and workspace-action logic
+- `clients/rttx/src/workspace_state.rs` now owns a first extracted slice of pure managed-workspace
+  transitions
+- `clients/rttx/src/terminal/handle.rs` is the shared terminal abstraction for direct and
+  daemon-backed panes
+- `window.rs` is still too large and `clients/rttx/src/session/layout.rs` still mixes layout,
+  state, and recovery concerns
+
+So this RFC is no longer speculative. It is the active refactor roadmap for code that has already
+started moving, with major remaining follow-up still tracked in the issue backlog.
+
 ---
 
 ## Goals
 
-- **G1** — Reduce the size and responsibility surface of `src/window.rs`
+- **G1** — Reduce the size and responsibility surface of `clients/rttx/src/window.rs`
 - **G2** — Separate pure layout data from pane recovery/runtime behavior
 - **G3** — Eliminate obvious duplication in sidebar CRUD and dialog code
 - **G4** — Make terminal lifecycle wiring explicit and less error-prone
@@ -42,10 +59,11 @@ too many responsibilities at once.
 
 Concrete pressure points:
 
-- `src/window.rs` now owns window construction, action registration, signal wiring, session
+- `clients/rttx/src/window.rs` now owns window construction, action registration, signal wiring,
+  session
   orchestration, terminal lifecycle, recovery logic, bookmark/command CRUD, sidebars, dialogs,
   notifications, and a large in-file test suite.
-- `src/session/layout.rs` mixes two different domains:
+- `clients/rttx/src/session/layout.rs` mixes two different domains:
   - pure layout tree structure and transforms
   - pane recovery types plus shell/SSH/tmux command generation
 - bookmark and command sidebars are rendered with near-duplicate code paths
@@ -128,25 +146,25 @@ This RFC prefers a few meaningful modules over a maze of tiny helpers.
 
 Proposed internal module split:
 
-- `src/window/mod.rs`
+- `clients/rttx/src/window/mod.rs`
   - object definition
   - `glib::wrapper!`
   - top-level construction entry points
-- `src/window/build.rs`
+- `clients/rttx/src/window/build.rs`
   - header bar and main window widget construction
   - left/right sidebar layout assembly
-- `src/window/actions.rs`
+- `clients/rttx/src/window/actions.rs`
   - action registration
   - accelerator wiring
-- `src/window/sessions.rs`
+- `clients/rttx/src/window/sessions.rs`
   - add/switch/close session
   - split/close/rebuild session content
   - sidebar row bookkeeping
-- `src/window/recovery.rs`
+- `clients/rttx/src/window/recovery.rs`
   - terminal recovery lookup and retry flow
   - bookmark/command execution to `PaneRecovery`
   - child-exit recovery handling
-- `src/window/sidebars.rs`
+- `clients/rttx/src/window/sidebars.rs`
   - bookmark sidebar rendering
   - command sidebar rendering
   - delete confirmation dialogs
@@ -156,7 +174,7 @@ that reflect ownership.
 
 ### 2. Split layout tree code from recovery/runtime code
 
-`src/session/layout.rs` currently mixes:
+`clients/rttx/src/session/layout.rs` currently mixes:
 
 - layout tree operations
 - session/window state structs
@@ -165,21 +183,21 @@ that reflect ownership.
 
 Proposed split:
 
-- `src/session/layout_tree.rs`
+- `clients/rttx/src/session/layout_tree.rs`
   - `LayoutNode`
   - `SplitOrientation`
   - layout transforms and queries
-- `src/session/recovery.rs`
+- `clients/rttx/src/session/recovery.rs`
   - `PaneSource`
   - `PaneTarget`
   - `PaneRecovery`
   - `StartupStep`
   - shell/ssh/tmux command generation
-- `src/session/state.rs`
+- `clients/rttx/src/session/state.rs`
   - `SessionState`
   - `WindowState`
   - persistence helpers and normalization helpers
-- `src/session/mod.rs`
+- `clients/rttx/src/session/mod.rs`
   - re-exports and filesystem save/load entry points
 
 The key design rule is simple:
@@ -329,13 +347,14 @@ This phase should be mostly mechanical and behavior-preserving.
 
 - [ ] Should packaging issues keep `packaging` only, or also carry `area/integration` for filtering consistency?
 - [ ] Should terminal search be finished as part of the refactor, or explicitly removed until the feature is real?
-- [ ] Do we want `src/window/` as a module directory immediately, or only after Phase 2 extracts enough code to justify it?
+- [ ] Do we want `clients/rttx/src/window/` as a module directory immediately, or only after
+  Phase 2 extracts enough code to justify it?
 
 ---
 
 ## References
 
-- `src/window.rs`
-- `src/terminal/widget.rs`
-- `src/session/layout.rs`
-- `META/todo.md`
+- `clients/rttx/src/window.rs`
+- `clients/rttx/src/terminal/widget.rs`
+- `clients/rttx/src/session/layout.rs`
+- GitHub issues #98, #99, #101, #130, #132, and #135

--- a/designs/RFC-011-flatpak-native-host-integration.md
+++ b/designs/RFC-011-flatpak-native-host-integration.md
@@ -2,7 +2,7 @@
 
 | Field         | Value                   |
 |---------------|-------------------------|
-| Status        | Draft                   |
+| Status        | Accepted / In Progress  |
 | Author(s)     | Illya Yalovyy           |
 | Supersedes    | —                       |
 | Superseded by | —                       |
@@ -13,6 +13,15 @@
 > This RFC remains relevant for packaging and host-integration constraints, but any language here
 > that assumes direct VTE sessions are the long-term primary execution path is superseded by
 > RFC-013.
+
+## Current implementation snapshot (2026-03)
+
+- The repo is now a monorepo, and packaging assets live under `packaging/rttx/`.
+- The daemon-backed runtime architecture from RFC-013 is the live baseline on `mainline`.
+- The Flatpak manifest and release workflow exist in-repo, but the broader host-integration and
+  permission profile decisions in this RFC are still an ongoing packaging/design track.
+- Any “host shell” or deeper Flatpak-native integration work must now layer on top of the
+  daemon-backed runtime model, not the earlier direct-terminal assumptions.
 
 ## Summary
 
@@ -92,12 +101,14 @@ The current codebase is still a good base for this design:
 - bookmark/session recovery already feeds ordinary shell commands such as `ssh` and `tmux` into the
   terminal rather than depending on custom IPC
 - clickable paths and links open through
-  [`gio::AppInfo::launch_default_for_uri()`](../src/terminal/widget.rs),
+  [`gio::AppInfo::launch_default_for_uri()`](../clients/rttx/src/terminal/widget.rs),
   which aligns well with portal-backed desktop integration
 - notifications go through
-  [`gio::Notification`](../src/window.rs), which GTK desktops and portals already understand
+  [`gio::Notification`](../clients/rttx/src/window.rs), which GTK desktops and portals already
+  understand
 - config lives under `glib::user_config_dir()` in
-  [`src/config.rs`](../src/config.rs), so the app already respects XDG-style
+  [`clients/rttx/src/config.rs`](../clients/rttx/src/config.rs), so the app already respects
+  XDG-style
   storage
 
 This means we do not need to redesign session recovery or UI architecture to make Flatpak possible.

--- a/designs/RFC-012-ci-cd-pipeline.md
+++ b/designs/RFC-012-ci-cd-pipeline.md
@@ -2,7 +2,7 @@
 
 | Field         | Value                   |
 |---------------|-------------------------|
-| Status        | Accepted                |
+| Status        | Implemented             |
 | Author(s)     | Illya Yalovyy           |
 | Supersedes    | —                       |
 | Superseded by | —                       |
@@ -15,6 +15,19 @@ rttx uses two GitHub Actions pipelines: a **quality gate** that runs on every pu
 request, and a **release pipeline** that builds all distribution artifacts on a version tag.
 Both pipelines are entirely free (GitHub Actions is free for public repositories; COPR and
 Flathub are free services). No paid CI infrastructure is required.
+
+## Current implementation snapshot (2026-03)
+
+- `mainline` is protected by required checks from `.github/workflows/quality.yml`:
+  `Format`, `Clippy`, `Test`, and `Flatpak manifest`
+- the quality workflow now runs `Clippy` and `Test` inside Fedora containers and delegates the
+  detailed commands to repo-local scripts:
+  - `.github/scripts/run-clippy.sh`
+  - `.github/scripts/run-quality-tests.sh`
+- the release workflow exists in `.github/workflows/release.yml` and builds Flatpak, DEB, and RPM
+  artifacts plus GitHub Release publication and COPR submission
+- nightly AT-SPI coverage remains a follow-up item, not part of the live workflow set
+- AppImage is not part of the current release workflow
 
 ---
 
@@ -38,7 +51,7 @@ Flathub are free services). No paid CI infrastructure is required.
 
 ---
 
-## Background & Motivation
+## Historical background
 
 As of the date this RFC was accepted there are no `.github/workflows/` files in the repository.
 The pre-commit hook (fmt + clippy) catches lint issues locally but has no equivalent in CI.
@@ -87,37 +100,28 @@ Version tag v*
 
 **Trigger**: `push` to `mainline`; `pull_request` targeting `mainline`.
 
-**Runner**: `ubuntu-latest` (Ubuntu 24.04 LTS).
+**Current implementation**:
 
-**System dependencies**:
+- `Format` runs on `ubuntu-latest`
+- `Clippy` and `Test` run on `ubuntu-latest` with `fedora:latest` containers
+- the manifest job validates `packaging/rttx/io.github.IllyaYalovyy.rttx.json`
+
+**System dependencies** for the Fedora container jobs:
 
 ```
-libgtk-4-dev libgtk-4-bin libadwaita-1-dev libvte-2.91-gtk4-dev
-meson ninja-build
+gtk4-devel libadwaita-devel vte291-gtk4-devel protobuf-compiler protobuf-devel
 ```
 
-`libgtk-4-bin` provides `gtkbroadwayd`, the headless Broadway display server used by the test
-suite. `meson` and `ninja-build` are needed for the Meson build configuration check.
-
-**Rust toolchain**: `dtolnay/rust-toolchain@stable` with `components: rustfmt, clippy`.
-Edition 2024 with let-chains requires Rust ≥ 1.88; stable is always ahead of that.
-
-**Broadway setup**:
-`gtkbroadwayd :0 &` starts the headless server on port 8080 before the test step. Tests are
-then run with `GDK_BACKEND=broadway GTK_A11Y=none cargo test`. Without broadwayd, GTK
-initialization fails gracefully and widget tests are skipped — but running broadwayd ensures
-the full test suite executes.
-
-**Cargo caching**: `actions/cache@v4` on `~/.cargo/registry`, `~/.cargo/git`, and `target/`
-keyed on `Cargo.lock`. Cuts subsequent job times significantly.
+The Broadway and targeted test orchestration now lives in `.github/scripts/run-quality-tests.sh`
+rather than being spelled out inline in the workflow YAML.
 
 **Jobs**:
 
 | Job | Command | Blocks merge if fails |
 | --- | --- | --- |
 | `fmt` | `cargo fmt --check` | Yes |
-| `clippy` | `cargo clippy -- -D warnings` | Yes |
-| `test` | `GDK_BACKEND=broadway GTK_A11Y=none cargo test` | Yes |
+| `clippy` | `bash .github/scripts/run-clippy.sh` | Yes |
+| `test` | `bash .github/scripts/run-quality-tests.sh` | Yes |
 | `manifest` | `python3 -m json.tool packaging/rttx/io.github.IllyaYalovyy.rttx.json > /dev/null` | Yes |
 
 The manifest validation job is a cheap JSON parse of the Flatpak manifest. It does not require
@@ -178,7 +182,7 @@ Command: `cargo build --release && cargo generate-rpm`
 
 Output artifact: `target/generate-rpm/rttx-*.rpm`
 
-Requires `[package.metadata.generate-rpm]` in `Cargo.toml` (see Development Plan).
+Requires `[package.metadata.generate-rpm]` in `clients/rttx/Cargo.toml` (still tracked separately).
 
 #### `github-release`
 

--- a/designs/RFC-013-persistent-host-sessions.md
+++ b/designs/RFC-013-persistent-host-sessions.md
@@ -2,7 +2,7 @@
 
 | Field         | Value                   |
 |---------------|-------------------------|
-| Status        | Draft (v3)              |
+| Status        | Accepted / In Progress  |
 | Author(s)     | Illya Yalovyy           |
 | Supersedes    | RFC-013 v1 (tmux-first) |
 | Superseded by | ---                       |
@@ -25,6 +25,24 @@ The core decisions:
   workspace UI
 - GUI state, daemon state, and bindings reconcile non-destructively; missing GUI metadata must
   never delete a daemon runtime or pane automatically
+
+## Current implementation snapshot (2026-03)
+
+The core direction in this RFC is now live on `mainline`:
+
+- `rttx-server` and `rttx-proto` live in the same repository as the client
+- daemon inventory, runtime revisions, retention policy, and single-writer ownership are
+  implemented in `services/rttx-server/`
+- the client has explicit `ephemeral` / `persistent` workspace policy, no implicit fallback,
+  explicit connection-state UI, and shared terminal-handle behavior for managed panes
+- pure state extraction has started in `clients/rttx/src/runtime.rs` and
+  `clients/rttx/src/workspace_state.rs`
+
+The remaining gaps are implementation follow-through, not architecture choice:
+
+- event delivery from the endpoint manager still has cleanup work
+- recovered-workspace synthesis from daemon inventory is still incomplete
+- higher-level workflow extraction out of `window.rs` is still in progress
 
 ---
 

--- a/designs/RFC-014-cloud-relay-service.md
+++ b/designs/RFC-014-cloud-relay-service.md
@@ -10,6 +10,12 @@
 
 A cloud relay service that brokers connections between rttx clients and rttx-server daemons over the internet, eliminating the need for SSH, open inbound ports, or VPN infrastructure. Daemons establish outbound-only WebSocket connections to the relay; clients connect to the same relay and are routed to their registered daemons. End-to-end encryption ensures the relay cannot read terminal content, while OAuth2-based user authentication and device registration provide access control. The relay is a dumb pipe by design - it forwards opaque frames without understanding the rttx protocol.
 
+## Current implementation baseline (2026-03)
+
+- Implemented endpoint types today are local Unix-socket and remote SSH stdio.
+- The monorepo consolidation and endpoint-manager work referenced below are now on `mainline`.
+- The relay itself is still unimplemented; this RFC remains a forward-looking design document.
+
 ## Terminology
 
 | Term              | Definition |


### PR DESCRIPTION
## Summary
- update key RFCs to match the current monorepo layout, daemon-backed runtime implementation, and live CI/release workflows
- reconcile open issues after the monorepo merge
- transfer daemon test backlog from `rttxd` into `rttx`

## Testing
- `git diff --check`
- commit hooks (cargo checks triggered by the repo hook)

## Tracker
- Fixes #143