### PR TITLE
fix(runtime): remove terminate/detach from normal close dialog

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -666,4 +666,19 @@ mod tests {
         assert!(presentation.body.contains("3 panes"));
         assert!(presentation.body.contains("running processes"));
     }
+
+    /// Close dialog copy must never mention detach or terminate.
+    #[test]
+    fn workspace_actions_never_mention_detach_or_terminate() {
+        for (policy, attached) in [
+            (Some(WorkspacePolicy::Persistent), true),
+            (Some(WorkspacePolicy::Ephemeral), true),
+            (Some(WorkspacePolicy::Persistent), false),
+            (None, false),
+        ] {
+            let p = present_workspace_actions(policy, attached, 1);
+            assert!(!p.body.contains("Detach"), "body must not mention Detach: {}", p.body);
+            assert!(!p.body.contains("Terminate"), "body must not mention Terminate: {}", p.body);
+        }
+    }
 }

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -284,14 +284,12 @@ pub struct ConnectionPresentation {
     pub input_enabled: bool,
 }
 
-/// UI-facing close/detach/terminate action configuration for a workspace.
+/// UI-facing close action configuration for a workspace.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceActionPresentation {
     pub title: String,
     pub body: String,
     pub close_label: String,
-    pub show_detach_runtime: bool,
-    pub show_terminate_runtime: bool,
 }
 
 /// Render workspace action semantics into user-facing copy.
