### PR TITLE
fix: preserve recovery context after daemon restart

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -179,11 +179,10 @@ impl ConnectionStatus {
         match self {
             Self::Starting => "Starting".into(),
             Self::Connecting => "Connecting".into(),
-            Self::Connected => "Connected".into(),
+            Self::Connected | Self::Recovered => "Connected".into(),
             Self::Reconnecting { retry_in_secs, .. } => format!("Retry {retry_in_secs}s"),
             Self::Blocked(_) => "Action Required".into(),
             Self::Disconnected => "Disconnected".into(),
-            Self::Recovered => "Recovered".into(),
         }
     }
 }
@@ -378,21 +377,10 @@ pub fn present_connection_status(
         && matches!(status, ConnectionStatus::Blocked(_));
 
     let (banner_title, banner_body, banner_visible, show_retry, show_close) = match status {
-        ConnectionStatus::Starting => (
-            "Starting local daemon".into(),
-            "This workspace is waiting for the local daemon to come online.".into(),
-            true,
-            false,
-            true,
-        ),
-        ConnectionStatus::Connecting => (
-            format!("Connecting to {endpoint_label}"),
-            "This workspace is attaching to its runtime.".into(),
-            true,
-            false,
-            true,
-        ),
-        ConnectionStatus::Connected => (String::new(), String::new(), false, false, false),
+        ConnectionStatus::Starting
+        | ConnectionStatus::Connecting
+        | ConnectionStatus::Connected
+        | ConnectionStatus::Recovered => (String::new(), String::new(), false, false, false),
         ConnectionStatus::Reconnecting { attempt, retry_in_secs } => (
             format!("Reconnecting in {retry_in_secs}s"),
             format!(
@@ -412,13 +400,6 @@ pub fn present_connection_status(
             true,
             true,
         ),
-        ConnectionStatus::Recovered => (
-            "Connection restored".into(),
-            format!("The workspace is connected to {endpoint_label} again."),
-            true,
-            false,
-            false,
-        ),
     };
 
     ConnectionPresentation {
@@ -430,6 +411,26 @@ pub fn present_connection_status(
         show_close,
         show_edit_connection,
         input_enabled: status.accepts_input(),
+    }
+}
+
+/// Render a compact workspace-row summary for connection state.
+#[must_use]
+pub fn workspace_connection_summary(
+    endpoint: &RuntimeEndpoint,
+    status: &ConnectionStatus,
+) -> String {
+    let endpoint_label = match endpoint {
+        RuntimeEndpoint::Local => "Local".to_string(),
+        RuntimeEndpoint::Remote { host } => host.clone(),
+    };
+
+    match status {
+        ConnectionStatus::Connected => match endpoint {
+            RuntimeEndpoint::Local => "Local runtime".into(),
+            RuntimeEndpoint::Remote { .. } => endpoint_label,
+        },
+        _ => format!("{endpoint_label} · {}", status.label()),
     }
 }
 
@@ -571,12 +572,21 @@ mod tests {
     }
 
     #[test]
-    fn connection_presentation_hides_banner_only_when_connected() {
+    fn connection_presentation_hides_banner_for_compact_states() {
         let presentation =
             present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
         assert!(!presentation.banner_visible);
         assert!(presentation.input_enabled);
         assert!(!presentation.show_retry);
+
+        let recovered =
+            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Recovered);
+        assert!(!recovered.banner_visible);
+        assert_eq!(recovered.header_label, "Connected");
+
+        let connecting =
+            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connecting);
+        assert!(!connecting.banner_visible);
     }
 
     #[test]
@@ -609,6 +619,25 @@ mod tests {
         assert!(presentation.show_edit_connection);
         assert!(!presentation.input_enabled);
         assert!(presentation.banner_body.contains("Permission denied"));
+    }
+
+    #[test]
+    fn workspace_connection_summary_omits_policy_and_keeps_recovery_compact() {
+        assert_eq!(
+            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Connected),
+            "Local runtime"
+        );
+        assert_eq!(
+            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Recovered),
+            "Local · Recovered"
+        );
+        assert_eq!(
+            workspace_connection_summary(
+                &RuntimeEndpoint::Remote { host: "builder.example".into() },
+                &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
+            ),
+            "builder.example · Action Required: Permission denied"
+        );
     }
 
     #[test]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -417,7 +417,11 @@ impl PersistentPaneView {
         status: &ConnectionStatus,
         presentation: &ConnectionPresentation,
     ) {
-        self.set_connection_status(status);
+        self.imp()
+            .connected
+            .set(matches!(status, ConnectionStatus::Connected | ConnectionStatus::Recovered));
+        self.imp().status_label.set_label(&presentation.header_label);
+        self.imp().status_label.set_tooltip_text(Some(&status.label()));
         self.imp().connection_title_label.set_label(&presentation.banner_title);
         self.imp().connection_body_label.set_label(&presentation.banner_body);
         self.imp().connection_banner.set_visible(presentation.banner_visible);
@@ -844,6 +848,12 @@ mod tests {
         pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
         assert!(!pane.connection_banner_visible_for_test());
         assert!(pane.input_enabled_for_test());
+
+        let recovered =
+            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Recovered);
+        pane.set_connection_presentation(&ConnectionStatus::Recovered, &recovered);
+        assert!(!pane.connection_banner_visible_for_test());
+        assert_eq!(pane.status_label_text_for_test(), "Connected");
     }
 
     #[test]

