### PR TITLE
build(ci): enforce runtime behavior proof gate

### DIFF
--- a/.github/scripts/check_runtime_behavior_policy.py
+++ b/.github/scripts/check_runtime_behavior_policy.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Enforce behavior-proof coverage for runtime-affecting pull requests."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import pathlib
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from typing import Iterable
+
+
+RUNTIME_AFFECTING_PATTERNS = (
+    "clients/rttx/src/window.rs",
+    "clients/rttx/src/window/**/*.rs",
+    "clients/rttx/src/workspace_state.rs",
+    "clients/rttx/src/runtime.rs",
+    "clients/rttx/src/daemon.rs",
+    "clients/rttx/src/daemon_bridge.rs",
+    "clients/rttx/src/session/layout.rs",
+    "clients/rttx/src/terminal/mod.rs",
+    "clients/rttx/src/terminal/widget.rs",
+    "clients/rttx/src/terminal/persistent_widget.rs",
+    "clients/rttx/src/terminal/handle.rs",
+    "services/rttx-server/src/*.rs",
+    "services/rttx-server/src/**/*.rs",
+    "protocols/rttx-proto/src/*.rs",
+    "protocols/rttx-proto/src/**/*.rs",
+)
+
+PURE_STATE_TEST_HOST_PATTERNS = (
+    "clients/rttx/src/workspace_state.rs",
+    "clients/rttx/src/runtime.rs",
+    "clients/rttx/src/daemon.rs",
+    "clients/rttx/src/daemon_bridge.rs",
+    "clients/rttx/src/session/layout.rs",
+    "clients/rttx/src/terminal/mod.rs",
+    "services/rttx-server/src/*.rs",
+    "services/rttx-server/src/**/*.rs",
+    "protocols/rttx-proto/src/*.rs",
+    "protocols/rttx-proto/src/**/*.rs",
+)
+
+BEHAVIOR_TEST_PATTERNS = (
+    "clients/rttx/tests/*.rs",
+    "clients/rttx/tests/**/*.rs",
+    "clients/rttx/tests/ui/*.py",
+    "clients/rttx/tests/ui/**/*.py",
+    "services/rttx-server/tests/*.rs",
+    "services/rttx-server/tests/**/*.rs",
+)
+
+RUST_TEST_DECLARATION = re.compile(r"^\s*(#\[(test|should_panic)\]|proptest!\s*)")
+PYTHON_TEST_DECLARATION = re.compile(r"^\s*def test_[A-Za-z0-9_]*\s*\(")
+
+
+@dataclasses.dataclass(frozen=True)
+class PolicyResult:
+    runtime_affecting: bool
+    allowed: bool
+    runtime_files: tuple[str, ...]
+    pure_state_test_files: tuple[str, ...]
+    behavior_test_files: tuple[str, ...]
+
+    @property
+    def has_pure_state_evidence(self) -> bool:
+        return bool(self.pure_state_test_files)
+
+    @property
+    def has_behavior_evidence(self) -> bool:
+        return bool(self.behavior_test_files)
+
+
+def matches_any(path: str, patterns: Iterable[str]) -> bool:
+    candidate = pathlib.PurePosixPath(path)
+    return any(candidate.match(pattern) for pattern in patterns)
+
+
+def has_test_declaration(path: str, added_lines: Iterable[str]) -> bool:
+    matcher = PYTHON_TEST_DECLARATION if path.endswith(".py") else RUST_TEST_DECLARATION
+    return any(matcher.match(line) for line in added_lines)
+
+
+def evaluate_policy(
+    *,
+    changed_files: Iterable[str],
+    added_lines_by_file: dict[str, list[str]],
+) -> PolicyResult:
+    changed_files = sorted(set(changed_files))
+    runtime_files = tuple(
+        path for path in changed_files if matches_any(path, RUNTIME_AFFECTING_PATTERNS)
+    )
+    if not runtime_files:
+        return PolicyResult(
+            runtime_affecting=False,
+            allowed=True,
+            runtime_files=(),
+            pure_state_test_files=(),
+            behavior_test_files=(),
+        )
+
+    pure_state_test_files = tuple(
+        sorted(
+            path
+            for path in changed_files
+            if matches_any(path, PURE_STATE_TEST_HOST_PATTERNS)
+            and has_test_declaration(path, added_lines_by_file.get(path, ()))
+        )
+    )
+    behavior_test_files = tuple(
+        sorted(
+            path
+            for path in changed_files
+            if matches_any(path, BEHAVIOR_TEST_PATTERNS)
+            and has_test_declaration(path, added_lines_by_file.get(path, ()))
+        )
+    )
+
+    return PolicyResult(
+        runtime_affecting=True,
+        allowed=bool(pure_state_test_files) and bool(behavior_test_files),
+        runtime_files=runtime_files,
+        pure_state_test_files=pure_state_test_files,
+        behavior_test_files=behavior_test_files,
+    )
+
+
+def git_output(repo_root: pathlib.Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        check=True,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def changed_files(repo_root: pathlib.Path, base: str, head: str) -> list[str]:
+    output = git_output(repo_root, "diff", "--name-only", "--diff-filter=ACMR", f"{base}..{head}")
+    return [line for line in output.splitlines() if line]
+
+
+def added_lines_by_file(repo_root: pathlib.Path, base: str, head: str) -> dict[str, list[str]]:
+    output = git_output(
+        repo_root,
+        "diff",
+        "--unified=0",
+        "--no-color",
+        "--diff-filter=ACMR",
+        f"{base}..{head}",
+    )
+    current_file: str | None = None
+    added: dict[str, list[str]] = defaultdict(list)
+
+    for raw_line in output.splitlines():
+        if raw_line.startswith("+++ b/"):
+            current_file = raw_line[6:]
+            continue
+        if raw_line.startswith("+++ "):
+            current_file = None
+            continue
+        if current_file is None:
+            continue
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            added[current_file].append(raw_line[1:])
+
+    return dict(added)
+
+
+def format_failure(result: PolicyResult) -> str:
+    lines = [
+        "Runtime-affecting changes were detected without the required proof layers.",
+        "",
+        "Changed runtime-affecting files:",
+        *[f"- {path}" for path in result.runtime_files],
+    ]
+
+    if result.has_pure_state_evidence:
+        lines.extend(
+            [
+                "",
+                "Pure-state evidence detected:",
+                *[f"- {path}" for path in result.pure_state_test_files],
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "Missing pure-state evidence.",
+                "Add at least one new unit-style regression test in a pure-state test host such as:",
+                "- clients/rttx/src/workspace_state.rs",
+                "- clients/rttx/src/runtime.rs",
+                "- clients/rttx/src/session/layout.rs",
+                "- services/rttx-server/src/**",
+                "- protocols/rttx-proto/src/**",
+            ]
+        )
+
+    if result.has_behavior_evidence:
+        lines.extend(
+            [
+                "",
+                "Behavior-layer evidence detected:",
+                *[f"- {path}" for path in result.behavior_test_files],
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "Missing integration or black-box evidence.",
+                "Add at least one new regression test in:",
+                "- clients/rttx/tests/*.rs",
+                "- clients/rttx/tests/ui/*.py",
+                "- services/rttx-server/tests/*.rs",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True, help="Base commit or ref for the PR diff")
+    parser.add_argument("--head", required=True, help="Head commit or ref for the PR diff")
+    parser.add_argument(
+        "--repo-root",
+        default=str(pathlib.Path(__file__).resolve().parents[2]),
+        help="Repository root containing the git checkout",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = pathlib.Path(args.repo_root).resolve()
+
+    result = evaluate_policy(
+        changed_files=changed_files(repo_root, args.base, args.head),
+        added_lines_by_file=added_lines_by_file(repo_root, args.base, args.head),
+    )
+    if result.allowed:
+        if result.runtime_affecting:
+            print("Runtime-affecting changes detected with both required coverage layers.")
+        else:
+            print("No runtime-affecting changes detected; behavior-proof gate skipped.")
+        return 0
+
+    print(format_failure(result), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/run-quality-tests.sh
+++ b/.github/scripts/run-quality-tests.sh
@@ -126,6 +126,10 @@ trap cleanup EXIT
 
 start_broadway_if_available
 
+run_logged_command \
+    "Runtime behavior gate tests" \
+    python3 -m unittest discover -s "${repo_root}/.github/scripts/tests" -p 'test_*.py'
+
 run_library_tests
 run_logged_command "Binary tests" cargo test --manifest-path "${client_manifest}" "${CLIENT_FEATURE_ARGS[@]}" --bins -- --nocapture
 

--- a/.github/scripts/tests/test_check_runtime_behavior_policy.py
+++ b/.github/scripts/tests/test_check_runtime_behavior_policy.py
@@ -1,0 +1,101 @@
+import pathlib
+import sys
+import unittest
+
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_runtime_behavior_policy import evaluate_policy
+
+
+class RuntimeBehaviorPolicyTests(unittest.TestCase):
+    def test_non_runtime_changes_do_not_require_extra_coverage(self) -> None:
+        result = evaluate_policy(
+            changed_files=["clients/rttx/src/bookmarks.rs"],
+            added_lines_by_file={},
+        )
+
+        self.assertFalse(result.runtime_affecting)
+        self.assertTrue(result.allowed)
+
+    def test_runtime_change_without_test_evidence_fails_both_requirements(self) -> None:
+        result = evaluate_policy(
+            changed_files=["clients/rttx/src/window.rs"],
+            added_lines_by_file={"clients/rttx/src/window.rs": ["fn load_state(&self) {"]},
+        )
+
+        self.assertTrue(result.runtime_affecting)
+        self.assertFalse(result.allowed)
+        self.assertFalse(result.has_pure_state_evidence)
+        self.assertFalse(result.has_behavior_evidence)
+
+    def test_runtime_change_with_only_pure_state_test_evidence_still_fails(self) -> None:
+        result = evaluate_policy(
+            changed_files=[
+                "clients/rttx/src/window.rs",
+                "clients/rttx/src/workspace_state.rs",
+            ],
+            added_lines_by_file={
+                "clients/rttx/src/workspace_state.rs": ["#[test]", "fn reducer_handles_restart() {"],
+            },
+        )
+
+        self.assertTrue(result.has_pure_state_evidence)
+        self.assertFalse(result.has_behavior_evidence)
+        self.assertFalse(result.allowed)
+
+    def test_runtime_change_with_only_behavior_test_evidence_still_fails(self) -> None:
+        result = evaluate_policy(
+            changed_files=[
+                "clients/rttx/src/window.rs",
+                "clients/rttx/tests/ui/test_managed_blackbox.py",
+            ],
+            added_lines_by_file={
+                "clients/rttx/tests/ui/test_managed_blackbox.py": [
+                    "def test_daemon_restart_restores_workspace(self) -> None:"
+                ],
+            },
+        )
+
+        self.assertFalse(result.has_pure_state_evidence)
+        self.assertTrue(result.has_behavior_evidence)
+        self.assertFalse(result.allowed)
+
+    def test_runtime_change_with_pure_state_and_black_box_evidence_passes(self) -> None:
+        result = evaluate_policy(
+            changed_files=[
+                "clients/rttx/src/window.rs",
+                "clients/rttx/src/workspace_state.rs",
+                "clients/rttx/tests/ui/test_managed_blackbox.py",
+            ],
+            added_lines_by_file={
+                "clients/rttx/src/workspace_state.rs": ["#[test]", "fn reducer_handles_restart() {"],
+                "clients/rttx/tests/ui/test_managed_blackbox.py": [
+                    "def test_daemon_restart_restores_workspace(self) -> None:"
+                ],
+            },
+        )
+
+        self.assertTrue(result.allowed)
+        self.assertTrue(result.has_pure_state_evidence)
+        self.assertTrue(result.has_behavior_evidence)
+
+    def test_server_runtime_changes_can_use_server_integration_tests(self) -> None:
+        result = evaluate_policy(
+            changed_files=[
+                "services/rttx-server/src/session.rs",
+                "services/rttx-server/src/screen.rs",
+                "services/rttx-server/tests/reconnect.rs",
+            ],
+            added_lines_by_file={
+                "services/rttx-server/src/session.rs": ["#[test]", "fn session_reconnects_cleanly() {"],
+                "services/rttx-server/tests/reconnect.rs": ["#[test]", "fn reconnect_after_restart() {"],
+            },
+        )
+
+        self.assertTrue(result.allowed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,6 +12,24 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  runtime-behavior-gate:
+    name: Runtime behavior gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Test runtime behavior gate
+        run: python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
+
+      - name: Enforce runtime behavior coverage
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 .github/scripts/check_runtime_behavior_policy.py \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -364,6 +364,12 @@ are safe to run while rttx is open for normal work — the dev instance uses a s
 - **Bug fixes** must include a regression test that fails before the fix and passes after.
 - **New features** must include tests covering the primary success path and any GTK-boundary
   interactions the feature introduces.
+- **Runtime-affecting changes** to daemon/runtime/reconnect/restore/reconciliation paths must add
+  both:
+  - at least one new pure-state regression test in a unit-style source test host
+  - at least one new integration, GTK boundary/widget, or AT-SPI behavioral regression test for
+    the user-visible behavior
+  PR CI enforces this rule for the tracked runtime-affecting source paths.
 - **New crash categories** must be added to the crash taxonomy in `designs/RFC-003-testing-strategy.md`.
 - Tautological tests (tests that assert the code does what it obviously does, without validating a
   user-visible invariant or a specific crash category) will be rejected.
@@ -452,6 +458,9 @@ Refs #57
 1. **Open an issue first** for any non-trivial change. Align on scope before writing code.
 2. **One PR, one concern.** Do not bundle unrelated changes.
 3. **All checks must pass:**
+   - PRs that touch tracked daemon/runtime/restore/reconciliation code must satisfy the runtime
+     behavior gate by adding both a pure-state regression test and an integration or behavioral
+     regression test
    - `cargo build --workspace`
    - `bash .github/scripts/run-clippy.sh`
    - `bash .github/scripts/run-quality-tests.sh`

--- a/designs/RFC-003-testing-strategy.md
+++ b/designs/RFC-003-testing-strategy.md
@@ -26,6 +26,9 @@ of GTK-Rust failure as a failing test before it reaches a user.
   remains a supported baseline command without crashing in the stock Rust harness.
 - The CI-equivalent local command remains `bash .github/scripts/run-quality-tests.sh`, which still
   provides the broader curated matrix and isolated GTK client test selection.
+- Pull request CI now includes a diff-aware runtime behavior gate for tracked daemon/runtime/UI
+  reconciliation paths. Those changes must add both a pure-state regression test and an
+  integration or black-box regression test.
 - `run_ui_tests.sh` and the AT-SPI suite exist and run locally/in CI-style environments, but the
   nightly GitHub job is still tracked separately.
 - The highest-value remaining testing gaps are now deeper client+daemon end-to-end recovery
@@ -197,6 +200,7 @@ non-main threads).
 - [x] Active-index bounds contract coverage
 - [x] Activity indicator timer regression coverage
 - [x] Nested split ratio restore regression coverage
+- [x] Runtime-affecting PR gate requiring pure-state plus behavior-layer evidence
 - [ ] Deterministic plain-harness GTK execution
 - [ ] Deeper client+daemon restart/reconcile integration coverage
 - [ ] Expanded daemon adversarial test matrix


### PR DESCRIPTION
## Summary
- add a diff-aware CI gate for runtime-affecting pull requests
- require both pure-state regression evidence and integration or black-box evidence
- cover the gate with Python unit tests and document the rule in contributor/testing docs

## Why
Runtime-affecting changes have been able to land with only compile-time or narrow test proof. This gate blocks tracked daemon/runtime/restore/reconciliation changes unless the PR also adds both proof layers required by issue #202.

## Tests added
- `python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'`

## Tests run
- `python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'`
- `python3 .github/scripts/check_runtime_behavior_policy.py --base origin/mainline --head HEAD`
- `cargo build --workspace --manifest-path Cargo.toml`
- `cargo test --workspace --manifest-path Cargo.toml`
- `bash .github/scripts/run-clippy.sh`
- `bash .github/scripts/run-quality-tests.sh`

## Manual verification
- reviewed the final staged diff for scope and policy coverage
- confirmed GitHub started from no open PRs and `mainline` as the only remote branch

## Skipped
- `./run_ui_tests.sh` not run because this change only touches CI/scripts/docs and does not modify GTK/runtime behavior directly

Fixes #202
