### PR TITLE
fix: normalize smart clipboard shortcut modifiers

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -3,3 +3,14 @@ pub mod handle;
 pub mod links;
 pub mod persistent_widget;
 pub mod widget;
+
+fn normalized_shortcut_modifiers(modifiers: gtk4::gdk::ModifierType) -> gtk4::gdk::ModifierType {
+    let shortcut_mask = gtk4::gdk::ModifierType::SHIFT_MASK
+        | gtk4::gdk::ModifierType::CONTROL_MASK
+        | gtk4::gdk::ModifierType::ALT_MASK
+        | gtk4::gdk::ModifierType::SUPER_MASK
+        | gtk4::gdk::ModifierType::HYPER_MASK
+        | gtk4::gdk::ModifierType::META_MASK;
+
+    modifiers & shortcut_mask
+}

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -13,6 +13,7 @@ use vte4::prelude::*;
 use crate::color_scheme;
 use crate::runtime::{ConnectionPresentation, ConnectionStatus};
 use crate::terminal::links;
+use crate::terminal::normalized_shortcut_modifiers;
 
 mod imp {
     use super::*;
@@ -735,8 +736,7 @@ fn should_pass_through_managed_shortcut(
     has_selection: bool,
     smart_clipboard_enabled: bool,
 ) -> bool {
-    let ignored_modifiers = gtk4::gdk::ModifierType::LOCK_MASK;
-    let normalized = modifiers & !ignored_modifiers;
+    let normalized = normalized_shortcut_modifiers(modifiers);
     let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
     let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
     let alt = gtk4::gdk::ModifierType::ALT_MASK;
@@ -956,6 +956,32 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
+            ),
+            ManagedInputAction::PassThrough
+        );
+    }
+
+    #[test]
+    fn managed_input_action_ignores_lock_modifiers_for_clipboard_shortcuts() {
+        let num_lock_mask = gtk4::gdk::ModifierType::from_bits_retain(1 << 4);
+
+        assert_eq!(
+            managed_input_action(
+                gtk4::gdk::Key::v,
+                gtk4::gdk::ModifierType::CONTROL_MASK | num_lock_mask,
+                false,
+                true,
+            ),
+            ManagedInputAction::PassThrough
+        );
+        assert_eq!(
+            managed_input_action(
+                gtk4::gdk::Key::c,
+                gtk4::gdk::ModifierType::CONTROL_MASK
+                    | gtk4::gdk::ModifierType::LOCK_MASK
+                    | num_lock_mask,
+                true,
+                true,
             ),
             ManagedInputAction::PassThrough
         );

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -6,6 +6,7 @@ use vte4::prelude::*;
 
 use crate::color_scheme;
 use crate::terminal::links;
+use crate::terminal::normalized_shortcut_modifiers;
 
 mod imp {
     use super::*;
@@ -617,8 +618,7 @@ fn smart_clipboard_action(
         return SmartClipboardAction::PassThrough;
     }
 
-    let ignored_modifiers = gtk4::gdk::ModifierType::LOCK_MASK;
-    let normalized = modifiers & !ignored_modifiers;
+    let normalized = normalized_shortcut_modifiers(modifiers);
     if normalized != gtk4::gdk::ModifierType::CONTROL_MASK {
         return SmartClipboardAction::PassThrough;
     }
@@ -712,6 +712,32 @@ mod tests {
                 false,
             ),
             SmartClipboardAction::PassThrough
+        );
+    }
+
+    #[test]
+    fn smart_clipboard_ignores_lock_modifiers_for_ctrl_shortcuts() {
+        let num_lock_mask = gtk4::gdk::ModifierType::from_bits_retain(1 << 4);
+
+        assert_eq!(
+            smart_clipboard_action(
+                gtk4::gdk::Key::v,
+                gtk4::gdk::ModifierType::CONTROL_MASK | num_lock_mask,
+                false,
+                true,
+            ),
+            SmartClipboardAction::Paste
+        );
+        assert_eq!(
+            smart_clipboard_action(
+                gtk4::gdk::Key::c,
+                gtk4::gdk::ModifierType::CONTROL_MASK
+                    | gtk4::gdk::ModifierType::LOCK_MASK
+                    | num_lock_mask,
+                true,
+                true,
+            ),
+            SmartClipboardAction::Copy
         );
     }
 }


### PR DESCRIPTION
## Summary
Smart clipboard shortcut matching treated `Ctrl+V` as valid only when GTK reported an exact plain-control modifier set after stripping Caps Lock. Real modifier states can include extra lock-state bits, so paste could fall through as terminal input instead of a clipboard action.

This change normalizes shortcut modifiers in one shared helper used by both direct and managed terminals and adds regression coverage for lock-modifier variants in both paths.

## Manual Verification
- Enable smart clipboard
- Focus a terminal pane
- Press `Ctrl+V` with normal lock-state bits present
- Confirm paste still triggers instead of forwarding `^V` to the terminal

## Tests
- `cargo fmt --all --manifest-path Cargo.toml`
- `cargo test -p rttx smart_clipboard_ignores_lock_modifiers_for_ctrl_shortcuts --lib`
- `cargo test -p rttx managed_input_action_ignores_lock_modifiers_for_clipboard_shortcuts --lib`
- `cargo build --workspace --manifest-path Cargo.toml`
- `cargo test --workspace --manifest-path Cargo.toml`
- `bash .github/scripts/run-clippy.sh`
- `bash .github/scripts/run-quality-tests.sh`
- `cargo build -p rttx`
- `./run_ui_tests.sh`

## Notes
- Plain `cargo test --workspace` still hits the existing unrelated GTK main-thread abort in `gtk_widget_tests` under the stock Rust harness. The repo's CI-equivalent quality script and AT-SPI UI suite are green.