--- a/clients/rttx/src/window.rs
+++ b/clients/rttx/src/window.rs
@@ -15,6 +15,7 @@ use crate::preferences::{self, Preferences};
 use crate::runtime::{
     ConnectionPresentation, ConnectionStatus, RuntimeEndpoint, WorkspaceActionPresentation,
     WorkspacePolicy, present_connection_status, present_workspace_actions,
+    workspace_connection_summary,
 };
 use crate::session::{
     self, LayoutNode, MAX_SPLIT_DEPTH, PaneRecovery, PaneSource, PaneTarget, SessionState,
@@ -1398,14 +1399,7 @@ impl Window {
         else {
             return;
         };
-        let summary = match &session.runtime.endpoint {
-            RuntimeEndpoint::Local => {
-                format!("{} · Local · {}", session.runtime.policy.label(), status.label())
-            }
-            RuntimeEndpoint::Remote { host } => {
-                format!("{} · {} · {}", session.runtime.policy.label(), host, status.label())
-            }
-        };
+        let summary = workspace_connection_summary(&session.runtime.endpoint, status);
         drop(state);
 
         let list = &self.imp().sidebar_list;
@@ -3077,6 +3071,21 @@ mod tests {
             .and_then(|row| row.child())
             .and_then(|child| child.downcast::<SessionRow>().ok())
             .expect("session row should exist")
+    }
+
+    fn session_row_for_uuid(window: &Window, session_uuid: &str) -> SessionRow {
+        let list = &window.imp().sidebar_list;
+        let mut idx = 0;
+        while let Some(row) = list.row_at_index(idx) {
+            if let Some(session_row) =
+                row.child().and_then(|child| child.downcast::<SessionRow>().ok())
+                && session_row.uuid() == session_uuid
+            {
+                return session_row;
+            }
+            idx += 1;
+        }
+        panic!("session row for {session_uuid} should exist");
     }
 
     fn emit_left_click(widget: &gtk4::Widget, n_press: i32) {
@@ -5709,6 +5718,52 @@ mod tests {
         assert_eq!(
             window.imp().workspace_connection_status.borrow().get(&session_state.uuid),
             Some(&ConnectionStatus::Reconnecting { attempt: 1, retry_in_secs: 1 })
+        );
+
+        window.close();
+        crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+    }
+
+    #[test]
+    fn recovered_workspace_uses_compact_sidebar_status_without_banner() {
+        require_display!();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+        crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+        let app = adw::Application::builder()
+            .application_id("com.illya.rttx.recovered-workspace-status-tests")
+            .build();
+        app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+        let window = Window::new(&app);
+        let session_state = crate::test_helpers::managed_session(
+            "workspace-local",
+            "Local Workspace",
+            LayoutNode::new_terminal_with_uuid("managed-pane"),
+        );
+        window.imp().state.borrow_mut().sessions.push(session_state.clone());
+        window.build_session(&session_state, false);
+
+        window.set_workspace_connection_status(&session_state.uuid, &ConnectionStatus::Recovered);
+
+        let pane = window
+            .imp()
+            .persistent_terminals
+            .borrow()
+            .get("managed-pane")
+            .cloned()
+            .expect("managed pane should be present");
+        assert!(!pane.connection_banner_visible_for_test());
+        assert_eq!(pane.status_label_text_for_test(), "Connected");
+
+        let row = session_row_for_uuid(&window, &session_state.uuid);
+        let subtitle = row.subtitle().map(|value| value.to_string());
+        assert_eq!(subtitle.as_deref(), Some("Local · Recovered"));
+        assert!(
+            !subtitle.as_deref().is_some_and(|value| value.contains("Persistent")),
+            "workspace row status should no longer include the policy label"
         );
 
         window.close();

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -63,6 +63,9 @@ impl Pane {
         if let Some(title) = self.screen.title() {
             self.title = Some(title.to_string());
         }
+        if let Some(cwd) = self.screen.cwd() {
+            self.cwd = Some(cwd.to_string());
+        }
     }
 
     /// Flush pending scrollback bytes to the log file on disk.
@@ -178,6 +181,13 @@ mod tests {
         let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
         pane.feed_output(b"hello");
         assert_eq!(pane.screen.raw_bytes(), b"hello");
+    }
+
+    #[test]
+    fn feed_output_updates_current_directory_from_osc7() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"\x1b]7;file://localhost/tmp/project\x07");
+        assert_eq!(pane.cwd.as_deref(), Some("/tmp/project"));
     }
 
     #[test]

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -25,6 +25,8 @@ struct ScreenPerformer {
     cursor_col: usize,
     /// Terminal title set via OSC.
     title: Option<String>,
+    /// Current working directory reported via OSC 7.
+    cwd: Option<String>,
 }
 
 impl PaneScreen {
@@ -39,6 +41,7 @@ impl PaneScreen {
                 cursor_row: 0,
                 cursor_col: 0,
                 title: None,
+                cwd: None,
             },
         }
     }
@@ -67,6 +70,12 @@ impl PaneScreen {
     #[must_use]
     pub fn title(&self) -> Option<&str> {
         self.performer.title.as_deref()
+    }
+
+    /// Return the current working directory if set via OSC 7.
+    #[must_use]
+    pub fn cwd(&self) -> Option<&str> {
+        self.performer.cwd.as_deref()
     }
 
     /// Return cursor position (row, col).
@@ -114,6 +123,14 @@ impl vte::Perform for ScreenPerformer {
         {
             self.title = Some(title.to_string());
         }
+
+        if params.len() >= 2
+            && params[0] == b"7"
+            && let Ok(uri) = std::str::from_utf8(params[1])
+            && let Some(cwd) = parse_osc7_current_directory(uri)
+        {
+            self.cwd = Some(cwd);
+        }
     }
 
     fn csi_dispatch(
@@ -148,6 +165,42 @@ impl vte::Perform for ScreenPerformer {
     }
 
     fn esc_dispatch(&mut self, _intermediates: &[u8], _ignore: bool, _byte: u8) {}
+}
+
+fn parse_osc7_current_directory(uri: &str) -> Option<String> {
+    let path_with_host = uri.strip_prefix("file://")?;
+    let path_start = path_with_host.find('/')?;
+    let encoded_path = &path_with_host[path_start..];
+    percent_decode_path(encoded_path)
+}
+
+fn percent_decode_path(encoded: &str) -> Option<String> {
+    let bytes = encoded.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let hi = *bytes.get(index + 1)?;
+            let lo = *bytes.get(index + 2)?;
+            decoded.push((hex_value(hi)? << 4) | hex_value(lo)?);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+
+    String::from_utf8(decoded).ok()
+}
+
+const fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -190,6 +243,13 @@ mod tests {
         // OSC 0 ; title BEL
         screen.feed(b"\x1b]0;my title\x07");
         assert_eq!(screen.title(), Some("my title"));
+    }
+
+    #[test]
+    fn osc7_current_directory_is_parsed_and_percent_decoded() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b]7;file://localhost/tmp/work%20tree\x07");
+        assert_eq!(screen.cwd(), Some("/tmp/work tree"));
     }
 
     #[test]

