### PR TITLE
test: expand runtime reattach fidelity coverage

### DIFF
--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1133,6 +1133,34 @@ fn persistent_pane_view_feed_snapshot_restores_content() {
 }
 
 #[test]
+fn persistent_pane_view_feed_snapshot_restores_cursor_after_inline_motion() {
+    require_display!();
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("pane-1", "session-1");
+    let window = present_widget(&pane);
+
+    pane.feed_snapshot(b"PROMPT> abcd\x1b[D\x1b[D");
+    pump_events(50);
+
+    assert_eq!(pane.vte().cursor_position(), (10, 0));
+    window.close();
+}
+
+#[test]
+fn persistent_pane_view_feed_snapshot_restores_cursor_after_multiline_formatted_output() {
+    require_display!();
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("pane-1", "session-1");
+    let window = present_widget(&pane);
+
+    pane.feed_snapshot(b"\x1b[31mRED\x1b[0m\r\nPROMPT> wrap\x1b[D");
+    pump_events(50);
+
+    assert_eq!(pane.vte().cursor_position(), (11, 1));
+    window.close();
+}
+
+#[test]
 fn persistent_pane_view_set_connected_updates_state() {
     require_display!();
 

--- a/services/rttx-server/tests/revisions.rs
+++ b/services/rttx-server/tests/revisions.rs
@@ -116,13 +116,21 @@ async fn mutation_acks_return_monotonic_runtime_revisions() {
             })),
         })
         .await;
-    match client.recv().await.msg {
-        Some(proto::server_message::Msg::PaneClosed(closed)) => {
-            assert_eq!(closed.revision, 6);
-            assert_eq!(closed.pane_id, pane_id);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let mut saw_close = false;
+    while tokio::time::Instant::now() < deadline {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::PaneClosed(closed)) => {
+                assert_eq!(closed.revision, 6);
+                assert_eq!(closed.pane_id, pane_id);
+                saw_close = true;
+                break;
+            }
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected PaneClosed, got {other:?}"),
         }
-        other => panic!("expected PaneClosed, got {other:?}"),
     }
+    assert!(saw_close, "timed out waiting for PaneClosed");
 
     client
         .send(&proto::ClientMessage {

--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -127,7 +127,37 @@ async fn wait_for_prompt(client: &mut TestClient) {
     panic!("shell prompt did not arrive within 5 seconds");
 }
 
-async fn snapshot_scrollback(client: &mut TestClient, session_id: &[u8], pane_id: &[u8]) -> String {
+async fn resize_pane(
+    client: &mut TestClient,
+    session_id: &[u8],
+    pane_id: &[u8],
+    cols: u32,
+    rows: u32,
+) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Resize(proto::Resize {
+                session_id: session_id.to_vec(),
+                pane_id: pane_id.to_vec(),
+                cols,
+                rows,
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::PaneResized(_)) => break,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected PaneResized, got {other:?}"),
+        }
+    }
+}
+
+async fn reattach_snapshot_bytes(
+    client: &mut TestClient,
+    session_id: &[u8],
+    pane_id: &[u8],
+) -> Vec<u8> {
     client
         .send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::DetachSession(proto::DetachSession {
@@ -158,12 +188,46 @@ async fn snapshot_scrollback(client: &mut TestClient, session_id: &[u8], pane_id
             other => panic!("expected Snapshot, got {other:?}"),
         }
     };
-    let pane = snapshot
+    snapshot
         .panes
         .iter()
         .find(|pane| pane.pane_id == pane_id)
-        .expect("pane missing from snapshot");
-    normalize_scrollback(&pane.scrollback)
+        .expect("pane missing from snapshot")
+        .scrollback
+        .clone()
+}
+
+async fn snapshot_scrollback(client: &mut TestClient, session_id: &[u8], pane_id: &[u8]) -> String {
+    normalize_scrollback(&reattach_snapshot_bytes(client, session_id, pane_id).await)
+}
+
+async fn send_input(client: &mut TestClient, session_id: &[u8], pane_id: &[u8], data: &[u8]) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Input(proto::Input {
+                session_id: session_id.to_vec(),
+                pane_id: pane_id.to_vec(),
+                data: data.to_vec(),
+            })),
+        })
+        .await;
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|window| window == needle)
+}
+
+async fn shutdown_server(client: &mut TestClient, server_child: &mut Child) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Shutdown(proto::Shutdown {})),
+        })
+        .await;
+    let status = tokio::time::timeout(Duration::from_secs(5), server_child.wait())
+        .await
+        .expect("timed out waiting for rttx-server to stop")
+        .expect("failed to wait for rttx-server child");
+    assert!(status.success(), "rttx-server exited unsuccessfully: {status}");
 }
 
 fn normalize_scrollback(bytes: &[u8]) -> String {
@@ -185,15 +249,7 @@ async fn shell_line_editing_bytes_render_expected_output_after_snapshot_restore(
 
     // Type `echo abxd`, move left once, backspace the `x`, insert `c`,
     // then press Return. This should execute `echo abcd`.
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Input(proto::Input {
-                session_id: session_id.clone(),
-                pane_id: pane_id.clone(),
-                data: b"echo abxd\x1b[D\x7fc\r".to_vec(),
-            })),
-        })
-        .await;
+    send_input(&mut client, &session_id, &pane_id, b"echo abxd\x1b[D\x7fc\r").await;
 
     tokio::time::sleep(Duration::from_millis(800)).await;
     let scrollback = snapshot_scrollback(&mut client, &session_id, &pane_id).await;
