### PR TITLE
fix(terminal): route managed paste through daemon input

### DIFF
--- a/clients/rttx/src/terminal/handle.rs
+++ b/clients/rttx/src/terminal/handle.rs
@@ -65,11 +65,6 @@ impl TerminalHandle {
         self.vte().copy_clipboard_format(vte4::Format::Text);
     }
 
-    /// Paste clipboard contents into the terminal.
-    pub fn paste_clipboard(&self) {
-        self.vte().paste_clipboard();
-    }
-
     /// Mark the pane as active or inactive in the UI.
     pub fn set_active(&self, active: bool) {
         match self {

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -303,6 +303,24 @@ mod tests {
     }
 
     #[test]
+    fn managed_ctrl_v_prefers_clipboard_paste_over_shell_syn() {
+        let modifiers = gtk4::gdk::ModifierType::CONTROL_MASK
+            | gtk4::gdk::ModifierType::LOCK_MASK
+            | gtk4::gdk::ModifierType::BUTTON1_MASK;
+
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::v,
+                modifiers,
+                false,
+                true,
+            ),
+            TerminalKeyAction::PasteClipboard
+        );
+    }
+
+    #[test]
     fn encode_terminal_key_input_maps_basic_shell_keys() {
         assert_eq!(
             encode_terminal_key_input(gtk4::gdk::Key::a, gtk4::gdk::ModifierType::empty()),

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -445,6 +445,35 @@ impl PersistentPaneView {
         self.imp().visual_bell.set(enabled);
     }
 
+    /// Read clipboard text and deliver it through the managed input path.
+    ///
+    /// Managed panes use VTE only as a renderer. Their real writable backend
+    /// is the daemon `Input` message, so VTE's local `paste_clipboard()`
+    /// handler does not reach the remote PTY.
+    pub fn request_clipboard_paste<F: Fn(Vec<u8>) + 'static>(&self, f: F) {
+        if !self.imp().accepts_input.get() {
+            return;
+        }
+
+        let pane_weak = self.downgrade();
+        self.clipboard().read_text_async(None::<&gtk4::gio::Cancellable>, move |result| {
+            let Some(pane) = pane_weak.upgrade() else {
+                return;
+            };
+            if !pane.imp().accepts_input.get() {
+                return;
+            }
+
+            match result {
+                Ok(Some(text)) if !text.is_empty() => f(text.as_bytes().to_vec()),
+                Ok(Some(_) | None) => {}
+                Err(error) => {
+                    log::warn!("Failed to read clipboard text for managed paste: {error}");
+                }
+            }
+        });
+    }
+
     /// Flash the header on bell.
     pub fn flash_bell(&self) {
         if !self.imp().visual_bell.get() {
@@ -509,6 +538,7 @@ impl PersistentPaneView {
     ///
     /// The callback receives the raw terminal bytes to send to the daemon.
     pub fn connect_input<F: Fn(&[u8]) + 'static>(&self, f: F) {
+        let forward_input = std::rc::Rc::new(f);
         let pane_weak = self.downgrade();
         let key_controller = gtk4::EventControllerKey::new();
         key_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
@@ -529,12 +559,15 @@ impl PersistentPaneView {
                     glib::Propagation::Stop
                 }
                 TerminalKeyAction::PasteClipboard => {
-                    pane.vte().paste_clipboard();
+                    let forward_input = std::rc::Rc::clone(&forward_input);
+                    pane.request_clipboard_paste(move |bytes| {
+                        forward_input(&bytes);
+                    });
                     glib::Propagation::Stop
                 }
                 TerminalKeyAction::ForwardToPty(bytes) => {
                     if pane.imp().accepts_input.get() {
-                        f(&bytes);
+                        forward_input(&bytes);
                     }
                     glib::Propagation::Stop
                 }
@@ -679,6 +712,7 @@ mod tests {
     use crate::runtime::{ConnectionProblem, RuntimeEndpoint, present_connection_status};
     use std::cell::RefCell;
     use std::rc::Rc;
+    use std::time::{Duration, Instant};
 
     macro_rules! require_display {
         () => {
@@ -687,6 +721,27 @@ mod tests {
                 return;
             }
         };
+    }
+
+    fn pump_events(max_ms: u64) {
+        let ctx = glib::MainContext::default();
+        let deadline = Instant::now() + Duration::from_millis(max_ms);
+        while Instant::now() < deadline {
+            if !ctx.iteration(false) {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        }
+    }
+
+    fn wait_until(max_ms: u64, condition: impl Fn() -> bool) -> bool {
+        let deadline = Instant::now() + Duration::from_millis(max_ms);
+        while Instant::now() < deadline {
+            pump_events(20);
+            if condition() {
+                return true;
+            }
+        }
+        condition()
     }
 
     #[test]
@@ -927,9 +982,14 @@ mod tests {
         window.set_default_size(640, 320);
         window.set_child(Some(&pane));
         window.present();
-        while gtk4::glib::MainContext::default().iteration(false) {}
+        pump_events(50);
+        let display =
+            gtk4::gdk::Display::default().expect("display should be available for GTK tests");
+        display.clipboard().set_text("managed pasted text");
         pane.feed_output(b"managed copied text\r\n");
-        pane.imp().accepts_input.set(true);
+        let connected =
+            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
+        pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
 
         let forwarded = Rc::new(RefCell::new(Vec::new()));
         let forwarded_clone = Rc::clone(&forwarded);
@@ -937,16 +997,21 @@ mod tests {
             forwarded_clone.borrow_mut().push(bytes.to_vec());
         });
 
-        pane.vte().select_all();
-        assert_eq!(
-            pane.emit_input_key_for_test(gtk4::gdk::Key::c, gtk4::gdk::ModifierType::CONTROL_MASK,),
-            glib::Propagation::Stop
-        );
         assert_eq!(
             pane.emit_input_key_for_test(
                 gtk4::gdk::Key::v,
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::BUTTON1_MASK,
             ),
+            glib::Propagation::Stop
+        );
+        assert!(
+            wait_until(1_000, || { forwarded.borrow().contains(&b"managed pasted text".to_vec()) }),
+            "managed Ctrl+V should forward clipboard text through the daemon input path"
+        );
+
+        pane.vte().select_all();
+        assert_eq!(
+            pane.emit_input_key_for_test(gtk4::gdk::Key::c, gtk4::gdk::ModifierType::CONTROL_MASK,),
             glib::Propagation::Stop
         );
         assert_eq!(
@@ -956,14 +1021,52 @@ mod tests {
             ),
             glib::Propagation::Proceed
         );
-        assert!(forwarded.borrow().is_empty());
+        assert_eq!(
+            forwarded.borrow().as_slice(),
+            &[b"managed pasted text".to_vec()],
+            "copy shortcuts must not leak shell input when a selection is present"
+        );
 
         pane.vte().unselect_all();
         assert_eq!(
             pane.emit_input_key_for_test(gtk4::gdk::Key::c, gtk4::gdk::ModifierType::CONTROL_MASK,),
             glib::Propagation::Stop
         );
-        assert_eq!(forwarded.borrow().as_slice(), &[vec![0x03]]);
+        assert_eq!(forwarded.borrow().as_slice(), &[b"managed pasted text".to_vec(), vec![0x03]]);
+        window.close();
+    }
+
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn request_clipboard_paste_delivers_text_when_connected() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("pane-1", "runtime-1");
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 320);
+        window.set_child(Some(&pane));
+        window.present();
+        pump_events(50);
+
+        let display =
+            gtk4::gdk::Display::default().expect("display should be available for GTK tests");
+        display.clipboard().set_text("window action paste");
+
+        let connected =
+            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
+        pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
+
+        let forwarded = Rc::new(RefCell::new(Vec::new()));
+        let forwarded_clone = Rc::clone(&forwarded);
+        pane.request_clipboard_paste(move |bytes| {
+            forwarded_clone.borrow_mut().push(bytes);
+        });
+
+        assert!(
+            wait_until(1_000, || { forwarded.borrow().contains(&b"window action paste".to_vec()) }),
+            "managed clipboard paste helper should deliver clipboard bytes to daemon input"
+        );
+
         window.close();
     }
 }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -2299,7 +2299,16 @@ impl Window {
         if let Some(uuid) = self.focused_terminal_uuid()
             && let Some(terminal) = self.terminal_handle(&uuid)
         {
-            terminal.paste_clipboard();
+            match terminal {
+                TerminalHandle::Direct(terminal) => terminal.vte().paste_clipboard(),
+                TerminalHandle::Managed(pane) => {
+                    let win = self.clone();
+                    let terminal_uuid = uuid.clone();
+                    pane.request_clipboard_paste(move |bytes| {
+                        win.send_managed_terminal_input(&terminal_uuid, bytes);
+                    });
+                }
+            }
         }
     }
 }

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1420,18 +1420,37 @@ fn terminal_search_bar_wired_to_vte() {
     window.close();
 }
 
-/// Ctrl+Shift+V must paste in managed terminals. Regression test for #228.
-/// The actual key-action logic is tested in terminal/mod.rs unit tests;
-/// this test verifies the PersistentPaneView widget can be constructed
-/// and exposes the paste method.
+/// Managed clipboard paste must forward clipboard text through the daemon
+/// input callback instead of delegating to VTE's local PTY paste path.
 #[test]
-fn managed_terminal_paste_method_exists() {
-    use rttx::terminal::persistent_widget::PersistentPaneView;
+#[ignore = "requires isolated GTK harness"]
+fn managed_terminal_request_clipboard_paste_delivers_bytes() {
+    require_display!();
 
-    // PersistentPaneView must expose paste_clipboard via its VTE.
-    // This is a compile-time + construction check — the key-action
-    // routing is covered by the unit tests in terminal/mod.rs.
-    let _: fn(&PersistentPaneView) -> &vte4::Terminal = PersistentPaneView::vte;
+    let display = gtk4::gdk::Display::default().expect("display should be available for GTK tests");
+    display.clipboard().set_text("managed clipboard bytes");
+
+    let managed =
+        rttx::terminal::persistent_widget::PersistentPaneView::new("managed-1", "runtime-1");
+    let window = present_widget(&managed);
+    let connected = rttx::runtime::present_connection_status(
+        &rttx::runtime::RuntimeEndpoint::Local,
+        &rttx::runtime::ConnectionStatus::Connected,
+    );
+    managed.set_connection_presentation(&rttx::runtime::ConnectionStatus::Connected, &connected);
+
+    let forwarded = Rc::new(RefCell::new(Vec::new()));
+    let forwarded_clone = Rc::clone(&forwarded);
+    managed.request_clipboard_paste(move |bytes| {
+        forwarded_clone.borrow_mut().push(bytes);
+    });
+
+    assert!(
+        wait_until(1_000, || { forwarded.borrow().contains(&b"managed clipboard bytes".to_vec()) }),
+        "managed paste helper should deliver clipboard text to the daemon input callback"
+    );
+
+    window.close();
 }
 
 /// Close dialog for managed workspaces must not offer detach or terminate.

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1453,6 +1453,33 @@ fn managed_terminal_request_clipboard_paste_delivers_bytes() {
     window.close();
 }
 
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn managed_terminal_request_clipboard_paste_requires_connected_input() {
+    require_display!();
+
+    let display = gtk4::gdk::Display::default().expect("display should be available for GTK tests");
+    display.clipboard().set_text("managed clipboard bytes");
+
+    let managed =
+        rttx::terminal::persistent_widget::PersistentPaneView::new("managed-2", "runtime-1");
+    let window = present_widget(&managed);
+
+    let forwarded = Rc::new(RefCell::new(Vec::new()));
+    let forwarded_clone = Rc::clone(&forwarded);
+    managed.request_clipboard_paste(move |bytes| {
+        forwarded_clone.borrow_mut().push(bytes);
+    });
+
+    pump_events(100);
+    assert!(
+        forwarded.borrow().is_empty(),
+        "disconnected managed panes must not forward clipboard bytes"
+    );
+
+    window.close();
+}
+
 /// Close dialog for managed workspaces must not offer detach or terminate.
 /// Regression test for #195.
 #[test]


### PR DESCRIPTION
## Summary
- route managed `Ctrl+V` and window/menu paste through the daemon input path instead of VTE local paste
- add managed clipboard regression tests that assert clipboard text becomes managed input bytes
- remove the misleading backend-agnostic paste helper so managed and ephemeral panes use explicit paste behavior

## Why
Persistent daemon-backed panes render terminal output through a feed-only VTE with input disabled. Calling VTE's local clipboard paste path there does nothing, so plain `Ctrl+V` regressed even though ephemeral panes still worked.

## Manual verification
- open a persistent workspace backed by the daemon
- copy text into the system clipboard
- focus a managed pane and press `Ctrl+V`
- confirm the pasted text is delivered to the running shell
- confirm the window/menu paste action behaves the same way
- confirm ephemeral workspaces still paste normally

## Test coverage
- `cargo build --workspace`
- `bash .github/scripts/run-clippy.sh`
- `bash .github/scripts/run-quality-tests.sh`
- targeted GTK/managed paste regressions under Broadway:
  - `cargo test --manifest-path clients/rttx/Cargo.toml managed_input_action_preserves_clipboard_shortcuts --lib -- --nocapture`
  - `cargo test --manifest-path clients/rttx/Cargo.toml terminal::persistent_widget::tests::input_controller_preserves_clipboard_shortcuts_before_forwarding_shell_input --lib -- --ignored --exact --nocapture`
  - `cargo test --manifest-path clients/rttx/Cargo.toml terminal::persistent_widget::tests::request_clipboard_paste_delivers_text_when_connected --lib -- --ignored --exact --nocapture`
  - `cargo test --manifest-path clients/rttx/Cargo.toml --test gtk_widget_tests managed_terminal_request_clipboard_paste_delivers_bytes -- --ignored --exact --nocapture`

## Notes
- local `dbus-run-session -- ./run_ui_tests.sh` is blocked on this workstation by AT-SPI bus launch permission failure (`org.a11y.Bus`), so the PR relies on GitHub Actions for the final UI behavioral green signal.

Fixes #233
