### PR TITLE
refactor(test): consolidate daemon test harness utilities

### DIFF
--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -162,3 +162,169 @@ pub async fn wait_for_state_file(cache_dir: &std::path::Path, timeout: std::time
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
 }
+
+// ── Reusable protocol helpers ───────────────────────────────────
+//
+// These cover the most common test operations. All helpers that receive
+// server responses drain interleaved Delta messages so they work
+// reliably on slow CI runners.
+
+/// Create a session and return its ID.
+pub async fn create_session(
+    client: &mut TestClient,
+    name: &str,
+    policy: proto::RuntimePolicy,
+) -> Vec<u8> {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+                name: name.into(),
+                policy: policy as i32,
+            })),
+        })
+        .await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    }
+}
+
+/// Attach as read-write and return the snapshot.
+pub async fn attach_rw(client: &mut TestClient, session_id: &[u8]) -> proto::Snapshot {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+                session_id: session_id.to_vec(),
+                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+            })),
+        })
+        .await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(s)) => s,
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+}
+
+/// Attach as read-only and return the snapshot.
+pub async fn attach_ro(client: &mut TestClient, session_id: &[u8]) -> proto::Snapshot {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+                session_id: session_id.to_vec(),
+                attach_mode: proto::RuntimeAttachMode::ReadOnly as i32,
+            })),
+        })
+        .await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(s)) => s,
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+}
+
+/// Create a pane, draining interleaved Deltas until `PaneCreated` arrives.
+pub async fn create_pane(client: &mut TestClient, session_id: &[u8]) -> Vec<u8> {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+                session_id: session_id.to_vec(),
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::PaneCreated(pc)) => return pc.pane_id,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected PaneCreated, got {other:?}"),
+        }
+    }
+}
+
+/// Close a pane, draining interleaved Deltas and `PaneExited` until `PaneClosed`.
+pub async fn close_pane(client: &mut TestClient, session_id: &[u8], pane_id: &[u8]) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::ClosePane(proto::ClosePane {
+                session_id: session_id.to_vec(),
+                pane_id: pane_id.to_vec(),
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::PaneClosed(_)) => return,
+            Some(
+                proto::server_message::Msg::Delta(_) | proto::server_message::Msg::PaneExited(_),
+            ) => {}
+            other => panic!("expected PaneClosed, got {other:?}"),
+        }
+    }
+}
+
+/// Detach from a session, draining Deltas until `SessionDetached` or `SessionTerminated`.
+pub async fn detach_session(client: &mut TestClient, session_id: &[u8]) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::DetachSession(proto::DetachSession {
+                session_id: session_id.to_vec(),
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(
+                proto::server_message::Msg::SessionDetached(_)
+                | proto::server_message::Msg::SessionTerminated(_),
+            ) => return,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected SessionDetached/Terminated, got {other:?}"),
+        }
+    }
+}
+
+/// Terminate a session, draining Deltas until `SessionTerminated`.
+pub async fn terminate_session(client: &mut TestClient, session_id: &[u8]) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::TerminateSession(proto::TerminateSession {
+                session_id: session_id.to_vec(),
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionTerminated(_)) => return,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected SessionTerminated, got {other:?}"),
+        }
+    }
+}
+
+/// List sessions, draining pending Deltas.
+pub async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
+    client.drain(std::time::Duration::from_millis(50)).await;
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionList(sl)) => return sl.sessions,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected SessionList, got {other:?}"),
+        }
+    }
+}
+
+/// Send input to a pane (fire-and-forget, no response expected).
+pub async fn send_input(client: &mut TestClient, session_id: &[u8], pane_id: &[u8], data: &[u8]) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Input(proto::Input {
+                session_id: session_id.to_vec(),
+                pane_id: pane_id.to_vec(),
+                data: data.to_vec(),
+            })),
+        })
+        .await;
+}

--- a/services/rttx-server/tests/inventory.rs
+++ b/services/rttx-server/tests/inventory.rs
@@ -2,22 +2,9 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::{TestClient, list_sessions, start_test_server};
 use rttx_proto::proto;
 use std::time::Duration;
