### PR TITLE
feat(window): add Attach to Remote Runtime action

### DIFF
--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -111,6 +111,7 @@ mod imp {
             menu.append(Some("New Persistent Workspace"), Some("win.new-session"));
             menu.append(Some("New Ephemeral Workspace"), Some("win.new-ephemeral-workspace"));
             menu.append(Some("New Remote Workspace"), Some("win.new-remote-workspace"));
+            menu.append(Some("Attach to Remote Runtime"), Some("win.browse-remote-runtimes"));
             menu.append(Some("About rttx"), Some("win.about"));
             menu.append(Some("Bookmark This Workspace"), Some("win.bookmark-session"));
             menu.append(Some("Preferences"), Some("win.preferences"));
@@ -455,6 +456,7 @@ impl Window {
             ("new-session", &["<Ctrl><Shift>T"], Self::add_session),
             ("new-ephemeral-workspace", &["<Ctrl><Shift><Alt>T"], Self::add_ephemeral_session),
             ("new-remote-workspace", &[], Self::show_new_remote_workspace_dialog),
+            ("browse-remote-runtimes", &[], Self::show_browse_remote_runtimes_dialog),
             ("toggle-utility-sidebar", &["<Ctrl><Shift>B"], |w| {
                 let sidebar = &w.imp().utility_sidebar_box;
                 sidebar.set_visible(!sidebar.is_visible());

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -54,6 +54,63 @@ impl Window {
         dialog.present(Some(self));
     }
 
+    pub(super) fn show_browse_remote_runtimes_dialog(&self) {
+        let dialog =
+            adw::Dialog::builder().title("Attach to Remote Runtime").content_width(440).build();
+        let header = adw::HeaderBar::new();
+        let connect_button = gtk4::Button::with_label("Connect");
+        connect_button.add_css_class("suggested-action");
+        header.pack_end(&connect_button);
+
+        let host_row = adw::EntryRow::builder().title("SSH host (e.g. user@host)").build();
+
+        let status_label = gtk4::Label::new(None);
+        status_label.set_xalign(0.0);
+        status_label.add_css_class("dim-label");
+        status_label.set_text("Existing runtimes on the host will appear in the sidebar.");
+
+        let group = adw::PreferencesGroup::new();
+        group.add(&host_row);
+
+        let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+        content_box.set_margin_start(18);
+        content_box.set_margin_end(18);
+        content_box.set_margin_top(18);
+        content_box.set_margin_bottom(18);
+        content_box.append(&group);
+        content_box.append(&status_label);
+
+        let toolbar_view = adw::ToolbarView::new();
+        toolbar_view.add_top_bar(&header);
+        toolbar_view.set_content(Some(&content_box));
+        dialog.set_child(Some(&toolbar_view));
+
+        let dialog_ref = dialog.clone();
+        let win = self.clone();
+        connect_button.connect_clicked(move |_| {
+            let host = host_row.text().trim().to_string();
+            if host.is_empty() {
+                status_label.set_text("SSH host is required");
+                return;
+            }
+            win.browse_remote_runtimes(&host);
+            dialog_ref.close();
+        });
+
+        dialog.present(Some(self));
+    }
+
+    fn browse_remote_runtimes(&self, host: &str) {
+        if !self.ensure_connection_manager() {
+            return;
+        }
+        let endpoint = RuntimeEndpoint::Remote { host: host.into() };
+        if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
+            manager.refresh_inventory(&endpoint);
+        }
+        self.show_toast(&format!("Connecting to {host}…"));
+    }
+
     fn add_remote_managed_session(&self, host: &str) {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -734,3 +734,29 @@ fn close_remote_workspace_prevents_resurrection_on_reconnect() {
     );
     assert!(restored.sessions.is_empty());
 }
+
+/// Remote managed session must be ready for inventory binding after
+/// creation. Regression test for #249.
+#[test]
+fn remote_managed_session_is_ready_for_inventory_binding() {
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+    use rttx::session::state::WindowState;
+
+    let endpoint = RuntimeEndpoint::Remote { host: "gpu-box".into() };
+
+    let mut state = WindowState::default();
+    state.sessions.clear();
+    let session = rttx::session::SessionState::new_managed_remote(
+        "ML Training".into(),
+        "gpu-box",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+    state.sessions.push(session);
+
+    let remote_session = &state.sessions[0];
+    assert!(remote_session.runtime.is_managed());
+    assert_eq!(remote_session.runtime.endpoint, endpoint);
+    assert!(remote_session.runtime.runtime_id.is_none());
+    assert!(!remote_session.runtime.pending_layout_panes.is_empty());
+}


### PR DESCRIPTION
Add a UI action to browse and attach to existing runtimes on a remote host, per RFC-013 R11.

## What changed

- "Attach to Remote Runtime" menu item in hamburger menu
- `win.browse-remote-runtimes` action opens a dialog asking for SSH host
- On connect, triggers `refresh_inventory()` for the remote endpoint
- The existing reconciliation flow (`InventoryLoaded` → `recover_managed_workspaces_from_inventory`) automatically creates workspaces for unattached runtimes
- Toast notification confirms the connection attempt

## How it works

1. User clicks "Attach to Remote Runtime" in the menu
2. Enters SSH host (e.g. `user@remote-host`)
3. Clicks "Connect"
4. rttx connects to the remote daemon and loads its inventory
5. Any unattached runtimes appear as recovered workspaces in the sidebar
6. User can then interact with them normally

## Manual verification

1. Have a remote host with `rttx-server` running and some runtimes
2. Menu → "Attach to Remote Runtime" → enter host → Connect
3. Existing runtimes appear in the sidebar

## Tests added

- `remote_managed_session_is_ready_for_inventory_binding` — integration test verifying remote session state is correct for inventory binding

## Tests run

- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- clippy, fmt — clean

Fixes #249