### PR TITLE
refactor(runtime): extract endpoint event reducer

### DIFF
--- a/clients/rttx/src/window.rs
+++ b/clients/rttx/src/window.rs
@@ -25,6 +25,7 @@ use crate::sidebar::SessionRow;
 use crate::terminal::handle::TerminalHandle;
 use crate::terminal::persistent_widget::PersistentPaneView;
 use crate::terminal::widget::TerminalWidget;
+use crate::workspace_state::{EndpointEventTransition, WorkspacePaneRestore};
 use std::collections::HashMap;
 
 mod imp {
@@ -1184,69 +1185,6 @@ impl Window {
         use crate::daemon_bridge::EndpointEvent;
 
         match event {
-            EndpointEvent::WorkspaceConnectionChanged { workspace_id, status } => {
-                self.set_workspace_connection_status(&workspace_id, &status);
-            }
-            EndpointEvent::WorkspaceOpened { workspace_id, runtime_id, snapshot } => {
-                self.handle_workspace_opened(&workspace_id, &runtime_id, &snapshot);
-            }
-            EndpointEvent::PaneCreated {
-                workspace_id,
-                layout_terminal_uuid,
-                runtime_id,
-                runtime_pane_id,
-            } => {
-                let applied = {
-                    let mut state = self.imp().state.borrow_mut();
-                    state.apply_managed_pane_created(
-                        &workspace_id,
-                        &layout_terminal_uuid,
-                        &runtime_id,
-                        &runtime_pane_id,
-                    )
-                };
-                if !applied {
-                    return;
-                }
-                if let Some(pane) =
-                    self.imp().persistent_terminals.borrow().get(&layout_terminal_uuid).cloned()
-                {
-                    pane.set_connected(true);
-                    let (cols, rows) = pane.terminal_size();
-                    if cols > 0 && rows > 0 {
-                        self.send_managed_terminal_resize(&layout_terminal_uuid, cols, rows);
-                    }
-                }
-                self.trigger_managed_recovery_for_terminal(&layout_terminal_uuid);
-                self.set_workspace_connection_status(&workspace_id, &ConnectionStatus::Connected);
-            }
-            EndpointEvent::PaneClosed { workspace_id, layout_terminal_uuid, .. } => {
-                self.apply_managed_pane_closed(&workspace_id, &layout_terminal_uuid);
-            }
-            EndpointEvent::WorkspaceDetached { workspace_id, .. } => {
-                self.set_workspace_connection_status(
-                    &workspace_id,
-                    &ConnectionStatus::Disconnected,
-                );
-            }
-            EndpointEvent::RuntimeTerminated { workspace_id, .. } => {
-                {
-                    let mut state = self.imp().state.borrow_mut();
-                    if let Some(session) =
-                        state.sessions.iter_mut().find(|session| session.uuid == workspace_id)
-                    {
-                        session.runtime.runtime_id = None;
-                        session.sync_legacy_mode_from_runtime();
-                    }
-                }
-                self.set_workspace_connection_status(
-                    &workspace_id,
-                    &ConnectionStatus::Disconnected,
-                );
-            }
-            EndpointEvent::InventoryLoaded { endpoint, sessions } => {
-                self.handle_inventory_loaded(&endpoint, &sessions);
-            }
             EndpointEvent::RuntimeMessage { endpoint, message } => {
                 self.dispatch_managed_runtime_message(&endpoint, &message);
             }
@@ -1256,88 +1194,103 @@ impl Window {
                     self.show_toast(&detail);
                 }
             }
+            other => {
+                let transition = {
+                    let mut state = self.imp().state.borrow_mut();
+                    state.reconcile_endpoint_event(&other)
+                };
+                self.apply_endpoint_event_transition(&transition);
+            }
         }
     }
 
