### PR TITLE
refactor(terminal): unify input shortcut policy

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -4,6 +4,20 @@ pub mod links;
 pub mod persistent_widget;
 pub mod widget;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TerminalInputBackend {
+    Direct,
+    Managed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TerminalKeyAction {
+    CopySelection,
+    PasteClipboard,
+    PassThrough,
+    ForwardToPty(Vec<u8>),
+}
+
 fn normalized_shortcut_modifiers(modifiers: gtk4::gdk::ModifierType) -> gtk4::gdk::ModifierType {
     let shortcut_mask = gtk4::gdk::ModifierType::SHIFT_MASK
         | gtk4::gdk::ModifierType::CONTROL_MASK
@@ -13,4 +27,292 @@ fn normalized_shortcut_modifiers(modifiers: gtk4::gdk::ModifierType) -> gtk4::gd
         | gtk4::gdk::ModifierType::META_MASK;
 
     modifiers & shortcut_mask
+}
+
+fn should_pass_through_window_accelerator(
+    key: gtk4::gdk::Key,
+    normalized: gtk4::gdk::ModifierType,
+) -> bool {
+    let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
+    let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
+    let alt = gtk4::gdk::ModifierType::ALT_MASK;
+    let desktop_shortcuts = gtk4::gdk::ModifierType::SUPER_MASK
+        | gtk4::gdk::ModifierType::HYPER_MASK
+        | gtk4::gdk::ModifierType::META_MASK;
+
+    if !(normalized & desktop_shortcuts).is_empty() {
+        return true;
+    }
+
+    (normalized == (ctrl | shift)
+        && matches!(
+            key,
+            gtk4::gdk::Key::c
+                | gtk4::gdk::Key::C
+                | gtk4::gdk::Key::v
+                | gtk4::gdk::Key::V
+                | gtk4::gdk::Key::w
+                | gtk4::gdk::Key::W
+                | gtk4::gdk::Key::e
+                | gtk4::gdk::Key::E
+                | gtk4::gdk::Key::o
+                | gtk4::gdk::Key::O
+                | gtk4::gdk::Key::f
+                | gtk4::gdk::Key::F
+                | gtk4::gdk::Key::n
+                | gtk4::gdk::Key::N
+                | gtk4::gdk::Key::b
+                | gtk4::gdk::Key::B
+                | gtk4::gdk::Key::i
+                | gtk4::gdk::Key::I
+                | gtk4::gdk::Key::t
+                | gtk4::gdk::Key::T
+                | gtk4::gdk::Key::Tab
+                | gtk4::gdk::Key::ISO_Left_Tab
+        ))
+        || (normalized == (ctrl | shift | alt)
+            && matches!(key, gtk4::gdk::Key::t | gtk4::gdk::Key::T))
+}
+
+const fn encode_control_character(ch: char) -> Option<u8> {
+    match ch {
+        'a'..='z' | 'A'..='Z' => Some((ch.to_ascii_uppercase() as u8) & 0x1f),
+        ' ' | '@' | '`' | '2' => Some(0x00),
+        '[' | '{' | '3' => Some(0x1b),
+        '\\' | '|' | '4' => Some(0x1c),
+        ']' | '}' | '5' => Some(0x1d),
+        '^' | '~' | '6' => Some(0x1e),
+        '_' | '7' | '/' => Some(0x1f),
+        '?' => Some(0x7f),
+        _ => None,
+    }
+}
+
+fn encode_terminal_key_input(
+    key: gtk4::gdk::Key,
+    state: gtk4::gdk::ModifierType,
+) -> Option<Vec<u8>> {
+    let ctrl = state.contains(gtk4::gdk::ModifierType::CONTROL_MASK);
+    let alt = state.contains(gtk4::gdk::ModifierType::ALT_MASK);
+    let base = match key {
+        gtk4::gdk::Key::Return | gtk4::gdk::Key::KP_Enter => Some(vec![b'\r']),
+        gtk4::gdk::Key::BackSpace => Some(vec![0x7f]),
+        gtk4::gdk::Key::Tab | gtk4::gdk::Key::KP_Tab => Some(vec![b'\t']),
+        gtk4::gdk::Key::ISO_Left_Tab => Some(b"\x1b[Z".to_vec()),
+        gtk4::gdk::Key::Escape => Some(vec![0x1b]),
+        gtk4::gdk::Key::Up | gtk4::gdk::Key::KP_Up => Some(b"\x1b[A".to_vec()),
+        gtk4::gdk::Key::Down | gtk4::gdk::Key::KP_Down => Some(b"\x1b[B".to_vec()),
+        gtk4::gdk::Key::Right | gtk4::gdk::Key::KP_Right => Some(b"\x1b[C".to_vec()),
+        gtk4::gdk::Key::Left | gtk4::gdk::Key::KP_Left => Some(b"\x1b[D".to_vec()),
+        gtk4::gdk::Key::Home | gtk4::gdk::Key::KP_Home => Some(b"\x1b[H".to_vec()),
+        gtk4::gdk::Key::End | gtk4::gdk::Key::KP_End => Some(b"\x1b[F".to_vec()),
+        gtk4::gdk::Key::Insert | gtk4::gdk::Key::KP_Insert => Some(b"\x1b[2~".to_vec()),
+        gtk4::gdk::Key::Delete | gtk4::gdk::Key::KP_Delete => Some(b"\x1b[3~".to_vec()),
+        gtk4::gdk::Key::Page_Up | gtk4::gdk::Key::KP_Page_Up => Some(b"\x1b[5~".to_vec()),
+        gtk4::gdk::Key::Page_Down | gtk4::gdk::Key::KP_Page_Down => Some(b"\x1b[6~".to_vec()),
+        _ => {
+            let ch = key.to_unicode()?;
+            if ctrl {
+                Some(vec![encode_control_character(ch)?])
+            } else {
+                Some(ch.to_string().into_bytes())
+            }
+        }
+    }?;
+
+    if alt {
+        let mut prefixed = vec![0x1b];
+        prefixed.extend(base);
+        Some(prefixed)
+    } else {
+        Some(base)
+    }
+}
+
+fn smart_clipboard_action(
+    key: gtk4::gdk::Key,
+    normalized: gtk4::gdk::ModifierType,
+    has_selection: bool,
+    smart_clipboard_enabled: bool,
+) -> Option<TerminalKeyAction> {
+    if smart_clipboard_enabled && normalized == gtk4::gdk::ModifierType::CONTROL_MASK {
+        match key {
+            gtk4::gdk::Key::c | gtk4::gdk::Key::C if has_selection => {
+                return Some(TerminalKeyAction::CopySelection);
+            }
+            gtk4::gdk::Key::v | gtk4::gdk::Key::V => {
+                return Some(TerminalKeyAction::PasteClipboard);
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn terminal_key_action(
+    backend: TerminalInputBackend,
+    key: gtk4::gdk::Key,
+    modifiers: gtk4::gdk::ModifierType,
+    has_selection: bool,
+    smart_clipboard_enabled: bool,
+) -> TerminalKeyAction {
+    let normalized = normalized_shortcut_modifiers(modifiers);
+
+    if let Some(action) =
+        smart_clipboard_action(key, normalized, has_selection, smart_clipboard_enabled)
+    {
+        return action;
+    }
+
+    if should_pass_through_window_accelerator(key, normalized) {
+        return TerminalKeyAction::PassThrough;
+    }
+
+    match backend {
+        TerminalInputBackend::Direct => TerminalKeyAction::PassThrough,
+        TerminalInputBackend::Managed => encode_terminal_key_input(key, modifiers)
+            .map_or(TerminalKeyAction::PassThrough, TerminalKeyAction::ForwardToPty),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        TerminalInputBackend, TerminalKeyAction, encode_terminal_key_input, terminal_key_action,
+    };
+
+    #[test]
+    fn direct_and_managed_share_clipboard_policy() {
+        let modifiers = gtk4::gdk::ModifierType::CONTROL_MASK
+            | gtk4::gdk::ModifierType::LOCK_MASK
+            | gtk4::gdk::ModifierType::BUTTON1_MASK;
+
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
+                gtk4::gdk::Key::v,
+                modifiers,
+                false,
+                true,
+            ),
+            TerminalKeyAction::PasteClipboard
+        );
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::v,
+                modifiers,
+                false,
+                true,
+            ),
+            TerminalKeyAction::PasteClipboard
+        );
+    }
+
+    #[test]
+    fn direct_and_managed_preserve_window_accelerators() {
+        let modifiers = gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK;
+
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
+                gtk4::gdk::Key::F,
+                modifiers,
+                false,
+                false,
+            ),
+            TerminalKeyAction::PassThrough
+        );
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::F,
+                modifiers,
+                false,
+                false,
+            ),
+            TerminalKeyAction::PassThrough
+        );
+    }
+
+    #[test]
+    fn super_modified_keys_are_left_for_window_or_desktop_shortcuts() {
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
+                gtk4::gdk::Key::c,
+                gtk4::gdk::ModifierType::SUPER_MASK,
+                false,
+                false,
+            ),
+            TerminalKeyAction::PassThrough
+        );
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::c,
+                gtk4::gdk::ModifierType::SUPER_MASK,
+                false,
+                false,
+            ),
+            TerminalKeyAction::PassThrough
+        );
+    }
+
+    #[test]
+    fn managed_input_still_forwards_shell_control_and_alt_sequences() {
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::c,
+                gtk4::gdk::ModifierType::CONTROL_MASK,
+                false,
+                true,
+            ),
+            TerminalKeyAction::ForwardToPty(vec![0x03])
+        );
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::x,
+                gtk4::gdk::ModifierType::ALT_MASK,
+                false,
+                false,
+            ),
+            TerminalKeyAction::ForwardToPty(b"\x1bx".to_vec())
+        );
+    }
+
+    #[test]
+    fn encode_terminal_key_input_maps_basic_shell_keys() {
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::a, gtk4::gdk::ModifierType::empty()),
+            Some(vec![b'a'])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Return, gtk4::gdk::ModifierType::empty()),
+            Some(vec![b'\r'])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::BackSpace, gtk4::gdk::ModifierType::empty()),
+            Some(vec![0x7f])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Left, gtk4::gdk::ModifierType::empty()),
+            Some(b"\x1b[D".to_vec())
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::c, gtk4::gdk::ModifierType::CONTROL_MASK),
+            Some(vec![0x03])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::x, gtk4::gdk::ModifierType::ALT_MASK),
+            Some(b"\x1bx".to_vec())
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Shift_L, gtk4::gdk::ModifierType::SHIFT_MASK,),
+            None
+        );
+    }
 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -12,8 +12,10 @@ use vte4::prelude::*;
 
 use crate::color_scheme;
 use crate::runtime::{ConnectionPresentation, ConnectionStatus};