-
-async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
-        })
-        .await;
-
-    match client.recv().await.msg {
-        Some(proto::server_message::Msg::SessionList(list)) => list.sessions,
-        other => panic!("expected SessionList, got {other:?}"),
-    }
-}
 
 #[tokio::test]
 async fn list_sessions_includes_runtime_inventory_metadata() {

--- a/services/rttx-server/tests/lifecycle_leaks.rs
+++ b/services/rttx-server/tests/lifecycle_leaks.rs
@@ -6,139 +6,8 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::*;
 use rttx_proto::proto;
-use std::time::Duration;
-
-// ── Helpers ─────────────────────────────────────────────────────
-
-async fn create_session(
-    client: &mut TestClient,
-    name: &str,
-    policy: proto::RuntimePolicy,
-) -> Vec<u8> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
-                name: name.into(),
-                policy: policy as i32,
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
-        other => panic!("expected SessionCreated, got {other:?}"),
-    }
-}
-
-async fn attach_rw(client: &mut TestClient, session_id: &[u8]) {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
-                session_id: session_id.to_vec(),
-                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::Snapshot(_)) => {}
-        other => panic!("expected Snapshot, got {other:?}"),
-    }
-}
-
-async fn create_pane(client: &mut TestClient, session_id: &[u8]) -> Vec<u8> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
-                session_id: session_id.to_vec(),
-            })),
-        })
-        .await;
-    loop {
-        match client.recv_or_timeout().await.msg {
-            Some(proto::server_message::Msg::PaneCreated(pc)) => return pc.pane_id,
-            Some(proto::server_message::Msg::Delta(_)) => {}
-            other => panic!("expected PaneCreated, got {other:?}"),
-        }
-    }
-}
-
-async fn close_pane(client: &mut TestClient, session_id: &[u8], pane_id: &[u8]) {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ClosePane(proto::ClosePane {
-                session_id: session_id.to_vec(),
-                pane_id: pane_id.to_vec(),
-            })),
-        })
-        .await;
-    // Drain until PaneClosed — Deltas and PaneExited may interleave.
-    loop {
-        match client.recv_or_timeout().await.msg {
-            Some(proto::server_message::Msg::PaneClosed(_)) => return,
-            Some(
-                proto::server_message::Msg::Delta(_) | proto::server_message::Msg::PaneExited(_),
-            ) => {}
-            other => panic!("expected PaneClosed, got {other:?}"),
-        }
-    }
-}
-
-async fn detach(client: &mut TestClient, session_id: &[u8]) {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::DetachSession(proto::DetachSession {
-                session_id: session_id.to_vec(),
-            })),
-        })
-        .await;
-    // Drain Deltas until we get SessionDetached or SessionTerminated.
-    loop {
-        match client.recv_or_timeout().await.msg {
-            Some(
-                proto::server_message::Msg::SessionDetached(_)
-                | proto::server_message::Msg::SessionTerminated(_),
-            ) => return,
-            Some(proto::server_message::Msg::Delta(_)) => {}
-            other => panic!("expected SessionDetached/Terminated, got {other:?}"),
-        }
-    }
-}
-
-async fn terminate(client: &mut TestClient, session_id: &[u8]) {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::TerminateSession(proto::TerminateSession {
-                session_id: session_id.to_vec(),
-            })),
-        })
-        .await;
-    loop {
-        match client.recv_or_timeout().await.msg {
-            Some(proto::server_message::Msg::SessionTerminated(_)) => return,
-            Some(proto::server_message::Msg::Delta(_)) => {}
-            other => panic!("expected SessionTerminated, got {other:?}"),
-        }
-    }
-}
-
-async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
-    client.drain(Duration::from_millis(50)).await;
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
-        })
-        .await;
-    loop {
-        match client.recv_or_timeout().await.msg {
-            Some(proto::server_message::Msg::SessionList(sl)) => return sl.sessions,
-            Some(proto::server_message::Msg::Delta(_)) => {}
-            other => panic!("expected SessionList, got {other:?}"),
-        }
-    }
-}
-
-// ── Create-terminate loop ───────────────────────────────────────
 
 #[tokio::test]
 async fn create_terminate_loop_leaves_zero_sessions() {
@@ -153,14 +22,12 @@ async fn create_terminate_loop_leaves_zero_sessions() {
             create_session(&mut client, &format!("loop-{i}"), proto::RuntimePolicy::Persistent)
                 .await;
         attach_rw(&mut client, &sid).await;
-        terminate(&mut client, &sid).await;
+        terminate_session(&mut client, &sid).await;
     }
 
     let sessions = list_sessions(&mut client).await;
     assert_eq!(sessions.len(), 0, "all terminated sessions must be cleaned up");
 }
