### PR TITLE
test(runtime): add black-box client daemon recovery coverage

### DIFF
--- a/clients/rttx/src/window.rs
+++ b/clients/rttx/src/window.rs
@@ -339,6 +339,19 @@ impl Window {
         if let Some(row) = self.imp().sidebar_list.row_at_index(active_index as i32) {
             self.imp().sidebar_list.select_row(Some(&row));
         }
+
+        if state.needs_inventory_bootstrap(&RuntimeEndpoint::Local)
+            && crate::daemon::default_socket_path().exists()
+        {
+            let win = self.clone();
+            glib::idle_add_local_once(move || {
+                if win.ensure_connection_manager()
+                    && let Some(manager) = win.imp().connection_manager.borrow().as_ref()
+                {
+                    manager.refresh_inventory(&RuntimeEndpoint::Local);
+                }
+            });
+        }
     }
 
     pub fn save_state(&self) {

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -72,6 +72,15 @@ pub struct EndpointEventTransition {
 }
 
 impl WindowState {
+    /// True when startup should query an endpoint for inventory bootstrap.
+    #[must_use]
+    pub fn needs_inventory_bootstrap(&self, endpoint: &RuntimeEndpoint) -> bool {
+        !self
+            .sessions
+            .iter()
+            .any(|session| session.uses_managed_runtime() && &session.runtime.endpoint == endpoint)
+    }
+
     /// Reconcile a daemon endpoint event into pure state updates plus follow-on effects.
     #[must_use]
     pub fn reconcile_endpoint_event(&mut self, event: &EndpointEvent) -> EndpointEventTransition {
@@ -500,7 +509,8 @@ mod tests {
     use crate::runtime::ConnectionStatus;
     use crate::runtime::WorkspacePolicy;
     use crate::test_helpers::{
-        hsplit, managed_session, managed_session_with_runtime, term, term_full, window_state,
+        hsplit, managed_session, managed_session_with_runtime, session, term, term_full,
+        window_state,
     };
 
     fn pane_snapshot(
@@ -934,6 +944,48 @@ mod tests {
                 .sessions
                 .iter()
                 .any(|session| session.uuid == format!("inventory:local:{runtime_id}"))
+        );
+    }
+
+    #[test]
+    fn needs_inventory_bootstrap_when_no_managed_workspace_uses_endpoint() {
+        let state = window_state(vec![session("session-1", "Session 1", term("pane-1"))]);
+
+        assert!(state.needs_inventory_bootstrap(&RuntimeEndpoint::Local));
+        assert!(state.needs_inventory_bootstrap(&RuntimeEndpoint::Remote {
+            host: "builder.example".into(),
+        }));
+    }
+
+    #[test]
+    fn needs_inventory_bootstrap_skips_endpoints_already_present_in_state() {
+        let state = window_state(vec![
+            managed_session_with_runtime(
+                "workspace-1",
+                "Local Workspace",
+                term("local-pane"),
+                RuntimeEndpoint::Local,
+                WorkspacePolicy::Persistent,
+                Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
+            ),
+            managed_session_with_runtime(
+                "workspace-2",
+                "Remote Workspace",
+                term("remote-pane"),
+                RuntimeEndpoint::Remote { host: "builder.example".into() },
+                WorkspacePolicy::Persistent,
+                Some("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
+            ),
+        ]);
+
+        assert!(!state.needs_inventory_bootstrap(&RuntimeEndpoint::Local));
+        assert!(!state.needs_inventory_bootstrap(&RuntimeEndpoint::Remote {
+            host: "builder.example".into(),
+        }));
+        assert!(
+            state.needs_inventory_bootstrap(&RuntimeEndpoint::Remote {
+                host: "other.example".into(),
+            })
         );
     }
 

--- a/clients/rttx/tests/ui/common.py
+++ b/clients/rttx/tests/ui/common.py
@@ -1,8 +1,11 @@
 """Shared fixture and helpers for AT-SPI2 UI tests."""
 
 import os
+import shutil
 import subprocess
+import tempfile
 import time
+import uuid
 
 import gi
 
@@ -16,9 +19,11 @@ REPO_ROOT = os.path.abspath(
 )
 TARGET_DIR = os.environ.get("CARGO_TARGET_DIR", os.path.join(REPO_ROOT, "target"))
 BINARY = os.path.join(TARGET_DIR, "debug", "rttx")
+DAEMON_BINARY = os.path.join(TARGET_DIR, "debug", "rttx-server")
 
 # Private Wayland socket name — avoids any clash with the user's compositor.
 WAYLAND_SOCKET = "rttx-test"
+DEV_CONFIG_DIR = "rttx-devel"
 
 # Dev mode: uses app ID io.github.IllyaYalovyy.rttx.Devel so the test instance
 # never conflicts with the production rttx the user runs for daily work.
@@ -47,6 +52,19 @@ def click(node: Atspi.Accessible) -> bool:
         return False
 
 
+def click_center(node: Atspi.Accessible) -> bool:
+    """Trigger a primary-button click at the center of *node*."""
+    try:
+        rect = node.get_extents(Atspi.CoordType.SCREEN)
+        return Atspi.generate_mouse_event(
+            rect.x + rect.width // 2,
+            rect.y + rect.height // 2,
+            "b1c",
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def find_all_by_role(root: Atspi.Accessible, role: Atspi.Role) -> list:
     """Depth-first search for all accessible nodes with the given role."""
     results = []
@@ -67,6 +85,30 @@ def _collect(node: Atspi.Accessible, role: Atspi.Role, out: list) -> None:
         pass
 
 
+def is_showing(node: Atspi.Accessible) -> bool:
+    """Return whether *node* is currently visible in the accessibility tree."""
+    try:
+        state_set = node.get_state_set()
+        return state_set.contains(Atspi.StateType.SHOWING) and state_set.contains(
+            Atspi.StateType.VISIBLE
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def find_showing_by_role_and_name(
+    root: Atspi.Accessible, role: Atspi.Role, name: str
+) -> Atspi.Accessible | None:
+    """Return the first visible node matching both *role* and *name*."""
+    for node in find_all_by_role(root, role):
+        try:
+            if is_showing(node) and node.get_name().lower() == name.lower():
+                return node
+        except Exception:  # noqa: BLE001
+            pass
+    return None
+
+
 def find_app_by_pid(pid: int, timeout: float = 10.0) -> Atspi.Accessible | None:
     """Poll the AT-SPI desktop until the application with *pid* appears."""
     deadline = time.monotonic() + timeout
@@ -82,6 +124,24 @@ def find_app_by_pid(pid: int, timeout: float = 10.0) -> Atspi.Accessible | None:
                 pass
         time.sleep(0.2)
     return None
+
+
+def wait_for_name(
+    root: Atspi.Accessible,
+    role: Atspi.Role,
+    name: str,
+    timeout: float = 10.0,
+    showing_only: bool = False,
+) -> Atspi.Accessible | None:
+    """Poll until a node with *role* and *name* appears."""
+    deadline = time.monotonic() + timeout
+    finder = find_showing_by_role_and_name if showing_only else find_by_role_and_name
+    while time.monotonic() < deadline:
+        found = finder(root, role, name)
+        if found is not None:
+            return found
+        time.sleep(0.2)
+    return finder(root, role, name)
 
 
 def wait_for_role(
@@ -100,6 +160,209 @@ def wait_for_role(
     return find_all_by_role(root, role)
 
 
+def wait_for_showing_role(
+    root: Atspi.Accessible,
+    role: Atspi.Role,
+    count: int = 1,
+    timeout: float = 10.0,
+) -> list:
+    """Poll until at least *count* visible nodes with *role* appear under *root*."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        found = [node for node in find_all_by_role(root, role) if is_showing(node)]
+        if len(found) >= count:
+            return found
+        time.sleep(0.2)
+    return [node for node in find_all_by_role(root, role) if is_showing(node)]
+
+
+def terminal_text(node: Atspi.Accessible, max_chars: int | None = None) -> str:
+    """Return the visible terminal text exposed through the AT-SPI text interface."""
+    try:
+        char_count = node.get_character_count()
+        if char_count <= 0:
+            return ""
+        start = 0
+        if max_chars is not None and char_count > max_chars:
+            start = char_count - max_chars
+        return "".join(chr(node.get_character_at_offset(i)) for i in range(start, char_count))
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def terminal_caret_offset(node: Atspi.Accessible) -> int:
+    """Return the caret offset for a terminal accessible node."""
+    try:
+        return node.get_caret_offset()
+    except Exception:  # noqa: BLE001
+        return -1
+
+
+class TestEnvironment:
+    """Isolated weston/XDG environment shared by one UI test."""
+
+    def __init__(self) -> None:
+        self.root_dir = tempfile.mkdtemp(prefix="rttx-ui-test-")
+        self.runtime_dir = os.path.join(self.root_dir, "run")
+        self.config_home = os.path.join(self.root_dir, "config")
+        self.cache_home = os.path.join(self.root_dir, "cache")
+        os.makedirs(self.runtime_dir, mode=0o700, exist_ok=True)
+        os.makedirs(self.config_home, exist_ok=True)
+        os.makedirs(self.cache_home, exist_ok=True)
+        self.wayland_socket = f"{WAYLAND_SOCKET}-{uuid.uuid4().hex[:8]}"
+        self._weston: subprocess.Popen | None = None
+        self._daemon: subprocess.Popen | None = None
+
+    @property
+    def weston_socket_path(self) -> str:
+        return os.path.join(self.runtime_dir, self.wayland_socket)
+
+    @property
+    def daemon_socket_path(self) -> str:
+        return os.path.join(
+            self.runtime_dir, "rttx-server-devel", "v1", "rttx-server.sock"
+        )
+
+    @property
+    def sessions_file(self) -> str:
+        return os.path.join(self.config_home, DEV_CONFIG_DIR, "sessions.json")
+
+    def process_env(self, disable_shell_spawn: bool = False) -> dict[str, str]:
+        """Environment for the private weston/client/daemon processes."""
+        env = os.environ.copy()
+        env["WAYLAND_DISPLAY"] = self.wayland_socket
+        env["GDK_BACKEND"] = "wayland"
+        env["RTTX_DEV_MODE"] = "1"
+        env["XDG_RUNTIME_DIR"] = self.runtime_dir
+        env["XDG_CONFIG_HOME"] = self.config_home
+        env["XDG_CACHE_HOME"] = self.cache_home
+        env["NO_AT_BRIDGE"] = "0"
+        env["PATH"] = os.path.join(TARGET_DIR, "debug") + os.pathsep + env["PATH"]
+        env.pop("GTK_A11Y", None)
+        env.pop("DISPLAY", None)
+        if disable_shell_spawn:
+            env["RTTX_DISABLE_SHELL_SPAWN"] = "1"
+        else:
+            env.pop("RTTX_DISABLE_SHELL_SPAWN", None)
+        return env
+
+    def start_weston(self) -> None:
+        """Start the private headless compositor."""
+        if self._weston is not None and self._weston.poll() is None:
+            return
+
+        self._weston = subprocess.Popen(
+            [
+                "weston",
+                "--backend=headless",
+                f"--socket={self.wayland_socket}",
+                "--width=1280",
+                "--height=800",
+            ],
+            env={**os.environ, "XDG_RUNTIME_DIR": self.runtime_dir},
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        deadline = time.monotonic() + 10.0
+        while not os.path.exists(self.weston_socket_path):
+            if time.monotonic() > deadline:
+                self.stop_weston()
+                raise RuntimeError(
+                    f"weston socket {self.weston_socket_path} did not appear within 10 s"
+                )
+            time.sleep(0.1)
+
+    def stop_weston(self) -> None:
+        """Terminate the private compositor."""
+        if self._weston is None:
+            return
+        try:
+            self._weston.terminate()
+            self._weston.wait(timeout=5)
+        except Exception:  # noqa: BLE001
+            self._weston.kill()
+        self._weston = None
+
+    def start_daemon(self) -> None:
+        """Start a foreground rttx-server bound to the private XDG roots."""
+        if not os.path.isfile(DAEMON_BINARY):
+            raise FileNotFoundError(
+                f"rttx-server debug binary not found: {DAEMON_BINARY}\n"
+                "Run `cargo build --workspace` or `cargo build -p rttx-server` first."
+            )
+
+        if self._daemon is not None and self._daemon.poll() is None:
+            return
+
+        self._daemon = subprocess.Popen(
+            [DAEMON_BINARY, "start", "--foreground"],
+            env=self.process_env(),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        deadline = time.monotonic() + 10.0
+        while not os.path.exists(self.daemon_socket_path):
+            if self._daemon.poll() is not None:
+                raise RuntimeError("rttx-server exited before the daemon socket appeared")
+            if time.monotonic() > deadline:
+                self.stop_daemon()
+                raise RuntimeError(
+                    f"daemon socket {self.daemon_socket_path} did not appear within 10 s"
+                )
+            time.sleep(0.1)
+
+    def stop_daemon(self) -> None:
+        """Cooperatively stop the private daemon if it is running."""
+        if self._daemon is None and not os.path.exists(self.daemon_socket_path):
+            return
+
+        if os.path.exists(self.daemon_socket_path):
+            subprocess.run(
+                [DAEMON_BINARY, "stop"],
+                env=self.process_env(),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+
+        if self._daemon is not None:
+            try:
+                self._daemon.wait(timeout=10)
+            except Exception:  # noqa: BLE001
+                self._daemon.terminate()
+                try:
+                    self._daemon.wait(timeout=5)
+                except Exception:  # noqa: BLE001
+                    self._daemon.kill()
+            self._daemon = None
+
+        deadline = time.monotonic() + 5.0
+        while os.path.exists(self.daemon_socket_path):
+            if time.monotonic() > deadline:
+                break
+            time.sleep(0.1)
+
+    def restart_daemon(self) -> None:
+        """Restart the private daemon while preserving config/cache state."""
+        self.stop_daemon()
+        self.start_daemon()
+
+    def clear_saved_state(self) -> None:
+        """Remove the GUI sessions file so startup recovery uses daemon inventory."""
+        try:
+            os.remove(self.sessions_file)
+        except FileNotFoundError:
+            pass
+
+    def cleanup(self) -> None:
+        """Stop all managed processes and remove the private temp roots."""
+        self.stop_daemon()
+        self.stop_weston()
+        shutil.rmtree(self.root_dir, ignore_errors=True)
+
+
 class AppFixture:
     """Launches rttx on a private headless weston compositor and exposes the AT-SPI tree.
 
@@ -113,8 +376,9 @@ class AppFixture:
     rttx instance.
     """
 
-    def __init__(self) -> None:
-        self._weston: subprocess.Popen | None = None
+    def __init__(self, disable_shell_spawn: bool = True) -> None:
+        self.environment = TestEnvironment()
+        self.disable_shell_spawn = disable_shell_spawn
         self._app: subprocess.Popen | None = None
         self.atspi_app: Atspi.Accessible | None = None
 
@@ -124,30 +388,11 @@ class AppFixture:
 
     def start(self) -> None:
         """Start weston (headless) + rttx; wait until the AT-SPI tree is populated."""
-        runtime_dir = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        self.environment.start_weston()
+        self.start_app()
 
-        self._weston = subprocess.Popen(
-            [
-                "weston",
-                "--backend=headless",
-                f"--socket={WAYLAND_SOCKET}",
-                "--width=1280",
-                "--height=800",
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-
-        # Wait for the socket to appear in XDG_RUNTIME_DIR.
-        socket_path = os.path.join(runtime_dir, WAYLAND_SOCKET)
-        deadline = time.monotonic() + 10.0
-        while not os.path.exists(socket_path):
-            if time.monotonic() > deadline:
-                self.stop()
-                raise RuntimeError(
-                    f"weston socket {socket_path} did not appear within 10 s"
-                )
-            time.sleep(0.1)
+    def start_app(self) -> None:
+        """Start the GTK client inside the already-prepared private environment."""
 
         binary = os.path.abspath(BINARY)
         if not os.path.isfile(binary):
@@ -156,27 +401,11 @@ class AppFixture:
                 "Run `cargo build` first."
             )
 
-        # Throwaway config dir so every test run starts with no saved session state.
-        tmp_config = os.path.join(
-            os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"),
-            "rttx-ui-test-config",
-        )
-        os.makedirs(tmp_config, exist_ok=True)
-
-        env = os.environ.copy()
-        env["WAYLAND_DISPLAY"] = WAYLAND_SOCKET
-        env["GDK_BACKEND"] = "wayland"
-        env["RTTX_DEV_MODE"] = "1"             # devel app ID — no conflict with production rttx
-        env["RTTX_DISABLE_SHELL_SPAWN"] = "1"  # no real PTY; keeps tests fast
-        env["XDG_CONFIG_HOME"] = tmp_config    # isolated config — no saved session to restore
-        env.pop("GTK_A11Y", None)              # must NOT disable a11y — AT-SPI needs it
-        env["NO_AT_BRIDGE"] = "0"              # allow the app to register with AT-SPI
-        # Remove any stale display variables so GTK doesn't fall back to X11.
-        env.pop("DISPLAY", None)
-
         self._app = subprocess.Popen(
             [binary],
-            env=env,
+            env=self.environment.process_env(
+                disable_shell_spawn=self.disable_shell_spawn
+            ),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -190,8 +419,8 @@ class AppFixture:
             )
         self.atspi_app = app
 
-    def stop(self) -> None:
-        """Terminate the app and weston."""
+    def stop_app(self) -> None:
+        """Terminate the client while keeping the private environment alive."""
         if self._app is not None:
             try:
                 self._app.terminate()
@@ -200,15 +429,33 @@ class AppFixture:
                 self._app.kill()
             self._app = None
 
-        if self._weston is not None:
-            try:
-                self._weston.terminate()
-                self._weston.wait(timeout=5)
-            except Exception:  # noqa: BLE001
-                self._weston.kill()
-            self._weston = None
-
         self.atspi_app = None
+
+    def restart_app(self) -> None:
+        """Restart the client without resetting daemon/config state."""
+        self.stop_app()
+        self.start_app()
+
+    def start_daemon(self) -> None:
+        """Start the private rttx-server instance."""
+        self.environment.start_daemon()
+
+    def stop_daemon(self) -> None:
+        """Stop the private rttx-server instance."""
+        self.environment.stop_daemon()
+
+    def restart_daemon(self) -> None:
+        """Restart the private rttx-server instance."""
+        self.environment.restart_daemon()
+
+    def clear_saved_state(self) -> None:
+        """Delete the GUI sessions file so startup recovery uses daemon inventory."""
+        self.environment.clear_saved_state()
+
+    def stop(self) -> None:
+        """Terminate all managed processes and remove the private temp roots."""
+        self.stop_app()
+        self.environment.cleanup()
 
     # ------------------------------------------------------------------
     # Convenience accessors
@@ -218,7 +465,59 @@ class AppFixture:
         """Return all TERMINAL-role nodes currently in the tree."""
         return find_all_by_role(self.atspi_app, Atspi.Role.TERMINAL)
 
+    def showing_terminals(self) -> list:
+        """Return all visible TERMINAL-role nodes currently in the tree."""
+        return [node for node in self.terminals() if is_showing(node)]
+
     def window(self) -> Atspi.Accessible | None:
         """Return the first top-level window node."""
         wins = find_all_by_role(self.atspi_app, Atspi.Role.FRAME)
         return wins[0] if wins else None
+
+    def focus_terminal(self, terminal: Atspi.Accessible | None = None) -> bool:
+        """Focus the visible terminal by clicking its center."""
+        target = terminal or (self.showing_terminals()[0] if self.showing_terminals() else None)
+        if target is None:
+            return False
+        return click_center(target)
+
+    def send_text(self, text: str) -> bool:
+        """Inject text into the focused widget through the AT-SPI keyboard bridge."""
+        return Atspi.generate_keyboard_event(0, text, Atspi.KeySynthType.STRING)
+
+    def showing_name(self, role: Atspi.Role, name: str) -> bool:
+        """Return whether a visible accessible node with *role* and *name* exists."""
+        return find_showing_by_role_and_name(self.atspi_app, role, name) is not None
+
+    def wait_for_showing_name(
+        self, role: Atspi.Role, name: str, timeout: float = 10.0
+    ) -> Atspi.Accessible | None:
+        """Wait until a visible accessible node with *role* and *name* appears."""
+        return wait_for_name(
+            self.atspi_app, role, name, timeout=timeout, showing_only=True
+        )
+
+    def wait_for_terminal_count(self, count: int, timeout: float = 10.0) -> list:
+        """Wait until exactly *count* visible terminals are exposed."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            terminals = self.showing_terminals()
+            if len(terminals) == count:
+                return terminals
+            time.sleep(0.2)
+        return self.showing_terminals()
+
+    def wait_for_terminal_text(
+        self, needle: str, timeout: float = 10.0
+    ) -> Atspi.Accessible | None:
+        """Wait until a visible terminal exposes *needle* in its accessible text."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            for terminal in self.showing_terminals():
+                if needle in terminal_text(terminal):
+                    return terminal
+            time.sleep(0.2)
+        for terminal in self.showing_terminals():
+            if needle in terminal_text(terminal):
+                return terminal
+        return None

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -1,0 +1,121 @@
+"""Black-box client+daemon AT-SPI tests for managed workspace recovery."""
+
+import unittest
+
+import gi
+
+gi.require_version("Atspi", "2.0")
+from gi.repository import Atspi
+
+from common import AppFixture, click, wait_for_name
+
+
+class TestManagedBlackBox(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.fixture = AppFixture(disable_shell_spawn=False)
+        self.fixture.start_daemon()
+        self.fixture.start()
+
+    def tearDown(self) -> None:
+        self.fixture.stop()
+
+    def _create_managed_workspace(self) -> None:
+        button = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "New persistent workspace"
+        )
+        self.assertIsNotNone(button, "persistent workspace button not visible")
+        click(button)
+
+        close_pane = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0
+        )
+        self.assertIsNotNone(close_pane, "managed workspace controls never appeared")
+
+        connected = self.fixture.wait_for_showing_name(
+            Atspi.Role.LABEL, "Connected", timeout=20.0
+        )
+        self.assertIsNotNone(connected, "managed workspace never reached Connected state")
+
+    def test_startup_inventory_recovery_keeps_direct_session_visible(self) -> None:
+        """Cold-start recovery must restore the workspace row without stealing visibility."""
+        self._create_managed_workspace()
+
+        self.fixture.stop_app()
+        self.fixture.clear_saved_state()
+        self.fixture.start_app()
+
+        workspace_row = wait_for_name(
+            self.fixture.atspi_app, Atspi.Role.LIST_ITEM, "Workspace 2", timeout=20.0
+        )
+        self.assertIsNotNone(
+            workspace_row,
+            "daemon inventory should recover the managed workspace on cold start",
+        )
+
+        close_terminal = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Close terminal", timeout=20.0
+        )
+        self.assertIsNotNone(
+            close_terminal,
+            "cold start should leave the direct session visible after inventory recovery",
+        )
+        self.assertFalse(
+            self.fixture.showing_name(Atspi.Role.PUSH_BUTTON, "Close pane"),
+            "recovered managed workspace must not steal visible content from the direct session",
+        )
+
+    def test_daemon_restart_split_close_and_reconnect_preserve_visible_layout(self) -> None:
+        """Restarting the daemon must preserve managed pane counts through reconnect flows."""
+        self._create_managed_workspace()
+
+        split = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Split vertically", timeout=10.0
+        )
+        self.assertIsNotNone(split, "managed split control not visible")
+        click(split)
+        self.assertEqual(
+            len(self.fixture.wait_for_terminal_count(2, timeout=20.0)),
+            2,
+            "managed split should expose two terminals before restart",
+        )
+
+        self.fixture.restart_daemon()
+        connected = self.fixture.wait_for_showing_name(
+            Atspi.Role.LABEL, "Connected", timeout=20.0
+        )
+        self.assertIsNotNone(connected, "managed workspace did not reconnect after daemon restart")
+        self.assertEqual(
+            len(self.fixture.wait_for_terminal_count(2, timeout=20.0)),
+            2,
+            "split managed workspace lost a pane after daemon restart",
+        )
+
+        close_pane = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Close pane", timeout=10.0
+        )
+        self.assertIsNotNone(close_pane, "managed close-pane control not visible after reconnect")
+        click(close_pane)
+        self.assertEqual(
+            len(self.fixture.wait_for_terminal_count(1, timeout=20.0)),
+            1,
+            "closing one managed pane after reconnect should leave one visible terminal",
+        )
+
+        self.fixture.restart_daemon()
+        connected = self.fixture.wait_for_showing_name(
+            Atspi.Role.LABEL, "Connected", timeout=20.0
+        )
+        self.assertIsNotNone(
+            connected,
+            "single-pane managed workspace did not reconnect after the second daemon restart",
+        )
+        self.assertEqual(
+            len(self.fixture.wait_for_terminal_count(1, timeout=20.0)),
+            1,
+            "pane bindings drifted after close/reconnect and changed the visible pane count",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/run_ui_tests.sh
+++ b/run_ui_tests.sh
@@ -7,7 +7,7 @@
 # while rttx is open for normal work.
 #
 # Prerequisites:
-#   - cargo build  (produces target/debug/rttx)
+#   - cargo build --workspace  (produces target/debug/rttx and target/debug/rttx-server)
 #   - python3 with gi.repository.Atspi (python3-atspi / typelib-1_0-Atspi-2_0)
 #   - weston (headless Wayland compositor — dnf install weston)
 #
@@ -24,6 +24,12 @@ UI_TEST_DIR="$SCRIPT_DIR/clients/rttx/tests/ui"
 BINARY="$SCRIPT_DIR/target/debug/rttx"
 if [[ ! -f "$BINARY" ]]; then
     echo "ERROR: $BINARY not found. Run 'cargo build' first." >&2
+    exit 1
+fi
+
+DAEMON_BINARY="$SCRIPT_DIR/target/debug/rttx-server"
+if [[ ! -f "$DAEMON_BINARY" ]]; then
+    echo "ERROR: $DAEMON_BINARY not found. Run 'cargo build --workspace' first." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add a real black-box AT-SPI client+daemon test layer for managed runtime recovery flows
- bootstrap local daemon inventory on cold start when saved GUI state has no managed workspace
- extend the UI harness with daemon/app restart controls and visible-terminal assertions

## Problem
Issue #185 is about the missing protection around startup, restart, reattach, selection-sync, and split/close/reconnect behavior through a real `rttx-server` plus GTK client. The existing unit coverage was not enough to catch cold-start recovery gaps.

## Changes
- add `WindowState::needs_inventory_bootstrap()` and focused pure tests
- trigger local inventory refresh during `load_state()` when a daemon is already present but the restored GUI state has no local managed workspace
- extend `clients/rttx/tests/ui/common.py` with daemon/app lifecycle helpers and stronger visible-state queries
- add `clients/rttx/tests/ui/test_managed_blackbox.py` covering:
  - cold-start inventory recovery while keeping the direct session visible
  - split/close/reconnect behavior across daemon restarts
- tighten `run_ui_tests.sh` prerequisites so the daemon binary must exist before UI runs

## Validation
- `cargo fmt --all --manifest-path Cargo.toml`
- `cargo build --workspace --manifest-path Cargo.toml`
- `cargo test -p rttx needs_inventory_bootstrap_ --lib`
- `python3 -m py_compile clients/rttx/tests/ui/common.py clients/rttx/tests/ui/test_managed_blackbox.py`
- `./run_ui_tests.sh test_managed_blackbox`
- `cargo test --workspace --manifest-path Cargo.toml`
- `bash .github/scripts/run-clippy.sh`
- `bash .github/scripts/run-quality-tests.sh`
- `./run_ui_tests.sh`

Fixes #185