+use crate::terminal::TerminalInputBackend;
+use crate::terminal::TerminalKeyAction;
 use crate::terminal::links;
-use crate::terminal::normalized_shortcut_modifiers;
+use crate::terminal::terminal_key_action;
 
 mod imp {
     use super::*;
@@ -479,28 +481,29 @@ impl PersistentPaneView {
             let Some(pane) = pane_weak.upgrade() else {
                 return glib::Propagation::Proceed;
             };
-            match managed_input_action(
+            match terminal_key_action(
+                TerminalInputBackend::Managed,
                 key,
                 state,
                 pane.vte().has_selection(),
                 pane.imp().smart_clipboard.get(),
             ) {
-                ManagedInputAction::Copy => {
+                TerminalKeyAction::CopySelection => {
                     pane.vte().copy_clipboard_format(vte4::Format::Text);
                     pane.vte().unselect_all();
                     glib::Propagation::Stop
                 }
-                ManagedInputAction::Paste => {
+                TerminalKeyAction::PasteClipboard => {
                     pane.vte().paste_clipboard();
                     glib::Propagation::Stop
                 }
-                ManagedInputAction::Forward(bytes) => {
+                TerminalKeyAction::ForwardToPty(bytes) => {
                     if pane.imp().accepts_input.get() {
                         f(&bytes);
                     }
                     glib::Propagation::Stop
                 }
-                ManagedInputAction::PassThrough => glib::Propagation::Proceed,
+                TerminalKeyAction::PassThrough => glib::Propagation::Proceed,
             }
         });
         self.imp().input_key_controller.replace(Some(key_controller.clone()));
@@ -635,133 +638,6 @@ impl PersistentPaneView {
     }
 }
 
-fn encode_terminal_key_input(
-    key: gtk4::gdk::Key,
-    state: gtk4::gdk::ModifierType,
-) -> Option<Vec<u8>> {
-    let ctrl = state.contains(gtk4::gdk::ModifierType::CONTROL_MASK);
-    let alt = state.contains(gtk4::gdk::ModifierType::ALT_MASK);
-    let base = match key {
-        gtk4::gdk::Key::Return | gtk4::gdk::Key::KP_Enter => Some(vec![b'\r']),
-        gtk4::gdk::Key::BackSpace => Some(vec![0x7f]),
-        gtk4::gdk::Key::Tab | gtk4::gdk::Key::KP_Tab => Some(vec![b'\t']),
-        gtk4::gdk::Key::ISO_Left_Tab => Some(b"\x1b[Z".to_vec()),
-        gtk4::gdk::Key::Escape => Some(vec![0x1b]),
-        gtk4::gdk::Key::Up | gtk4::gdk::Key::KP_Up => Some(b"\x1b[A".to_vec()),
-        gtk4::gdk::Key::Down | gtk4::gdk::Key::KP_Down => Some(b"\x1b[B".to_vec()),
-        gtk4::gdk::Key::Right | gtk4::gdk::Key::KP_Right => Some(b"\x1b[C".to_vec()),
-        gtk4::gdk::Key::Left | gtk4::gdk::Key::KP_Left => Some(b"\x1b[D".to_vec()),
-        gtk4::gdk::Key::Home | gtk4::gdk::Key::KP_Home => Some(b"\x1b[H".to_vec()),
-        gtk4::gdk::Key::End | gtk4::gdk::Key::KP_End => Some(b"\x1b[F".to_vec()),
-        gtk4::gdk::Key::Insert | gtk4::gdk::Key::KP_Insert => Some(b"\x1b[2~".to_vec()),
-        gtk4::gdk::Key::Delete | gtk4::gdk::Key::KP_Delete => Some(b"\x1b[3~".to_vec()),
-        gtk4::gdk::Key::Page_Up | gtk4::gdk::Key::KP_Page_Up => Some(b"\x1b[5~".to_vec()),
-        gtk4::gdk::Key::Page_Down | gtk4::gdk::Key::KP_Page_Down => Some(b"\x1b[6~".to_vec()),
-        _ => {
-            let ch = key.to_unicode()?;
-            if ctrl {
-                Some(vec![encode_control_character(ch)?])
-            } else {
-                Some(ch.to_string().into_bytes())
-            }
-        }
-    }?;
-
-    if alt {
-        let mut prefixed = vec![0x1b];
-        prefixed.extend(base);
-        Some(prefixed)
-    } else {
-        Some(base)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ManagedInputAction {
-    Copy,
-    Paste,
-    Forward(Vec<u8>),
-    PassThrough,
-}
-
-fn managed_input_action(
-    key: gtk4::gdk::Key,
-    modifiers: gtk4::gdk::ModifierType,
-    has_selection: bool,
-    smart_clipboard_enabled: bool,
-) -> ManagedInputAction {
-    let normalized = normalized_shortcut_modifiers(modifiers);
-
-    if smart_clipboard_enabled && normalized == gtk4::gdk::ModifierType::CONTROL_MASK {
-        match key {
-            gtk4::gdk::Key::c | gtk4::gdk::Key::C if has_selection => {
-                return ManagedInputAction::Copy;
-            }
-            gtk4::gdk::Key::v | gtk4::gdk::Key::V => return ManagedInputAction::Paste,
-            _ => {}
-        }
-    }
-
-    if should_pass_through_managed_shortcut(key, normalized) {
-        return ManagedInputAction::PassThrough;
-    }
-
-    encode_terminal_key_input(key, modifiers)
-        .map_or(ManagedInputAction::PassThrough, ManagedInputAction::Forward)
-}
-
-fn should_pass_through_managed_shortcut(
-    key: gtk4::gdk::Key,
-    normalized: gtk4::gdk::ModifierType,
-) -> bool {
-    let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
-    let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
-    let alt = gtk4::gdk::ModifierType::ALT_MASK;
-
-    (normalized == (ctrl | shift)
-        && matches!(
-            key,
-            gtk4::gdk::Key::c
-                | gtk4::gdk::Key::C
-                | gtk4::gdk::Key::v
-                | gtk4::gdk::Key::V
-                | gtk4::gdk::Key::w
-                | gtk4::gdk::Key::W
-                | gtk4::gdk::Key::e
-                | gtk4::gdk::Key::E
-                | gtk4::gdk::Key::o
-                | gtk4::gdk::Key::O
-                | gtk4::gdk::Key::f
-                | gtk4::gdk::Key::F
-                | gtk4::gdk::Key::n
-                | gtk4::gdk::Key::N
-                | gtk4::gdk::Key::b
-                | gtk4::gdk::Key::B
-                | gtk4::gdk::Key::i
-                | gtk4::gdk::Key::I
-                | gtk4::gdk::Key::t
-                | gtk4::gdk::Key::T
-                | gtk4::gdk::Key::Tab
-                | gtk4::gdk::Key::ISO_Left_Tab
-        ))
-        || (normalized == (ctrl | shift | alt)
-            && matches!(key, gtk4::gdk::Key::t | gtk4::gdk::Key::T))
-}
-
-const fn encode_control_character(ch: char) -> Option<u8> {
-    match ch {
-        'a'..='z' | 'A'..='Z' => Some((ch.to_ascii_uppercase() as u8) & 0x1f),
-        ' ' | '@' | '`' | '2' => Some(0x00),
-        '[' | '{' | '3' => Some(0x1b),
-        '\\' | '|' | '4' => Some(0x1c),
-        ']' | '}' | '5' => Some(0x1d),
-        '^' | '~' | '6' => Some(0x1e),
-        '_' | '7' | '/' => Some(0x1f),
-        '?' => Some(0x7f),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -852,82 +728,46 @@ mod tests {
     }
 
     #[test]
-    fn encode_terminal_key_input_maps_basic_shell_keys() {
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::a, gtk4::gdk::ModifierType::empty()),
-            Some(vec![b'a'])
-        );
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Return, gtk4::gdk::ModifierType::empty()),
-            Some(vec![b'\r'])
-        );
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::BackSpace, gtk4::gdk::ModifierType::empty()),
-            Some(vec![0x7f])
-        );
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Left, gtk4::gdk::ModifierType::empty()),
-            Some(b"\x1b[D".to_vec())
-        );
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::c, gtk4::gdk::ModifierType::CONTROL_MASK),
-            Some(vec![0x03])
-        );
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::x, gtk4::gdk::ModifierType::ALT_MASK),
-            Some(b"\x1bx".to_vec())
-        );
-    }
-
-    #[test]
-    fn encode_terminal_key_input_ignores_unknown_modifier_keys() {
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Shift_L, gtk4::gdk::ModifierType::SHIFT_MASK),
-            None
-        );
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Super_L, gtk4::gdk::ModifierType::SUPER_MASK),
-            None
-        );
-    }
-
-    #[test]
     fn managed_input_action_preserves_clipboard_shortcuts() {
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::c,
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 true,
                 true,
             ),