--- a/services/rttx-server/tests/reconstruction.rs
+++ b/services/rttx-server/tests/reconstruction.rs
@@ -123,3 +123,133 @@ async fn reconstruct_session_after_restart() {
         assert!(panes[0].exit_status.is_none(), "reconstructed pane should have a live shell");
     }
 }
+
+#[tokio::test]
+async fn reconstruct_session_respawns_shell_in_last_reported_cwd() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let project_dir = tmp.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let project_dir_string = project_dir.to_string_lossy().to_string();
+
+    let session_id;
+    let pane_id;
+    {
+        let (sock, handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&sock).await;
+        client.handshake().await;
+
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+                    name: "reconstruct-cwd".into(),
+                    policy: proto::RuntimePolicy::Persistent as i32,
+                })),
+            })
+            .await;
+        session_id = match client.recv().await.msg {
+            Some(proto::server_message::Msg::SessionCreated(created)) => created.session_id,
+            other => panic!("expected SessionCreated, got {other:?}"),
+        };
+
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+                    session_id: session_id.clone(),
+                })),
+            })
+            .await;
+        pane_id = match client.recv().await.msg {
+            Some(proto::server_message::Msg::PaneCreated(created)) => created.pane_id,
+            other => panic!("expected PaneCreated, got {other:?}"),
+        };
+
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+                    session_id: session_id.clone(),
+                    attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+                })),
+            })
+            .await;
+        match client.recv().await.msg {
+            Some(proto::server_message::Msg::Snapshot(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+
+        let cwd_command = format!(
+            "cd '{}'\nprintf '\\033]7;file://localhost%s\\007' \"$PWD\"\n",
+            shell_quote(&project_dir_string)
+        );
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::Input(proto::Input {
+                    session_id: session_id.clone(),
+                    pane_id: pane_id.clone(),
+                    data: cwd_command.into_bytes(),
+                })),
+            })
+            .await;
+
+        tokio::time::sleep(Duration::from_millis(2500)).await;
+        let _ = tokio::time::timeout(Duration::from_millis(200), client.recv()).await;
+
+        handle.abort();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    {
+        let (sock, _handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&sock).await;
+        client.handshake().await;
+
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+                    session_id: session_id.clone(),
+                    attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+                })),
+            })
+            .await;
+
+        let panes = match client.recv().await.msg {
+            Some(proto::server_message::Msg::Snapshot(snapshot)) => snapshot.panes,
+            other => panic!("expected Snapshot, got {other:?}"),
+        };
+        let pane = panes
+            .iter()
+            .find(|pane| pane.pane_id == pane_id)
+            .expect("reconstructed pane should be present");
+        assert_eq!(pane.cwd, project_dir_string);
+
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::Input(proto::Input {
+                    session_id: session_id.clone(),
+                    pane_id: pane_id.clone(),
+                    data: b"pwd\n".to_vec(),
+                })),
+            })
+            .await;
+
+        let output = collect_delta_text(&mut client, Duration::from_secs(2)).await;
+        assert!(
+            output.contains(&project_dir_string),
+            "reconstructed shell should start in the last reported cwd.\noutput:\n{output}"
+        );
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    value.replace('\'', "'\"'\"'")
+}
+
+async fn collect_delta_text(client: &mut TestClient, window: Duration) -> String {
+    let messages = client.drain(window).await;
+    let mut output = Vec::new();
+    for message in messages {
+        if let Some(proto::server_message::Msg::Delta(delta)) = message.msg {
+            output.extend(delta.data);
+        }
+    }
+    String::from_utf8_lossy(&output).to_string()
+}


### PR DESCRIPTION
## Summary
- preserve pane working directories across daemon restart by parsing and persisting OSC 7 cwd updates
- keep recovered workspaces compact by moving healthy reconnect state out of the large inline banner
- add restart and GTK regressions for both paths

## Testing
- cargo build --workspace --manifest-path Cargo.toml
- bash .github/scripts/run-clippy.sh
- bash .github/scripts/run-quality-tests.sh
- ./run_ui_tests.sh