-    fn handle_workspace_opened(
-        &self,
-        workspace_id: &str,
-        runtime_id: &str,
-        snapshot: &rttx_proto::proto::Snapshot,
-    ) {
-        let Some(opened) = ({
-            let mut state = self.imp().state.borrow_mut();
-            state.apply_managed_workspace_opened(workspace_id, runtime_id, snapshot)
-        }) else {
-            return;
-        };
+    fn apply_endpoint_event_transition(&self, transition: &EndpointEventTransition) {
+        for session_state in &transition.recovered_workspaces {
+            self.build_session(session_state, false);
+        }
 
-        for runtime_pane_id in &opened.skipped_runtime_panes {
+        for runtime_pane_id in &transition.skipped_runtime_panes {
             log::warn!("Failed to recover runtime pane {runtime_pane_id}: split depth limit");
         }
 
-        self.rebuild_session_content(workspace_id, &opened.session_state);
+        for layout_terminal_uuid in &transition.removed_layout_terminals {
+            self.imp().persistent_terminals.borrow_mut().remove(layout_terminal_uuid);
+        }
+
+        for rebuild in &transition.rebuilt_workspaces {
+            self.rebuild_session_content(&rebuild.workspace_id, &rebuild.session_state);
+        }
 
         if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
-            for layout_terminal_uuid in &opened.panes_to_create {
-                if opened.session_state.runtime.pane_bindings.get(layout_terminal_uuid).is_some_and(
-                    |bound_runtime_pane_id| bound_runtime_pane_id == layout_terminal_uuid,
-                ) {
-                    manager.create_pane(
-                        workspace_id,
-                        &opened.session_state.runtime.endpoint,
-                        runtime_id,
-                        layout_terminal_uuid,
-                    );
-                }
+            for request in &transition.pane_create_requests {
+                manager.create_pane(
+                    &request.workspace_id,
+                    &request.endpoint,
+                    &request.runtime_id,
+                    &request.layout_terminal_uuid,
+                );
             }
         }
 
-        for restore in opened.snapshot_restores {
-            let pane = {
-                let panes = self.imp().persistent_terminals.borrow();
-                panes.get(&restore.layout_terminal_uuid).cloned()
-            };
-            let Some(pane) = pane else { continue };
-
-            pane.vte().reset(true, true);
-            pane.feed_snapshot(&restore.scrollback);
-            pane.set_current_directory(Some(&restore.cwd));
-            if !restore.title.is_empty() && pane.custom_title().is_none() {
-                pane.set_title(&restore.title);
-            }
-            pane.set_connected(true);
-
-            let (cols, rows) = pane.terminal_size();
-            if cols > 0 && rows > 0 {
-                self.send_managed_terminal_resize(&restore.layout_terminal_uuid, cols, rows);
-            }
-        }
-    }
-
-    fn handle_inventory_loaded(
-        &self,
-        endpoint: &RuntimeEndpoint,
-        sessions: &[rttx_proto::proto::SessionInfo],
-    ) {
-        let recovered = {
-            let mut state = self.imp().state.borrow_mut();
-            state.recover_managed_workspaces_from_inventory(endpoint, sessions)
-        };
-        if recovered.is_empty() {
-            return;
+        for restore in &transition.pane_snapshot_restores {
+            self.restore_managed_snapshot(restore);
         }
 
-        for session_state in &recovered {
-            self.build_session(session_state, false);
+        for layout_terminal_uuid in &transition.connected_layout_terminals {
+            self.mark_managed_pane_connected(layout_terminal_uuid);
+        }
+
+        for layout_terminal_uuid in &transition.layout_terminals_to_recover {
+            self.trigger_managed_recovery_for_terminal(layout_terminal_uuid);
+        }
+
+        for status_update in &transition.connection_status_updates {
             self.set_workspace_connection_status(
-                &session_state.uuid,
-                &ConnectionStatus::Connecting,
+                &status_update.workspace_id,
+                &status_update.status,
             );
+        }
+
+        for session_state in &transition.recovered_workspaces {
             self.connect_managed_workspace(session_state);
         }
 
-        self.save_state();
+        if transition.persist_window_state {
+            self.save_state();
+        }
+    }
+
+    fn restore_managed_snapshot(&self, restore: &WorkspacePaneRestore) {
+        let pane = {
+            let panes = self.imp().persistent_terminals.borrow();
+            panes.get(&restore.layout_terminal_uuid).cloned()
+        };
+        let Some(pane) = pane else { return };
+
+        pane.vte().reset(true, true);
+        pane.feed_snapshot(&restore.scrollback);
+        pane.set_current_directory(Some(&restore.cwd));
+        if !restore.title.is_empty() && pane.custom_title().is_none() {
+            pane.set_title(&restore.title);
+        }
+        pane.set_connected(true);
+
+        let (cols, rows) = pane.terminal_size();
+        if cols > 0 && rows > 0 {
+            self.send_managed_terminal_resize(&restore.layout_terminal_uuid, cols, rows);
+        }
+    }
+
+    fn mark_managed_pane_connected(&self, layout_terminal_uuid: &str) {
+        if let Some(pane) =
+            self.imp().persistent_terminals.borrow().get(layout_terminal_uuid).cloned()
+        {
+            pane.set_connected(true);
+            let (cols, rows) = pane.terminal_size();
+            if cols > 0 && rows > 0 {
+                self.send_managed_terminal_resize(layout_terminal_uuid, cols, rows);
+            }
+        }
     }
 
     fn replace_workspace_connection_status(&self, workspace_id: &str, status: &ConnectionStatus) {
@@ -1459,18 +1412,6 @@ impl Window {
             if let Some(pane) = panes.get(&terminal_uuid) {
                 pane.set_connection_presentation(status, &presentation);
             }
-        }
-    }
-
-    fn apply_managed_pane_closed(&self, workspace_id: &str, layout_terminal_uuid: &str) {
-        let session_state = {
-            let mut state = self.imp().state.borrow_mut();
-            state.apply_managed_pane_closed(workspace_id, layout_terminal_uuid)
-        };
-
-        self.imp().persistent_terminals.borrow_mut().remove(layout_terminal_uuid);
-        if let Some(session_state) = session_state {
-            self.rebuild_session_content(workspace_id, &session_state);
         }
     }
 

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1,4 +1,5 @@
-use crate::runtime::{RuntimeEndpoint, WorkspacePolicy, reconcile_bindings};
+use crate::daemon_bridge::EndpointEvent;
+use crate::runtime::{ConnectionStatus, RuntimeEndpoint, WorkspacePolicy, reconcile_bindings};
 use crate::session::layout::{
     LayoutNode, PaneRecovery, SessionState, SplitOrientation, WindowState,
 };
@@ -32,7 +33,159 @@ pub struct ManagedWorkspaceOpenResult {
     pub skipped_runtime_panes: Vec<String>,
 }
 
+/// Pure connection-status update derived from an endpoint event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionStatusUpdate {
+    pub workspace_id: String,
+    pub status: ConnectionStatus,
+}
+
+/// Pure request to rebuild one workspace from mutated state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedWorkspaceRebuild {
+    pub workspace_id: String,
+    pub session_state: SessionState,
+}
+
+/// Pure request to create a missing daemon pane for a layout terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedPaneCreateRequest {
+    pub workspace_id: String,
+    pub endpoint: RuntimeEndpoint,
+    pub runtime_id: String,
+    pub layout_terminal_uuid: String,
+}
+
+/// Pure outcome of reconciling a daemon endpoint event against app state.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct EndpointEventTransition {
+    pub recovered_workspaces: Vec<SessionState>,
+    pub rebuilt_workspaces: Vec<ManagedWorkspaceRebuild>,
+    pub pane_create_requests: Vec<ManagedPaneCreateRequest>,
+    pub pane_snapshot_restores: Vec<WorkspacePaneRestore>,
+    pub connected_layout_terminals: Vec<String>,
+    pub layout_terminals_to_recover: Vec<String>,
+    pub removed_layout_terminals: Vec<String>,
+    pub connection_status_updates: Vec<ConnectionStatusUpdate>,
+    pub skipped_runtime_panes: Vec<String>,
+    pub persist_window_state: bool,
+}
+
 impl WindowState {
+    /// Reconcile a daemon endpoint event into pure state updates plus follow-on effects.
+    #[must_use]
+    pub fn reconcile_endpoint_event(&mut self, event: &EndpointEvent) -> EndpointEventTransition {
+        let mut transition = EndpointEventTransition::default();
+
+        match event {
+            EndpointEvent::WorkspaceConnectionChanged { workspace_id, status } => {
+                transition.connection_status_updates.push(ConnectionStatusUpdate {
+                    workspace_id: workspace_id.clone(),
+                    status: status.clone(),
+                });
+            }
+            EndpointEvent::WorkspaceOpened { workspace_id, runtime_id, snapshot } => {
+                let Some(opened) =
+                    self.apply_managed_workspace_opened(workspace_id, runtime_id, snapshot)
+                else {
+                    return transition;
+                };
+                let ManagedWorkspaceOpenResult {
+                    session_state,
+                    panes_to_create,
+                    snapshot_restores,
+                    skipped_runtime_panes,
+                } = opened;
+
+                transition.rebuilt_workspaces.push(ManagedWorkspaceRebuild {
+                    workspace_id: workspace_id.clone(),
+                    session_state: session_state.clone(),
+                });
+                transition.skipped_runtime_panes = skipped_runtime_panes;
+                transition.pane_snapshot_restores = snapshot_restores;
+
+                for layout_terminal_uuid in panes_to_create {
+                    transition.pane_create_requests.push(ManagedPaneCreateRequest {
+                        workspace_id: workspace_id.clone(),
+                        endpoint: session_state.runtime.endpoint.clone(),
+                        runtime_id: runtime_id.clone(),
+                        layout_terminal_uuid,
+                    });
+                }
+            }
+            EndpointEvent::PaneCreated {
+                workspace_id,
+                layout_terminal_uuid,
+                runtime_id,
+                runtime_pane_id,
+            } => {
+                let applied = self.apply_managed_pane_created(
+                    workspace_id,
+                    layout_terminal_uuid,
+                    runtime_id,
+                    runtime_pane_id,
+                );
+                if !applied {
+                    return transition;
+                }
+
+                transition.connected_layout_terminals.push(layout_terminal_uuid.clone());
+                transition.layout_terminals_to_recover.push(layout_terminal_uuid.clone());
+                transition.connection_status_updates.push(ConnectionStatusUpdate {
+                    workspace_id: workspace_id.clone(),
+                    status: ConnectionStatus::Connected,
+                });
+            }
+            EndpointEvent::PaneClosed { workspace_id, layout_terminal_uuid, .. } => {
+                let session_state =
+                    self.apply_managed_pane_closed(workspace_id, layout_terminal_uuid);
+                transition.removed_layout_terminals.push(layout_terminal_uuid.clone());
+                if let Some(session_state) = session_state {
+                    transition.rebuilt_workspaces.push(ManagedWorkspaceRebuild {
+                        workspace_id: workspace_id.clone(),
+                        session_state,
+                    });
+                }
+            }
+            EndpointEvent::WorkspaceDetached { workspace_id, .. } => {
+                transition.connection_status_updates.push(ConnectionStatusUpdate {
+                    workspace_id: workspace_id.clone(),
+                    status: ConnectionStatus::Disconnected,
+                });
+            }
+            EndpointEvent::RuntimeTerminated { workspace_id, .. } => {
+                if let Some(session) =
+                    self.sessions.iter_mut().find(|session| session.uuid == *workspace_id)
+                {
+                    session.runtime.runtime_id = None;
+                    session.sync_legacy_mode_from_runtime();
+                }
+                transition.connection_status_updates.push(ConnectionStatusUpdate {
+                    workspace_id: workspace_id.clone(),
+                    status: ConnectionStatus::Disconnected,
+                });
+            }
+            EndpointEvent::InventoryLoaded { endpoint, sessions } => {
+                let recovered = self.recover_managed_workspaces_from_inventory(endpoint, sessions);
+                if recovered.is_empty() {
+                    return transition;
+                }
+
+                for session_state in &recovered {
+                    transition.recovered_workspaces.push(session_state.clone());
+                    transition.connection_status_updates.push(ConnectionStatusUpdate {
+                        workspace_id: session_state.uuid.clone(),
+                        status: ConnectionStatus::Connecting,
+                    });
+                }
+                transition.persist_window_state = true;
+            }
+            EndpointEvent::RuntimeMessage { .. } | EndpointEvent::WorkspaceError { .. } => {}
+        }
+
+        transition
+    }
+
     /// Recover daemon-managed workspaces that exist in inventory but not in the GUI state.
     pub fn recover_managed_workspaces_from_inventory(
         &mut self,
@@ -343,6 +496,8 @@ fn snapshot_pane_id(pane_snapshot: &proto::PaneSnapshot) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::daemon_bridge::EndpointEvent;
+    use crate::runtime::ConnectionStatus;
     use crate::runtime::WorkspacePolicy;
     use crate::test_helpers::{
         hsplit, managed_session, managed_session_with_runtime, term, term_full, window_state,
@@ -727,5 +882,218 @@ mod tests {
 
         assert_eq!(opened.panes_to_create, vec![placeholder_uuid]);
         assert!(opened.snapshot_restores.is_empty());
+    }
+
+    #[test]
+    fn reconcile_endpoint_event_status_change_emits_workspace_status_update() {
+        let mut state = WindowState::default_for_test();
+
+        let transition =
+            state.reconcile_endpoint_event(&EndpointEvent::WorkspaceConnectionChanged {
+                workspace_id: "workspace-1".into(),
+                status: ConnectionStatus::Reconnecting { attempt: 2, retry_in_secs: 4 },
+            });
+
+        assert_eq!(
+            transition.connection_status_updates,
+            vec![ConnectionStatusUpdate {
+                workspace_id: "workspace-1".into(),
+                status: ConnectionStatus::Reconnecting { attempt: 2, retry_in_secs: 4 },
+            }],
+        );
+    }
+
+    #[test]
+    fn reconcile_endpoint_event_inventory_loaded_recovers_workspace_and_persists() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let pane_id = uuid::Uuid::new_v4().to_string();
+        let mut state = WindowState::default_for_test();
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::InventoryLoaded {
+            endpoint: RuntimeEndpoint::Local,
+            sessions: vec![session_info(
+                &runtime_id,
+                "Recovered Workspace",
+                proto::RuntimePolicy::Persistent,
+                vec![pane_info(&pane_id, "Shell", "/srv/project")],
+                Some(&pane_id),
+            )],
+        });
+
+        assert_eq!(transition.recovered_workspaces.len(), 1);
+        assert!(transition.persist_window_state);
+        assert_eq!(
+            transition.connection_status_updates,
+            vec![ConnectionStatusUpdate {
+                workspace_id: format!("inventory:local:{runtime_id}"),
+                status: ConnectionStatus::Connecting,
+            }],
+        );
+        assert!(
+            state
+                .sessions
+                .iter()
+                .any(|session| session.uuid == format!("inventory:local:{runtime_id}"))
+        );
+    }
+
+    #[test]
+    fn reconcile_endpoint_event_workspace_opened_rebuilds_restores_and_requests_missing_panes() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let first_terminal_uuid = uuid::Uuid::new_v4().to_string();
+        let second_terminal_uuid = uuid::Uuid::new_v4().to_string();
+        let mut state = window_state(vec![managed_session(
+            "workspace-1",
+            "Workspace",
+            hsplit(term(&first_terminal_uuid), term(&second_terminal_uuid)),
+        )]);
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "workspace-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(
+                &runtime_id,
+                vec![pane_snapshot(
+                    &first_terminal_uuid,
+                    "Shell",
+                    "/srv/project",
+                    b"restored output",
+                )],
+            ),
+        });
+
+        assert_eq!(
+            transition.rebuilt_workspaces,
+            vec![ManagedWorkspaceRebuild {
+                workspace_id: "workspace-1".into(),
+                session_state: state.sessions[0].clone(),
+            }],
+        );
+        assert_eq!(
+            transition.pane_create_requests,
+            vec![ManagedPaneCreateRequest {
+                workspace_id: "workspace-1".into(),
+                endpoint: RuntimeEndpoint::Local,
+                runtime_id: runtime_id.clone(),
+                layout_terminal_uuid: second_terminal_uuid,
+            }],
+        );
+        assert_eq!(
+            transition.pane_snapshot_restores,
+            vec![WorkspacePaneRestore {
+                layout_terminal_uuid: first_terminal_uuid,
+                title: "Shell".into(),
+                cwd: "/srv/project".into(),
+                scrollback: b"restored output".to_vec(),
+            }],
+        );
+        assert_eq!(state.sessions[0].runtime.runtime_id.as_deref(), Some(runtime_id.as_str()));
+    }
+
+    #[test]
+    fn reconcile_endpoint_event_pane_created_updates_binding_and_requests_recovery() {
+        let mut state =
+            window_state(vec![managed_session("workspace-1", "Workspace", term("pane-1"))]);
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::PaneCreated {
+            workspace_id: "workspace-1".into(),
+            layout_terminal_uuid: "pane-1".into(),
+            runtime_id: "d7d04564-b2bf-4302-9495-e65c4df12ac6".into(),
+            runtime_pane_id: "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26".into(),
+        });
+
+        assert_eq!(transition.connected_layout_terminals, vec!["pane-1".to_string()]);
+        assert_eq!(transition.layout_terminals_to_recover, vec!["pane-1".to_string()]);
+        assert_eq!(
+            transition.connection_status_updates,
+            vec![ConnectionStatusUpdate {
+                workspace_id: "workspace-1".into(),
+                status: ConnectionStatus::Connected,
+            }],
+        );
+        assert_eq!(
+            state.sessions[0].runtime.pane_bindings.get("pane-1").map(String::as_str),
+            Some("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
+        );
+    }
+
+    #[test]
+    fn reconcile_endpoint_event_pane_closed_removes_terminal_and_rebuilds_workspace() {
+        let mut session = managed_session_with_runtime(
+            "workspace-1",
+            "Workspace",
+            hsplit(term("left"), term("right")),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
+        );
+        session.runtime.bind_runtime_pane("left", "07fa83b4-9ae3-4354-a1c5-1f685ffab370");
+        session.runtime.bind_runtime_pane("right", "0d88f17f-626d-40b8-a1d3-6a42af628ac9");
+        let mut state = window_state(vec![session]);
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::PaneClosed {
+            workspace_id: "workspace-1".into(),
+            layout_terminal_uuid: "right".into(),
+            runtime_id: "d7d04564-b2bf-4302-9495-e65c4df12ac6".into(),
+            runtime_pane_id: "0d88f17f-626d-40b8-a1d3-6a42af628ac9".into(),
+        });
+
+        assert_eq!(transition.removed_layout_terminals, vec!["right".to_string()]);
+        assert_eq!(transition.rebuilt_workspaces.len(), 1);
+        assert_eq!(state.sessions[0].layout.terminal_uuids(), vec!["left".to_string()]);
+    }
+
+    #[test]
+    fn reconcile_endpoint_event_workspace_detached_preserves_runtime_id_and_marks_disconnected() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let mut state = window_state(vec![managed_session_with_runtime(
+            "workspace-1",
+            "Workspace",
+            term("pane-1"),
+            RuntimeEndpoint::Remote { host: "builder.example".into() },
+            WorkspacePolicy::Persistent,
+            Some(&runtime_id),
+        )]);
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceDetached {
+            workspace_id: "workspace-1".into(),
+            runtime_id: runtime_id.clone(),
+        });
+
+        assert_eq!(state.sessions[0].runtime.runtime_id.as_deref(), Some(runtime_id.as_str()));
+        assert_eq!(
+            transition.connection_status_updates,
+            vec![ConnectionStatusUpdate {
+                workspace_id: "workspace-1".into(),
+                status: ConnectionStatus::Disconnected,
+            }],
+        );
+    }
+
+    #[test]
+    fn reconcile_endpoint_event_runtime_terminated_clears_runtime_id_and_marks_disconnected() {
+        let mut state = window_state(vec![managed_session_with_runtime(
+            "workspace-1",
+            "Workspace",
+            term("pane-1"),
+            RuntimeEndpoint::Remote { host: "builder.example".into() },
+            WorkspacePolicy::Persistent,
+            Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
+        )]);
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::RuntimeTerminated {
+            workspace_id: "workspace-1".into(),
+            runtime_id: "d7d04564-b2bf-4302-9495-e65c4df12ac6".into(),
+            reason: proto::RuntimeTerminationReason::Explicit,
+        });
+
+        assert_eq!(state.sessions[0].runtime.runtime_id, None);
+        assert_eq!(
+            transition.connection_status_updates,
+            vec![ConnectionStatusUpdate {
+                workspace_id: "workspace-1".into(),
+                status: ConnectionStatus::Disconnected,
+            }],
+        );
     }
 }


