### PR TITLE
fix(terminal): wire search bar to VTE buffer search

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -316,3 +316,17 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod search_tests {
+    /// The PCRE2 literal escape pattern wraps user input safely so special
+    /// regex characters are not interpreted.
+    #[test]
+    fn search_regex_literal_escaping() {
+        let text = "hello.world*[test](foo)+";
+        let pattern = format!("\\Q{text}\\E");
+        assert!(pattern.starts_with("\\Q"));
+        assert!(pattern.ends_with("\\E"));
+        assert!(pattern.contains(text));
+    }
+}

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -238,6 +238,7 @@ impl PersistentPaneView {
         let obj: Self = glib::Object::builder().build();
         obj.imp().uuid.replace(uuid.to_string());
         obj.imp().session_id.replace(session_id.to_string());
+        obj.connect_search();
         obj
     }
 
@@ -324,7 +325,41 @@ impl PersistentPaneView {
         bar.set_search_mode(!bar.is_search_mode());
         if bar.is_search_mode() {
             self.imp().search_entry.grab_focus();
+        } else {
+            self.imp().vte.search_set_regex(None::<&vte4::Regex>, 0);
+            let _ = self.imp().vte.grab_focus();
         }
+    }
+
+    fn connect_search(&self) {
+        let vte = self.imp().vte.clone();
+        self.imp().search_entry.connect_search_changed(move |entry| {
+            let text = entry.text();
+            if text.is_empty() {
+                vte.search_set_regex(None::<&vte4::Regex>, 0);
+                return;
+            }
+            if let Ok(regex) = vte4::Regex::for_search(&format!("\\Q{text}\\E"), 0) {
+                vte.search_set_regex(Some(&regex), 0);
+                vte.search_set_wrap_around(true);
+                vte.search_find_previous();
+            }
+        });
+
+        let vte_next = self.imp().vte.clone();
+        self.imp().search_entry.connect_next_match(move |_| {
+            vte_next.search_find_next();
+        });
+
+        let vte_prev = self.imp().vte.clone();
+        self.imp().search_entry.connect_previous_match(move |_| {
+            vte_prev.search_find_previous();
+        });
+
+        let vte_activate = self.imp().vte.clone();
+        self.imp().search_entry.connect_activate(move |_| {
+            vte_activate.search_find_next();
+        });
     }
 
     /// Current working directory reported by the runtime.

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -260,6 +260,7 @@ impl TerminalWidget {
         let obj: Self = glib::Object::builder().build();
         obj.imp().uuid.replace(uuid.to_string());
         obj.imp().initial_cwd.replace(cwd.map(str::to_string));
+        obj.connect_search();
         obj
     }
 
@@ -324,7 +325,41 @@ impl TerminalWidget {
         bar.set_search_mode(!bar.is_search_mode());
         if bar.is_search_mode() {
             self.imp().search_entry.grab_focus();
+        } else {
+            self.imp().vte.search_set_regex(None::<&vte4::Regex>, 0);
+            let _ = self.imp().vte.grab_focus();
         }
+    }
+
+    fn connect_search(&self) {
+        let vte = self.imp().vte.clone();
+        self.imp().search_entry.connect_search_changed(move |entry| {
+            let text = entry.text();
+            if text.is_empty() {
+                vte.search_set_regex(None::<&vte4::Regex>, 0);
+                return;
+            }
+            if let Ok(regex) = vte4::Regex::for_search(&format!("\\Q{text}\\E"), 0) {
+                vte.search_set_regex(Some(&regex), 0);
+                vte.search_set_wrap_around(true);
+                vte.search_find_previous();
+            }
+        });
+
+        let vte_next = self.imp().vte.clone();
+        self.imp().search_entry.connect_next_match(move |_| {
+            vte_next.search_find_next();
+        });
+
+        let vte_prev = self.imp().vte.clone();
+        self.imp().search_entry.connect_previous_match(move |_| {
+            vte_prev.search_find_previous();
+        });
+
+        let vte_activate = self.imp().vte.clone();
+        self.imp().search_entry.connect_activate(move |_| {
+            vte_activate.search_find_next();
+        });
     }
 
     #[must_use]

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1377,3 +1377,45 @@ fn window_add_session_materializes_managed_runtime_controls() {
     remove_env("RTTX_DISABLE_SHELL_SPAWN");
     remove_env("XDG_CONFIG_HOME");
 }
+
+#[test]
+#[ignore = "requires GTK display"]
+fn terminal_search_bar_wired_to_vte() {
+    require_display!();
+
+    let term = rttx::terminal::widget::TerminalWidget::new("search-wire-test", None);
+    let window = gtk4::Window::new();
+    window.set_default_size(640, 320);
+    window.set_child(Some(&term));
+    window.present();
+    pump_events(50);
+
+    assert!(!term.search_bar().is_search_mode());
+
+    term.toggle_search();
+    assert!(term.search_bar().is_search_mode());
+
+    term.search_entry().set_text("hello");
+    pump_events(50);
+    assert!(
+        term.vte().search_get_regex().is_some(),
+        "typing in search entry must set VTE search regex"
+    );
+
+    term.search_entry().set_text("");
+    pump_events(50);
+    assert!(
+        term.vte().search_get_regex().is_none(),
+        "clearing search entry must clear VTE search regex"
+    );
+
+    term.search_entry().set_text("world");
+    pump_events(50);
+    term.toggle_search();
+    assert!(
+        term.vte().search_get_regex().is_none(),
+        "closing search bar must clear VTE search regex"
+    );
+
+    window.close();
+}


### PR DESCRIPTION
The terminal search bar was visible but never connected to VTE's search API — typing in it did nothing. Per #24.

**What changed:**
Connected `SearchEntry` signals to VTE search methods in both `TerminalWidget` (direct) and `PersistentPaneView` (managed):
- `search_changed` → `vte.search_set_regex` with PCRE2 literal pattern (`\Q...\E`)
- `activate` (Enter) → `search_find_next`
- `next_match` / `previous_match` → navigate matches
- Closing search bar clears regex and refocuses terminal

**Manual verification:**
- Build with `cargo build -p rttx --no-default-features --features vte-0_76`
- Launch rttx, type some text in terminal, press Ctrl+Shift+F (or right-click → Search)
- Type search text — VTE highlights matches and scrolls to them
- Enter navigates to next match, Shift+Enter to previous
- Closing the search bar clears highlights

**Tests run:**
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 229 pass
- `bash .github/scripts/run-quality-tests.sh` — all pass
- `dbus-run-session -- ./run_ui_tests.sh` — ran (pre-existing failures unrelated to search)
- clippy, fmt — clean

Fixes #24