-            ManagedInputAction::Copy
+            TerminalKeyAction::CopySelection
         );
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::v,
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
             ),
-            ManagedInputAction::Paste
+            TerminalKeyAction::PasteClipboard
         );
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::C,
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
             ),
-            ManagedInputAction::PassThrough
+            TerminalKeyAction::PassThrough
         );
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::V,
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
             ),
-            ManagedInputAction::PassThrough
+            TerminalKeyAction::PassThrough
         );
     }
 
@@ -936,16 +776,18 @@ mod tests {
         let pointer_mask = gtk4::gdk::ModifierType::BUTTON1_MASK;
 
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::v,
                 gtk4::gdk::ModifierType::CONTROL_MASK | pointer_mask,
                 false,
                 true,
             ),
-            ManagedInputAction::Paste
+            TerminalKeyAction::PasteClipboard
         );
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::c,
                 gtk4::gdk::ModifierType::CONTROL_MASK
                     | gtk4::gdk::ModifierType::LOCK_MASK
@@ -953,23 +795,25 @@ mod tests {
                 true,
                 true,
             ),
-            ManagedInputAction::Copy
+            TerminalKeyAction::CopySelection
         );
     }
 
     #[test]
     fn managed_input_action_preserves_window_accelerators() {
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::T,
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
             ),