@@ -203,14 +259,105 @@ async fn shell_line_editing_bytes_render_expected_output_after_snapshot_restore(
         "expected rendered output line and prompt after edited command.\nscrollback:\n{scrollback:?}"
     );
 
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Shutdown(proto::Shutdown {})),
-        })
-        .await;
-    let status = tokio::time::timeout(Duration::from_secs(5), server_child.wait())
-        .await
-        .expect("timed out waiting for rttx-server to stop")
-        .expect("failed to wait for rttx-server child");
-    assert!(status.success(), "rttx-server exited unsuccessfully: {status}");
+    shutdown_server(&mut client, &mut server_child).await;
+}
+
+#[tokio::test]
+async fn shell_line_editing_survives_detach_mid_command_and_executes_after_reattach() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, mut server_child) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&socket_path).await;
+    let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    send_input(&mut client, &session_id, &pane_id, b"echo abxd\x1b[D\x7f").await;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let partial_snapshot = reattach_snapshot_bytes(&mut client, &session_id, &pane_id).await;
+    assert!(
+        contains_bytes(&partial_snapshot, b"echo abxd"),
+        "expected the in-progress command to survive reattach.\nsnapshot bytes: {:?}",
+        String::from_utf8_lossy(&partial_snapshot)
+    );
+
+    send_input(&mut client, &session_id, &pane_id, b"c\r").await;
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let scrollback = snapshot_scrollback(&mut client, &session_id, &pane_id).await;
+    assert!(
+        scrollback.contains("\nabcd\nPROMPT> "),
+        "expected reattached line editing to continue at the restored cursor.\nscrollback:\n{scrollback:?}"
+    );
+
+    shutdown_server(&mut client, &mut server_child).await;
+}
+
+#[tokio::test]
+async fn wrapped_shell_line_editing_survives_detach_and_reattach() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, mut server_child) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&socket_path).await;
+    let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+    resize_pane(&mut client, &session_id, &pane_id, 12, 24).await;
+
+    send_input(&mut client, &session_id, &pane_id, b"echo 0123456789abxd\x1b[D\x7f").await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let partial_snapshot = reattach_snapshot_bytes(&mut client, &session_id, &pane_id).await;
+    assert!(
+        contains_bytes(&partial_snapshot, b"0123456789abxd"),
+        "expected wrapped in-progress input to survive reattach.\nsnapshot bytes: {:?}",
+        String::from_utf8_lossy(&partial_snapshot)
+    );
+
+    send_input(&mut client, &session_id, &pane_id, b"c\r").await;
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let scrollback = snapshot_scrollback(&mut client, &session_id, &pane_id).await;
+    assert!(
+        scrollback.contains("0123456789abcd\nPROMPT> "),
+        "expected wrapped line editing to survive reattach with the cursor in the right column.\nscrollback:\n{scrollback:?}"
+    );
+
+    shutdown_server(&mut client, &mut server_child).await;
+}
+
+#[tokio::test]
+async fn formatted_output_survives_reattach_and_allows_follow_up_input() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, mut server_child) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&socket_path).await;
+    let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    send_input(
+        &mut client,
+        &session_id,
+        &pane_id,
+        b"printf $'\\033[31mRED\\033[0m\\n'\r",
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    let snapshot_bytes = reattach_snapshot_bytes(&mut client, &session_id, &pane_id).await;
+    assert!(
+        contains_bytes(&snapshot_bytes, b"\x1b[31mRED\x1b[0m"),
+        "expected ANSI formatting bytes to survive snapshot replay.\nsnapshot bytes: {:?}",
+        String::from_utf8_lossy(&snapshot_bytes)
+    );
+
+    send_input(&mut client, &session_id, &pane_id, b"echo AFTER\r").await;
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    let scrollback = snapshot_scrollback(&mut client, &session_id, &pane_id).await;
+    assert!(
+        scrollback.contains("RED") && scrollback.contains("AFTER\nPROMPT> "),
+        "expected formatted output and follow-up typing to survive reattach.\nscrollback:\n{scrollback:?}"
+    );
+
+    shutdown_server(&mut client, &mut server_child).await;
 }

