### PR TITLE
refactor(server): Migrate CLI to clap and logging to tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +156,52 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "daemonize"
@@ -654,6 +750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +779,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -743,6 +851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +904,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +926,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pango"
@@ -1193,12 +1325,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "clap",
  "daemonize",
  "interprocess",
- "log",
  "nix",
  "pretty_assertions",
- "pretty_env_logger",
  "prost",
  "pty-process",
  "rstest",
@@ -1212,6 +1343,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "vte",
 ]
@@ -1321,6 +1454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1515,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1444,6 +1592,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1557,6 +1714,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1809,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"

--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -59,10 +59,13 @@ nix = { version = "0.29", features = ["signal"] }
 signal-hook = { version = "0.3", features = ["iterator"] }
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 
+# CLI
+clap = { version = "4", features = ["derive"] }
+
 # Utilities
 uuid = { version = "1", features = ["v4", "serde"] }
-log = "0.4"
-pretty_env_logger = "0.5"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "2"
 anyhow = "1"
 

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -1,7 +1,6 @@
 //! CLI entry point for rttx-server.
-//!
-//! Supports `start`, `stop`, and `--foreground` commands.
 
+use clap::{Parser, Subcommand};
 use rttx_proto::proto;
 use rttx_server::ipc;
 use rttx_server::os::OsInterface;
@@ -9,35 +8,48 @@ use rttx_server::os::unix::UnixOs;
 use rttx_server::server::Server;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser)]