-            ManagedInputAction::PassThrough
+            TerminalKeyAction::PassThrough
         );
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::T,
                 gtk4::gdk::ModifierType::CONTROL_MASK
                     | gtk4::gdk::ModifierType::SHIFT_MASK
@@ -977,56 +821,61 @@ mod tests {
                 false,
                 false,
             ),
-            ManagedInputAction::PassThrough
+            TerminalKeyAction::PassThrough
         );
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::ISO_Left_Tab,
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
             ),
-            ManagedInputAction::PassThrough
+            TerminalKeyAction::PassThrough
         );
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::F,
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
             ),
-            ManagedInputAction::PassThrough
+            TerminalKeyAction::PassThrough
         );
     }
 
     #[test]
     fn managed_input_action_keeps_shell_control_sequences_when_no_shortcut_applies() {
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::c,
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
             ),
-            ManagedInputAction::Forward(vec![0x03])
+            TerminalKeyAction::ForwardToPty(vec![0x03])
         );
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::v,
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 false,
             ),
-            ManagedInputAction::Forward(vec![0x16])
+            TerminalKeyAction::ForwardToPty(vec![0x16])
         );
         assert_eq!(
-            managed_input_action(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
                 gtk4::gdk::Key::X,
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
             ),
-            ManagedInputAction::Forward(vec![0x18])
+            TerminalKeyAction::ForwardToPty(vec![0x18])
         );
     }
 

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -5,8 +5,10 @@ use gtk4::subclass::prelude::*;
 use vte4::prelude::*;
 
 use crate::color_scheme;
