### PR TITLE
fix: restore clickable terminal link activation

### DIFF
--- a/clients/rttx/src/terminal/links.rs
+++ b/clients/rttx/src/terminal/links.rs
@@ -8,10 +8,8 @@ const OPENABLE_URI_PREFIXES: &[&str] = &["http://", "https://", "mailto:", "file
 const URI_MATCH_REGEX: &str = r#"(?:https?://|mailto:|file://)[^\s<>'"`)\]\}]+"#;
 const PATH_MATCH_REGEX: &str = r#"(?:~/|\.\.?/|/|[A-Za-z0-9._-]+/)[^\s<>'"`]+"#;
 
-#[cfg(test)]
 type TestUriLauncher = Box<dyn Fn(&str) -> bool>;
 
-#[cfg(test)]
 thread_local! {
     static TEST_URI_LAUNCHER: std::cell::RefCell<Option<TestUriLauncher>> = std::cell::RefCell::new(None);
 }
@@ -82,7 +80,6 @@ pub(crate) fn openable_uri_at(
 }
 
 pub(crate) fn launch_uri(uri: &str) -> bool {
-    #[cfg(test)]
     if let Some(result) =
         TEST_URI_LAUNCHER.with(|launcher| launcher.borrow().as_ref().map(|launcher| launcher(uri)))
     {
@@ -190,8 +187,8 @@ fn resolve_openable_path(path: &str, current_directory: Option<&str>) -> Option<
     current_directory.map(|cwd| Path::new(cwd).join(path))
 }
 
-#[cfg(test)]
-pub(crate) fn with_test_uri_launcher<R>(
+#[doc(hidden)]
+pub fn with_test_uri_launcher<R>(
     launcher: impl Fn(&str) -> bool + 'static,
     f: impl FnOnce() -> R,
 ) -> R {
@@ -220,75 +217,6 @@ mod tests {
     use gtk4::prelude::*;
     use std::cell::RefCell;
     use std::rc::Rc;
-    use std::sync::Once;
-    use vte4::prelude::*;
-
-    static GTK_INIT: Once = Once::new();
-    static GTK_AVAILABLE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-    fn ensure_gtk_init() -> bool {
-        GTK_INIT.call_once(|| {
-            // SAFETY: GTK init runs once before any threads spawn; no concurrent env readers.
-            #[allow(unsafe_code)]
-            unsafe {
-                std::env::set_var("GTK_A11Y", "none");
-            };
-            let ok =
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| gtk4::init().is_ok()))
-                    .unwrap_or(false);
-            if ok && let Some(display) = gtk4::gdk::Display::default() {
-                std::mem::forget(display);
-            }
-            GTK_AVAILABLE.store(ok, std::sync::atomic::Ordering::Relaxed);
-        });
-        GTK_AVAILABLE.load(std::sync::atomic::Ordering::Relaxed)
-    }
-
-    macro_rules! require_display {
-        () => {
-            if !ensure_gtk_init() {
-                eprintln!(
-                    "SKIPPED: no display available (run with GDK_BACKEND=broadway or xvfb-run)"
-                );
-                return;
-            }
-        };
-    }
-
-    fn pump_events(max_ms: u64) {
-        let ctx = gtk4::glib::MainContext::default();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(max_ms);
-        while std::time::Instant::now() < deadline {
-            if !ctx.iteration(false) {
-                break;
-            }
-        }
-    }
-
-    fn present_widget(widget: &impl gtk4::prelude::IsA<gtk4::Widget>) -> gtk4::Window {
-        let window = gtk4::Window::new();
-        window.set_default_size(800, 500);
-        window.set_child(Some(widget));
-        window.present();
-        pump_events(100);
-        window
-    }
-
-    fn emit_left_click_at(widget: &gtk4::Widget, n_press: i32, x: f64, y: f64) {
-        let controllers = widget.observe_controllers();
-        for index in 0..controllers.n_items() {
-            let Some(controller) = controllers.item(index) else {
-                continue;
-            };
-            if let Ok(gesture) = controller.downcast::<gtk4::GestureClick>()
-                && gesture.button() == 1
-            {
-                gesture.emit_by_name::<()>("released", &[&n_press, &x, &y]);
-                return;
-            }
-        }
-        panic!("widget should have a left-click GestureClick controller");
-    }
 
     #[test]
     fn parse_standard_vte_uri() {
@@ -390,66 +318,5 @@ mod tests {
 
         assert!(result);
         assert_eq!(launched.borrow().as_slice(), ["https://example.com/docs"]);
-    }
-
-    #[test]
-    fn direct_terminal_clicking_highlighted_url_launches_it() {
-        require_display!();
-
-        let term = crate::terminal::widget::TerminalWidget::new("direct-link", None);
-        let window = present_widget(&term);
-        term.vte().feed(b"https://example.com/direct\n");
-        pump_events(100);
-
-        let (matched, _tag) = term.vte().check_match_at(4.0, 4.0);
-        assert_eq!(matched.as_deref(), Some("https://example.com/direct"));
-
-        let launched = Rc::new(RefCell::new(Vec::new()));
-        let launched_clone = Rc::clone(&launched);
-        with_test_uri_launcher(
-            move |uri| {
-                launched_clone.borrow_mut().push(uri.to_string());
-                true
-            },
-            || {
-                emit_left_click_at(term.vte().upcast_ref::<gtk4::Widget>(), 1, 4.0, 4.0);
-                pump_events(50);
-            },
-        );
-
-        assert_eq!(launched.borrow().as_slice(), ["https://example.com/direct"]);
-        window.close();
-    }
-
-    #[test]
-    fn persistent_terminal_clicking_highlighted_url_launches_it() {
-        require_display!();
-
-        let pane = crate::terminal::persistent_widget::PersistentPaneView::new(
-            "managed-link",
-            "runtime-1",
-        );
-        let window = present_widget(&pane);
-        pane.feed_output(b"https://example.com/persistent\n");
-        pump_events(100);
-
-        let (matched, _tag) = pane.vte().check_match_at(4.0, 4.0);
-        assert_eq!(matched.as_deref(), Some("https://example.com/persistent"));
-
-        let launched = Rc::new(RefCell::new(Vec::new()));
-        let launched_clone = Rc::clone(&launched);
-        with_test_uri_launcher(
-            move |uri| {
-                launched_clone.borrow_mut().push(uri.to_string());
-                true
-            },
-            || {
-                emit_left_click_at(pane.vte().upcast_ref::<gtk4::Widget>(), 1, 4.0, 4.0);
-                pump_events(50);
-            },
-        );
-
-        assert_eq!(launched.borrow().as_slice(), ["https://example.com/persistent"]);
-        window.close();
     }
 }

--- a/clients/rttx/src/terminal/links.rs
+++ b/clients/rttx/src/terminal/links.rs
@@ -1,0 +1,455 @@
+use gtk4::glib;
+use gtk4::prelude::*;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use vte4::prelude::*;
+
+const OPENABLE_URI_PREFIXES: &[&str] = &["http://", "https://", "mailto:", "file://"];
+const URI_MATCH_REGEX: &str = r#"(?:https?://|mailto:|file://)[^\s<>'"`)\]\}]+"#;
+const PATH_MATCH_REGEX: &str = r#"(?:~/|\.\.?/|/|[A-Za-z0-9._-]+/)[^\s<>'"`]+"#;
+
+#[cfg(test)]
+type TestUriLauncher = Box<dyn Fn(&str) -> bool>;
+
+#[cfg(test)]
+thread_local! {
+    static TEST_URI_LAUNCHER: std::cell::RefCell<Option<TestUriLauncher>> = std::cell::RefCell::new(None);
+}
+
+pub(crate) fn configure_openable_matches(vte: &vte4::Terminal) {
+    vte.set_allow_hyperlink(true);
+    register_openable_match(vte, URI_MATCH_REGEX);
+    register_openable_match(vte, PATH_MATCH_REGEX);
+}
+
+pub(crate) fn install_openable_link_controllers<F>(vte: &vte4::Terminal, current_directory: F)
+where
+    F: Fn() -> Option<String> + 'static,
+{
+    let current_directory = Rc::new(current_directory);
+
+    let click_vte = vte.clone();
+    let click_current_directory = Rc::clone(&current_directory);
+    let open_match_click = gtk4::GestureClick::new();
+    open_match_click.set_button(1);
+    open_match_click.set_propagation_phase(gtk4::PropagationPhase::Capture);
+    open_match_click.connect_released(move |gesture, n_press, x, y| {
+        if n_press != 1 {
+            return;
+        }
+        let current_directory = click_current_directory();
+        let Some(uri) = openable_uri_at(&click_vte, x, y, current_directory.as_deref()) else {
+            return;
+        };
+        if launch_uri(&uri) {
+            gesture.set_state(gtk4::EventSequenceState::Claimed);
+        }
+    });
+    vte.add_controller(open_match_click);
+
+    let hover_vte = vte.clone();
+    let hover_current_directory = Rc::clone(&current_directory);
+    let hover_controller = gtk4::EventControllerMotion::new();
+    hover_controller.connect_motion(move |_, x, y| {
+        let current_directory = hover_current_directory();
+        let cursor_name =
+            if openable_uri_at(&hover_vte, x, y, current_directory.as_deref()).is_some() {
+                Some("pointer")
+            } else {
+                None
+            };
+        hover_vte.set_cursor_from_name(cursor_name);
+    });
+    let leave_vte = vte.clone();
+    hover_controller.connect_leave(move |_| {
+        leave_vte.set_cursor_from_name(None);
+    });
+    vte.add_controller(hover_controller);
+}
+
+pub(crate) fn openable_uri_at(
+    vte: &vte4::Terminal,
+    x: f64,
+    y: f64,
+    current_directory: Option<&str>,
+) -> Option<String> {
+    if let Some(uri) = vte.check_hyperlink_at(x, y) {
+        return Some(uri.to_string());
+    }
+
+    let (matched, _tag) = vte.check_match_at(x, y);
+    matched.as_deref().and_then(|text| openable_uri_from_match_text(text, current_directory))
+}
+
+pub(crate) fn launch_uri(uri: &str) -> bool {
+    #[cfg(test)]
+    if let Some(result) =
+        TEST_URI_LAUNCHER.with(|launcher| launcher.borrow().as_ref().map(|launcher| launcher(uri)))
+    {
+        return result;
+    }
+
+    match gtk4::gio::AppInfo::launch_default_for_uri(uri, gtk4::gio::AppLaunchContext::NONE) {
+        Ok(()) => true,
+        Err(error) => {
+            log::warn!("Failed to open terminal match '{uri}': {error}");
+            false
+        }
+    }
+}
+
+pub(crate) fn parse_file_uri(uri: &str) -> Option<String> {
+    glib::filename_from_uri(uri).ok().map(|(path, _hostname)| path.display().to_string())
+}
+
+pub(crate) fn openable_uri_from_match_text(
+    match_text: &str,
+    current_directory: Option<&str>,
+) -> Option<String> {
+    let trimmed = trim_openable_match(match_text);
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if OPENABLE_URI_PREFIXES.iter().any(|prefix| trimmed.starts_with(prefix)) {
+        return Some(trimmed.to_string());
+    }
+
+    let path_text = strip_editor_position_suffix(trimmed);
+    if !looks_like_path(path_text) {
+        return None;
+    }
+
+    let path = resolve_openable_path(path_text, current_directory)?;
+    Some(gtk4::gio::File::for_path(path).uri().to_string())
+}
+
+fn register_openable_match(vte: &vte4::Terminal, pattern: &str) {
+    // VTE 0.78 asserts PCRE2_MULTILINE on match_add_regex. Pass the same
+    // defaults VTE uses internally (VTE_REGEX_FLAGS_DEFAULT from vteregex.hh).
+    const PCRE2_FLAGS: u32 = 0x0008_0000  // PCRE2_UTF
+        | 0x4000_0000  // PCRE2_NO_UTF_CHECK
+        | 0x0000_0008  // PCRE2_CASELESS
+        | 0x0000_0400  // PCRE2_MULTILINE
+        | 0x0000_0020; // PCRE2_DOTALL
+    match vte4::Regex::for_match(pattern, PCRE2_FLAGS) {
+        Ok(regex) => {
+            let tag = vte.match_add_regex(&regex, 0);
+            vte.match_set_cursor_name(tag, "pointer");
+        }
+        Err(error) => {
+            log::error!("Failed to register terminal match regex '{pattern}': {error}");
+        }
+    }
+}
+
+fn trim_openable_match(match_text: &str) -> &str {
+    match_text.trim_end_matches(['.', ',', ';', '!', '?', ')', ']', '}', '>'])
+}
+
+fn strip_editor_position_suffix(path: &str) -> &str {
+    let bytes = path.as_bytes();
+    let mut end = path.len();
+    let mut stripped_any = false;
+
+    loop {
+        let mut start = end;
+        while start > 0 && bytes[start - 1].is_ascii_digit() {
+            start -= 1;
+        }
+
+        if start == end || start == 0 || bytes[start - 1] != b':' {
+            break;
+        }
+
+        stripped_any = true;
+        end = start - 1;
+    }
+
+    if stripped_any { &path[..end] } else { path }
+}
+
+fn looks_like_path(path: &str) -> bool {
+    path.starts_with('/')
+        || path.starts_with("~/")
+        || path.starts_with("./")
+        || path.starts_with("../")
+        || path.contains('/')
+}
+
+fn resolve_openable_path(path: &str, current_directory: Option<&str>) -> Option<PathBuf> {
+    if let Some(home_relative) = path.strip_prefix("~/") {
+        return Some(glib::home_dir().join(home_relative));
+    }
+
+    let path = Path::new(path);
+    if path.is_absolute() {
+        return Some(path.to_path_buf());
+    }
+
+    current_directory.map(|cwd| Path::new(cwd).join(path))
+}
+
+#[cfg(test)]
+pub(crate) fn with_test_uri_launcher<R>(
+    launcher: impl Fn(&str) -> bool + 'static,
+    f: impl FnOnce() -> R,
+) -> R {
+    struct Reset;
+
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            TEST_URI_LAUNCHER.with(|slot| {
+                slot.borrow_mut().take();
+            });
+        }
+    }
+
+    TEST_URI_LAUNCHER.with(|slot| {
+        assert!(slot.borrow().is_none(), "test URI launcher must not be nested");
+        slot.borrow_mut().replace(Box::new(launcher));
+    });
+    let _reset = Reset;
+    f()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{launch_uri, openable_uri_from_match_text, parse_file_uri, with_test_uri_launcher};
+    use gtk4::gio;
+    use gtk4::prelude::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use std::sync::Once;
+    use vte4::prelude::*;
+
+    static GTK_INIT: Once = Once::new();
+    static GTK_AVAILABLE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+    fn ensure_gtk_init() -> bool {
+        GTK_INIT.call_once(|| {
+            // SAFETY: GTK init runs once before any threads spawn; no concurrent env readers.
+            #[allow(unsafe_code)]
+            unsafe {
+                std::env::set_var("GTK_A11Y", "none");
+            };
+            let ok =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| gtk4::init().is_ok()))
+                    .unwrap_or(false);
+            if ok && let Some(display) = gtk4::gdk::Display::default() {
+                std::mem::forget(display);
+            }
+            GTK_AVAILABLE.store(ok, std::sync::atomic::Ordering::Relaxed);
+        });
+        GTK_AVAILABLE.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    macro_rules! require_display {
+        () => {
+            if !ensure_gtk_init() {
+                eprintln!(
+                    "SKIPPED: no display available (run with GDK_BACKEND=broadway or xvfb-run)"
+                );
+                return;
+            }
+        };
+    }
+
+    fn pump_events(max_ms: u64) {
+        let ctx = gtk4::glib::MainContext::default();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(max_ms);
+        while std::time::Instant::now() < deadline {
+            if !ctx.iteration(false) {
+                break;
+            }
+        }
+    }
+
+    fn present_widget(widget: &impl gtk4::prelude::IsA<gtk4::Widget>) -> gtk4::Window {
+        let window = gtk4::Window::new();
+        window.set_default_size(800, 500);
+        window.set_child(Some(widget));
+        window.present();
+        pump_events(100);
+        window
+    }
+
+    fn emit_left_click_at(widget: &gtk4::Widget, n_press: i32, x: f64, y: f64) {
+        let controllers = widget.observe_controllers();
+        for index in 0..controllers.n_items() {
+            let Some(controller) = controllers.item(index) else {
+                continue;
+            };
+            if let Ok(gesture) = controller.downcast::<gtk4::GestureClick>()
+                && gesture.button() == 1
+            {
+                gesture.emit_by_name::<()>("released", &[&n_press, &x, &y]);
+                return;
+            }
+        }
+        panic!("widget should have a left-click GestureClick controller");
+    }
+
+    #[test]
+    fn parse_standard_vte_uri() {
+        assert_eq!(
+            parse_file_uri("file:///home/user/projects"),
+            Some("/home/user/projects".into())
+        );
+    }
+
+    #[test]
+    fn parse_uri_with_percent_encoding() {
+        assert_eq!(
+            parse_file_uri("file:///home/user/my%20project"),
+            Some("/home/user/my project".into())
+        );
+    }
+
+    #[test]
+    fn parse_uri_root() {
+        assert_eq!(parse_file_uri("file:///"), Some("/".into()));
+    }
+
+    #[test]
+    fn parse_non_file_uri_returns_none() {
+        assert_eq!(parse_file_uri("https://example.com/path"), None);
+        assert_eq!(parse_file_uri("ssh://host/path"), None);
+    }
+
+    #[test]
+    fn parse_empty_string_returns_none() {
+        assert_eq!(parse_file_uri(""), None);
+    }
+
+    #[test]
+    fn strip_prefix_regression() {
+        let old_way = "file:///home/user/my%20dir".strip_prefix("file://").map(str::to_string);
+        let new_way = parse_file_uri("file:///home/user/my%20dir");
+        assert_eq!(old_way, Some("/home/user/my%20dir".into()));
+        assert_eq!(new_way, Some("/home/user/my dir".into()));
+        assert_ne!(old_way, new_way);
+    }
+
+    #[test]
+    fn http_match_opens_as_uri() {
+        assert_eq!(
+            openable_uri_from_match_text("https://example.com/docs?q=rust#intro", None),
+            Some("https://example.com/docs?q=rust#intro".into())
+        );
+    }
+
+    #[test]
+    fn trailing_punctuation_is_trimmed_from_uri_match() {
+        assert_eq!(
+            openable_uri_from_match_text("https://example.com/docs).", None),
+            Some("https://example.com/docs".into())
+        );
+    }
+
+    #[test]
+    fn absolute_path_match_becomes_file_uri() {
+        let expected = gio::File::for_path("/tmp/rttx.log").uri().to_string();
+        assert_eq!(openable_uri_from_match_text("/tmp/rttx.log", None), Some(expected));
+    }
+
+    #[test]
+    fn relative_path_match_uses_terminal_cwd() {
+        let expected = gio::File::for_path("/workspace/rttx/src/main.rs").uri().to_string();
+        assert_eq!(
+            openable_uri_from_match_text("src/main.rs", Some("/workspace/rttx")),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn line_and_column_suffix_do_not_block_path_opening() {
+        let expected = gio::File::for_path("/workspace/rttx/src/main.rs").uri().to_string();
+        assert_eq!(
+            openable_uri_from_match_text("src/main.rs:42:7", Some("/workspace/rttx")),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn bare_word_is_not_treated_as_openable_path() {
+        assert_eq!(openable_uri_from_match_text("Cargo.toml", Some("/workspace/rttx")), None);
+    }
+
+    #[test]
+    fn launch_uri_uses_test_launcher_when_installed() {
+        let launched = Rc::new(RefCell::new(Vec::new()));
+        let launched_clone = Rc::clone(&launched);
+        let result = with_test_uri_launcher(
+            move |uri| {
+                launched_clone.borrow_mut().push(uri.to_string());
+                true
+            },
+            || launch_uri("https://example.com/docs"),
+        );
+
+        assert!(result);
+        assert_eq!(launched.borrow().as_slice(), ["https://example.com/docs"]);
+    }
+
+    #[test]
+    fn direct_terminal_clicking_highlighted_url_launches_it() {
+        require_display!();
+
+        let term = crate::terminal::widget::TerminalWidget::new("direct-link", None);
+        let window = present_widget(&term);
+        term.vte().feed(b"https://example.com/direct\n");
+        pump_events(100);
+
+        let (matched, _tag) = term.vte().check_match_at(4.0, 4.0);
+        assert_eq!(matched.as_deref(), Some("https://example.com/direct"));
+
+        let launched = Rc::new(RefCell::new(Vec::new()));
+        let launched_clone = Rc::clone(&launched);
+        with_test_uri_launcher(
+            move |uri| {
+                launched_clone.borrow_mut().push(uri.to_string());
+                true
+            },
+            || {
+                emit_left_click_at(term.vte().upcast_ref::<gtk4::Widget>(), 1, 4.0, 4.0);
+                pump_events(50);
+            },
+        );
+
+        assert_eq!(launched.borrow().as_slice(), ["https://example.com/direct"]);
+        window.close();
+    }
+
+    #[test]
+    fn persistent_terminal_clicking_highlighted_url_launches_it() {
+        require_display!();
+
+        let pane = crate::terminal::persistent_widget::PersistentPaneView::new(
+            "managed-link",
+            "runtime-1",
+        );
+        let window = present_widget(&pane);
+        pane.feed_output(b"https://example.com/persistent\n");
+        pump_events(100);
+
+        let (matched, _tag) = pane.vte().check_match_at(4.0, 4.0);
+        assert_eq!(matched.as_deref(), Some("https://example.com/persistent"));
+
+        let launched = Rc::new(RefCell::new(Vec::new()));
+        let launched_clone = Rc::clone(&launched);
+        with_test_uri_launcher(
+            move |uri| {
+                launched_clone.borrow_mut().push(uri.to_string());
+                true
+            },
+            || {
+                emit_left_click_at(pane.vte().upcast_ref::<gtk4::Widget>(), 1, 4.0, 4.0);
+                pump_events(50);
+            },
+        );
+
+        assert_eq!(launched.borrow().as_slice(), ["https://example.com/persistent"]);
+        window.close();
+    }
+}

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1,4 +1,5 @@
 pub mod handle;
-pub(crate) mod links;
+#[doc(hidden)]
+pub mod links;
 pub mod persistent_widget;
 pub mod widget;

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1,3 +1,4 @@
 pub mod handle;
+pub(crate) mod links;
 pub mod persistent_widget;
 pub mod widget;

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -12,6 +12,7 @@ use vte4::prelude::*;
 
 use crate::color_scheme;
 use crate::runtime::{ConnectionPresentation, ConnectionStatus};
+use crate::terminal::links;
 
 mod imp {
     use super::*;
@@ -136,6 +137,11 @@ mod imp {
             self.vte.set_scroll_on_output(false);
             self.vte.set_scroll_on_keystroke(true);
             self.vte.set_scrollback_lines(10000);
+            links::configure_openable_matches(&self.vte);
+            let link_target = obj.downgrade();
+            links::install_openable_link_controllers(&self.vte, move || {
+                link_target.upgrade().and_then(|pane| pane.current_directory())
+            });
 
             self.search_entry.set_hexpand(true);
             self.search_bar.set_child(Some(&self.search_entry));

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -2,10 +2,10 @@ use gtk4::glib;
 use gtk4::glib::subclass::prelude::*;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
-use std::path::{Path, PathBuf};
 use vte4::prelude::*;
 
 use crate::color_scheme;
+use crate::terminal::links;
 
 mod imp {
     use super::*;
@@ -123,7 +123,7 @@ mod imp {
             self.vte.set_scroll_on_output(false);
             self.vte.set_scroll_on_keystroke(true);
             self.vte.set_scrollback_lines(10000);
-            configure_openable_matches(&self.vte);
+            links::configure_openable_matches(&self.vte);
 
             self.terminal_scroller.set_hscrollbar_policy(gtk4::PolicyType::Never);
             self.terminal_scroller.set_vscrollbar_policy(gtk4::PolicyType::Automatic);
@@ -132,40 +132,10 @@ mod imp {
             self.terminal_scroller.add_css_class("terminal-scroller");
             self.terminal_scroller.set_child(Some(&self.vte));
 
-            let click_target = obj.downgrade();
-            let open_match_click = gtk4::GestureClick::new();
-            open_match_click.set_button(1);
-            open_match_click.connect_released(move |gesture, n_press, x, y| {
-                if n_press != 1 {
-                    return;
-                }
-                let Some(widget) = gesture.widget() else { return };
-                let Ok(vte) = widget.downcast::<vte4::Terminal>() else { return };
-                let Some(term) = click_target.upgrade() else { return };
-                if term.try_open_match_at(x, y, &vte) {
-                    gesture.set_state(gtk4::EventSequenceState::Claimed);
-                }
+            let link_target = obj.downgrade();
+            links::install_openable_link_controllers(&self.vte, move || {
+                link_target.upgrade().and_then(|term| term.current_directory())
             });
-            self.vte.add_controller(open_match_click);
-
-            let hover_target = obj.downgrade();
-            let hover_controller = gtk4::EventControllerMotion::new();
-            hover_controller.connect_motion(move |controller, x, y| {
-                let Some(widget) = controller.widget() else { return };
-                let Ok(vte) = widget.downcast::<vte4::Terminal>() else { return };
-                let Some(term) = hover_target.upgrade() else { return };
-                let cursor_name =
-                    if term.openable_uri_at(x, y, &vte).is_some() { Some("pointer") } else { None };
-                vte.set_cursor_from_name(cursor_name);
-            });
-            let leave_target = obj.downgrade();
-            hover_controller.connect_leave(move |controller| {
-                let Some(_term) = leave_target.upgrade() else { return };
-                let Some(widget) = controller.widget() else { return };
-                let Ok(vte) = widget.downcast::<vte4::Terminal>() else { return };
-                vte.set_cursor_from_name(None);
-            });
-            self.vte.add_controller(hover_controller);
 
             let vte = self.vte.clone();
             let smart_clipboard_controller = gtk4::ShortcutController::new();
@@ -272,7 +242,12 @@ mod imp {
             let obj_weak = obj.downgrade();
             right_click.connect_pressed(move |gesture, _, x, y| {
                 if let Some(obj) = obj_weak.upgrade() {
-                    let matched = obj.openable_uri_at(x, y, &obj.imp().vte);
+                    let matched = links::openable_uri_at(
+                        &obj.imp().vte,
+                        x,
+                        y,
+                        obj.current_directory().as_deref(),
+                    );
                     copy_link_ref.set_enabled(matched.is_some());
                     obj.imp().last_match_at_click.replace(matched);
                 }
@@ -377,7 +352,7 @@ impl TerminalWidget {
         if let Some(cwd) = self.imp().current_directory_override.borrow().clone() {
             return cwd;
         }
-        self.imp().vte.current_directory_uri().and_then(|uri| parse_file_uri(uri.as_str()))
+        self.imp().vte.current_directory_uri().and_then(|uri| links::parse_file_uri(uri.as_str()))
     }
 
     pub fn set_smart_clipboard(&self, enabled: bool) {
@@ -623,135 +598,6 @@ impl TerminalWidget {
             vte.set_color_bold(Some(&bold));
         }
     }
-
-    fn try_open_match_at(&self, x: f64, y: f64, vte: &vte4::Terminal) -> bool {
-        let Some(uri) = self.openable_uri_at(x, y, vte) else {
-            return false;
-        };
-        self.open_uri(&uri)
-    }
-
-    fn openable_uri_at(&self, x: f64, y: f64, vte: &vte4::Terminal) -> Option<String> {
-        if let Some(uri) = vte.check_hyperlink_at(x, y) {
-            return Some(uri.to_string());
-        }
-
-        let (matched, _tag) = vte.check_match_at(x, y);
-        let cwd = self.current_directory();
-        matched.as_deref().and_then(|text| openable_uri_from_match_text(text, cwd.as_deref()))
-    }
-
-    fn open_uri(&self, uri: &str) -> bool {
-        match gtk4::gio::AppInfo::launch_default_for_uri(uri, gtk4::gio::AppLaunchContext::NONE) {
-            Ok(()) => true,
-            Err(error) => {
-                log::warn!("Failed to open terminal match '{uri}': {error}");
-                false
-            }
-        }
-    }
-}
-
-pub(crate) fn parse_file_uri(uri: &str) -> Option<String> {
-    glib::filename_from_uri(uri).ok().map(|(path, _hostname)| path.display().to_string())
-}
-
-const OPENABLE_URI_PREFIXES: &[&str] = &["http://", "https://", "mailto:", "file://"];
-const URI_MATCH_REGEX: &str = r#"(?:https?://|mailto:|file://)[^\s<>'"`)\]\}]+"#;
-const PATH_MATCH_REGEX: &str = r#"(?:~/|\.\.?/|/|[A-Za-z0-9._-]+/)[^\s<>'"`]+"#;
-
-fn configure_openable_matches(vte: &vte4::Terminal) {
-    vte.set_allow_hyperlink(true);
-    register_openable_match(vte, URI_MATCH_REGEX);
-    register_openable_match(vte, PATH_MATCH_REGEX);
-}
-
-fn register_openable_match(vte: &vte4::Terminal, pattern: &str) {
-    // VTE 0.78 asserts PCRE2_MULTILINE on match_add_regex. Pass the same
-    // defaults VTE uses internally (VTE_REGEX_FLAGS_DEFAULT from vteregex.hh).
-    const PCRE2_FLAGS: u32 = 0x0008_0000  // PCRE2_UTF
-        | 0x4000_0000  // PCRE2_NO_UTF_CHECK
-        | 0x0000_0008  // PCRE2_CASELESS
-        | 0x0000_0400  // PCRE2_MULTILINE
-        | 0x0000_0020; // PCRE2_DOTALL
-    match vte4::Regex::for_match(pattern, PCRE2_FLAGS) {
-        Ok(regex) => {
-            let tag = vte.match_add_regex(&regex, 0);
-            vte.match_set_cursor_name(tag, "pointer");
-        }
-        Err(error) => {
-            log::error!("Failed to register terminal match regex '{pattern}': {error}");
-        }
-    }
-}
-
-fn openable_uri_from_match_text(
-    match_text: &str,
-    current_directory: Option<&str>,
-) -> Option<String> {
-    let trimmed = trim_openable_match(match_text);
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    if OPENABLE_URI_PREFIXES.iter().any(|prefix| trimmed.starts_with(prefix)) {
-        return Some(trimmed.to_string());
-    }
-
-    let path_text = strip_editor_position_suffix(trimmed);
-    if !looks_like_path(path_text) {
-        return None;
-    }
-
-    let path = resolve_openable_path(path_text, current_directory)?;
-    Some(gtk4::gio::File::for_path(path).uri().to_string())
-}
-
-fn trim_openable_match(match_text: &str) -> &str {
-    match_text.trim_end_matches(['.', ',', ';', '!', '?', ')', ']', '}', '>'])
-}
-
-fn strip_editor_position_suffix(path: &str) -> &str {
-    let bytes = path.as_bytes();
-    let mut end = path.len();
-    let mut stripped_any = false;
-
-    loop {
-        let mut start = end;
-        while start > 0 && bytes[start - 1].is_ascii_digit() {
-            start -= 1;
-        }
-
-        if start == end || start == 0 || bytes[start - 1] != b':' {
-            break;
-        }
-
-        stripped_any = true;
-        end = start - 1;
-    }
-
-    if stripped_any { &path[..end] } else { path }
-}
-
-fn looks_like_path(path: &str) -> bool {
-    path.starts_with('/')
-        || path.starts_with("~/")
-        || path.starts_with("./")
-        || path.starts_with("../")
-        || path.contains('/')
-}
-
-fn resolve_openable_path(path: &str, current_directory: Option<&str>) -> Option<PathBuf> {
-    if let Some(home_relative) = path.strip_prefix("~/") {
-        return Some(glib::home_dir().join(home_relative));
-    }
-
-    let path = Path::new(path);
-    if path.is_absolute() {
-        return Some(path.to_path_buf());
-    }
-
-    current_directory.map(|cwd| Path::new(cwd).join(path))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -786,12 +632,7 @@ fn smart_clipboard_action(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        SmartClipboardAction, openable_uri_from_match_text, parse_file_uri, smart_clipboard_action,
-    };
-    use gtk4::gio;
-    use gtk4::prelude::*;
-
+    use super::{SmartClipboardAction, smart_clipboard_action};
     /// Verify that the RESET constant inside `reset_terminal_state()` contains
     /// the expected escape sequences without requiring a live VTE widget.
     #[test]
@@ -819,92 +660,6 @@ mod tests {
         assert!(reset.contains("\x1b[?1049l"), "alt-screen exit missing");
         assert!(reset.contains("\x1b[?25h"), "cursor show missing");
         assert!(reset.contains("\x1b[0m"), "SGR reset missing");
-    }
-
-    #[test]
-    fn parse_standard_vte_uri() {
-        assert_eq!(
-            parse_file_uri("file:///home/user/projects"),
-            Some("/home/user/projects".into())
-        );
-    }
-
-    #[test]
-    fn parse_uri_with_percent_encoding() {
-        assert_eq!(
-            parse_file_uri("file:///home/user/my%20project"),
-            Some("/home/user/my project".into())
-        );
-    }
-
-    #[test]
-    fn parse_uri_root() {
-        assert_eq!(parse_file_uri("file:///"), Some("/".into()));
-    }
-
-    #[test]
-    fn parse_non_file_uri_returns_none() {
-        assert_eq!(parse_file_uri("https://example.com/path"), None);
-        assert_eq!(parse_file_uri("ssh://host/path"), None);
-    }
-
-    #[test]
-    fn parse_empty_string_returns_none() {
-        assert_eq!(parse_file_uri(""), None);
-    }
-
-    #[test]
-    fn strip_prefix_regression() {
-        let old_way = "file:///home/user/my%20dir".strip_prefix("file://").map(str::to_string);
-        let new_way = parse_file_uri("file:///home/user/my%20dir");
-        assert_eq!(old_way, Some("/home/user/my%20dir".into()));
-        assert_eq!(new_way, Some("/home/user/my dir".into()));
-        assert_ne!(old_way, new_way);
-    }
-
-    #[test]
-    fn http_match_opens_as_uri() {
-        assert_eq!(
-            openable_uri_from_match_text("https://example.com/docs?q=rust#intro", None),
-            Some("https://example.com/docs?q=rust#intro".into())
-        );
-    }
-
-    #[test]
-    fn trailing_punctuation_is_trimmed_from_uri_match() {
-        assert_eq!(
-            openable_uri_from_match_text("https://example.com/docs).", None),
-            Some("https://example.com/docs".into())
-        );
-    }
-
-    #[test]
-    fn absolute_path_match_becomes_file_uri() {
-        let expected = gio::File::for_path("/tmp/rttx.log").uri().to_string();
-        assert_eq!(openable_uri_from_match_text("/tmp/rttx.log", None), Some(expected));
-    }
-
-    #[test]
-    fn relative_path_match_uses_terminal_cwd() {
-        let expected = gio::File::for_path("/workspace/rttx/src/main.rs").uri().to_string();
-        assert_eq!(
-            openable_uri_from_match_text("src/main.rs", Some("/workspace/rttx")),
-            Some(expected)
-        );
-    }
-
-    #[test]
-    fn line_and_column_suffix_do_not_block_path_opening() {
-        let expected = gio::File::for_path("/workspace/rttx/src/main.rs").uri().to_string();
-        assert_eq!(
-            openable_uri_from_match_text("src/main.rs:42:7", Some("/workspace/rttx")),
-            Some(expected)
-        );
-    }
-
-    #[test]
-    fn bare_word_is_not_treated_as_openable_path() {
-        assert_eq!(openable_uri_from_match_text("Cargo.toml", Some("/workspace/rttx")), None);
     }
 
     #[test]

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -430,6 +430,47 @@ fn emit_left_click(widget: &gtk4::Widget, n_press: i32) {
     panic!("widget should have a GestureClick controller");
 }
 
+fn emit_left_click_at(widget: &gtk4::Widget, n_press: i32, x: f64, y: f64) {
+    let controllers = widget.observe_controllers();
+    for index in 0..controllers.n_items() {
+        let Some(controller) = controllers.item(index) else {
+            continue;
+        };
+        if let Ok(gesture) = controller.downcast::<gtk4::GestureClick>()
+            && gesture.button() == 1
+        {
+            gesture.emit_by_name::<()>("released", &[&n_press, &x, &y]);
+            return;
+        }
+    }
+    panic!("widget should have a left-click GestureClick controller");
+}
+
+fn find_match_coords(vte: &vte4::Terminal, expected: &str) -> Option<(f64, f64)> {
+    let width = vte.width().max(120);
+    let height = vte.height().max(40);
+    for y in (2..height).step_by(2) {
+        for x in (2..width).step_by(2) {
+            let (matched, _tag) = vte.check_match_at(f64::from(x), f64::from(y));
+            if matched.as_deref() == Some(expected) {
+                return Some((f64::from(x), f64::from(y)));
+            }
+        }
+    }
+    None
+}
+
+fn wait_for_match_coords(vte: &vte4::Terminal, expected: &str, max_ms: u64) -> Option<(f64, f64)> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(max_ms);
+    while std::time::Instant::now() < deadline {
+        if let Some(coords) = find_match_coords(vte, expected) {
+            return Some(coords);
+        }
+        pump_events(10);
+    }
+    find_match_coords(vte, expected)
+}
+
 // ── M2: RefCell re-entrancy (GTK signal timing) ───────────────────────────────
 
 /// Proves that GTK property-change signals fire SYNCHRONOUSLY in the same
@@ -999,6 +1040,63 @@ fn terminal_handle_copy_clipboard_uses_managed_terminal_selection() {
     assert!(wait_until(1000, || {
         clipboard_text().is_some_and(|text| text.contains("managed copied text"))
     }));
+    window.close();
+}
+
+#[test]
+fn direct_terminal_clicking_highlighted_url_launches_it() {
+    require_display!();
+
+    let term = rttx::terminal::widget::TerminalWidget::new("direct-link", None);
+    let window = present_widget(&term);
+    let expected = "https://example.com/direct";
+    term.vte().feed(format!("{expected}\n").as_bytes());
+    let (x, y) =
+        wait_for_match_coords(term.vte(), expected, 1000).expect("link match should be present");
+
+    let launched = Rc::new(RefCell::new(Vec::new()));
+    let launched_clone = Rc::clone(&launched);
+    rttx::terminal::links::with_test_uri_launcher(
+        move |uri| {
+            launched_clone.borrow_mut().push(uri.to_string());
+            true
+        },
+        || {
+            emit_left_click_at(term.vte().upcast_ref::<gtk4::Widget>(), 1, x, y);
+            pump_events(50);
+        },
+    );
+
+    assert_eq!(launched.borrow().as_slice(), [expected]);
+    window.close();
+}
+
+#[test]
+fn persistent_terminal_clicking_highlighted_url_launches_it() {
+    require_display!();
+
+    let pane =
+        rttx::terminal::persistent_widget::PersistentPaneView::new("managed-link", "runtime-1");
+    let window = present_widget(&pane);
+    let expected = "https://example.com/persistent";
+    pane.feed_output(format!("{expected}\n").as_bytes());
+    let (x, y) =
+        wait_for_match_coords(pane.vte(), expected, 1000).expect("link match should be present");
+
+    let launched = Rc::new(RefCell::new(Vec::new()));
+    let launched_clone = Rc::clone(&launched);
+    rttx::terminal::links::with_test_uri_launcher(
+        move |uri| {
+            launched_clone.borrow_mut().push(uri.to_string());
+            true
+        },
+        || {
+            emit_left_click_at(pane.vte().upcast_ref::<gtk4::Widget>(), 1, x, y);
+            pump_events(50);
+        },
+    );
+
+    assert_eq!(launched.borrow().as_slice(), [expected]);
     window.close();
 }
 

--- a/designs/RFC-008-terminal-links.md
+++ b/designs/RFC-008-terminal-links.md
@@ -16,13 +16,20 @@ includes OSC 8 hyperlinks, plain `http(s)` URLs, and local file paths such as `/
 `src/main.rs:42`. The feature is intentionally narrow: it improves real terminal workflows without
 turning rttx into a general-purpose terminal hyperlink engine.
 
+Current implementation snapshot (2026-03):
+
+- link detection and launch are now shared across both `TerminalWidget` and
+  `PersistentPaneView`
+- activation is covered by GTK regression tests for both direct and daemon-backed panes
+- the launch path still uses `gio::AppInfo::launch_default_for_uri()`
+
 ---
 
 ## Goals
 
 - **G1** — Detect common developer-facing links in terminal output
 - **G2** — Open them directly with the system default handler
-- **G3** — Keep the implementation local to `TerminalWidget`
+- **G3** — Keep the implementation scoped to terminal widgets rather than `window.rs`
 
 ## Non-Goals
 
@@ -48,7 +55,7 @@ and sysadmin workflows and open them with one click.
 | Audience | Impact |
 | --- | --- |
 | End users | Links and local paths in terminal output become directly clickable |
-| Contributors | Behavior is isolated to `src/terminal/widget.rs`; no `window.rs` involvement |
+| Contributors | Behavior is isolated to shared terminal-widget helpers; no `window.rs` involvement |
 | Packagers | No new dependencies |
 
 ---
@@ -84,13 +91,13 @@ resolved target with the system default application on click.
 
 ## Design
 
-`TerminalWidget` configures VTE with:
+The terminal widgets configure VTE with:
 
 - `allow-hyperlink = true` for OSC 8 support
 - One regex for `http(s)` / `mailto:` / `file://` URIs
 - One regex for local-looking file paths (`/tmp/x`, `./x`, `../x`, `~/x`, `src/x`)
 
-Click handling lives on the VTE widget:
+Click handling lives on the VTE widget in both pane implementations:
 
 1. Check for an OSC 8 hyperlink at the click position
 2. Otherwise check for a regex match
@@ -112,7 +119,7 @@ Path resolution rules:
 | --- | --- |
 | G1 — detect useful links | VTE regex matches for URLs and local paths, plus OSC 8 support |
 | G2 — open directly | `gio::AppInfo::launch_default_for_uri` |
-| G3 — keep it local | All behavior lives in `TerminalWidget` helper logic and event handlers |
+| G3 — keep it local | All behavior lives in terminal-widget helper logic and event handlers |
 
 ---
 


### PR DESCRIPTION
## Summary
- extract shared terminal link detection and launch helpers
- wire clickable link activation into both direct and daemon-backed panes
- add regression tests for direct and persistent click-launch behavior
- update RFC-008 to match the shared terminal-widget implementation

## Testing
- cargo build --workspace
- bash .github/scripts/run-clippy.sh
- bash .github/scripts/run-quality-tests.sh
- ./run_ui_tests.sh

Fixes #158