### PR TITLE
feat(session): add SessionState::new_managed_remote() factory

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -82,9 +82,27 @@ impl WorkspaceRuntime {
     /// Create managed local runtime metadata for a new workspace.
     #[must_use]
     pub fn managed_local(policy: WorkspacePolicy, layout_terminal_uuids: &[String]) -> Self {
+        Self::managed(RuntimeEndpoint::Local, policy, layout_terminal_uuids)
+    }
+
+    /// Create managed remote runtime metadata for a new workspace.
+    #[must_use]
+    pub fn managed_remote(
+        host: &str,
+        policy: WorkspacePolicy,
+        layout_terminal_uuids: &[String],
+    ) -> Self {
+        Self::managed(RuntimeEndpoint::Remote { host: host.into() }, policy, layout_terminal_uuids)
+    }
+
+    fn managed(
+        endpoint: RuntimeEndpoint,
+        policy: WorkspacePolicy,
+        layout_terminal_uuids: &[String],
+    ) -> Self {
         let mut runtime = Self {
             managed: true,
-            endpoint: RuntimeEndpoint::Local,
+            endpoint,
             policy,
             runtime_id: None,
             pane_bindings: BTreeMap::new(),
@@ -680,5 +698,19 @@ mod tests {
             assert!(!p.body.contains("Detach"), "body must not mention Detach: {}", p.body);
             assert!(!p.body.contains("Terminate"), "body must not mention Terminate: {}", p.body);
         }
+    }
+
+    #[test]
+    fn managed_remote_sets_endpoint_and_policy() {
+        let uuids = vec!["t1".into()];
+        let runtime = WorkspaceRuntime::managed_remote(
+            "server.example.com",
+            WorkspacePolicy::Persistent,
+            &uuids,
+        );
+        assert!(runtime.is_managed());
+        assert_eq!(runtime.endpoint, RuntimeEndpoint::Remote { host: "server.example.com".into() });
+        assert_eq!(runtime.policy, WorkspacePolicy::Persistent);
+        assert!(runtime.pending_layout_panes.contains("t1"));
     }
 }

--- a/clients/rttx/src/session/state.rs
+++ b/clients/rttx/src/session/state.rs
@@ -111,6 +111,20 @@ impl SessionState {
         session
     }
 
+    #[must_use]
+    pub fn new_managed_remote(
+        name: String,
+        host: &str,
+        policy: WorkspacePolicy,
+        initial_cwd: Option<String>,
+    ) -> Self {
+        let mut session = Self::new_with_initial_cwd(name, initial_cwd);
+        let layout_terminal_uuids = session.layout.terminal_uuids();
+        session.runtime = WorkspaceRuntime::managed_remote(host, policy, &layout_terminal_uuids);
+        session.sync_legacy_mode_from_runtime();
+        session
+    }
+
     #[cfg(test)]
     #[must_use]
     pub fn default_for_test() -> Self {
@@ -650,5 +664,32 @@ mod module_boundary_tests {
         assert_eq!(session.layout.terminal_count(), 1);
         assert!(session.recovery_for(&new_uuid).is_none());
         assert!(session.recovery_for(&uuid).is_some());
+    }
+
+    #[test]
+    fn new_managed_remote_sets_endpoint_and_mode() {
+        let session = SessionState::new_managed_remote(
+            "Work".into(),
+            "server.example.com",
+            WorkspacePolicy::Persistent,
+            Some("/home/user".into()),
+        );
+        assert!(session.runtime.is_managed());
+        assert_eq!(
+            session.runtime.endpoint,
+            RuntimeEndpoint::Remote { host: "server.example.com".into() }
+        );
+        assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
+        assert_eq!(
+            session.mode,
+            SessionMode::RemotePersistent {
+                host: "server.example.com".into(),
+                daemon_session_id: String::new(),
+            }
+        );
+        assert_eq!(
+            session.layout.terminal_cwd(&session.layout.terminal_uuids()[0]).as_deref(),
+            Some("/home/user")
+        );
     }
 }

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -482,3 +482,25 @@ fn layout_cwd_survives_reconnect_cycle() {
     // Simulate disconnect: CWD should not be cleared.
     assert_eq!(session.layout.terminal_cwd(&uuid).as_deref(), Some("/project/dir"),);
 }
+
+/// `new_managed_remote` must produce a valid remote-persistent session.
+#[test]
+fn new_managed_remote_produces_remote_persistent_session() {
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+    use rttx::session::SessionState;
+
+    let session = SessionState::new_managed_remote(
+        "Remote Work".into(),
+        "dev-box.internal",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+
+    assert!(session.runtime.is_managed());
+    assert_eq!(
+        session.runtime.endpoint,
+        RuntimeEndpoint::Remote { host: "dev-box.internal".into() }
+    );
+    assert!(!session.layout.terminal_uuids().is_empty());
+    assert!(!session.runtime.pending_layout_panes.is_empty());
+}


### PR DESCRIPTION
Add `WorkspaceRuntime::managed_remote()` and `SessionState::new_managed_remote()` to create managed workspaces targeting a remote daemon endpoint via SSH.

## What changed

- `WorkspaceRuntime::managed_remote(host, policy, layout_terminal_uuids)` — creates managed runtime metadata with `RuntimeEndpoint::Remote { host }`
- `SessionState::new_managed_remote(name, host, policy, initial_cwd)` — creates a complete session state for a remote managed workspace
- Refactored `managed_local()` to share implementation with `managed_remote()` through a private `managed()` helper — no behavior change for existing callers

## Manual verification

```rust
let session = SessionState::new_managed_remote(
    "Work".into(),
    "dev-box.internal",
    WorkspacePolicy::Persistent,
    Some("/home/user".into()),
);
assert!(session.runtime.is_managed());
assert_eq!(session.runtime.endpoint, RuntimeEndpoint::Remote { host: "dev-box.internal".into() });
assert!(matches!(session.mode, SessionMode::RemotePersistent { .. }));
```

## Tests added

- `managed_remote_sets_endpoint_and_policy` — pure-state unit test for `WorkspaceRuntime::managed_remote()`
- `new_managed_remote_sets_endpoint_and_mode` — pure-state unit test for `SessionState::new_managed_remote()` verifying endpoint, mode, policy, and CWD
- `new_managed_remote_produces_remote_persistent_session` — integration test in `session_lifecycle.rs`

## Tests run

- `cargo test -p rttx --lib -- --test-threads=1` — 242 pass
- `cargo test -p rttx-server -p rttx-proto` — all pass
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- Runtime behavior gate — passes
- clippy, fmt — clean

Fixes #241