### PR TITLE
fix(build): Pass VTE feature flags to clippy in meson, improve docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 /repo
 /rttx.flatpak
 .claude
+.kiro
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ daemon runtime service, and the shared wire protocol in one workspace.
 
 Package names stay unchanged even though the repository now uses role-based directories.
 
+## Prerequisites
+
+**Rust 1.85+** (edition 2024), **Meson**, and the GTK4 development libraries.
+
+Fedora:
+```bash
+sudo dnf install cargo meson pkg-config gtk4-devel libadwaita-devel vte291-gtk4-devel
+```
+
+Ubuntu / Debian:
+```bash
+sudo apt install cargo meson pkg-config libgtk-4-dev libadwaita-1-dev libvte-2.91-gtk4-dev
+```
+
+Arch Linux:
+```bash
+sudo pacman -S rust meson pkgconf gtk4 libadwaita vte4
+```
+
+Minimum library versions: GTK4 4.14, libadwaita 1.5, VTE 0.76+ (0.78 recommended).
+
+Check your VTE version — this is the most common build issue:
+```bash
+pkg-config --modversion vte-2.91-gtk4
+```
+
 ## Build
 
 Run all commands from the repository root.
@@ -32,6 +58,15 @@ cargo build -p rttx
 cargo build -p rttx-server
 cargo build -p rttx-proto
 ```
+
+**If your system has VTE 0.76 instead of 0.78** (e.g., Fedora 40, Ubuntu 24.04):
+
+```bash
+cargo build -p rttx --no-default-features --features vte-0_76
+```
+
+The default feature is `vte-0_78`. If you skip the flag on a VTE 0.76 system, the build will fail
+with `vte-2.91-gtk4 >= 0.78 not found`.
 
 Run the client in normal mode:
 
@@ -59,12 +94,23 @@ RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground
 
 ## Install
 
-### Client Only
+For pre-built packages (Fedora COPR, Flatpak), see [clients/rttx/INSTALL.md](clients/rttx/INSTALL.md).
 
-Use Meson when you want a desktop-integrated client install with the binary, desktop file, icons,
-and AppStream metadata.
+### Client Only (Meson)
 
-Production install of the client from source:
+Meson installs the client binary, desktop file, icons, and AppStream metadata.
+
+User-local install (no sudo needed, binary goes to `~/.local/bin/rttx`):
+
+```bash
+meson setup build --prefix="$HOME/.local"
+meson compile -C build
+meson install -C build
+gtk-update-icon-cache -f -t "$HOME/.local/share/icons/hicolor"
+update-desktop-database "$HOME/.local/share/applications"
+```
+
+System-wide install:
 
 ```bash
 meson setup build --prefix=/usr/local
@@ -74,10 +120,27 @@ sudo gtk-update-icon-cache -f -t /usr/local/share/icons/hicolor
 sudo update-desktop-database /usr/local/share/applications
 ```
 
-If `build/` already exists, refresh it instead of creating it again:
+**If your system has VTE 0.76**, pass `-Dvte_version=0.76` to `meson setup`:
 
 ```bash
-meson setup --reconfigure build --prefix=/usr/local
+meson setup build --prefix="$HOME/.local" -Dvte_version=0.76
+meson compile -C build
+meson install -C build
+```
+
+Without this flag, Meson defaults to VTE 0.78 and the build will fail.
+
+**If `build/` already exists**, use `--reconfigure` to change options:
+
+```bash
+meson setup --reconfigure build --prefix="$HOME/.local" -Dvte_version=0.76
+meson compile -C build
+```
+
+**If the build is in a broken state**, wipe and start fresh:
+
+```bash
+meson setup --wipe build --prefix="$HOME/.local" -Dvte_version=0.76
 meson compile -C build
 ```
 
@@ -85,7 +148,19 @@ meson compile -C build
 
 Use Cargo for the daemon. Meson does not install `rttx-server`.
 
-Production install of the daemon from source:
+The daemon must be on `$PATH` for the client to auto-start it. Without it, daemon-backed
+workspaces will fail to connect.
+
+User-local install (no sudo needed, binary goes to `~/.local/bin/rttx-server`):
+
+```bash
+cargo build --release -p rttx-server
+install -Dm755 target/release/rttx-server "$HOME/.local/bin/rttx-server"
+```
+
+Make sure `~/.local/bin` is in your `$PATH` (most distros include it by default).
+
+System-wide install:
 
 ```bash
 cargo build --release -p rttx-server

--- a/clients/rttx/README.md
+++ b/clients/rttx/README.md
@@ -63,6 +63,14 @@ sudo gtk-update-icon-cache -f -t /usr/local/share/icons/hicolor
 sudo update-desktop-database /usr/local/share/applications
 ```
 
+If your system has VTE 0.76 instead of 0.78, pass `-Dvte_version=0.76`:
+
+```bash
+meson setup build --prefix=/usr/local -Dvte_version=0.76
+meson compile -C build
+sudo meson install -C build
+```
+
 If `build/` already exists, reconfigure it:
 
 ```bash

--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,7 @@ custom_target('rttx-binary',
   command: [
     'sh', '-c',
     cargo.full_path() + ' fmt --manifest-path ' + workspace_manifest + ' --all --check && ' +
-    cargo.full_path() + ' clippy --manifest-path ' + client_dir / 'Cargo.toml' + ' -- -D warnings && ' +
+    cargo.full_path() + ' clippy --manifest-path ' + client_dir / 'Cargo.toml' + ' ' + cargo_vte_features + ' -- -D warnings && ' +
     cargo.full_path() + ' build --release -p rttx ' + cargo_vte_features + ' --manifest-path ' + workspace_manifest +
     ' --target-dir ' + meson.project_build_root() / 'cargo-target && ' +
     'cp ' + meson.project_build_root() / 'cargo-target' / 'release' / 'rttx' + ' @OUTPUT@'

--- a/services/rttx-server/README.md
+++ b/services/rttx-server/README.md
@@ -135,7 +135,23 @@ propagates the env var when auto-starting it.
 
 ## Install
 
-Production install from source:
+The daemon must be on `$PATH` for the rttx client to auto-start it. Without it, daemon-backed
+workspaces (both ephemeral and persistent) will fail to connect.
+
+User-local install (no sudo needed):
+
+```bash
+cargo build --release -p rttx-server
+install -Dm755 target/release/rttx-server "$HOME/.local/bin/rttx-server"
+```
+
+Make sure `~/.local/bin` is in your `$PATH`. Most distributions include it by default; if not:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+```
+
+System-wide install:
 
 ```bash
 cargo build --release -p rttx-server
@@ -151,6 +167,12 @@ meson compile -C build
 sudo meson install -C build
 cargo build --release -p rttx-server
 sudo install -Dm755 target/release/rttx-server /usr/local/bin/rttx-server
+```
+
+Verify the daemon is reachable:
+
+```bash
+rttx-server --help
 ```
 
 ## Testing


### PR DESCRIPTION
Fix meson.build: cargo clippy was invoked without VTE feature flags, causing build failures on systems with VTE 0.76. Now clippy uses the same --features/--no-default-features as the build step.

Improve documentation across all READMEs:
- Root README: add Prerequisites section with distro packages and VTE version check, VTE 0.76 flags for both cargo and meson, user-local install, --reconfigure vs --wipe guidance, link to INSTALL.md
- Client README: add VTE 0.76 meson flag to install section
- Daemon README: add user-local install, explain PATH requirement, add verification step
- .gitignore: add .kiro