### PR TITLE
test: verify split pane on remote workspace inherits endpoint

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -713,4 +713,31 @@ mod tests {
         assert_eq!(runtime.policy, WorkspacePolicy::Persistent);
         assert!(runtime.pending_layout_panes.contains("t1"));
     }
+
+    #[test]
+    fn ensure_placeholder_bindings_adds_new_pane_to_remote_runtime() {
+        let mut runtime =
+            WorkspaceRuntime::managed_remote("host", WorkspacePolicy::Persistent, &["t1".into()]);
+
+        runtime.ensure_placeholder_bindings(&["t1".into(), "t2".into()]);
+
+        assert!(runtime.pane_bindings.contains_key("t2"));
+        assert!(runtime.pending_layout_panes.contains("t2"));
+        assert_eq!(runtime.endpoint, RuntimeEndpoint::Remote { host: "host".into() });
+    }
+
+    #[test]
+    fn ensure_placeholder_bindings_removes_closed_pane() {
+        let mut runtime = WorkspaceRuntime::managed_remote(
+            "host",
+            WorkspacePolicy::Persistent,
+            &["t1".into(), "t2".into()],
+        );
+
+        runtime.ensure_placeholder_bindings(&["t1".into()]);
+
+        assert!(!runtime.pane_bindings.contains_key("t2"));
+        assert!(!runtime.pending_layout_panes.contains("t2"));
+        assert!(runtime.pane_bindings.contains_key("t1"));
+    }
 }

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -619,3 +619,80 @@ fn ssh_bookmark_remote_command_strips_ssh_for_same_host() {
     assert!(inner.contains("/srv/app"));
     assert!(inner.contains("tmux"));
 }
+
+/// Splitting a pane in a remote managed session must preserve the remote
+/// endpoint and add the new pane to pending bindings. Issue #246.
+#[test]
+fn split_remote_session_preserves_endpoint_and_adds_pending_pane() {
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+    use rttx::session::layout::SplitOrientation;
+    use rttx::session::{PaneRecovery, SessionState};
+
+    let mut session = SessionState::new_managed_remote(
+        "Remote".into(),
+        "build-host.internal",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+
+    let original_uuid = session.layout.terminal_uuids()[0].clone();
+    assert_eq!(session.runtime.pending_layout_panes.len(), 1);
+
+    // Split — mirrors the logic in window/mod.rs split_terminal().
+    let (new_layout, new_uuid) = session
+        .layout
+        .split_terminal_with_new_uuid(&original_uuid, SplitOrientation::Horizontal)
+        .unwrap();
+    session.layout = new_layout;
+    session.set_recovery(&new_uuid, PaneRecovery::empty_shell());
+    session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
+
+    // Endpoint must still be remote.
+    assert_eq!(
+        session.runtime.endpoint,
+        RuntimeEndpoint::Remote { host: "build-host.internal".into() },
+        "split must not change the workspace endpoint"
+    );
+
+    // Both panes must be in pending bindings.
+    assert!(
+        session.runtime.pending_layout_panes.contains(&new_uuid),
+        "new pane must be in pending_layout_panes"
+    );
+    assert_eq!(session.layout.terminal_count(), 2);
+    assert!(session.runtime.is_managed());
+}
+
+/// Splitting twice must keep all panes pending and endpoint unchanged.
+#[test]
+fn double_split_remote_session_keeps_all_panes_pending() {
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+    use rttx::session::layout::SplitOrientation;
+    use rttx::session::{PaneRecovery, SessionState};
+
+    let mut session = SessionState::new_managed_remote(
+        "Remote".into(),
+        "gpu-box",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+
+    let t1 = session.layout.terminal_uuids()[0].clone();
+
+    let (layout, t2) =
+        session.layout.split_terminal_with_new_uuid(&t1, SplitOrientation::Horizontal).unwrap();
+    session.layout = layout;
+    session.set_recovery(&t2, PaneRecovery::empty_shell());
+    session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
+
+    let (layout, t3) =
+        session.layout.split_terminal_with_new_uuid(&t2, SplitOrientation::Vertical).unwrap();
+    session.layout = layout;
+    session.set_recovery(&t3, PaneRecovery::empty_shell());
+    session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
+
+    assert_eq!(session.runtime.endpoint, RuntimeEndpoint::Remote { host: "gpu-box".into() });
+    assert_eq!(session.layout.terminal_count(), 3);
+    assert!(session.runtime.pending_layout_panes.contains(&t2));
+    assert!(session.runtime.pending_layout_panes.contains(&t3));
+}


### PR DESCRIPTION
Add test coverage confirming that splitting a pane in a remote managed workspace preserves the remote endpoint and correctly manages pane bindings. Issue #246.

## Tests added

**Unit tests** (`runtime.rs`):
- `ensure_placeholder_bindings_adds_new_pane_to_remote_runtime` — new pane gets binding and pending entry
- `ensure_placeholder_bindings_removes_closed_pane` — removed pane is cleaned from bindings

**Integration tests** (`session_lifecycle.rs`):
- `split_remote_session_preserves_endpoint_and_adds_pending_pane` — single split preserves `RuntimeEndpoint::Remote`, adds new pane to pending
- `double_split_remote_session_keeps_all_panes_pending` — two splits keep endpoint and all panes tracked

## Tests run

- `cargo test -p rttx --lib -- --test-threads=1` — 250 pass
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- clippy, fmt — clean

Fixes #246