### PR TITLE
feat(window): wire Edit Connection dialog to sidebar context menu

### DIFF
--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -660,6 +660,16 @@ impl Window {
         });
         row.add_controller(drop_target);
 
+        let win = self.clone();
+        let session_uuid_for_ctx = session_state.uuid.clone();
+        let ctx_gesture = gtk4::GestureClick::new();
+        ctx_gesture.set_button(3);
+        ctx_gesture.connect_released(move |gesture, _, _, _| {
+            gesture.set_state(gtk4::EventSequenceState::Claimed);
+            win.show_sidebar_context_menu(&session_uuid_for_ctx);
+        });
+        row.add_controller(ctx_gesture);
+
         let list_row = gtk4::ListBoxRow::new();
         list_row.set_child(Some(&row));
         imp.sidebar_list.append(&list_row);
@@ -775,6 +785,66 @@ impl Window {
             return;
         }
         self.attempt_recovery_for_terminal(term, recovery);
+    }
+
+    fn show_sidebar_context_menu(&self, session_uuid: &str) {
+        let is_remote = {
+            let state = self.imp().state.borrow();
+            state
+                .sessions
+                .iter()
+                .find(|s| s.uuid == session_uuid)
+                .is_some_and(|s| matches!(s.runtime.endpoint, RuntimeEndpoint::Remote { .. }))
+        };
+        if !is_remote {
+            return;
+        }
+
+        let menu = gtk4::gio::Menu::new();
+        menu.append(Some("Edit Connection…"), Some("win.edit-connection"));
+        menu.append(Some("Retry Connection"), Some("win.retry-connection"));
+
+        let popover = gtk4::PopoverMenu::from_model(Some(&menu));
+        popover.set_has_arrow(true);
+
+        let row = self
+            .sidebar_row_for_uuid(session_uuid)
+            .and_then(|r| r.parent())
+            .unwrap_or_else(|| self.imp().sidebar_list.clone().upcast());
+        popover.set_parent(&row);
+        popover.connect_closed(gtk4::prelude::WidgetExt::unparent);
+
+        let win = self.clone();
+        let uuid = session_uuid.to_string();
+        let edit_action = gtk4::gio::SimpleAction::new("edit-connection", None);
+        edit_action.connect_activate(move |_, _| {
+            win.show_edit_workspace_connection_dialog(&uuid);
+        });
+
+        let win2 = self.clone();
+        let uuid2 = session_uuid.to_string();
+        let retry_action = gtk4::gio::SimpleAction::new("retry-connection", None);
+        retry_action.connect_activate(move |_, _| {
+            win2.retry_workspace_connection(&uuid2);
+        });
+
+        self.add_action(&edit_action);
+        self.add_action(&retry_action);
+        popover.popup();
+    }
+
+    fn sidebar_row_for_uuid(&self, session_uuid: &str) -> Option<SessionRow> {
+        let imp = self.imp();
+        let mut idx = 0;
+        while let Some(row) = imp.sidebar_list.row_at_index(idx) {
+            if let Some(sr) = row.child().and_then(|c| c.downcast::<SessionRow>().ok())
+                && sr.uuid() == session_uuid
+            {
+                return Some(sr);
+            }
+            idx += 1;
+        }
+        None
     }
 
     fn show_rename_session_popover(&self, row: &SessionRow, session_uuid: &str) {

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -189,7 +189,6 @@ impl Window {
         });
     }
 
-    #[allow(dead_code)] // Will be wired to sidebar actions in #196 follow-up
     pub(super) fn retry_workspace_connection(&self, workspace_id: &str) {
         let session_state = {
             let state = self.imp().state.borrow();
@@ -610,7 +609,6 @@ impl Window {
         Some(present_workspace_actions(policy, runtime_attached, session.layout.terminal_count()))
     }
 
-    #[allow(dead_code)] // Will be wired to sidebar actions in #196 follow-up
     pub(super) fn show_edit_workspace_connection_dialog(&self, workspace_id: &str) {
         let current_host = {
             let state = self.imp().state.borrow();
@@ -669,7 +667,6 @@ impl Window {
         dialog.present(Some(self));
     }
 
-    #[allow(dead_code)] // Will be wired to sidebar actions in #196 follow-up
     pub(super) fn update_workspace_endpoint(&self, workspace_id: &str, host: String) {
         let (session_state, previous_endpoint) = {
             let mut state = self.imp().state.borrow_mut();

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -573,3 +573,29 @@ fn local_bookmark_creates_direct_session() {
 
     assert!(bookmark.remote_host().is_none());
 }
+
+/// Updating a remote workspace endpoint must change the host and sync mode.
+#[test]
+fn update_remote_endpoint_changes_host_and_mode() {
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+    use rttx::session::{SessionMode, SessionState};
+
+    let mut session = SessionState::new_managed_remote(
+        "Remote".into(),
+        "old-host.example.com",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+
+    session.runtime.endpoint = RuntimeEndpoint::Remote { host: "new-host.example.com".into() };
+    session.sync_legacy_mode_from_runtime();
+
+    assert_eq!(
+        session.runtime.endpoint,
+        RuntimeEndpoint::Remote { host: "new-host.example.com".into() }
+    );
+    assert!(matches!(
+        session.mode,
+        SessionMode::RemotePersistent { ref host, .. } if host == "new-host.example.com"
+    ));
+}


### PR DESCRIPTION
## Problem

`show_edit_workspace_connection_dialog()`, `retry_workspace_connection()`, and `update_workspace_endpoint()` were implemented but marked `#[allow(dead_code)]` — unreachable from any UI action.

## What changed

- Added right-click context menu on remote workspace sidebar rows
- Menu shows "Edit Connection…" and "Retry Connection" actions
- Actions call the existing dialog/retry methods
- Removed `#[allow(dead_code)]` annotations from the three methods
- Context menu only appears for remote workspaces (local workspaces have no connection to edit)

## Manual verification

1. Create a remote workspace (menu → New Remote Workspace)
2. Right-click the workspace in the sidebar
3. Click "Edit Connection…" → dialog opens with current host
4. Change host → Save → workspace reconnects to new host
5. Right-click → "Retry Connection" → workspace retries connection

## Tests added

- `update_remote_endpoint_changes_host_and_mode` — pure-state test verifying endpoint update + mode sync

## Tests run

- `cargo test -p rttx --lib -- --test-threads=1` — 245 pass
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- clippy, fmt — clean

Fixes #244