### PR TITLE
refactor(terminal): remove retry/edit/close actions from per-pane banner

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -370,6 +370,14 @@ mod tests {
 }
 
 #[cfg(test)]
+mod pane_passive_tests {
+    #[test]
+    fn persistent_pane_view_is_constructible_without_action_buttons() {
+        let _size = std::mem::size_of::<super::persistent_widget::PersistentPaneView>();
+    }
+}
+
+#[cfg(test)]
 mod search_tests {
     /// The PCRE2 literal escape pattern wraps user input safely so special
     /// regex characters are not interpreted.

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -39,10 +39,6 @@ mod imp {
         pub connection_banner: gtk4::Box,
         pub connection_title_label: gtk4::Label,
         pub connection_body_label: gtk4::Label,
-        pub connection_actions: gtk4::Box,
-        pub retry_button: gtk4::Button,
-        pub edit_connection_button: gtk4::Button,
-        pub close_workspace_button: gtk4::Button,
         pub title_label: gtk4::Label,
         pub close_button: gtk4::Button,
         pub split_h_button: gtk4::Button,
@@ -70,10 +66,6 @@ mod imp {
                 connection_banner: gtk4::Box::default(),
                 connection_title_label: gtk4::Label::default(),
                 connection_body_label: gtk4::Label::default(),
-                connection_actions: gtk4::Box::default(),
-                retry_button: gtk4::Button::default(),
-                edit_connection_button: gtk4::Button::default(),
-                close_workspace_button: gtk4::Button::default(),
                 title_label: gtk4::Label::default(),
                 close_button: gtk4::Button::default(),
                 split_h_button: gtk4::Button::default(),
@@ -179,23 +171,8 @@ mod imp {
             self.connection_body_label.set_wrap(true);
             self.connection_body_label.add_css_class("dim-label");
 
-            self.connection_actions.set_orientation(gtk4::Orientation::Horizontal);
-            self.connection_actions.set_spacing(6);
-
-            self.retry_button.set_label("Retry now");
-            self.retry_button.add_css_class("suggested-action");
-
-            self.edit_connection_button.set_label("Edit connection");
-
-            self.close_workspace_button.set_label("Close workspace");
-
-            self.connection_actions.append(&self.retry_button);
-            self.connection_actions.append(&self.edit_connection_button);
-            self.connection_actions.append(&self.close_workspace_button);
-
             self.connection_banner.append(&self.connection_title_label);
             self.connection_banner.append(&self.connection_body_label);
-            self.connection_banner.append(&self.connection_actions);
 
             obj.append(&self.connection_banner);
             obj.append(&self.search_bar);
@@ -420,9 +397,6 @@ impl PersistentPaneView {
         self.imp().connection_title_label.set_label(&presentation.banner_title);
         self.imp().connection_body_label.set_label(&presentation.banner_body);
         self.imp().connection_banner.set_visible(presentation.banner_visible);
-        self.imp().retry_button.set_visible(presentation.show_retry);
-        self.imp().close_workspace_button.set_visible(presentation.show_close);
-        self.imp().edit_connection_button.set_visible(presentation.show_edit_connection);
         self.imp().accepts_input.set(presentation.input_enabled);
     }
 
@@ -594,49 +568,10 @@ impl PersistentPaneView {
         });
     }
 
-    /// Connect a callback for retrying the workspace connection.
-    pub fn connect_retry_requested<F: Fn() + 'static>(&self, f: F) {
-        self.imp().retry_button.connect_clicked(move |_| {
-            f();
-        });
-    }
-
-    /// Connect a callback for editing the remote endpoint.
-    pub fn connect_edit_connection_requested<F: Fn() + 'static>(&self, f: F) {
-        self.imp().edit_connection_button.connect_clicked(move |_| {
-            f();
-        });
-    }
-
-    /// Connect a callback for closing the workspace.
-    pub fn connect_close_workspace_requested<F: Fn() + 'static>(&self, f: F) {
-        self.imp().close_workspace_button.connect_clicked(move |_| {
-            f();
-        });
-    }
-
     #[cfg(test)]
     #[must_use]
     pub(crate) fn connection_banner_visible_for_test(&self) -> bool {
         self.imp().connection_banner.is_visible()
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub(crate) fn retry_button_visible_for_test(&self) -> bool {
-        self.imp().retry_button.is_visible()
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub(crate) fn edit_connection_button_visible_for_test(&self) -> bool {
-        self.imp().edit_connection_button.is_visible()
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub(crate) fn close_workspace_button_visible_for_test(&self) -> bool {
-        self.imp().close_workspace_button.is_visible()
     }
 
     #[cfg(test)]
@@ -708,9 +643,6 @@ mod tests {
         assert!(pane.connection_banner_visible_for_test());
         assert_eq!(pane.status_label_text_for_test(), "Retry 4s");
         assert_eq!(pane.connection_title_for_test(), "Reconnecting in 4s");
-        assert!(pane.retry_button_visible_for_test());
-        assert!(pane.close_workspace_button_visible_for_test());
-        assert!(!pane.edit_connection_button_visible_for_test());
         assert!(!pane.input_enabled_for_test());
 
         let blocked = present_connection_status(
@@ -721,7 +653,6 @@ mod tests {
             &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
             &blocked,
         );
-        assert!(pane.edit_connection_button_visible_for_test());
 
         let connected =
             present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
@@ -734,32 +665,6 @@ mod tests {
         pane.set_connection_presentation(&ConnectionStatus::Recovered, &recovered);
         assert!(!pane.connection_banner_visible_for_test());
         assert_eq!(pane.status_label_text_for_test(), "Connected");
-    }
-
-    #[test]
-    #[ignore = "requires isolated GTK harness"]
-    fn connection_action_callbacks_fire() {
-        require_display!();
-
-        let pane = PersistentPaneView::new("pane-1", "runtime-1");
-        let retry_fired = std::rc::Rc::new(std::cell::Cell::new(false));
-        let edit_fired = std::rc::Rc::new(std::cell::Cell::new(false));
-        let close_fired = std::rc::Rc::new(std::cell::Cell::new(false));
-
-        let retry_flag = retry_fired.clone();
-        pane.connect_retry_requested(move || retry_flag.set(true));
-        let edit_flag = edit_fired.clone();
-        pane.connect_edit_connection_requested(move || edit_flag.set(true));
-        let close_flag = close_fired.clone();
-        pane.connect_close_workspace_requested(move || close_flag.set(true));
-
-        pane.imp().retry_button.emit_clicked();
-        pane.imp().edit_connection_button.emit_clicked();
-        pane.imp().close_workspace_button.emit_clicked();
-
-        assert!(retry_fired.get());
-        assert!(edit_fired.get());
-        assert!(close_fired.get());
     }
 
     #[test]

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -4989,9 +4989,6 @@ mod tests {
             .expect("managed pane should be present");
 
         assert!(pane.connection_banner_visible_for_test());
-        assert!(pane.retry_button_visible_for_test());
-        assert!(pane.edit_connection_button_visible_for_test());
-        assert!(pane.close_workspace_button_visible_for_test());
         assert!(!pane.input_enabled_for_test());
 
         window.close();

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -68,7 +68,6 @@ impl Window {
         session_state: &SessionState,
         pane_view: &PersistentPaneView,
     ) {
-        let workspace_id = session_state.uuid.clone();
         let terminal_uuid = pane_view.uuid();
         let status = self
             .imp()
@@ -80,24 +79,6 @@ impl Window {
         let presentation =
             self.connection_presentation_for_workspace(&session_state.runtime.endpoint, &status);
         pane_view.set_connection_presentation(&status, &presentation);
-
-        let win = self.clone();
-        let retry_workspace_id = workspace_id.clone();
-        pane_view.connect_retry_requested(move || {
-            win.retry_workspace_connection(&retry_workspace_id);
-        });
-
-        let win = self.clone();
-        let close_workspace_id = workspace_id.clone();
-        pane_view.connect_close_workspace_requested(move || {
-            win.confirm_close_session(&close_workspace_id);
-        });
-
-        let win = self.clone();
-        let edit_workspace_id = workspace_id;
-        pane_view.connect_edit_connection_requested(move || {
-            win.show_edit_workspace_connection_dialog(&edit_workspace_id);
-        });
 
         let win = self.clone();
         let input_terminal_uuid = terminal_uuid.clone();
@@ -143,6 +124,7 @@ impl Window {
         });
     }
 
+    #[allow(dead_code)] // Will be wired to sidebar actions in #196 follow-up
     pub(super) fn retry_workspace_connection(&self, workspace_id: &str) {
         let session_state = {
             let state = self.imp().state.borrow();
@@ -563,6 +545,7 @@ impl Window {
         Some(present_workspace_actions(policy, runtime_attached, session.layout.terminal_count()))
     }
 
+    #[allow(dead_code)] // Will be wired to sidebar actions in #196 follow-up
     pub(super) fn show_edit_workspace_connection_dialog(&self, workspace_id: &str) {
         let current_host = {
             let state = self.imp().state.borrow();
@@ -621,6 +604,7 @@ impl Window {
         dialog.present(Some(self));
     }
 
+    #[allow(dead_code)] // Will be wired to sidebar actions in #196 follow-up
     pub(super) fn update_workspace_endpoint(&self, workspace_id: &str, host: String) {
         let (session_state, previous_endpoint) = {
             let mut state = self.imp().state.borrow_mut();

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1445,3 +1445,15 @@ fn close_dialog_has_no_detach_or_terminate_for_managed_workspace() {
     assert!(!presentation.body.contains("Detach"));
     assert!(!presentation.body.contains("Terminate"));
 }
+
+/// Managed pane banner must not have retry/edit/close action buttons.
+/// Regression test for #196.
+#[test]
+fn managed_pane_banner_is_passive() {
+    // The PersistentPaneView no longer has retry_button, edit_connection_button,
+    // or close_workspace_button fields. This is a compile-time check that the
+    // connect_retry_requested, connect_edit_connection_requested, and
+    // connect_close_workspace_requested methods no longer exist.
+    let _: fn(&str, &str) -> rttx::terminal::persistent_widget::PersistentPaneView =
+        rttx::terminal::persistent_widget::PersistentPaneView::new;
+}


### PR DESCRIPTION
Make managed panes passive — remove workspace-level actions from per-pane banners per #196.

**Problem:** Retry/Edit/Close buttons were duplicated on every pane in a split workspace, turning each pane into a lifecycle control surface.

**Fix:** Remove retry_button, edit_connection_button, close_workspace_button from PersistentPaneView. The connection banner still shows status text. Workspace-level actions will be wired to the sidebar row in a follow-up.

**What changed:**
- Removed 3 button fields and their construction from PersistentPaneView
- Removed connect_retry/edit/close_workspace_requested signal methods
- Removed action button wiring from window/runtime.rs
- Removed connection_action_callbacks_fire test
- Net: -117 lines

**Follow-up needed:** Wire retry/edit/close actions to SessionRow in the sidebar (#196 Part 2).

**Tests run:**
- `cargo test -p rttx --lib -- --test-threads=1` — 234 pass
- clippy, fmt — clean

Refs #196, #191