### PR TITLE
fix: restore Meson client build in monorepo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,10 +174,14 @@ cargo build --release -p rttx
 For production installation of the client (desktop file, icons, AppStream metadata):
 ```bash
 meson setup build --prefix="$HOME/.local"
+meson compile -C build
 meson install -C build
 gtk-update-icon-cache -f -t "$HOME/.local/share/icons/hicolor"
 update-desktop-database "$HOME/.local/share/applications"
 ```
+
+Run Meson from the repository root. If `build/` already exists, use
+`meson setup --reconfigure build --prefix="$HOME/.local"` before `meson compile -C build`.
 
 ### Persistent session daemon (`rttx-server`)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Package names stay unchanged even though the repository now uses role-based dire
 
 ## Build
 
+Run all commands from the repository root.
+
 Development build for the whole workspace:
 
 ```bash
@@ -57,6 +59,11 @@ RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground
 
 ## Install
 
+### Client Only
+
+Use Meson when you want a desktop-integrated client install with the binary, desktop file, icons,
+and AppStream metadata.
+
 Production install of the client from source:
 
 ```bash
@@ -67,6 +74,17 @@ sudo gtk-update-icon-cache -f -t /usr/local/share/icons/hicolor
 sudo update-desktop-database /usr/local/share/applications
 ```
 
+If `build/` already exists, refresh it instead of creating it again:
+
+```bash
+meson setup --reconfigure build --prefix=/usr/local
+meson compile -C build
+```
+
+### Daemon Only
+
+Use Cargo for the daemon. Meson does not install `rttx-server`.
+
 Production install of the daemon from source:
 
 ```bash
@@ -74,7 +92,9 @@ cargo build --release -p rttx-server
 sudo install -Dm755 target/release/rttx-server /usr/local/bin/rttx-server
 ```
 
-Production install of both from source:
+### Full Production Install
+
+Install both client and daemon from source:
 
 ```bash
 meson setup build --prefix=/usr/local

--- a/clients/rttx/INSTALL.md
+++ b/clients/rttx/INSTALL.md
@@ -113,10 +113,11 @@ cargo build --release --no-default-features --features vte-0_76
 ### Full install (desktop integration)
 
 This installs the binary, desktop file, icons, and AppStream metadata so rttx appears in the app
-grid:
+grid. Run these commands from the repository root:
 
 ```bash
 meson setup build --prefix="$HOME/.local"
+meson compile -C build
 meson install -C build
 ```
 
@@ -124,6 +125,7 @@ For systems with VTE 0.76 instead of 0.78:
 
 ```bash
 meson setup build --prefix="$HOME/.local" -Dvte_version=0.76
+meson compile -C build
 meson install -C build
 ```
 
@@ -138,7 +140,15 @@ For a system-wide install:
 
 ```bash
 meson setup build --prefix=/usr/local
+meson compile -C build
 sudo meson install -C build
+```
+
+If `build/` already exists, refresh it instead of recreating it:
+
+```bash
+meson setup --reconfigure build --prefix="$HOME/.local"
+meson compile -C build
 ```
 
 If the GNOME app grid still shows a generic icon after a user-local install, log out and back in.

--- a/clients/rttx/README.md
+++ b/clients/rttx/README.md
@@ -51,6 +51,8 @@ flatpak install --user ./rttx.flatpak
 
 **From source** — see [INSTALL.md](INSTALL.md) for full instructions.
 
+Run these commands from the repository root. Meson installs the client only.
+
 Production install from source:
 
 ```bash
@@ -59,6 +61,13 @@ meson compile -C build
 sudo meson install -C build
 sudo gtk-update-icon-cache -f -t /usr/local/share/icons/hicolor
 sudo update-desktop-database /usr/local/share/applications
+```
+
+If `build/` already exists, reconfigure it:
+
+```bash
+meson setup --reconfigure build --prefix=/usr/local
+meson compile -C build
 ```
 
 ## Terminology

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ endif
 
 # Find cargo
 cargo = find_program('cargo')
+workspace_manifest = meson.project_source_root() / 'Cargo.toml'
 client_dir = meson.project_source_root() / 'clients' / 'rttx'
 client_data_dir = client_dir / 'data'
 
@@ -43,9 +44,9 @@ custom_target('rttx-binary',
   output: 'rttx',
   command: [
     'sh', '-c',
-    cargo.full_path() + ' fmt --check && ' +
+    cargo.full_path() + ' fmt --manifest-path ' + workspace_manifest + ' --all --check && ' +
     cargo.full_path() + ' clippy --manifest-path ' + client_dir / 'Cargo.toml' + ' -- -D warnings && ' +
-    cargo.full_path() + ' build --release -p rttx ' + cargo_vte_features + ' --manifest-path ' + meson.project_source_root() / 'Cargo.toml' +
+    cargo.full_path() + ' build --release -p rttx ' + cargo_vte_features + ' --manifest-path ' + workspace_manifest +
     ' --target-dir ' + meson.project_build_root() / 'cargo-target && ' +
     'cp ' + meson.project_build_root() / 'cargo-target' / 'release' / 'rttx' + ' @OUTPUT@'
   ],

--- a/services/rttx-server/README.md
+++ b/services/rttx-server/README.md
@@ -145,6 +145,7 @@ sudo install -Dm755 target/release/rttx-server /usr/local/bin/rttx-server
 Combined source install with the client:
 
 ```bash
+# Run from the repository root. Meson installs the client only.
 meson setup build --prefix=/usr/local
 meson compile -C build
 sudo meson install -C build


### PR DESCRIPTION
## Summary
- run Meson client builds against the workspace manifest so `cargo fmt --check` works from the build directory
- clarify that Meson installs the client and Cargo installs the daemon
- document repo-root and reconfigure flows for Meson builds

## Validation
- `cargo fmt --all --manifest-path Cargo.toml --check`
- `meson setup --reconfigure build --prefix=/usr/local`
- `meson compile -C build`
