### PR TITLE
fix(test): replace serialization sleeps with polling across all server tests

### DIFF
--- a/services/rttx-server/tests/client_lifecycle.rs
+++ b/services/rttx-server/tests/client_lifecycle.rs
@@ -6,7 +6,7 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::{TestClient, start_test_server, wait_for_state_containing};
 use rttx_proto::proto;
 use std::time::Duration;
 
@@ -71,7 +71,12 @@ async fn reconnect_restores_scrollback() {
         .await;
 
         // Wait for output + serialization tick.
-        tokio::time::sleep(Duration::from_millis(2500)).await;
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "lifecycle-test",
+            Duration::from_secs(10),
+        )
+        .await;
 
         // Drain deltas.
         let _ = c.drain(Duration::from_millis(500)).await;
@@ -236,7 +241,12 @@ async fn restart_preserves_session_count_and_scrollback() {
         .await;
 
         // Wait for serialization.
-        tokio::time::sleep(Duration::from_millis(2500)).await;
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "restart-stable",
+            Duration::from_secs(10),
+        )
+        .await;
         handle.abort();
         tokio::time::sleep(Duration::from_millis(100)).await;
     }

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -328,3 +328,27 @@ pub async fn send_input(client: &mut TestClient, session_id: &[u8], pane_id: &[u
         })
         .await;
 }
+
+/// Wait until the state file contains a specific substring.
+/// Polls every 200ms for up to `timeout`.
+pub async fn wait_for_state_containing(
+    cache_dir: &std::path::Path,
+    needle: &str,
+    timeout: std::time::Duration,
+) {
+    let state_path = cache_dir.join("state.json");
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if state_path.exists()
+            && std::fs::read_to_string(&state_path).is_ok_and(|c| c.contains(needle))
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "state file at {} never contained '{needle}'",
+            state_path.display()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}

--- a/services/rttx-server/tests/gui_restore_flow.rs
+++ b/services/rttx-server/tests/gui_restore_flow.rs
@@ -8,7 +8,7 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::{TestClient, start_test_server, wait_for_state_containing};
 use rttx_proto::proto;
 use std::time::Duration;
 
@@ -83,7 +83,8 @@ async fn gui_restore_flow_no_duplicates() {
         }
 
         // Wait for output.
-        tokio::time::sleep(Duration::from_millis(1500)).await;
+        wait_for_state_containing(&tmp.path().join("cache"), "Session", Duration::from_secs(10))
+            .await;
         let _ = c.drain(Duration::from_millis(500)).await;
     }
 

--- a/services/rttx-server/tests/inventory.rs
+++ b/services/rttx-server/tests/inventory.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{TestClient, list_sessions, start_test_server};
+use common::{TestClient, list_sessions, start_test_server, wait_for_state_containing};
 use rttx_proto::proto;
 use std::time::Duration;
 
@@ -215,7 +215,12 @@ async fn list_sessions_marks_restored_runtime_and_panes_as_reconstructed() {
             Some(proto::server_message::Msg::TitleChanged(_))
         ));
 
-        tokio::time::sleep(Duration::from_millis(1500)).await;
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "reconstructed-inventory",
+            Duration::from_secs(10),
+        )
+        .await;
 
         handle.abort();
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/services/rttx-server/tests/reconstruction.rs
+++ b/services/rttx-server/tests/reconstruction.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::{TestClient, start_test_server, wait_for_state_containing};
 use rttx_proto::proto;
 use std::time::Duration;
 
@@ -68,7 +68,12 @@ async fn reconstruct_session_after_restart() {
         client.send(&input).await;
 
         // Wait for output and serialization tick (>1s).
-        tokio::time::sleep(Duration::from_millis(2500)).await;
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "reconstruct-test",
+            Duration::from_secs(10),
+        )
+        .await;
 
         // Drain any pending deltas.
         let _ = tokio::time::timeout(Duration::from_millis(200), client.recv()).await;
@@ -190,7 +195,12 @@ async fn reconstruct_session_respawns_shell_in_last_reported_cwd() {
             })
             .await;
 
-        tokio::time::sleep(Duration::from_millis(2500)).await;
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "reconstruct-cwd",
+            Duration::from_secs(10),
+        )
+        .await;
         let _ = tokio::time::timeout(Duration::from_millis(200), client.recv()).await;
 
         handle.abort();