-
-// ── Create-pane-close-pane loop ─────────────────────────────────
 
 #[tokio::test]
 async fn create_close_pane_loop_returns_to_zero_panes() {
@@ -182,8 +49,6 @@ async fn create_close_pane_loop_returns_to_zero_panes() {
     assert_eq!(sessions[0].pane_count, 0, "all closed panes must be cleaned up");
 }
 
-// ── Attach-detach loop on persistent runtime ────────────────────
-
 #[tokio::test]
 async fn attach_detach_loop_persistent_session_survives() {
     let tmp = tempfile::tempdir().unwrap();
@@ -196,7 +61,7 @@ async fn attach_detach_loop_persistent_session_survives() {
 
     for _ in 0..10 {
         attach_rw(&mut client, &sid).await;
-        detach(&mut client, &sid).await;
+        detach_session(&mut client, &sid).await;
     }
 
     let sessions = list_sessions(&mut client).await;
@@ -204,8 +69,6 @@ async fn attach_detach_loop_persistent_session_survives() {
     assert_eq!(sessions[0].attached_client_count, 0);
     assert!(!sessions[0].has_write_owner);
 }
-
-// ── Ephemeral create-attach-detach loop ─────────────────────────
 
 #[tokio::test]
 async fn ephemeral_create_detach_loop_leaves_zero_sessions() {
@@ -219,14 +82,12 @@ async fn ephemeral_create_detach_loop_leaves_zero_sessions() {
         let sid =
             create_session(&mut client, &format!("eph-{i}"), proto::RuntimePolicy::Ephemeral).await;
         attach_rw(&mut client, &sid).await;
-        detach(&mut client, &sid).await;
+        detach_session(&mut client, &sid).await;
     }
 
     let sessions = list_sessions(&mut client).await;
     assert_eq!(sessions.len(), 0, "ephemeral sessions must terminate on last detach");
 }
-
-// ── Full lifecycle loop ─────────────────────────────────────────
 
 #[tokio::test]
 async fn full_lifecycle_loop_returns_to_clean_state() {
@@ -245,28 +106,24 @@ async fn full_lifecycle_loop_returns_to_clean_state() {
         let p2 = create_pane(&mut client, &sid).await;
         close_pane(&mut client, &sid, &p1).await;
         close_pane(&mut client, &sid, &p2).await;
-        terminate(&mut client, &sid).await;
+        terminate_session(&mut client, &sid).await;
     }
 
     let sessions = list_sessions(&mut client).await;
     assert_eq!(sessions.len(), 0, "full lifecycle loop must leave zero sessions");
 }
 
-// ── Reconnect loop with transport disconnect ────────────────────
-
 #[tokio::test]
 async fn reconnect_loop_does_not_leak_sessions() {
     let tmp = tempfile::tempdir().unwrap();
     let (sock, _handle) = start_test_server(tmp.path()).await;
 
-    // Create one persistent session.
     let mut c = TestClient::connect(&sock).await;
     c.handshake().await;
     let sid = create_session(&mut c, "reconnect-loop", proto::RuntimePolicy::Persistent).await;
     attach_rw(&mut c, &sid).await;
     drop(c);
 
-    // Reconnect 10 times — session count must stay at 1.
     for _ in 0..10 {
         let mut c = TestClient::connect(&sock).await;
         c.handshake().await;
@@ -276,7 +133,6 @@ async fn reconnect_loop_does_not_leak_sessions() {
         drop(c);
     }
 
-    // Final check.
     let mut c = TestClient::connect(&sock).await;
     c.handshake().await;
     let sessions = list_sessions(&mut c).await;

--- a/services/rttx-server/tests/negative_protocol.rs
+++ b/services/rttx-server/tests/negative_protocol.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::*;
 use rttx_proto::{proto, uuid_to_bytes};
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
@@ -163,7 +163,7 @@ async fn close_pane_with_nonexistent_pane_returns_error() {
     let mut client = TestClient::connect(&socket_path).await;
     client.handshake().await;
 
-    let session_id = create_session(&mut client, "test").await;
+    let session_id = create_session(&mut client, "test", proto::RuntimePolicy::Persistent).await;
 
     let msg = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::ClosePane(proto::ClosePane {
@@ -185,7 +185,7 @@ async fn resize_nonexistent_pane_returns_error() {
     let mut client = TestClient::connect(&socket_path).await;
     client.handshake().await;
 
-    let session_id = create_session(&mut client, "test").await;
+    let session_id = create_session(&mut client, "test", proto::RuntimePolicy::Persistent).await;
     attach_session(&mut client, &session_id).await;
 
     let msg = proto::ClientMessage {
@@ -212,7 +212,7 @@ async fn duplicate_close_pane_returns_error_on_second_call() {
     let mut client = TestClient::connect(&socket_path).await;
     client.handshake().await;
 
-    let session_id = create_session(&mut client, "test").await;
+    let session_id = create_session(&mut client, "test", proto::RuntimePolicy::Persistent).await;
     let pane_id = attach_and_create_pane(&mut client, &session_id).await;
 
     // First close succeeds.
@@ -246,7 +246,7 @@ async fn detach_without_attach_is_harmless() {
     let mut client = TestClient::connect(&socket_path).await;
     client.handshake().await;
 
-    let session_id = create_session(&mut client, "test").await;
+    let session_id = create_session(&mut client, "test", proto::RuntimePolicy::Persistent).await;
 
     // Detach without ever attaching — should not panic or error.
     let msg = proto::ClientMessage {
@@ -291,7 +291,7 @@ async fn input_to_nonexistent_pane_does_not_crash() {
     let mut client = TestClient::connect(&socket_path).await;
     client.handshake().await;
 
-    let session_id = create_session(&mut client, "test").await;
+    let session_id = create_session(&mut client, "test", proto::RuntimePolicy::Persistent).await;
     attach_session(&mut client, &session_id).await;
 
     let msg = proto::ClientMessage {
@@ -322,21 +322,6 @@ fn expect_error(resp: &proto::ServerMessage) -> &proto::Error {
     match &resp.msg {
         Some(proto::server_message::Msg::Error(e)) => e,
         other => panic!("expected Error, got {other:?}"),
-    }
-}
-
-async fn create_session(client: &mut TestClient, name: &str) -> Vec<u8> {
-    let msg = proto::ClientMessage {
-        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
-            name: name.into(),
-            policy: proto::RuntimePolicy::Persistent as i32,
-        })),
-    };
-    client.send(&msg).await;
-    let resp = client.recv_or_timeout().await;
-    match resp.msg {
-        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
-        other => panic!("expected SessionCreated, got {other:?}"),
     }
 }
 

--- a/services/rttx-server/tests/ownership.rs
+++ b/services/rttx-server/tests/ownership.rs
@@ -2,21 +2,8 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::{TestClient, list_sessions, start_test_server};
 use rttx_proto::proto;
-
-async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
-        })
-        .await;
-
-    match client.recv().await.msg {
-        Some(proto::server_message::Msg::SessionList(list)) => list.sessions,
-        other => panic!("expected SessionList, got {other:?}"),
-    }
-}
 
 #[tokio::test]
 async fn second_writer_attach_returns_attach_blocked() {

--- a/services/rttx-server/tests/ownership_races.rs
+++ b/services/rttx-server/tests/ownership_races.rs
@@ -6,79 +6,11 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::*;
 use rttx_proto::proto;
 use std::time::Duration;
 
 // ── Helpers ─────────────────────────────────────────────────────
-
-async fn create_session(client: &mut TestClient, name: &str) -> Vec<u8> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
-                name: name.into(),
-                policy: proto::RuntimePolicy::Persistent as i32,
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
-        other => panic!("expected SessionCreated, got {other:?}"),
-    }
-}
-
-async fn attach_rw(client: &mut TestClient, session_id: &[u8]) -> proto::Snapshot {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
-                session_id: session_id.to_vec(),
-                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::Snapshot(s)) => s,
-        other => panic!("expected Snapshot, got {other:?}"),
-    }
-}
-
-async fn attach_ro(client: &mut TestClient, session_id: &[u8]) -> proto::Snapshot {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
-                session_id: session_id.to_vec(),
-                attach_mode: proto::RuntimeAttachMode::ReadOnly as i32,
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::Snapshot(s)) => s,
-        other => panic!("expected Snapshot, got {other:?}"),
-    }
-}
-
-async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::SessionList(sl)) => sl.sessions,
-        other => panic!("expected SessionList, got {other:?}"),
-    }
-}
-
-async fn detach(client: &mut TestClient, session_id: &[u8]) {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::DetachSession(proto::DetachSession {
-                session_id: session_id.to_vec(),
-            })),
-        })
-        .await;
-    client.recv_or_timeout().await;
-}
 
 // ── Competing writer attaches ───────────────────────────────────
 