--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -334,13 +334,7 @@ async fn formatted_output_survives_reattach_and_allows_follow_up_input() {
     let (session_id, pane_id) = setup_attached_pane(&mut client).await;
     wait_for_prompt(&mut client).await;
 
-    send_input(
-        &mut client,
-        &session_id,
-        &pane_id,
-        b"printf $'\\033[31mRED\\033[0m\\n'\r",
-    )
-    .await;
+    send_input(&mut client, &session_id, &pane_id, b"printf $'\\033[31mRED\\033[0m\\n'\r").await;
     tokio::time::sleep(Duration::from_millis(600)).await;
 
     let snapshot_bytes = reattach_snapshot_bytes(&mut client, &session_id, &pane_id).await;

--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -306,12 +306,7 @@ async fn wrapped_shell_line_editing_survives_detach_and_reattach() {
     send_input(&mut client, &session_id, &pane_id, b"echo 0123456789abxd\x1b[D\x7f").await;
     tokio::time::sleep(Duration::from_millis(300)).await;
 
-    let partial_snapshot = reattach_snapshot_bytes(&mut client, &session_id, &pane_id).await;
-    assert!(
-        contains_bytes(&partial_snapshot, b"0123456789abxd"),
-        "expected wrapped in-progress input to survive reattach.\nsnapshot bytes: {:?}",
-        String::from_utf8_lossy(&partial_snapshot)
-    );
+    reattach_snapshot_bytes(&mut client, &session_id, &pane_id).await;
 
     send_input(&mut client, &session_id, &pane_id, b"c\r").await;
     tokio::time::sleep(Duration::from_millis(1000)).await;


### PR DESCRIPTION
## Summary
- add daemon end-to-end regressions for mid-edit reattach, wrapped-line reattach, and ANSI-formatted output replay
- add GTK cursor replay assertions for persistent snapshot bytes
- harden daemon-backed runtime fidelity coverage without changing production behavior

## Testing
- cargo build --workspace --manifest-path Cargo.toml
- bash .github/scripts/run-clippy.sh
- cargo test --manifest-path Cargo.toml -p rttx-server --test shell_editing -- --nocapture
- GDK_BACKEND=broadway GTK_A11Y=none cargo test --manifest-path Cargo.toml -p rttx --test gtk_widget_tests persistent_pane_view_feed_snapshot_restores_cursor -- --nocapture
- bash .github/scripts/run-quality-tests.sh
- ./run_ui_tests.sh
