### PR TITLE
fix: bootstrap startup inventory recovery

### DIFF
--- a/clients/rttx/src/window.rs
+++ b/clients/rttx/src/window.rs
@@ -318,6 +318,7 @@ impl Window {
         for session in &state.sessions {
             self.build_session(session, true);
         }
+        self.bootstrap_startup_inventory();
 
         if is_maximized {
             self.maximize();
@@ -337,6 +338,22 @@ impl Window {
 
         if let Some(row) = self.imp().sidebar_list.row_at_index(active_index as i32) {
             self.imp().sidebar_list.select_row(Some(&row));
+        }
+    }
+
+    fn bootstrap_startup_inventory(&self) {
+        let should_refresh_local_inventory = {
+            let state = self.imp().state.borrow();
+            state.should_refresh_local_inventory_on_startup()
+        };
+        if !should_refresh_local_inventory || !crate::daemon::default_socket_path().exists() {
+            return;
+        }
+        if !self.ensure_connection_manager() {
+            return;
+        }
+        if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
+            manager.refresh_inventory(&RuntimeEndpoint::Local);
         }
     }
 
@@ -3065,7 +3082,12 @@ fn preferred_command_target_uuid(
 )]
 mod tests {
     use super::*;
+    use bytes::BytesMut;
+    use rttx_proto::{PROTOCOL_VERSION, decode_frame, encode_frame, proto, uuid_to_bytes};
+    use std::io::{Read, Write};
+    use std::os::unix::net::{UnixListener, UnixStream};
     use std::time::{Duration, Instant};
+    use uuid::Uuid;
 
     macro_rules! require_display {
         () => {
@@ -3095,6 +3117,164 @@ mod tests {
             }
         }
         condition()
+    }
+
+    fn recv_client_message(
+        stream: &mut UnixStream,
+        read_buf: &mut BytesMut,
+    ) -> proto::ClientMessage {
+        loop {
+            match decode_frame::<proto::ClientMessage>(read_buf) {
+                Ok(message) => return message,
+                Err(rttx_proto::FrameError::Incomplete) => {}
+                Err(error) => panic!("failed to decode client message: {error}"),
+            }
+
+            let mut chunk = [0_u8; 4096];
+            let n = stream.read(&mut chunk).expect("read client message");
+            assert!(n > 0, "unexpected EOF while waiting for client message");
+            read_buf.extend_from_slice(&chunk[..n]);
+        }
+    }
+
+    fn send_server_message(stream: &mut UnixStream, message: &proto::ServerMessage) {
+        let mut buf = BytesMut::new();
+        encode_frame(message, &mut buf).expect("encode server message");
+        stream.write_all(&buf).expect("write server message");
+        stream.flush().expect("flush server message");
+    }
+
+    fn accept_client(listener: &UnixListener) -> UnixStream {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            match listener.accept() {
+                Ok((stream, _)) => return stream,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "client never connected to the fake daemon socket",
+                    );
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("failed to accept daemon client: {error}"),
+            }
+        }
+    }
+
+    fn spawn_startup_inventory_daemon(
+        socket_path: &std::path::Path,
+        runtime_id: Uuid,
+        pane_id: Uuid,
+    ) -> std::thread::JoinHandle<()> {
+        let socket_dir = socket_path.parent().expect("daemon socket should have a parent");
+        std::fs::create_dir_all(socket_dir).expect("create daemon socket directory");
+        let listener = UnixListener::bind(socket_path).expect("bind fake daemon socket");
+        listener.set_nonblocking(true).expect("set listener nonblocking");
+
+        std::thread::spawn(move || {
+            let mut stream = accept_client(&listener);
+            stream.set_read_timeout(Some(Duration::from_secs(3))).expect("set daemon read timeout");
+            stream
+                .set_write_timeout(Some(Duration::from_secs(3)))
+                .expect("set daemon write timeout");
+
+            let mut read_buf = BytesMut::with_capacity(4096);
+            let hello = recv_client_message(&mut stream, &mut read_buf);
+            match hello.msg {
+                Some(proto::client_message::Msg::Hello(_)) => {}
+                other => panic!("expected Hello, got {other:?}"),
+            }
+            send_server_message(
+                &mut stream,
+                &proto::ServerMessage {
+                    msg: Some(proto::server_message::Msg::HelloAck(proto::HelloAck {
+                        protocol_version: PROTOCOL_VERSION,
+                        server_id: uuid_to_bytes(Uuid::new_v4()),
+                    })),
+                },
+            );
+
+            let list_sessions = recv_client_message(&mut stream, &mut read_buf);
+            match list_sessions.msg {
+                Some(proto::client_message::Msg::ListSessions(_)) => {}
+                other => panic!("expected initial ListSessions, got {other:?}"),
+            }
+
+            let runtime_session = proto::SessionInfo {
+                id: uuid_to_bytes(runtime_id),
+                name: "Recovered Workspace".into(),
+                pane_count: 1,
+                has_attached_client: false,
+                active_pane_id: Some(uuid_to_bytes(pane_id)),
+                panes: vec![proto::PaneInfo {
+                    id: uuid_to_bytes(pane_id),
+                    title: "Shell".into(),
+                    cwd: "/srv/project".into(),
+                    cols: 120,
+                    rows: 40,
+                    exit_status: None,
+                    reconstructed: true,
+                }],
+                policy: proto::RuntimePolicy::Persistent as i32,
+                attached_client_count: 0,
+                reconstructed: true,
+                revision: 7,
+                current_client_role: proto::RuntimeClientRole::Unattached as i32,
+                has_write_owner: false,
+                read_only_client_count: 0,
+            };
+            send_server_message(
+                &mut stream,
+                &proto::ServerMessage {
+                    msg: Some(proto::server_message::Msg::SessionList(proto::SessionList {
+                        sessions: vec![runtime_session.clone()],
+                    })),
+                },
+            );
+
+            let attach = recv_client_message(&mut stream, &mut read_buf);
+            match attach.msg {
+                Some(proto::client_message::Msg::AttachSession(attach)) => {
+                    assert_eq!(rttx_proto::bytes_to_uuid(&attach.session_id).unwrap(), runtime_id,);
+                }
+                other => panic!("expected AttachSession, got {other:?}"),
+            }
+            send_server_message(
+                &mut stream,
+                &proto::ServerMessage {
+                    msg: Some(proto::server_message::Msg::Snapshot(proto::Snapshot {
+                        session_id: uuid_to_bytes(runtime_id),
+                        panes: vec![proto::PaneSnapshot {
+                            pane_id: uuid_to_bytes(pane_id),
+                            title: "Shell".into(),
+                            cwd: "/srv/project".into(),
+                            cols: 120,
+                            rows: 40,
+                            scrollback: b"restored output".to_vec(),
+                            exit_status: None,
+                        }],
+                        revision: 7,
+                        current_client_role: proto::RuntimeClientRole::Writer as i32,
+                    })),
+                },
+            );
+
+            let repeated_list_sessions = recv_client_message(&mut stream, &mut read_buf);
+            match repeated_list_sessions.msg {
+                Some(proto::client_message::Msg::ListSessions(_)) => {}
+                other => panic!("expected repeated ListSessions, got {other:?}"),
+            }
+            send_server_message(
+                &mut stream,
+                &proto::ServerMessage {
+                    msg: Some(proto::server_message::Msg::SessionList(proto::SessionList {
+                        sessions: vec![runtime_session],
+                    })),
+                },
+            );
+
+            std::thread::sleep(Duration::from_secs(2));
+        })
     }
 
     fn session_row_at(window: &Window, index: i32) -> SessionRow {
@@ -5848,6 +6028,77 @@ mod tests {
 
         window.close();
         crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+    }
+
+    #[test]
+    fn startup_recovers_local_inventory_without_saved_managed_workspace() {
+        require_display!();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+        crate::test_helpers::set_env("XDG_RUNTIME_DIR", &runtime_dir);
+        crate::test_helpers::set_env("RTTX_DEV_MODE", "0");
+        crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+        let runtime_id = Uuid::new_v4();
+        let pane_id = Uuid::new_v4();
+        let recovered_uuid = format!("inventory:local:{runtime_id}");
+        let daemon = spawn_startup_inventory_daemon(
+            &crate::daemon::default_socket_path(),
+            runtime_id,
+            pane_id,
+        );
+
+        let app = adw::Application::builder()
+            .application_id("com.illya.rttx.startup-inventory-recovery-tests")
+            .build();
+        app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+        let window = Window::new(&app);
+
+        assert!(
+            wait_until(3_000, || {
+                window
+                    .imp()
+                    .state
+                    .borrow()
+                    .sessions
+                    .iter()
+                    .any(|session| session.uuid == recovered_uuid)
+            }),
+            "startup should recover daemon inventory even when no managed GUI workspace is saved",
+        );
+        assert!(
+            wait_until(3_000, || {
+                window.imp().workspace_connection_status.borrow().get(&recovered_uuid)
+                    == Some(&ConnectionStatus::Connected)
+            }),
+            "recovered startup workspace should attach without manual action",
+        );
+
+        let runtime_id = runtime_id.to_string();
+        let pane_id = pane_id.to_string();
+        let state = window.imp().state.borrow();
+        let session = state
+            .sessions
+            .iter()
+            .find(|session| session.uuid == recovered_uuid)
+            .expect("startup inventory should synthesize the recovered workspace");
+        assert_eq!(session.runtime.runtime_id.as_deref(), Some(runtime_id.as_str()));
+        assert_eq!(session.layout.terminal_uuids(), vec![pane_id.clone()]);
+        drop(state);
+
+        assert!(
+            window.imp().persistent_terminals.borrow().contains_key(&pane_id),
+            "startup recovery should materialize the managed pane widget",
+        );
+
+        daemon.join().expect("fake daemon should serve startup inventory recovery");
+        window.close();
+        crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+        crate::test_helpers::remove_env("RTTX_DEV_MODE");
+        crate::test_helpers::remove_env("XDG_RUNTIME_DIR");
     }
 
     #[test]

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -33,6 +33,15 @@ pub struct ManagedWorkspaceOpenResult {
 }
 
 impl WindowState {
+    /// Whether startup should query the local daemon inventory to recover
+    /// persistent runtimes that have no saved GUI workspace.
+    #[must_use]
+    pub fn should_refresh_local_inventory_on_startup(&self) -> bool {
+        !self.sessions.iter().any(|session| {
+            session.uses_managed_runtime() && session.runtime.endpoint == RuntimeEndpoint::Local
+        })
+    }
+
     /// Recover daemon-managed workspaces that exist in inventory but not in the GUI state.
     pub fn recover_managed_workspaces_from_inventory(
         &mut self,
@@ -696,6 +705,65 @@ mod tests {
         assert!(recovered.is_empty());
         assert_eq!(state.sessions.len(), 1);
         assert_eq!(state.sessions[0].uuid, "workspace-1");
+    }
+
+    #[test]
+    fn recover_managed_workspaces_from_inventory_is_idempotent_across_refreshes() {
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+        let sessions = vec![session_info(
+            runtime_id,
+            "Recovered Workspace",
+            proto::RuntimePolicy::Persistent,
+            vec![pane_info("07fa83b4-9ae3-4354-a1c5-1f685ffab370", "Shell", "/srv/project")],
+            None,
+        )];
+        let mut state = window_state(vec![]);
+
+        let first =
+            state.recover_managed_workspaces_from_inventory(&RuntimeEndpoint::Local, &sessions);
+        let second =
+            state.recover_managed_workspaces_from_inventory(&RuntimeEndpoint::Local, &sessions);
+
+        assert_eq!(first.len(), 1, "first inventory refresh should recover the runtime");
+        assert!(
+            second.is_empty(),
+            "repeated inventory refreshes must not duplicate recovered workspaces",
+        );
+        assert_eq!(state.sessions.len(), 1);
+        assert_eq!(state.sessions[0].runtime.runtime_id.as_deref(), Some(runtime_id),);
+    }
+
+    #[test]
+    fn startup_refreshes_local_inventory_only_when_gui_has_no_local_managed_workspace() {
+        let local_managed = managed_session_with_runtime(
+            "workspace-local",
+            "Local Workspace",
+            term("local-pane"),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
+        );
+        let remote_managed = managed_session_with_runtime(
+            "workspace-remote",
+            "Remote Workspace",
+            term("remote-pane"),
+            RuntimeEndpoint::Remote { host: "builder.example".into() },
+            WorkspacePolicy::Persistent,
+            Some("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
+        );
+
+        assert!(
+            window_state(vec![]).should_refresh_local_inventory_on_startup(),
+            "an empty GUI should still probe the local daemon for recovered runtimes",
+        );
+        assert!(
+            window_state(vec![remote_managed]).should_refresh_local_inventory_on_startup(),
+            "remote-only state should still probe the local daemon for recovered runtimes",
+        );
+        assert!(
+            !window_state(vec![local_managed]).should_refresh_local_inventory_on_startup(),
+            "saved local managed workspaces already trigger their own inventory refresh",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- bootstrap local daemon inventory on startup when no saved local managed workspace exists
- only probe startup inventory when an existing local daemon socket is already present
- add regressions for startup recovery and repeated inventory-refresh idempotency

## Testing
- cargo fmt --all --manifest-path Cargo.toml
- cargo test -p rttx startup_recovers_local_inventory_without_saved_managed_workspace --lib
- cargo test -p rttx recover_managed_workspaces_from_inventory_is_idempotent_across_refreshes --lib
- cargo test -p rttx startup_refreshes_local_inventory_only_when_gui_has_no_local_managed_workspace --lib
- cargo test -p rttx inventory_loaded_recovers_missing_managed_workspace --lib
- cargo test -p rttx inventory_loaded_skips_workspace_for_known_runtime --lib
- cargo test -p rttx load_state_keeps_selected_row_and_visible_session_in_sync --lib
- cargo build --workspace --manifest-path Cargo.toml
- cargo test --workspace --manifest-path Cargo.toml *(hits the repo's existing GTK/sidebar stock-harness abort outside the supported script path)*
- bash .github/scripts/run-clippy.sh
- bash .github/scripts/run-quality-tests.sh
- cargo build -p rttx --manifest-path Cargo.toml
- ./run_ui_tests.sh