@@ -89,7 +21,7 @@ async fn three_competing_writers_only_first_succeeds() {
 
     let mut c1 = TestClient::connect(&sock).await;
     c1.handshake().await;
-    let session_id = create_session(&mut c1, "race").await;
+    let session_id = create_session(&mut c1, "race", proto::RuntimePolicy::Persistent).await;
     let snap = attach_rw(&mut c1, &session_id).await;
     assert_eq!(snap.current_client_role, proto::RuntimeClientRole::Writer as i32);
 
@@ -121,7 +53,8 @@ async fn readers_observe_pane_created_push() {
 
     let mut writer = TestClient::connect(&sock).await;
     writer.handshake().await;
-    let session_id = create_session(&mut writer, "push-test").await;
+    let session_id =
+        create_session(&mut writer, "push-test", proto::RuntimePolicy::Persistent).await;
     attach_rw(&mut writer, &session_id).await;
 
     let mut reader = TestClient::connect(&sock).await;
@@ -159,7 +92,8 @@ async fn multiple_readers_see_consistent_revision() {
 
     let mut writer = TestClient::connect(&sock).await;
     writer.handshake().await;
-    let session_id = create_session(&mut writer, "rev-test").await;
+    let session_id =
+        create_session(&mut writer, "rev-test", proto::RuntimePolicy::Persistent).await;
     let snap = attach_rw(&mut writer, &session_id).await;
     let base_rev = snap.revision;
 
@@ -191,7 +125,8 @@ async fn writer_detach_then_reader_detach_leaves_clean_state() {
 
     let mut writer = TestClient::connect(&sock).await;
     writer.handshake().await;
-    let session_id = create_session(&mut writer, "detach-race").await;
+    let session_id =
+        create_session(&mut writer, "detach-race", proto::RuntimePolicy::Persistent).await;
     attach_rw(&mut writer, &session_id).await;
 
     let mut reader = TestClient::connect(&sock).await;
@@ -199,12 +134,12 @@ async fn writer_detach_then_reader_detach_leaves_clean_state() {
     attach_ro(&mut reader, &session_id).await;
 
     // Writer detaches first.
-    detach(&mut writer, &session_id).await;
+    detach_session(&mut writer, &session_id).await;
     // Reader gets SessionDetached push.
     reader.drain(Duration::from_millis(200)).await;
 
     // Reader detaches.
-    detach(&mut reader, &session_id).await;
+    detach_session(&mut reader, &session_id).await;
 
     // Session should still exist (persistent policy).
     let mut checker = TestClient::connect(&sock).await;
@@ -222,7 +157,8 @@ async fn terminate_while_reader_attached_notifies_reader() {
 
     let mut writer = TestClient::connect(&sock).await;
     writer.handshake().await;
-    let session_id = create_session(&mut writer, "term-race").await;
+    let session_id =
+        create_session(&mut writer, "term-race", proto::RuntimePolicy::Persistent).await;
     attach_rw(&mut writer, &session_id).await;
 
     let mut reader = TestClient::connect(&sock).await;
@@ -261,7 +197,8 @@ async fn writer_disconnect_frees_ownership_for_new_writer() {
 
     let mut writer = TestClient::connect(&sock).await;
     writer.handshake().await;
-    let session_id = create_session(&mut writer, "disconnect").await;
+    let session_id =
+        create_session(&mut writer, "disconnect", proto::RuntimePolicy::Persistent).await;
     attach_rw(&mut writer, &session_id).await;
 
     // Drop the writer (simulates disconnect).
@@ -282,7 +219,8 @@ async fn reader_survives_writer_disconnect() {
 
     let mut writer = TestClient::connect(&sock).await;
     writer.handshake().await;
-    let session_id = create_session(&mut writer, "reader-survives").await;
+    let session_id =
+        create_session(&mut writer, "reader-survives", proto::RuntimePolicy::Persistent).await;
     attach_rw(&mut writer, &session_id).await;
 
     let mut reader = TestClient::connect(&sock).await;
@@ -309,7 +247,7 @@ async fn revisions_monotonic_across_attach_detach_cycle() {
 
     let mut c1 = TestClient::connect(&sock).await;
     c1.handshake().await;
-    let session_id = create_session(&mut c1, "mono-rev").await;
+    let session_id = create_session(&mut c1, "mono-rev", proto::RuntimePolicy::Persistent).await;
 
     let mut last_rev = 0u64;
 
@@ -319,7 +257,7 @@ async fn revisions_monotonic_across_attach_detach_cycle() {
         assert!(snap.revision > last_rev, "revision must increase on attach");
         last_rev = snap.revision;
 
-        detach(&mut c1, &session_id).await;
+        detach_session(&mut c1, &session_id).await;
     }
 
     // Final inventory check.

--- a/services/rttx-server/tests/pty_chaos.rs
+++ b/services/rttx-server/tests/pty_chaos.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::*;
 use rttx_proto::proto;
 use std::time::Duration;
 
@@ -37,52 +37,6 @@ async fn create_and_attach(client: &mut TestClient, name: &str) -> Vec<u8> {
         other => panic!("expected Snapshot, got {other:?}"),
     }
     session_id
-}
-
-async fn create_pane(client: &mut TestClient, session_id: &[u8]) -> Vec<u8> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
-                session_id: session_id.to_vec(),
-            })),
-        })
-        .await;
-    loop {
-        match client.recv_or_timeout().await.msg {
-            Some(proto::server_message::Msg::PaneCreated(pc)) => return pc.pane_id,
-            Some(proto::server_message::Msg::Delta(_)) => {}
-            other => panic!("expected PaneCreated, got {other:?}"),
-        }
-    }
-}
-
-async fn send_input(client: &mut TestClient, session_id: &[u8], pane_id: &[u8], data: &[u8]) {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Input(proto::Input {
-                session_id: session_id.to_vec(),
-                pane_id: pane_id.to_vec(),
-                data: data.to_vec(),
-            })),
-        })
-        .await;
-}
-
-async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
-    // Drain pending Deltas before sending ListSessions.
-    client.drain(Duration::from_millis(100)).await;
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
-        })
-        .await;
-    loop {
-        match client.recv_or_timeout().await.msg {
-            Some(proto::server_message::Msg::SessionList(sl)) => return sl.sessions,
-            Some(proto::server_message::Msg::Delta(_)) => {}
-            other => panic!("expected SessionList, got {other:?}"),
-        }
-    }
 }
 
 /// Drain messages until we find exactly one `PaneExited` for the given pane.