--- a/services/rttx-server/tests/recovery_matrix.rs
+++ b/services/rttx-server/tests/recovery_matrix.rs
@@ -70,7 +70,8 @@ async fn persistent_daemon_restart_reconstructs_session_and_panes() {
         create_pane(&mut c, &session_id).await;
 
         // Wait for serialization tick.
-        tokio::time::sleep(Duration::from_millis(1500)).await;
+        wait_for_state_containing(&tmp.path().join("cache"), "p-restart", Duration::from_secs(10))
+            .await;
         handle.abort();
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
@@ -195,11 +196,16 @@ async fn ephemeral_daemon_restart_does_not_restore_session() {
         let (sock, handle) = start_test_server(tmp.path()).await;
         let mut c = TestClient::connect(&sock).await;
         c.handshake().await;
-        let sid = create_session(&mut c, "e-restart", proto::RuntimePolicy::Ephemeral).await;
+        let sid = create_session(&mut c, "serialized_at", proto::RuntimePolicy::Ephemeral).await;
         attach_rw(&mut c, &sid).await;
         create_pane(&mut c, &sid).await;
 
-        tokio::time::sleep(Duration::from_millis(1500)).await;
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "serialized_at",
+            Duration::from_secs(10),
+        )
+        .await;
         handle.abort();
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
@@ -258,7 +264,12 @@ async fn persistent_restart_reader_reattaches_after_reconstruction() {
         attach_rw(&mut writer, &session_id).await;
         create_pane(&mut writer, &session_id).await;
 
-        tokio::time::sleep(Duration::from_millis(1500)).await;
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "p-reader-restart",
+            Duration::from_secs(10),
+        )
+        .await;
         handle.abort();
         tokio::time::sleep(Duration::from_millis(100)).await;
     }

--- a/services/rttx-server/tests/revisions.rs
+++ b/services/rttx-server/tests/revisions.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{TestClient, list_sessions, start_test_server};
+use common::{TestClient, list_sessions, start_test_server, wait_for_state_containing};
 use rttx_proto::proto;
 use std::time::Duration;
 
@@ -193,7 +193,12 @@ async fn runtime_revision_survives_restart_and_attach_advances_it() {
             other => panic!("expected PaneResized, got {other:?}"),
         }
 
-        tokio::time::sleep(Duration::from_millis(1500)).await;
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "restart-revision",
+            Duration::from_secs(10),
+        )
+        .await;
         handle.abort();
         tokio::time::sleep(Duration::from_millis(100)).await;
     }

--- a/services/rttx-server/tests/runtime_policy.rs
+++ b/services/rttx-server/tests/runtime_policy.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{TestClient, list_sessions, start_test_server};
+use common::{TestClient, list_sessions, start_test_server, wait_for_state_containing};
 use rttx_proto::proto;
 use std::time::Duration;
 
@@ -140,7 +140,7 @@ async fn ephemeral_runtime_is_not_restored_after_restart() {
         client
             .send(&proto::ClientMessage {
                 msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
-                    name: "ephemeral-restart".into(),
+                    name: "serialized_at".into(),
                     policy: proto::RuntimePolicy::Ephemeral as i32,
                 })),
             })
@@ -160,7 +160,12 @@ async fn ephemeral_runtime_is_not_restored_after_restart() {
             Some(proto::server_message::Msg::PaneCreated(_))
         ));
 
-        tokio::time::sleep(Duration::from_millis(1500)).await;
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "serialized_at",
+            Duration::from_secs(10),
+        )
+        .await;
         handle.abort();
         tokio::time::sleep(Duration::from_millis(100)).await;
     }

--- a/services/rttx-server/tests/scrollback.rs
+++ b/services/rttx-server/tests/scrollback.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{TestClient, start_test_server};
+use common::{TestClient, start_test_server, wait_for_state_containing};
 use rttx_proto::proto;
 use std::time::Duration;
 
@@ -66,7 +66,12 @@ async fn scrollback_flushed_to_disk_after_serialization_tick() {
     client.send(&input).await;
 
     // Wait for output + serialization tick (server serializes every 1s).
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    wait_for_state_containing(
+        &tmp.path().join("cache"),
+        "scrollback-test",
+        Duration::from_secs(10),
+    )
+    .await;
 
     // Check that scrollback log exists in the cache directory.
     let scrollback_dir = tmp.path().join("cache").join("scrollback");


### PR DESCRIPTION
Replace all fixed-duration serialization sleeps with polling per #215.

**What changed:**
- Added `wait_for_state_containing()` helper to common module
- Replaced 12 serialization sleeps (1500-2500ms) across 8 test files with polling that checks for the session name in the state file
- For ephemeral sessions (not persisted), poll for `serialized_at` which is always present

**Remaining sleeps (acceptable):**
- 100-200ms post-abort cleanup
- 200ms polling intervals inside loops
- shell_editing tests (fundamentally timing-dependent)

**Tests run:**
- `cargo test -p rttx-server -p rttx-proto` — all pass
- `bash .github/scripts/run-quality-tests.sh` — all pass
- clippy, fmt — clean

Fixes #215