@@ -308,40 +306,21 @@ pub fn present_workspace_actions(
     };
 
     match (policy, runtime_attached) {
-        (Some(WorkspacePolicy::Persistent), true) => WorkspaceActionPresentation {
-            title: "Workspace Actions".into(),
+        (Some(_), true) => WorkspaceActionPresentation {
+            title: "Close Workspace?".into(),
             body: format!(
-                "{pane_summary}Close Workspace removes this workspace from rttx and deletes its \
-                 local metadata. The persistent runtime keeps running on the daemon. Detach \
-                 Runtime keeps the workspace so you can reconnect later. Terminate Runtime stops \
-                 the runtime and its running processes."
+                "{pane_summary}Closing this workspace will stop its runtime and all running \
+                 processes."
             ),
             close_label: "Close Workspace".into(),
-            show_detach_runtime: true,
-            show_terminate_runtime: true,
-        },
-        (Some(WorkspacePolicy::Ephemeral), true) => WorkspaceActionPresentation {
-            title: "Workspace Actions".into(),
-            body: format!(
-                "{pane_summary}Close Workspace removes this workspace from rttx and deletes its \
-                 local metadata. This workspace uses an ephemeral runtime, so detaching the last \
-                 client will terminate that runtime automatically. Detach Runtime keeps the \
-                 workspace visible but still ends the runtime when this is the last attached \
-                 client. Terminate Runtime stops it immediately."
-            ),
-            close_label: "Close Workspace".into(),
-            show_detach_runtime: true,
-            show_terminate_runtime: true,
         },
         (Some(_), false) => WorkspaceActionPresentation {
             title: "Close Workspace?".into(),
             body: format!(
-                "{pane_summary}This workspace is not attached to a runtime right now. Close \
-                 Workspace removes its local metadata from rttx."
+                "{pane_summary}This workspace is not connected to a runtime. Closing it removes \
+                 its local metadata."
             ),
             close_label: "Close Workspace".into(),
-            show_detach_runtime: false,
-            show_terminate_runtime: false,
         },
         (None, _) => {
             let body = if pane_count > 1 {
@@ -356,8 +335,6 @@ pub fn present_workspace_actions(
                 title: "Close Workspace?".into(),
                 body,
                 close_label: "Close Workspace".into(),
-                show_detach_runtime: false,
-                show_terminate_runtime: false,
             }
         }
     }
@@ -655,26 +632,21 @@ mod tests {
     }
 
     #[test]
-    fn workspace_actions_for_persistent_runtime_offer_detach_and_terminate() {
+    fn workspace_actions_for_attached_managed_workspace_shows_destructive_close() {
         let presentation = present_workspace_actions(Some(WorkspacePolicy::Persistent), true, 2);
 
-        assert_eq!(presentation.title, "Workspace Actions");
+        assert_eq!(presentation.title, "Close Workspace?");
         assert_eq!(presentation.close_label, "Close Workspace");
-        assert!(presentation.show_detach_runtime);
-        assert!(presentation.show_terminate_runtime);
-        assert!(presentation.body.contains("persistent runtime keeps running"));
-        assert!(presentation.body.contains("reconnect later"));
+        assert!(presentation.body.contains("stop its runtime"));
         assert!(presentation.body.contains("2 panes"));
     }
 
     #[test]
-    fn workspace_actions_for_ephemeral_runtime_warn_about_last_detach() {
+    fn workspace_actions_for_ephemeral_attached_shows_same_close() {
         let presentation = present_workspace_actions(Some(WorkspacePolicy::Ephemeral), true, 1);
 
-        assert!(presentation.show_detach_runtime);
-        assert!(presentation.show_terminate_runtime);
-        assert!(presentation.body.contains("ephemeral runtime"));
-        assert!(presentation.body.contains("last attached client"));
+        assert_eq!(presentation.title, "Close Workspace?");
+        assert!(presentation.body.contains("stop its runtime"));
     }
 
     #[test]
@@ -682,9 +654,7 @@ mod tests {
         let presentation = present_workspace_actions(Some(WorkspacePolicy::Persistent), false, 1);
 
         assert_eq!(presentation.title, "Close Workspace?");
-        assert!(!presentation.show_detach_runtime);
-        assert!(!presentation.show_terminate_runtime);
-        assert!(presentation.body.contains("not attached to a runtime"));
+        assert!(presentation.body.contains("not connected to a runtime"));
     }
 
     #[test]
@@ -693,8 +663,6 @@ mod tests {
 
         assert_eq!(presentation.title, "Close Workspace?");
         assert_eq!(presentation.close_label, "Close Workspace");
-        assert!(!presentation.show_detach_runtime);
-        assert!(!presentation.show_terminate_runtime);
         assert!(presentation.body.contains("3 panes"));
         assert!(presentation.body.contains("running processes"));
     }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1512,22 +1512,14 @@ impl Window {
         let uuid = session_uuid.to_string();
         let alert = adw::AlertDialog::new(Some(&presentation.title), Some(&presentation.body));
         alert.add_response("cancel", "Cancel");
-        if presentation.show_detach_runtime {
-            alert.add_response("detach", "Detach Runtime");
-        }
-        if presentation.show_terminate_runtime {
-            alert.add_response("terminate", "Terminate Runtime");
-            alert.set_response_appearance("terminate", adw::ResponseAppearance::Destructive);
-        }
         alert.add_response("close", &presentation.close_label);
         alert.set_response_appearance("close", adw::ResponseAppearance::Destructive);
         alert.set_default_response(Some("cancel"));
         alert.set_close_response("cancel");
-        alert.connect_response(None, move |_, response| match response {
-            "close" => win.close_session(&uuid),
-            "detach" => win.detach_workspace_runtime(&uuid),
-            "terminate" => win.terminate_workspace_runtime(&uuid),
-            _ => {}
+        alert.connect_response(None, move |_, response| {
+            if response == "close" {
+                win.close_session(&uuid);
+            }
         });
         alert.present(Some(self));
     }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -563,50 +563,6 @@ impl Window {
         Some(present_workspace_actions(policy, runtime_attached, session.layout.terminal_count()))
     }
 
-    pub(super) fn detach_workspace_runtime(&self, session_uuid: &str) {
-        let managed_runtime = {
-            let state = self.imp().state.borrow();
-            state.sessions.iter().find(|s| s.uuid == session_uuid).and_then(|session| {
-                session
-                    .runtime
-                    .runtime_id
-                    .clone()
-                    .map(|runtime_id| (session.runtime.endpoint.clone(), runtime_id))
-            })
-        };
-
-        let Some((endpoint, runtime_id)) = managed_runtime else {
-            return;
-        };
-        let connection_manager = self.imp().connection_manager.borrow();
-        let Some(manager) = connection_manager.as_ref() else {
-            return;
-        };
-        manager.detach_runtime(session_uuid, &endpoint, &runtime_id);
-    }
-
-    pub(super) fn terminate_workspace_runtime(&self, session_uuid: &str) {
-        let managed_runtime = {
-            let state = self.imp().state.borrow();
-            state.sessions.iter().find(|s| s.uuid == session_uuid).and_then(|session| {
-                session
-                    .runtime
-                    .runtime_id
-                    .clone()
-                    .map(|runtime_id| (session.runtime.endpoint.clone(), runtime_id))
-            })
-        };
-
-        let Some((endpoint, runtime_id)) = managed_runtime else {
-            return;
-        };
-        let connection_manager = self.imp().connection_manager.borrow();
-        let Some(manager) = connection_manager.as_ref() else {
-            return;
-        };
-        manager.terminate_runtime(session_uuid, &endpoint, &runtime_id);
-    }
-
     pub(super) fn show_edit_workspace_connection_dialog(&self, workspace_id: &str) {
         let current_host = {
             let state = self.imp().state.borrow();

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1433,3 +1433,15 @@ fn managed_terminal_paste_method_exists() {
     // routing is covered by the unit tests in terminal/mod.rs.
     let _: fn(&PersistentPaneView) -> &vte4::Terminal = PersistentPaneView::vte;
 }
+
+/// Close dialog for managed workspaces must not offer detach or terminate.
+/// Regression test for #195.
+#[test]
+fn close_dialog_has_no_detach_or_terminate_for_managed_workspace() {
+    use rttx::runtime::{WorkspacePolicy, present_workspace_actions};
+
+    let presentation = present_workspace_actions(Some(WorkspacePolicy::Persistent), true, 1);
+    assert_eq!(presentation.close_label, "Close Workspace");
+    assert!(!presentation.body.contains("Detach"));
+    assert!(!presentation.body.contains("Terminate"));
+}


### PR DESCRIPTION
Simplify managed workspace close flow per #195.

**Problem:** The close dialog offered Detach Runtime, Terminate Runtime, and Close Workspace — forcing users to understand daemon semantics for a simple close action.

**Fix:** Remove Detach Runtime and Terminate Runtime from the dialog. Only Cancel and Close Workspace remain. Close Workspace already terminates the runtime and suppresses resurrection (from #192).

**What changed:**
- Removed `show_detach_runtime` and `show_terminate_runtime` from `WorkspaceActionPresentation`
- Simplified dialog to Cancel + Close Workspace (destructive)
- Removed dead `detach_workspace_runtime` and `terminate_workspace_runtime` methods
- Simplified copy: no mention of detach/terminate semantics
- Net: -84 lines

**Tests run:**
- `cargo test -p rttx --lib -- --test-threads=1` — 233 pass
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- clippy, fmt — clean

Fixes #195
Refs #191