--- a/services/rttx-server/tests/recovery_matrix.rs
+++ b/services/rttx-server/tests/recovery_matrix.rs
@@ -15,71 +15,11 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::*;
 use rttx_proto::proto;
 use std::time::Duration;
 
 // ── Helpers ─────────────────────────────────────────────────────
-
-async fn create_session(
-    client: &mut TestClient,
-    name: &str,
-    policy: proto::RuntimePolicy,
-) -> Vec<u8> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
-                name: name.into(),
-                policy: policy as i32,
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
-        other => panic!("expected SessionCreated, got {other:?}"),
-    }
-}
-
-async fn attach_rw(client: &mut TestClient, session_id: &[u8]) -> proto::Snapshot {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
-                session_id: session_id.to_vec(),
-                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::Snapshot(s)) => s,
-        other => panic!("expected Snapshot, got {other:?}"),
-    }
-}
-
-async fn create_pane(client: &mut TestClient, session_id: &[u8]) -> Vec<u8> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
-                session_id: session_id.to_vec(),
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
-        other => panic!("expected PaneCreated, got {other:?}"),
-    }
-}
-
-async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::SessionList(sl)) => sl.sessions,
-        other => panic!("expected SessionList, got {other:?}"),
-    }
-}
 
 // ── Persistent × Transport disconnect ───────────────────────────
 

