### PR TITLE
fix: normalize smart clipboard shortcuts from live key state

### DIFF
--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -199,49 +199,6 @@ mod imp {
             obj.append(&self.search_bar);
             obj.append(&self.terminal_scroller);
 
-            // Smart clipboard: Ctrl+C copies if selection exists, Ctrl+V pastes.
-            let smart_clipboard_controller = gtk4::ShortcutController::new();
-            smart_clipboard_controller.set_name(Some("smart-clipboard"));
-            smart_clipboard_controller.set_scope(gtk4::ShortcutScope::Local);
-            smart_clipboard_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
-
-            let copy_vte = self.vte.clone();
-            let copy_flag = std::rc::Rc::clone(&self.smart_clipboard);
-            smart_clipboard_controller.add_shortcut(gtk4::Shortcut::new(
-                Some(gtk4::KeyvalTrigger::new(
-                    gtk4::gdk::Key::c,
-                    gtk4::gdk::ModifierType::CONTROL_MASK,
-                )),
-                Some(gtk4::CallbackAction::new(move |_, _| {
-                    if copy_flag.get() && copy_vte.has_selection() {
-                        copy_vte.copy_clipboard_format(vte4::Format::Text);
-                        copy_vte.unselect_all();
-                        glib::Propagation::Stop
-                    } else {
-                        glib::Propagation::Proceed
-                    }
-                })),
-            ));
-
-            let paste_vte = self.vte.clone();
-            let paste_flag = std::rc::Rc::clone(&self.smart_clipboard);
-            smart_clipboard_controller.add_shortcut(gtk4::Shortcut::new(
-                Some(gtk4::KeyvalTrigger::new(
-                    gtk4::gdk::Key::v,
-                    gtk4::gdk::ModifierType::CONTROL_MASK,
-                )),
-                Some(gtk4::CallbackAction::new(move |_, _| {
-                    if paste_flag.get() {
-                        paste_vte.paste_clipboard();
-                        glib::Propagation::Stop
-                    } else {
-                        glib::Propagation::Proceed
-                    }
-                })),
-            ));
-
-            self.vte.add_controller(smart_clipboard_controller);
-
             // Focus VTE on header click.
             let gesture = gtk4::GestureClick::new();
             gesture.set_button(1);
@@ -522,19 +479,29 @@ impl PersistentPaneView {
             let Some(pane) = pane_weak.upgrade() else {
                 return glib::Propagation::Proceed;
             };
-            let action = managed_input_action(
+            match managed_input_action(
                 key,
                 state,
                 pane.vte().has_selection(),
                 pane.imp().smart_clipboard.get(),
-            );
-            let ManagedInputAction::Forward(bytes) = action else {
-                return glib::Propagation::Proceed;
-            };
-            if pane.imp().accepts_input.get() {
-                f(&bytes);
+            ) {
+                ManagedInputAction::Copy => {
+                    pane.vte().copy_clipboard_format(vte4::Format::Text);
+                    pane.vte().unselect_all();
+                    glib::Propagation::Stop
+                }
+                ManagedInputAction::Paste => {
+                    pane.vte().paste_clipboard();
+                    glib::Propagation::Stop
+                }
+                ManagedInputAction::Forward(bytes) => {
+                    if pane.imp().accepts_input.get() {
+                        f(&bytes);
+                    }
+                    glib::Propagation::Stop
+                }
+                ManagedInputAction::PassThrough => glib::Propagation::Proceed,
             }
-            glib::Propagation::Stop
         });
         self.imp().input_key_controller.replace(Some(key_controller.clone()));
         self.imp().vte.add_controller(key_controller);
@@ -711,6 +678,8 @@ fn encode_terminal_key_input(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ManagedInputAction {
+    Copy,
+    Paste,
     Forward(Vec<u8>),
     PassThrough,
 }
@@ -721,8 +690,19 @@ fn managed_input_action(
     has_selection: bool,
     smart_clipboard_enabled: bool,
 ) -> ManagedInputAction {
-    if should_pass_through_managed_shortcut(key, modifiers, has_selection, smart_clipboard_enabled)
-    {
+    let normalized = normalized_shortcut_modifiers(modifiers);
+
+    if smart_clipboard_enabled && normalized == gtk4::gdk::ModifierType::CONTROL_MASK {
+        match key {
+            gtk4::gdk::Key::c | gtk4::gdk::Key::C if has_selection => {
+                return ManagedInputAction::Copy;
+            }
+            gtk4::gdk::Key::v | gtk4::gdk::Key::V => return ManagedInputAction::Paste,
+            _ => {}
+        }
+    }
+
+    if should_pass_through_managed_shortcut(key, normalized) {
         return ManagedInputAction::PassThrough;
     }
 
@@ -732,23 +712,11 @@ fn managed_input_action(
 
 fn should_pass_through_managed_shortcut(
     key: gtk4::gdk::Key,
-    modifiers: gtk4::gdk::ModifierType,
-    has_selection: bool,
-    smart_clipboard_enabled: bool,
+    normalized: gtk4::gdk::ModifierType,
 ) -> bool {
-    let normalized = normalized_shortcut_modifiers(modifiers);
     let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
     let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
     let alt = gtk4::gdk::ModifierType::ALT_MASK;
-
-    if smart_clipboard_enabled
-        && (normalized == ctrl && matches!(key, gtk4::gdk::Key::v | gtk4::gdk::Key::V)
-            || normalized == ctrl
-                && has_selection
-                && matches!(key, gtk4::gdk::Key::c | gtk4::gdk::Key::C))
-    {
-        return true;
-    }
 
     (normalized == (ctrl | shift)
         && matches!(
@@ -930,7 +898,7 @@ mod tests {
                 true,
                 true,
             ),
-            ManagedInputAction::PassThrough
+            ManagedInputAction::Copy
         );
         assert_eq!(
             managed_input_action(
@@ -939,7 +907,7 @@ mod tests {
                 false,
                 true,
             ),
-            ManagedInputAction::PassThrough
+            ManagedInputAction::Paste
         );
         assert_eq!(
             managed_input_action(
@@ -962,28 +930,28 @@ mod tests {
     }
 
     #[test]
-    fn managed_input_action_ignores_lock_modifiers_for_clipboard_shortcuts() {
-        let num_lock_mask = gtk4::gdk::ModifierType::from_bits_retain(1 << 4);
+    fn managed_input_action_ignores_extra_non_shortcut_modifiers_for_clipboard_shortcuts() {
+        let pointer_mask = gtk4::gdk::ModifierType::BUTTON1_MASK;
 
         assert_eq!(
             managed_input_action(
                 gtk4::gdk::Key::v,
-                gtk4::gdk::ModifierType::CONTROL_MASK | num_lock_mask,
+                gtk4::gdk::ModifierType::CONTROL_MASK | pointer_mask,
                 false,
                 true,
             ),
-            ManagedInputAction::PassThrough
+            ManagedInputAction::Paste
         );
         assert_eq!(
             managed_input_action(
                 gtk4::gdk::Key::c,
                 gtk4::gdk::ModifierType::CONTROL_MASK
                     | gtk4::gdk::ModifierType::LOCK_MASK
-                    | num_lock_mask,
+                    | pointer_mask,
                 true,
                 true,
             ),
-            ManagedInputAction::PassThrough
+            ManagedInputAction::Copy
         );
     }
 
@@ -1083,7 +1051,14 @@ mod tests {
         pane.vte().select_all();
         assert_eq!(
             pane.emit_input_key_for_test(gtk4::gdk::Key::c, gtk4::gdk::ModifierType::CONTROL_MASK,),
-            glib::Propagation::Proceed
+            glib::Propagation::Stop
+        );
+        assert_eq!(
+            pane.emit_input_key_for_test(
+                gtk4::gdk::Key::v,
+                gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::BUTTON1_MASK,
+            ),
+            glib::Propagation::Stop
         );
         assert_eq!(
             pane.emit_input_key_for_test(

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -19,6 +19,7 @@ mod imp {
         pub initial_cwd: RefCell<Option<String>>,
         pub shell_spawned: Cell<bool>,
         pub smart_clipboard: Cell<bool>,
+        pub smart_clipboard_key_controller: RefCell<Option<gtk4::EventControllerKey>>,
         pub visual_bell: Cell<bool>,
         pub pending_shell_inputs: RefCell<Vec<String>>,
         #[cfg(test)]
@@ -138,61 +139,35 @@ mod imp {
                 link_target.upgrade().and_then(|term| term.current_directory())
             });
 
-            let vte = self.vte.clone();
-            let smart_clipboard_controller = gtk4::ShortcutController::new();
-            smart_clipboard_controller.set_name(Some("smart-clipboard"));
-            smart_clipboard_controller.set_scope(gtk4::ShortcutScope::Local);
-            smart_clipboard_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
-
-            let copy_vte = vte.clone();
-            smart_clipboard_controller.add_shortcut(gtk4::Shortcut::new(
-                Some(gtk4::KeyvalTrigger::new(
-                    gtk4::gdk::Key::c,
-                    gtk4::gdk::ModifierType::CONTROL_MASK,
-                )),
-                Some(gtk4::CallbackAction::new(move |widget, _| {
-                    let term = widget.downcast_ref::<super::TerminalWidget>().unwrap();
-                    match smart_clipboard_action(
-                        gtk4::gdk::Key::c,
-                        gtk4::gdk::ModifierType::CONTROL_MASK,
-                        copy_vte.has_selection(),
-                        term.imp().smart_clipboard.get(),
-                    ) {
-                        SmartClipboardAction::Copy => {
-                            copy_vte.copy_clipboard_format(vte4::Format::Text);
-                            copy_vte.unselect_all();
-                            glib::Propagation::Stop
-                        }
-                        SmartClipboardAction::Paste => unreachable!(),
-                        SmartClipboardAction::PassThrough => glib::Propagation::Proceed,
+            let term_weak = obj.downgrade();
+            let smart_clipboard_key_controller = gtk4::EventControllerKey::new();
+            smart_clipboard_key_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
+            smart_clipboard_key_controller.connect_key_pressed(move |_, key, _keycode, state| {
+                let Some(term) = term_weak.upgrade() else {
+                    return glib::Propagation::Proceed;
+                };
+                let vte = term.imp().vte.clone();
+                match smart_clipboard_action(
+                    key,
+                    state,
+                    vte.has_selection(),
+                    term.imp().smart_clipboard.get(),
+                ) {
+                    SmartClipboardAction::Copy => {
+                        vte.copy_clipboard_format(vte4::Format::Text);
+                        vte.unselect_all();
+                        glib::Propagation::Stop
                     }
-                })),
-            ));
-
-            smart_clipboard_controller.add_shortcut(gtk4::Shortcut::new(
-                Some(gtk4::KeyvalTrigger::new(
-                    gtk4::gdk::Key::v,
-                    gtk4::gdk::ModifierType::CONTROL_MASK,
-                )),
-                Some(gtk4::CallbackAction::new(move |widget, _| {
-                    let term = widget.downcast_ref::<super::TerminalWidget>().unwrap();
-                    match smart_clipboard_action(
-                        gtk4::gdk::Key::v,
-                        gtk4::gdk::ModifierType::CONTROL_MASK,
-                        vte.has_selection(),
-                        term.imp().smart_clipboard.get(),
-                    ) {
-                        SmartClipboardAction::Paste => {
-                            vte.paste_clipboard();
-                            glib::Propagation::Stop
-                        }
-                        SmartClipboardAction::Copy => unreachable!(),
-                        SmartClipboardAction::PassThrough => glib::Propagation::Proceed,
+                    SmartClipboardAction::Paste => {
+                        vte.paste_clipboard();
+                        glib::Propagation::Stop
                     }
-                })),
-            ));
-
-            obj.add_controller(smart_clipboard_controller);
+                    SmartClipboardAction::PassThrough => glib::Propagation::Proceed,
+                }
+            });
+            self.smart_clipboard_key_controller
+                .replace(Some(smart_clipboard_key_controller.clone()));
+            self.vte.add_controller(smart_clipboard_key_controller);
 
             let copy_link_action = gtk4::gio::SimpleAction::new("copy-link", None);
             copy_link_action.set_enabled(false);
@@ -410,6 +385,21 @@ impl TerminalWidget {
     #[must_use]
     pub(crate) fn smart_clipboard_enabled_for_test(&self) -> bool {
         self.imp().smart_clipboard.get()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn emit_smart_clipboard_key_for_test(
+        &self,
+        key: gtk4::gdk::Key,
+        modifiers: gtk4::gdk::ModifierType,
+    ) -> glib::Propagation {
+        self.imp()
+            .smart_clipboard_key_controller
+            .borrow()
+            .as_ref()
+            .expect("smart clipboard key controller should be available")
+            .emit_by_name::<bool>("key-pressed", &[&key, &0u32, &modifiers])
+            .into()
     }
 
     pub fn queue_input_for_shell(&self, input: impl Into<String>) {
@@ -633,6 +623,9 @@ fn smart_clipboard_action(
 #[cfg(test)]
 mod tests {
     use super::{SmartClipboardAction, smart_clipboard_action};
+    use gtk4::glib;
+    use gtk4::prelude::*;
+
     /// Verify that the RESET constant inside `reset_terminal_state()` contains
     /// the expected escape sequences without requiring a live VTE widget.
     #[test]
@@ -716,13 +709,13 @@ mod tests {
     }
 
     #[test]
-    fn smart_clipboard_ignores_lock_modifiers_for_ctrl_shortcuts() {
-        let num_lock_mask = gtk4::gdk::ModifierType::from_bits_retain(1 << 4);
+    fn smart_clipboard_ignores_extra_non_shortcut_modifiers_for_ctrl_shortcuts() {
+        let pointer_mask = gtk4::gdk::ModifierType::BUTTON1_MASK;
 
         assert_eq!(
             smart_clipboard_action(
                 gtk4::gdk::Key::v,
-                gtk4::gdk::ModifierType::CONTROL_MASK | num_lock_mask,
+                gtk4::gdk::ModifierType::CONTROL_MASK | pointer_mask,
                 false,
                 true,
             ),
@@ -733,11 +726,37 @@ mod tests {
                 gtk4::gdk::Key::c,
                 gtk4::gdk::ModifierType::CONTROL_MASK
                     | gtk4::gdk::ModifierType::LOCK_MASK
-                    | num_lock_mask,
+                    | pointer_mask,
                 true,
                 true,
             ),
             SmartClipboardAction::Copy
         );
+    }
+
+    #[test]
+    fn smart_clipboard_key_controller_ignores_extra_non_shortcut_modifiers() {
+        if !crate::test_helpers::ensure_gtk() {
+            eprintln!("SKIPPED: no display available");
+            return;
+        }
+
+        let term = super::TerminalWidget::new("term-1", None);
+        term.set_smart_clipboard(true);
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 320);
+        window.set_child(Some(&term));
+        window.present();
+        while gtk4::glib::MainContext::default().iteration(false) {}
+
+        assert_eq!(
+            term.emit_smart_clipboard_key_for_test(
+                gtk4::gdk::Key::v,
+                gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::BUTTON1_MASK,
+            ),
+            glib::Propagation::Stop
+        );
+
+        window.close();
     }
 }


### PR DESCRIPTION
## Summary
- normalize shortcut modifiers through a shared helper instead of relying on exact GTK modifier masks
- handle direct-terminal smart copy/paste from live `EventControllerKey` state
- route managed smart copy/paste through the managed input controller before shell input forwarding
- add regressions for extra modifier bits and event propagation on both terminal paths

## Testing
- `cargo fmt --all --manifest-path Cargo.toml`
- `cargo test -p rttx smart_clipboard_ignores_extra_non_shortcut_modifiers_for_ctrl_shortcuts --lib`
- `cargo test -p rttx smart_clipboard_key_controller_ignores_extra_non_shortcut_modifiers --lib`
- `cargo test -p rttx managed_input_action_ignores_extra_non_shortcut_modifiers_for_clipboard_shortcuts --lib`
- `cargo test -p rttx input_controller_preserves_clipboard_shortcuts_before_forwarding_shell_input --lib`
- `cargo build --workspace --manifest-path Cargo.toml`
- `cargo test --workspace --manifest-path Cargo.toml`
- `bash .github/scripts/run-clippy.sh`
- `bash .github/scripts/run-quality-tests.sh`
- `./run_ui_tests.sh`

## Notes
- plain `cargo test --workspace` still hits the repo's existing stock-harness GTK `SIGSEGV` after the client test run starts; the repo-supported `run-quality-tests.sh` path passed, and the AT-SPI UI suite passed.

Fixes #180