### PR TITLE
fix(test): drain interleaved messages before SessionDetached in pty_io

### DIFF
--- a/services/rttx-server/tests/pty_io.rs
+++ b/services/rttx-server/tests/pty_io.rs
@@ -214,10 +214,17 @@ async fn close_pane_kills_pty() {
         })),
     };
     client.send(&detach).await;
-    assert!(matches!(
-        client.recv_or_timeout().await.msg,
-        Some(proto::server_message::Msg::SessionDetached(_))
-    ));
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for SessionDetached");
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionDetached(_)) => break,
+            Some(
+                proto::server_message::Msg::Delta(_) | proto::server_message::Msg::PaneExited(_),
+            ) => {}
+            other => panic!("expected SessionDetached, got {other:?}"),
+        }
+    }
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 


### PR DESCRIPTION
The `close_pane_kills_pty` test expected `SessionDetached` immediately after sending `DetachSession`, but `Delta` or `PaneExited` messages could arrive first on slow CI runners.

Fix: poll with a deadline, draining interleaved messages until `SessionDetached` arrives.