--- a/services/rttx-server/tests/revisions.rs
+++ b/services/rttx-server/tests/revisions.rs
@@ -2,22 +2,9 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::{TestClient, list_sessions, start_test_server};
 use rttx_proto::proto;
 use std::time::Duration;
-
-async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
-        })
-        .await;
-
-    match client.recv().await.msg {
-        Some(proto::server_message::Msg::SessionList(list)) => list.sessions,
-        other => panic!("expected SessionList, got {other:?}"),
-    }
-}
 
 #[tokio::test]
 async fn mutation_acks_return_monotonic_runtime_revisions() {

--- a/services/rttx-server/tests/runtime_policy.rs
+++ b/services/rttx-server/tests/runtime_policy.rs
@@ -2,22 +2,9 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::{TestClient, list_sessions, start_test_server};
 use rttx_proto::proto;
 use std::time::Duration;
-
-async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
-        })
-        .await;
-
-    match client.recv().await.msg {
-        Some(proto::server_message::Msg::SessionList(list)) => list.sessions,
-        other => panic!("expected SessionList, got {other:?}"),
-    }
-}
 
 #[tokio::test]
 async fn ephemeral_runtime_terminates_on_last_explicit_detach() {

--- a/services/rttx-server/tests/scale_stress.rs
+++ b/services/rttx-server/tests/scale_stress.rs
@@ -6,91 +6,11 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::*;
 use rttx_proto::proto;
 use std::time::Duration;
 
 // ── Helpers ─────────────────────────────────────────────────────
-
-async fn create_session(
-    client: &mut TestClient,
-    name: &str,
-    policy: proto::RuntimePolicy,
-) -> Vec<u8> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
-                name: name.into(),
-                policy: policy as i32,
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
-        other => panic!("expected SessionCreated, got {other:?}"),
-    }
-}
-
-async fn attach_rw(client: &mut TestClient, session_id: &[u8]) -> proto::Snapshot {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
-                session_id: session_id.to_vec(),
-                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
-            })),
-        })
-        .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::Snapshot(s)) => s,
-        other => panic!("expected Snapshot, got {other:?}"),
-    }
-}
-
-async fn create_pane(client: &mut TestClient, session_id: &[u8]) -> Vec<u8> {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
-                session_id: session_id.to_vec(),
-            })),
-        })
-        .await;
-    // Drain Deltas from earlier panes until we find PaneCreated.
-    loop {
-        match client.recv_or_timeout().await.msg {
-            Some(proto::server_message::Msg::PaneCreated(pc)) => return pc.pane_id,
-            Some(proto::server_message::Msg::Delta(_)) => {}
-            other => panic!("expected PaneCreated, got {other:?}"),
-        }
-    }
-}
-
-async fn list_sessions(client: &mut TestClient) -> Vec<proto::SessionInfo> {
-    client.drain(Duration::from_millis(50)).await;
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
-        })
-        .await;
-    loop {
-        match client.recv_or_timeout().await.msg {
-            Some(proto::server_message::Msg::SessionList(sl)) => return sl.sessions,
-            Some(proto::server_message::Msg::Delta(_)) => {}
-            other => panic!("expected SessionList, got {other:?}"),
-        }
-    }
-}
-
-async fn send_input(client: &mut TestClient, session_id: &[u8], pane_id: &[u8], data: &[u8]) {
-    client
-        .send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Input(proto::Input {
-                session_id: session_id.to_vec(),
-                pane_id: pane_id.to_vec(),
-                data: data.to_vec(),
-            })),
-        })
-        .await;
-}
 
 // ── Many runtimes in inventory ──────────────────────────────────
 


### PR DESCRIPTION
Move 9 duplicated protocol helpers into `common/mod.rs` per #153.

**Helpers consolidated:**
- `create_session`, `attach_rw`, `attach_ro`
- `create_pane`, `close_pane`, `send_input`
- `detach_session`, `terminate_session`, `list_sessions`

All helpers drain interleaved Delta messages for CI reliability.

**Impact:** -495 lines of duplicated boilerplate across 10 test files, +166 lines in common module. Net reduction: ~293 lines.

**Tests run:**
- `cargo test -p rttx-server -p rttx-proto` — all pass (165 tests)
- clippy, fmt — clean

Fixes #153