### PR TITLE
feat(bookmarks): indicate remote vs local in bookmark sidebar

### DIFF
--- a/clients/rttx/src/bookmarks.rs
+++ b/clients/rttx/src/bookmarks.rs
@@ -101,6 +101,21 @@ impl Bookmark {
         non_empty(self.ssh_target.as_deref())
     }
 
+    /// Tooltip for the "New workspace" button.
+    #[must_use]
+    pub fn new_workspace_tooltip(&self) -> String {
+        self.remote_host().map_or_else(
+            || "New workspace from bookmark".into(),
+            |host| format!("New workspace on {host}"),
+        )
+    }
+
+    /// Icon name for the "New workspace" button.
+    #[must_use]
+    pub fn new_workspace_icon(&self) -> &'static str {
+        if self.remote_host().is_some() { "network-server-symbolic" } else { "window-new-symbolic" }
+    }
+
     /// Command to run on a remote pane that is already connected to the bookmark's host.
     /// Returns the inner command (cd, tmux, etc.) without the SSH wrapper.
     /// None if the bookmark has no SSH target or no inner command beyond just connecting.
@@ -465,6 +480,27 @@ mod tests {
         let mut b = Bookmark::new("Empty");
         b.ssh_target = Some("  ".into());
         assert_eq!(b.remote_host(), None);
+    }
+
+    #[test]
+    fn new_workspace_tooltip_includes_host_for_remote() {
+        let mut b = Bookmark::new("Deploy");
+        b.ssh_target = Some("deploy@example.com".into());
+        assert_eq!(b.new_workspace_tooltip(), "New workspace on deploy@example.com");
+    }
+
+    #[test]
+    fn new_workspace_tooltip_is_generic_for_local() {
+        let b = Bookmark::new("Local");
+        assert_eq!(b.new_workspace_tooltip(), "New workspace from bookmark");
+    }
+
+    #[test]
+    fn new_workspace_icon_differs_for_remote() {
+        let mut remote = Bookmark::new("Remote");
+        remote.ssh_target = Some("host".into());
+        let local = Bookmark::new("Local");
+        assert_ne!(remote.new_workspace_icon(), local.new_workspace_icon());
     }
 
     #[test]

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1269,8 +1269,8 @@ impl Window {
             action_row.set_activatable(true);
 
             let new_session_button = gtk4::Button::builder()
-                .icon_name("window-new-symbolic")
-                .tooltip_text("New workspace from bookmark")
+                .icon_name(bookmark.new_workspace_icon())
+                .tooltip_text(bookmark.new_workspace_tooltip())
                 .valign(gtk4::Align::Center)
                 .build();
             new_session_button.add_css_class("flat");


### PR DESCRIPTION
Remote bookmarks now show a distinct icon and host-specific tooltip in the sidebar.

## What changed

- `Bookmark::new_workspace_tooltip()` — returns "New workspace on \<host\>" for remote, generic text for local
- `Bookmark::new_workspace_icon()` — returns `network-server-symbolic` for remote, `window-new-symbolic` for local
- `refresh_bookmark_sidebar()` uses these methods instead of hardcoded values

## Manual verification

1. Create a bookmark with SSH target (e.g. `deploy@example.com`)
2. Create a local bookmark (directory only)
3. Open the tools sidebar → Bookmarks
4. Remote bookmark shows network icon, tooltip says "New workspace on deploy@example.com"
5. Local bookmark shows window icon, tooltip says "New workspace from bookmark"

## Tests added

- `new_workspace_tooltip_includes_host_for_remote`
- `new_workspace_tooltip_is_generic_for_local`
- `new_workspace_icon_differs_for_remote`

## Tests run

- `cargo test -p rttx --lib -- --test-threads=1` — 253 pass
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- clippy, fmt — clean

Fixes #247