### PR TITLE
feat(window): add New Remote Workspace UI action

### DIFF
--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -110,6 +110,7 @@ mod imp {
             let menu = gtk4::gio::Menu::new();
             menu.append(Some("New Persistent Workspace"), Some("win.new-session"));
             menu.append(Some("New Ephemeral Workspace"), Some("win.new-ephemeral-workspace"));
+            menu.append(Some("New Remote Workspace"), Some("win.new-remote-workspace"));
             menu.append(Some("About rttx"), Some("win.about"));
             menu.append(Some("Bookmark This Workspace"), Some("win.bookmark-session"));
             menu.append(Some("Preferences"), Some("win.preferences"));
@@ -453,6 +454,7 @@ impl Window {
             ("zoom-reset", &["<Ctrl>0"], |w| w.zoom_focused(0)),
             ("new-session", &["<Ctrl><Shift>T"], Self::add_session),
             ("new-ephemeral-workspace", &["<Ctrl><Shift><Alt>T"], Self::add_ephemeral_session),
+            ("new-remote-workspace", &[], Self::show_new_remote_workspace_dialog),
             ("toggle-utility-sidebar", &["<Ctrl><Shift>B"], |w| {
                 let sidebar = &w.imp().utility_sidebar_box;
                 sidebar.set_visible(!sidebar.is_visible());

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -9,6 +9,71 @@ impl Window {
         self.add_managed_session(WorkspacePolicy::Ephemeral);
     }
 
+    pub(super) fn show_new_remote_workspace_dialog(&self) {
+        let dialog =
+            adw::Dialog::builder().title("New Remote Workspace").content_width(440).build();
+        let header = adw::HeaderBar::new();
+        let create_button = gtk4::Button::with_label("Create");
+        create_button.add_css_class("suggested-action");
+        header.pack_end(&create_button);
+
+        let host_row = adw::EntryRow::builder().title("SSH host (e.g. user@host)").build();
+
+        let status_label = gtk4::Label::new(None);
+        status_label.set_xalign(0.0);
+        status_label.add_css_class("dim-label");
+
+        let group = adw::PreferencesGroup::new();
+        group.add(&host_row);
+
+        let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+        content_box.set_margin_start(18);
+        content_box.set_margin_end(18);
+        content_box.set_margin_top(18);
+        content_box.set_margin_bottom(18);
+        content_box.append(&group);
+        content_box.append(&status_label);
+
+        let toolbar_view = adw::ToolbarView::new();
+        toolbar_view.add_top_bar(&header);
+        toolbar_view.set_content(Some(&content_box));
+        dialog.set_child(Some(&toolbar_view));
+
+        let dialog_ref = dialog.clone();
+        let win = self.clone();
+        create_button.connect_clicked(move |_| {
+            let host = host_row.text().trim().to_string();
+            if host.is_empty() {
+                status_label.set_text("SSH host is required");
+                return;
+            }
+            win.add_remote_managed_session(&host);
+            dialog_ref.close();
+        });
+
+        dialog.present(Some(self));
+    }
+
+    fn add_remote_managed_session(&self, host: &str) {
+        let imp = self.imp();
+        let count = imp.state.borrow().sessions.len() + 1;
+        let session_state = SessionState::new_managed_remote(
+            format!("Remote {count}"),
+            host,
+            WorkspacePolicy::Persistent,
+            None,
+        );
+        imp.state.borrow_mut().sessions.push(session_state.clone());
+        self.build_session(&session_state, false);
+        self.set_workspace_connection_status(&session_state.uuid, &ConnectionStatus::Connecting);
+        self.connect_managed_workspace(&session_state);
+
+        let index = imp.state.borrow().sessions.len() as i32 - 1;
+        if let Some(row) = imp.sidebar_list.row_at_index(index) {
+            imp.sidebar_list.select_row(Some(&row));
+        }
+    }
+
     pub(super) fn add_managed_session(&self, policy: WorkspacePolicy) {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1503,3 +1503,23 @@ fn managed_pane_banner_is_passive() {
     let _: fn(&str, &str) -> rttx::terminal::persistent_widget::PersistentPaneView =
         rttx::terminal::persistent_widget::PersistentPaneView::new;
 }
+
+/// The window must expose a `new-remote-workspace` action.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn window_has_new_remote_workspace_action() {
+    require_display!();
+
+    let app = adw::Application::builder()
+        .application_id("io.github.IllyaYalovyy.rttx.test.remote_action")
+        .build();
+    app.register(None::<&gtk4::gio::Cancellable>).unwrap();
+
+    let window = rttx::window::Window::new(&app);
+    let action_group: gtk4::gio::ActionGroup = window.clone().upcast();
+    assert!(
+        action_group.has_action("new-remote-workspace"),
+        "window must have new-remote-workspace action"
+    );
+    window.close();
+}

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -504,3 +504,31 @@ fn new_managed_remote_produces_remote_persistent_session() {
     assert!(!session.layout.terminal_uuids().is_empty());
     assert!(!session.runtime.pending_layout_panes.is_empty());
 }
+
+/// Remote managed session must round-trip through serialization.
+#[test]
+fn remote_managed_session_persists_and_restores() {
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+    use rttx::session::{SessionMode, SessionState};
+
+    let session = SessionState::new_managed_remote(
+        "Remote Work".into(),
+        "dev@build-host",
+        WorkspacePolicy::Persistent,
+        Some("/home/dev/project".into()),
+    );
+
+    let json = serde_json::to_string(&session).unwrap();
+    let restored: SessionState = serde_json::from_str(&json).unwrap();
+
+    assert!(restored.runtime.is_managed());
+    assert_eq!(
+        restored.runtime.endpoint,
+        RuntimeEndpoint::Remote { host: "dev@build-host".into() }
+    );
+    assert!(matches!(restored.mode, SessionMode::RemotePersistent { .. }));
+    assert_eq!(
+        restored.layout.terminal_cwd(&restored.layout.terminal_uuids()[0]).as_deref(),
+        Some("/home/dev/project")
+    );
+}


### PR DESCRIPTION
Add a "New Remote Workspace" menu item and dialog for creating managed workspaces connected to a remote `rttx-server` via SSH.

## What changed

- **Menu item**: "New Remote Workspace" in the hamburger menu (between Ephemeral and About)
- **Dialog**: `adw::Dialog` with an `adw::EntryRow` for the SSH host (e.g. `user@host`)
- **Action**: `win.new-remote-workspace` (no keyboard shortcut — this is a less frequent action)
- **On confirm**: calls `SessionState::new_managed_remote()` → `connect_managed_workspace()`

Follows the same dialog pattern as the existing "Edit Connection" dialog.

## Manual verification

1. Open rttx
2. Click hamburger menu → "New Remote Workspace"
3. Enter an SSH host (e.g. `user@remote-host`)
4. Click "Create"
5. A new workspace appears in the sidebar with "Remote N" name
6. The workspace attempts to connect to the remote daemon

## Tests added

- `remote_managed_session_persists_and_restores` — integration test verifying remote session round-trips through serialization
- `window_has_new_remote_workspace_action` — GTK widget test verifying the action exists on the window (ignored, requires GTK harness)

## Tests run

- `cargo test -p rttx --lib -- --test-threads=1` — 242 pass
- `cargo test -p rttx --test session_lifecycle` — all pass
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- `dbus-run-session -- ./run_ui_tests.sh` — pre-existing failures only (split tests), unrelated to this change
- clippy, fmt — clean
- Runtime behavior gate — passes

## Follow-ups

- Visual indicator in sidebar for remote workspaces
- Keyboard shortcut if usage warrants it

Fixes #242