### PR TITLE
fix(test): increase shell prompt timeout for CI reliability

### DIFF
--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -112,7 +112,7 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
 }
 
 async fn wait_for_prompt(client: &mut TestClient) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     let mut output = Vec::new();
     while tokio::time::Instant::now() < deadline {
         if let Some(message) = client.try_recv(Duration::from_millis(200)).await
@@ -124,7 +124,7 @@ async fn wait_for_prompt(client: &mut TestClient) {
             }
         }
     }
-    panic!("shell prompt did not arrive within 5 seconds");
+    panic!("shell prompt did not arrive within 15 seconds");
 }
 
 async fn resize_pane(


### PR DESCRIPTION
The `shell_line_editing_survives_detach_mid_command_and_executes_after_reattach` test was failing on CI because the 5-second timeout for the shell prompt was too tight for slow CI runners.

Increase to 15 seconds to match other integration test timeouts.