+use crate::terminal::TerminalInputBackend;
+use crate::terminal::TerminalKeyAction;
 use crate::terminal::links;
-use crate::terminal::normalized_shortcut_modifiers;
+use crate::terminal::terminal_key_action;
 
 mod imp {
     use super::*;
@@ -147,22 +149,25 @@ mod imp {
                     return glib::Propagation::Proceed;
                 };
                 let vte = term.imp().vte.clone();
-                match smart_clipboard_action(
+                match terminal_key_action(
+                    TerminalInputBackend::Direct,
                     key,
                     state,
                     vte.has_selection(),
                     term.imp().smart_clipboard.get(),
                 ) {
-                    SmartClipboardAction::Copy => {
+                    TerminalKeyAction::CopySelection => {
                         vte.copy_clipboard_format(vte4::Format::Text);
                         vte.unselect_all();
                         glib::Propagation::Stop
                     }
-                    SmartClipboardAction::Paste => {
+                    TerminalKeyAction::PasteClipboard => {
                         vte.paste_clipboard();
                         glib::Propagation::Stop
                     }
-                    SmartClipboardAction::PassThrough => glib::Propagation::Proceed,
+                    TerminalKeyAction::PassThrough | TerminalKeyAction::ForwardToPty(_) => {
+                        glib::Propagation::Proceed
+                    }
                 }
             });
             self.smart_clipboard_key_controller
@@ -591,38 +596,9 @@ impl TerminalWidget {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SmartClipboardAction {
-    Copy,
-    Paste,
-    PassThrough,
-}
-
-fn smart_clipboard_action(
-    key: gtk4::gdk::Key,
-    modifiers: gtk4::gdk::ModifierType,
-    has_selection: bool,
-    smart_clipboard_enabled: bool,
-) -> SmartClipboardAction {
-    if !smart_clipboard_enabled {
-        return SmartClipboardAction::PassThrough;
-    }
-
-    let normalized = normalized_shortcut_modifiers(modifiers);
-    if normalized != gtk4::gdk::ModifierType::CONTROL_MASK {
-        return SmartClipboardAction::PassThrough;
-    }
-
-    match key {
-        gtk4::gdk::Key::c | gtk4::gdk::Key::C if has_selection => SmartClipboardAction::Copy,
-        gtk4::gdk::Key::v | gtk4::gdk::Key::V => SmartClipboardAction::Paste,
-        _ => SmartClipboardAction::PassThrough,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{SmartClipboardAction, smart_clipboard_action};
+    use crate::terminal::{TerminalInputBackend, TerminalKeyAction, terminal_key_action};
     use gtk4::glib;
     use gtk4::prelude::*;
 
@@ -658,53 +634,58 @@ mod tests {
     #[test]
     fn smart_clipboard_only_copies_selected_ctrl_c() {
         assert_eq!(
-            smart_clipboard_action(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
                 gtk4::gdk::Key::c,
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 true,
                 true,
             ),
-            SmartClipboardAction::Copy
+            TerminalKeyAction::CopySelection
         );
         assert_eq!(
-            smart_clipboard_action(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
                 gtk4::gdk::Key::c,
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
             ),
-            SmartClipboardAction::PassThrough
+            TerminalKeyAction::PassThrough
         );
     }
 
     #[test]
     fn smart_clipboard_paste_requires_plain_ctrl_v_and_opt_in() {
         assert_eq!(
-            smart_clipboard_action(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
                 gtk4::gdk::Key::v,
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
             ),
-            SmartClipboardAction::Paste
+            TerminalKeyAction::PasteClipboard
         );
         assert_eq!(
-            smart_clipboard_action(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
                 gtk4::gdk::Key::v,
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 true,
             ),
-            SmartClipboardAction::PassThrough
+            TerminalKeyAction::PassThrough
         );
         assert_eq!(
-            smart_clipboard_action(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
                 gtk4::gdk::Key::v,
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 false,
             ),
-            SmartClipboardAction::PassThrough
+            TerminalKeyAction::PassThrough
         );
     }
 
@@ -713,16 +694,18 @@ mod tests {
         let pointer_mask = gtk4::gdk::ModifierType::BUTTON1_MASK;
 
         assert_eq!(
-            smart_clipboard_action(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
                 gtk4::gdk::Key::v,
                 gtk4::gdk::ModifierType::CONTROL_MASK | pointer_mask,
                 false,
                 true,
             ),
-            SmartClipboardAction::Paste
+            TerminalKeyAction::PasteClipboard
         );
         assert_eq!(
-            smart_clipboard_action(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
                 gtk4::gdk::Key::c,
                 gtk4::gdk::ModifierType::CONTROL_MASK
                     | gtk4::gdk::ModifierType::LOCK_MASK
@@ -730,7 +713,7 @@ mod tests {
                 true,
                 true,
             ),
-            SmartClipboardAction::Copy
+            TerminalKeyAction::CopySelection
         );
     }
 


### PR DESCRIPTION
## Summary
- route direct and managed terminal key handling through one shared policy layer
- remove duplicated modifier and shortcut rules from `widget.rs` and `persistent_widget.rs`
- add shared regression coverage for clipboard shortcuts, accelerators, and managed PTY input encoding

## Root Cause
The direct terminal widget and the managed persistent widget each carried their own shortcut policy logic. That duplication made `Ctrl+V`-style regressions likely because lock-modifier normalization, clipboard handling, accelerator passthrough, and managed-byte encoding could drift independently.

## What Changed
- add shared `TerminalInputBackend` and `TerminalKeyAction` policy handling in `clients/rttx/src/terminal/mod.rs`
- centralize:
  - shortcut modifier normalization
  - clipboard copy/paste classification
  - window accelerator passthrough
  - managed PTY byte encoding for shell control and Alt-prefixed input
- rewire `clients/rttx/src/terminal/widget.rs` to consume the shared policy for direct terminals
- rewire `clients/rttx/src/terminal/persistent_widget.rs` to consume the shared policy for managed terminals
- add shared regression tests for:
  - lock-modifier-insensitive clipboard shortcuts
  - window accelerator passthrough
  - shell control sequence forwarding
  - Alt-prefixed input forwarding
  - desktop shortcut passthrough

## Tests Added
- `terminal::tests::direct_and_managed_share_clipboard_policy`
- `terminal::tests::direct_and_managed_preserve_window_accelerators`
- `terminal::tests::managed_input_still_forwards_shell_control_and_alt_sequences`
- `terminal::tests::super_modified_keys_are_left_for_window_or_desktop_shortcuts`
- `terminal::tests::encode_terminal_key_input_maps_basic_shell_keys`

## Tests Run
- `cargo fmt --all --manifest-path Cargo.toml`
- `cargo build --workspace --manifest-path Cargo.toml`
- `cargo test -p rttx terminal:: --lib`
- `cargo test --workspace --manifest-path Cargo.toml`
- `bash .github/scripts/run-clippy.sh`
- `bash .github/scripts/run-quality-tests.sh`
- `cargo build -p rttx --manifest-path Cargo.toml && ./run_ui_tests.sh`

## Manual Verification
- reviewed the diff for scope after formatting
- verified the shared terminal suite passes after the refactor
- verified the full AT-SPI suite still passes with the GTK client rebuilt

Fixes #187
