### PR TITLE
fix(runtime): make close workspace destructive and suppress resurrection

### DIFF
--- a/clients/rttx/src/session/state.rs
+++ b/clients/rttx/src/session/state.rs
@@ -240,6 +240,10 @@ pub struct WindowState {
     pub left_sidebar_width: i32,
     #[serde(default = "default_right_sidebar_width")]
     pub right_sidebar_width: i32,
+    /// Runtime IDs that the user explicitly closed. Prevents inventory
+    /// resurrection until the daemon actually removes the runtime.
+    #[serde(default)]
+    pub dismissed_runtime_ids: std::collections::BTreeSet<String>,
 }
 
 impl Default for WindowState {
@@ -252,6 +256,7 @@ impl Default for WindowState {
             is_maximized: false,
             left_sidebar_width: default_left_sidebar_width(),
             right_sidebar_width: default_right_sidebar_width(),
+            dismissed_runtime_ids: std::collections::BTreeSet::new(),
         }
     }
 }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1654,11 +1654,16 @@ impl Window {
         if let Some((endpoint, runtime_id)) = managed_runtime
             && let Some(manager) = imp.connection_manager.borrow().as_ref()
         {
-            if let Some(runtime_id) = runtime_id {
-                manager.detach_runtime(session_uuid, &endpoint, &runtime_id);
+            if let Some(ref runtime_id) = runtime_id {
+                manager.terminate_runtime(session_uuid, &endpoint, runtime_id);
             }
             manager.forget_workspace(&endpoint, session_uuid);
             imp.workspace_connection_status.borrow_mut().remove(session_uuid);
+
+            // Prevent inventory resurrection of the terminated runtime.
+            if let Some(runtime_id) = runtime_id {
+                imp.state.borrow_mut().dismissed_runtime_ids.insert(runtime_id);
+            }
         }
         self.clear_workspace_reconnect_countdown(session_uuid);
 

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -70,6 +70,11 @@ pub struct EndpointEventTransition {
 }
 
 impl WindowState {
+    /// Record a runtime ID as dismissed so inventory refresh won't resurrect it.
+    pub fn dismiss_runtime(&mut self, _endpoint: &RuntimeEndpoint, runtime_id: &str) {
+        self.dismissed_runtime_ids.insert(runtime_id.to_string());
+    }
+
     /// True when startup should query an endpoint for inventory bootstrap.
     #[must_use]
     pub fn needs_inventory_bootstrap(&self, endpoint: &RuntimeEndpoint) -> bool {
@@ -216,6 +221,9 @@ impl WindowState {
             let Some(runtime_id) = session.runtime.runtime_id.clone() else {
                 continue;
             };
+            if self.dismissed_runtime_ids.contains(&runtime_id) {
+                continue;
+            }
             if !known_runtime_ids.insert(runtime_id) {
                 continue;
             }
@@ -1158,5 +1166,36 @@ mod tests {
         assert!(ws.recovery_for("t1").is_some());
         ws.prune_recovery();
         assert!(ws.recovery_for("t1").is_some());
+    }
+
+    #[test]
+    fn dismissed_runtime_is_not_resurrected_by_inventory() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let pane_id = uuid::Uuid::new_v4().to_string();
+        let mut state = WindowState::default_for_test();
+
+        // Dismiss the runtime (simulates user closing the workspace).
+        state.dismiss_runtime(&RuntimeEndpoint::Local, &runtime_id);
+
+        // Inventory refresh reports the runtime still exists on the daemon.
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::InventoryLoaded {
+            endpoint: RuntimeEndpoint::Local,
+            sessions: vec![session_info(
+                &runtime_id,
+                "Should Not Resurrect",
+                proto::RuntimePolicy::Persistent,
+                vec![pane_info(&pane_id, "Shell", "/tmp")],
+                Some(&pane_id),
+            )],
+        });
+
+        assert!(
+            transition.recovered_workspaces.is_empty(),
+            "dismissed runtime must not be resurrected by inventory"
+        );
+        assert!(
+            !state.sessions.iter().any(|s| s.runtime.runtime_id.as_deref() == Some(&runtime_id)),
+            "dismissed runtime must not appear in session state"
+        );
     }
 }

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -308,3 +308,62 @@ fn module_split_reexports_are_complete() {
     let state = WindowState::default();
     assert!(!state.sessions.is_empty());
 }
+
+/// Closing a managed workspace must dismiss the runtime so inventory
+/// refresh does not resurrect it.
+#[test]
+fn close_managed_workspace_prevents_inventory_resurrection() {
+    use rttx::daemon_bridge::EndpointEvent;
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+
+    let runtime_id = uuid::Uuid::new_v4().to_string();
+    let mut state = WindowState {
+        sessions: vec![
+            SessionState::new("Direct".into()),
+            SessionState::new_managed_local("Managed".into(), WorkspacePolicy::Persistent, None),
+        ],
+        active_session_index: 0,
+        ..WindowState::default()
+    };
+
+    // Assign a runtime ID to the managed session.
+    state.sessions[1].runtime.runtime_id = Some(runtime_id.clone());
+
+    // Simulate close: remove session and dismiss runtime.
+    state.dismiss_runtime(&RuntimeEndpoint::Local, &runtime_id);
+    state.sessions.retain(|s| s.runtime.runtime_id.as_deref() != Some(&runtime_id));
+
+    // Inventory reports the runtime still exists.
+    let pane_id = uuid::Uuid::new_v4().to_string();
+    let transition = state.reconcile_endpoint_event(&EndpointEvent::InventoryLoaded {
+        endpoint: RuntimeEndpoint::Local,
+        sessions: vec![rttx_proto::proto::SessionInfo {
+            id: uuid::Uuid::parse_str(&runtime_id).unwrap().as_bytes().to_vec(),
+            name: "Should Not Resurrect".into(),
+            pane_count: 1,
+            has_attached_client: false,
+            active_pane_id: None,
+            panes: vec![rttx_proto::proto::PaneInfo {
+                id: uuid::Uuid::parse_str(&pane_id).unwrap().as_bytes().to_vec(),
+                title: "bash".into(),
+                cwd: "/tmp".into(),
+                cols: 80,
+                rows: 24,
+                exit_status: None,
+                reconstructed: false,
+            }],
+            policy: rttx_proto::proto::RuntimePolicy::Persistent as i32,
+            attached_client_count: 0,
+            reconstructed: false,
+            revision: 1,
+            current_client_role: 0,
+            has_write_owner: false,
+            read_only_client_count: 0,
+        }],
+    });
+
+    assert!(
+        transition.recovered_workspaces.is_empty(),
+        "dismissed runtime must not be resurrected"
+    );
+}


### PR DESCRIPTION
Make Close Workspace terminate the managed runtime and prevent inventory resurrection per #192.

**Problem:** Close Workspace detached the runtime but didn't terminate it. A later inventory refresh would resurrect the workspace, violating the user contract.

**Fix:**
- `close_session`: call `terminate_runtime` instead of `detach_runtime`
- Track dismissed runtime IDs in `WindowState.dismissed_runtime_ids` (`#[serde(default)]` for backward compat)
- `recover_managed_workspaces_from_inventory`: skip dismissed runtime IDs

**Tests added:**
- `dismissed_runtime_is_not_resurrected_by_inventory` (pure-state, workspace_state.rs)
- `close_managed_workspace_prevents_inventory_resurrection` (integration, session_lifecycle.rs)

**Tests run:**
- `cargo test -p rttx --lib -- --test-threads=1` — 231 pass
- `bash .github/scripts/run-quality-tests.sh` — all pass
- Runtime behavior gate — pass
- clippy, fmt — clean

Fixes #192
Refs #191, #183