+#[command(
+    name = "rttx-server",
+    version,
+    about = "Daemon runtime service for the rttx terminal emulator"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Start the daemon
+    Start {
+        /// Run in foreground instead of daemonizing
+        #[arg(long)]
+        foreground: bool,
+    },
+    /// Stop the running daemon
+    Stop,
+    /// Serve one client over stdin/stdout (for SSH)
+    AttachStdio,
+}
 
 fn main() -> anyhow::Result<()> {
-    let args: Vec<String> = std::env::args().collect();
-    let command = args.get(1).map_or("start", String::as_str);
-    let foreground = args.iter().any(|a| a == "--foreground");
+    let cli = Cli::parse();
 
-    match command {
-        "start" => start(foreground),
-        "stop" => stop(),
-        "attach-stdio" => attach_stdio(),
-        "--help" | "-h" => {
-            print_usage();
-            Ok(())
-        }
-        other => {
-            eprintln!("Unknown command: {other}");
-            print_usage();
-            std::process::exit(1);
-        }
+    match cli.command.unwrap_or(Command::Start { foreground: false }) {
+        Command::Start { foreground } => start(foreground),
+        Command::Stop => stop(),
+        Command::AttachStdio => attach_stdio(),
     }
 }
 
-fn print_usage() {
-    eprintln!("Usage: rttx-server <command> [options]");
-    eprintln!();
-    eprintln!("Commands:");
-    eprintln!("  start [--foreground]  Start the daemon");
-    eprintln!("  stop                  Stop the running daemon");
-    eprintln!("  attach-stdio          Serve one client over stdin/stdout (for SSH)");
+fn init_tracing(dev_mode: bool) {
+    let default_level = if dev_mode { "debug" } else { "info" };
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+    tracing_subscriber::fmt().with_writer(std::io::stderr).with_env_filter(filter).init();
 }
 
 fn start(foreground: bool) -> anyhow::Result<()> {
@@ -67,15 +79,11 @@ fn start(foreground: bool) -> anyhow::Result<()> {
         }
     }
 
-    // Initialize logging. In dev mode, default to debug level.
-    let default_level = if dev_mode { "debug" } else { "info" };
-    let env_filter = std::env::var("RUST_LOG").unwrap_or_else(|_| default_level.to_string());
-    pretty_env_logger::formatted_builder().parse_filters(&env_filter).init();
+    init_tracing(dev_mode);
 
     if dev_mode {
-        log::info!("Starting rttx-server in DEVELOPMENT mode");
-        log::debug!("Runtime dir: {}", runtime_dir.display());
-        log::debug!("Cache dir: {}", os.cache_dir().display());
+        tracing::info!("Starting rttx-server in DEVELOPMENT mode");
+        tracing::debug!(runtime_dir = %runtime_dir.display(), cache_dir = %os.cache_dir().display());
     }
 
     // Write PID file in foreground mode too (daemonize writes it in daemon mode).
@@ -122,9 +130,7 @@ fn start(foreground: bool) -> anyhow::Result<()> {
 fn attach_stdio() -> anyhow::Result<()> {
     // Stderr is available for logging (stdout is the protocol channel).
     let dev_mode = rttx_server::os::unix::dev_mode_enabled();
-    let default_level = if dev_mode { "debug" } else { "info" };
-    let env_filter = std::env::var("RUST_LOG").unwrap_or_else(|_| default_level.to_string());
-    pretty_env_logger::formatted_builder().parse_filters(&env_filter).init();
+    init_tracing(dev_mode);
 
     let os = UnixOs;
     let rt = tokio::runtime::Runtime::new()?;
@@ -197,12 +203,12 @@ async fn handle_signals(server: Arc<Mutex<Server>>) {
     use tokio_stream::StreamExt;
 
     let Ok(mut signals) = Signals::new([SIGTERM, SIGINT]) else {
-        log::error!("Failed to register signal handlers");
+        tracing::error!("Failed to register signal handlers");
         return;
     };
 
     if signals.next().await.is_some() {
-        log::info!("Received OS shutdown signal, triggering cooperative shutdown");
+        tracing::info!("Received OS shutdown signal, triggering cooperative shutdown");
         let s = server.lock().await;
         s.request_shutdown();
     }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -76,17 +76,17 @@ impl Server {
         let state_path = default_state_path(&self.os.cache_dir());
         match load_state(&state_path) {
             Ok(Some(state)) => {
-                log::info!("Loaded {} persisted sessions", state.sessions.len());
+                tracing::info!("Loaded {} persisted sessions", state.sessions.len());
                 for ps in &state.sessions {
                     let session = Session::from_persisted(ps);
                     self.sessions.insert(session.id, session);
                 }
             }
             Ok(None) => {
-                log::info!("No persisted state found, starting fresh");
+                tracing::info!("No persisted state found, starting fresh");
             }
             Err(e) => {
-                log::error!("Failed to load persisted state: {e}");
+                tracing::error!("Failed to load persisted state: {e}");
             }
         }
     }
@@ -109,7 +109,7 @@ impl Server {
                     {
                         match std::fs::read(log_path) {
                             Ok(data) => {
-                                log::info!(
+                                tracing::info!(
                                     "Replaying {} bytes of scrollback for pane {}",
                                     data.len(),
                                     pane.id
@@ -117,7 +117,7 @@ impl Server {
                                 pane.screen.feed(&data);
                             }
                             Err(e) => {
-                                log::error!(
+                                tracing::error!(
                                     "Failed to read scrollback log for pane {}: {e}",
                                     pane.id
                                 );
@@ -142,7 +142,7 @@ impl Server {
             return;
         }
 
-        log::info!("Reconstructing {} panes", panes_to_reconstruct.len());
+        tracing::info!("Reconstructing {} panes", panes_to_reconstruct.len());
 
         for (session_id, pane_id, cwd, cols, rows) in panes_to_reconstruct {
             let pty_result = {
@@ -172,10 +172,10 @@ impl Server {
                         child,
                         kill_rx,
                     );
-                    log::info!("Reconstructed pane {pane_id} in session {session_id}");
+                    tracing::info!("Reconstructed pane {pane_id} in session {session_id}");
                 }
                 Err(e) => {
-                    log::error!("Failed to reconstruct pane {pane_id}: {e}");
+                    tracing::error!("Failed to reconstruct pane {pane_id}: {e}");
                     let mut s = server.lock().await;
                     if let Some(session) = s.sessions.get_mut(&session_id) {
                         let _ = session.set_pane_exit_status(pane_id, Some(-1));
@@ -482,7 +482,7 @@ impl Server {
                         Some(protocol::pane_created(session_id, pane_id, revision))
                     }
                     Err(e) => {
-                        log::error!("Failed to spawn PTY for pane {pane_id}: {e}");
+                        tracing::error!("Failed to spawn PTY for pane {pane_id}: {e}");
                         Some(protocol::error(
                             protocol::ERR_SPAWN_FAILED,
                             format!("failed to spawn pane: {e}"),
@@ -581,10 +581,10 @@ impl Server {
                 if let Some(writer) = writer {
                     let mut w = writer.lock().await;
                     if let Err(e) = w.write_all(&req.data).await {
-                        log::error!("Failed to write to PTY {pane_id}: {e}");
+                        tracing::error!("Failed to write to PTY {pane_id}: {e}");
                     }
                     if let Err(e) = w.flush().await {
-                        log::error!("Failed to flush PTY {pane_id}: {e}");
+                        tracing::error!("Failed to flush PTY {pane_id}: {e}");
                     }
                 }
                 None
@@ -654,7 +654,7 @@ impl Server {
                 {
                     let w = writer.lock().await;
                     if let Err(e) = w.resize(pty_process::Size::new(rows, cols)) {
-                        log::error!("Failed to resize PTY {pane_id}: {e}");
+                        tracing::error!("Failed to resize PTY {pane_id}: {e}");
                         return Some(protocol::error(
                             protocol::ERR_PANE_NOT_RUNNING,
                             format!("failed to resize pane: {e}"),
@@ -756,14 +756,14 @@ fn spawn_pty_read_loop(
                             s.broadcast_to_session(session_id, &msg);
                         }
                         Err(e) => {
-                            log::error!("PTY read error for pane {pane_id}: {e}");
+                            tracing::error!("PTY read error for pane {pane_id}: {e}");
                             break;
                         }
                     }
                 }
                 _ = &mut kill_rx => {
                     let _ = child.start_kill();
-                    log::info!("PTY read loop cancelled for pane {pane_id}");
+                    tracing::info!("PTY read loop cancelled for pane {pane_id}");
                     return;
                 }
             }
@@ -773,7 +773,7 @@ fn spawn_pty_read_loop(
         let status = match child.wait().await {
             Ok(s) => s.code().unwrap_or(-1),
             Err(e) => {
-                log::error!("Failed to wait on child for pane {pane_id}: {e}");
+                tracing::error!("Failed to wait on child for pane {pane_id}: {e}");
                 -1
             }
         };
@@ -789,7 +789,7 @@ fn spawn_pty_read_loop(
         s.pty_kill_senders.remove(&pane_id);
         drop(s);
 
-        log::info!("PTY exited for pane {pane_id}, status {status}");
+        tracing::info!("PTY exited for pane {pane_id}, status {status}");
     });
 }
 
@@ -806,7 +806,7 @@ pub async fn serialization_loop(
         tokio::select! {
             _ = ticker.tick() => {}
             _ = shutdown_rx.changed() => {
-                log::info!("Serialization loop stopping (shutdown)");
+                tracing::info!("Serialization loop stopping (shutdown)");
                 return;
             }
         }
@@ -819,7 +819,7 @@ pub async fn serialization_loop(
             if let Some(session) = s.sessions.get_mut(&session_id) {
                 for pane in session.panes.values_mut() {
                     if let Err(e) = pane.flush_scrollback(&cache_dir, session_id) {
-                        log::error!("Failed to flush scrollback for pane {}: {e}", pane.id);
+                        tracing::error!("Failed to flush scrollback for pane {}: {e}", pane.id);
                     }
                 }
             }
@@ -830,7 +830,7 @@ pub async fn serialization_loop(
         drop(s);
 
         if let Err(e) = write_state_atomic(&snapshot, &state_path) {
-            log::error!("Failed to serialize state: {e}");
+            tracing::error!("Failed to serialize state: {e}");
         }
     }
 }
@@ -843,7 +843,7 @@ pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
     for session in s.sessions.values_mut() {
         for pane in session.panes.values_mut() {
             if let Err(e) = pane.flush_scrollback(&cache_dir, session.id) {
-                log::error!("Failed to flush scrollback for pane {}: {e}", pane.id);
+                tracing::error!("Failed to flush scrollback for pane {}: {e}", pane.id);
             }
         }
     }
@@ -853,9 +853,9 @@ pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
     drop(s);
 
     if let Err(e) = write_state_atomic(&snapshot, &state_path) {
-        log::error!("Failed to persist final state: {e}");
+        tracing::error!("Failed to persist final state: {e}");
     } else {
-        log::info!("Final state persisted");
+        tracing::info!("Final state persisted");
     }
 }
 
@@ -871,7 +871,7 @@ pub async fn run(server: Arc<Mutex<Server>>) -> anyhow::Result<()> {
     };
 
     let listener = Listener::bind(&socket_path)?;
-    log::info!("Listening on {}", socket_path.display());
+    tracing::info!("Listening on {}", socket_path.display());
 
     // Start serialization loop.
     let ser_server = Arc::clone(&server);
@@ -887,12 +887,12 @@ pub async fn run(server: Arc<Mutex<Server>>) -> anyhow::Result<()> {
                 let server = Arc::clone(&server);
                 tokio::spawn(async move {
                     if let Err(e) = handle_client(server, conn).await {
-                        log::error!("Client error: {e}");
+                        tracing::error!("Client error: {e}");
                     }
                 });
             }
             _ = shutdown_rx.changed() => {
-                log::info!("Shutdown signal received, persisting state...");
+                tracing::info!("Shutdown signal received, persisting state...");
                 break;
             }
         }
@@ -922,7 +922,7 @@ where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     let client_id = Uuid::new_v4();
-    log::info!("Client {client_id} connected");
+    tracing::info!("Client {client_id} connected");
 
     let (tx, mut rx) = mpsc::unbounded_channel();
     {
@@ -935,12 +935,12 @@ where
             tokio::select! {
                 msg_result = conn.read_message() => {
                     let Some(msg) = msg_result? else {
-                        log::info!("Client {client_id} disconnected");
+                        tracing::info!("Client {client_id} disconnected");
                         break;
                     };
 
                     if matches!(msg.msg, Some(proto::client_message::Msg::Shutdown(_))) {
-                        log::info!("Shutdown requested by client {client_id}");
+                        tracing::info!("Shutdown requested by client {client_id}");
                         let s = server.lock().await;
                         s.request_shutdown();
                         break;


### PR DESCRIPTION
Replace hand-rolled argument parsing with clap derive for typed subcommands, auto-generated help, and version output. Replace log and pretty_env_logger with tracing and tracing-subscriber for structured, async-aware logging with RUST_LOG env filter support.

- Add clap v4 with derive feature for CLI parsing
- Add tracing v0.1 and tracing-subscriber v0.3 with env-filter
- Remove log v0.4 and pretty_env_logger v0.5
- Direct tracing output to stderr to preserve stdout for attach-stdio
- Default to start subcommand when invoked without arguments
- Use structured fields for dev-mode startup diagnostics
- Mechanical log:: to tracing:: replacement across server.rs