### PR DESCRIPTION
## Summary
- extract daemon endpoint-event reconciliation from `Window` into pure `WindowState::reconcile_endpoint_event()` transitions
- keep `Window` responsible only for applying GTK side effects from the reducer output
- add reducer regression coverage for connection, inventory recovery, workspace-opened, pane-created, pane-closed, detached, and terminated paths

## Root Cause
Daemon runtime correctness was still split across pure state helpers and ad hoc GTK handlers in `window.rs`. That made the recovery/reconnect logic hard to reason about, hard to test as a unit, and easy to regress.

## Tests Added
- `workspace_state::tests::reconcile_endpoint_event_status_change_emits_workspace_status_update`
- `workspace_state::tests::reconcile_endpoint_event_inventory_loaded_recovers_workspace_and_persists`
- `workspace_state::tests::reconcile_endpoint_event_workspace_opened_rebuilds_restores_and_requests_missing_panes`
- `workspace_state::tests::reconcile_endpoint_event_pane_created_updates_binding_and_requests_recovery`
- `workspace_state::tests::reconcile_endpoint_event_pane_closed_removes_terminal_and_rebuilds_workspace`
- `workspace_state::tests::reconcile_endpoint_event_workspace_detached_preserves_runtime_id_and_marks_disconnected`
- `workspace_state::tests::reconcile_endpoint_event_runtime_terminated_clears_runtime_id_and_marks_disconnected`

## Tests Run
- `cargo fmt --all --manifest-path Cargo.toml`
- `cargo test -p rttx reconcile_endpoint_event_ --lib`
- `cargo build --workspace --manifest-path Cargo.toml`
- `cargo test --workspace --manifest-path Cargo.toml`
- `bash .github/scripts/run-clippy.sh`
- `bash .github/scripts/run-quality-tests.sh`
- `cargo build -p rttx --manifest-path Cargo.toml`
- `./run_ui_tests.sh`

## Manual Verification
- exercised the reducer through targeted managed-workspace recovery and reconnect regressions already present in the GTK test layer
- verified the AT-SPI UI suite still passes after the refactor

## Limitations
- GTK tests skip locally when no display is available; the repo-supported isolated harness and AT-SPI suite both passed in this environment
