### PR TITLE
fix(bookmarks): strip SSH wrapper when running on same-host managed pane

### DIFF
--- a/clients/rttx/src/bookmarks.rs
+++ b/clients/rttx/src/bookmarks.rs
@@ -101,6 +101,15 @@ impl Bookmark {
         non_empty(self.ssh_target.as_deref())
     }
 
+    /// Command to run on a remote pane that is already connected to the bookmark's host.
+    /// Returns the inner command (cd, tmux, etc.) without the SSH wrapper.
+    /// None if the bookmark has no SSH target or no inner command beyond just connecting.
+    #[must_use]
+    pub fn remote_command(&self) -> Option<String> {
+        non_empty(self.ssh_target.as_deref())?;
+        local_command(non_empty(self.directory.as_deref()), non_empty(self.tmux_session.as_deref()))
+    }
+
     #[must_use]
     pub fn pane_target(&self) -> Option<PaneTarget> {
         let directory = non_empty(self.directory.as_deref()).map(str::to_string);
@@ -456,5 +465,35 @@ mod tests {
         let mut b = Bookmark::new("Empty");
         b.ssh_target = Some("  ".into());
         assert_eq!(b.remote_host(), None);
+    }
+
+    #[test]
+    fn remote_command_returns_inner_command_without_ssh() {
+        let mut b = Bookmark::new("Deploy");
+        b.ssh_target = Some("deploy@example.com".into());
+        b.directory = Some("/srv/app".into());
+        b.tmux_session = Some("web".into());
+
+        let full = b.command().unwrap();
+        assert!(full.starts_with("ssh"), "full command should start with ssh: {full}");
+
+        let inner = b.remote_command().unwrap();
+        assert!(!inner.contains("ssh"), "remote_command must not contain ssh: {inner}");
+        assert!(inner.contains("/srv/app"), "remote_command must contain directory");
+        assert!(inner.contains("tmux"), "remote_command must contain tmux");
+    }
+
+    #[test]
+    fn remote_command_for_ssh_only_bookmark_is_none() {
+        let mut b = Bookmark::new("Shell");
+        b.ssh_target = Some("deploy@example.com".into());
+        assert!(b.remote_command().is_none(), "SSH-only bookmark has no inner command to run");
+    }
+
+    #[test]
+    fn remote_command_for_local_bookmark_is_none() {
+        let mut b = Bookmark::new("Local");
+        b.directory = Some("/home/user".into());
+        assert!(b.remote_command().is_none());
     }
 }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1142,7 +1142,8 @@ impl Window {
             return;
         };
 
-        let Some(command) = bookmark.command() else {
+        let command = self.resolve_bookmark_command(bookmark);
+        let Some(command) = command else {
             return;
         };
         self.set_terminal_recovery(
@@ -1154,6 +1155,27 @@ impl Window {
             },
         );
         self.send_input_to_terminal(&terminal_uuid, &format!("{command}\n"));
+    }
+
+    fn resolve_bookmark_command(&self, bookmark: &Bookmark) -> Option<String> {
+        let bookmark_host = bookmark.remote_host();
+        if let Some(bh) = bookmark_host {
+            let session_host = self.visible_session_remote_host();
+            if session_host.as_deref() == Some(bh) {
+                return bookmark.remote_command().or_else(|| bookmark.command());
+            }
+        }
+        bookmark.command()
+    }
+
+    fn visible_session_remote_host(&self) -> Option<String> {
+        let state = self.imp().state.borrow();
+        let visible = self.imp().session_stack.visible_child_name()?;
+        let session = state.sessions.iter().find(|s| s.uuid == visible.as_str())?;
+        match &session.runtime.endpoint {
+            RuntimeEndpoint::Remote { host } if session.runtime.is_managed() => Some(host.clone()),
+            _ => None,
+        }
     }
 
     fn switch_to_session(&self, index: usize) {

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -599,3 +599,23 @@ fn update_remote_endpoint_changes_host_and_mode() {
         SessionMode::RemotePersistent { ref host, .. } if host == "new-host.example.com"
     ));
 }
+
+/// SSH bookmark targeting the same host as a managed pane must use the inner
+/// command (without SSH wrapper). Regression test for #245.
+#[test]
+fn ssh_bookmark_remote_command_strips_ssh_for_same_host() {
+    use rttx::bookmarks::Bookmark;
+
+    let mut bookmark = Bookmark::new("Deploy");
+    bookmark.ssh_target = Some("deploy@example.com".into());
+    bookmark.directory = Some("/srv/app".into());
+    bookmark.tmux_session = Some("web".into());
+
+    let full = bookmark.command().unwrap();
+    let inner = bookmark.remote_command().unwrap();
+
+    assert!(full.starts_with("ssh"), "full command wraps in ssh");
+    assert!(!inner.contains("ssh"), "inner command must not contain ssh");
+    assert!(inner.contains("/srv/app"));
+    assert!(inner.contains("tmux"));
+}


### PR DESCRIPTION
## Problem

`execute_bookmark()` injected the full SSH-wrapped command (e.g. `ssh -t deploy@example.com 'cd /srv/app && tmux attach'`) even when the focused pane was a managed remote pane already connected to the same host, causing nested SSH sessions.

## What changed

- Added `Bookmark::remote_command()` — returns the inner command (cd, tmux, etc.) without the SSH wrapper
- Added `resolve_bookmark_command()` — checks if the bookmark's SSH host matches the visible session's remote endpoint; if so, returns the inner command
- Added `visible_session_remote_host()` — returns the remote host of the currently visible managed session
- `execute_bookmark()` now uses `resolve_bookmark_command()` instead of `bookmark.command()` directly

When the bookmark targets a different host or the pane is local, the full SSH command is still used (unchanged behavior).

## Manual verification

1. Create a remote workspace connected to `deploy@example.com`
2. Create a bookmark with SSH target `deploy@example.com`, directory `/srv/app`, tmux session `web`
3. Focus the remote workspace pane
4. Click "Run" on the bookmark
5. Verify: only `cd '/srv/app' && (tmux attach-session -t 'web' || tmux new-session -s 'web')` is injected (no `ssh` wrapper)

## Tests added

- `remote_command_returns_inner_command_without_ssh` — pure-state
- `remote_command_for_ssh_only_bookmark_is_none` — edge case
- `remote_command_for_local_bookmark_is_none` — regression guard
- `ssh_bookmark_remote_command_strips_ssh_for_same_host` — integration

## Tests run

- `cargo test -p rttx --lib -- --test-threads=1` — 248 pass
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- clippy, fmt — clean

Fixes #245