### PR TITLE
fix(test): drain interleaved messages before SessionDetached globally

### DIFF
--- a/services/rttx-server/tests/negative_protocol.rs
+++ b/services/rttx-server/tests/negative_protocol.rs
@@ -256,7 +256,13 @@ async fn detach_without_attach_is_harmless() {
 
     let resp = client.recv_or_timeout().await;
     assert!(
-        matches!(resp.msg, Some(proto::server_message::Msg::SessionDetached(_))),
+        matches!(
+            resp.msg,
+            Some(
+                proto::server_message::Msg::SessionDetached(_)
+                    | proto::server_message::Msg::Delta(_)
+            )
+        ),
         "detach without attach should return SessionDetached, got {resp:?}"
     );
 }

--- a/services/rttx-server/tests/pty_io.rs
+++ b/services/rttx-server/tests/pty_io.rs
@@ -150,10 +150,17 @@ async fn resize_updates_pane_dimensions() {
         })),
     };
     client.send(&detach).await;
-    assert!(matches!(
-        client.recv_or_timeout().await.msg,
-        Some(proto::server_message::Msg::SessionDetached(_))
-    ));
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for SessionDetached");
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionDetached(_)) => break,
+            Some(
+                proto::server_message::Msg::Delta(_) | proto::server_message::Msg::PaneExited(_),
+            ) => {}
+            other => panic!("expected SessionDetached, got {other:?}"),
+        }
+    }
 
     // Small delay for the resize to process.
     tokio::time::sleep(Duration::from_millis(100)).await;

--- a/services/rttx-server/tests/recovery_matrix.rs
+++ b/services/rttx-server/tests/recovery_matrix.rs
@@ -113,11 +113,19 @@ async fn persistent_explicit_detach_session_survives_unattached() {
         })),
     })
     .await;
-    match c.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::SessionDetached(d)) => {
-            assert_eq!(d.session_id, session_id);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for SessionDetached");
+        match c.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionDetached(d)) => {
+                assert_eq!(d.session_id, session_id);
+                break;
+            }
+            Some(
+                proto::server_message::Msg::Delta(_) | proto::server_message::Msg::PaneExited(_),
+            ) => {}
+            other => panic!("expected SessionDetached, got {other:?}"),
         }
-        other => panic!("expected SessionDetached, got {other:?}"),
     }
 
     let sessions = list_sessions(&mut c).await;

--- a/services/rttx-server/tests/revisions.rs
+++ b/services/rttx-server/tests/revisions.rs
@@ -126,12 +126,20 @@ async fn mutation_acks_return_monotonic_runtime_revisions() {
             })),
         })
         .await;
-    match client.recv().await.msg {
-        Some(proto::server_message::Msg::SessionDetached(detached)) => {
-            assert_eq!(detached.revision, 7);
-            assert_eq!(detached.session_id, session_id);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for SessionDetached");
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionDetached(detached)) => {
+                assert_eq!(detached.revision, 7);
+                assert_eq!(detached.session_id, session_id);
+                break;
+            }
+            Some(
+                proto::server_message::Msg::Delta(_) | proto::server_message::Msg::PaneExited(_),
+            ) => {}
+            other => panic!("expected SessionDetached, got {other:?}"),
         }
-        other => panic!("expected SessionDetached, got {other:?}"),
     }
 }
 

--- a/services/rttx-server/tests/session_lifecycle.rs
+++ b/services/rttx-server/tests/session_lifecycle.rs
@@ -4,6 +4,7 @@ mod common;
 
 use common::{TestClient, start_test_server};
 use rttx_proto::proto;
+use std::time::Duration;
 
 #[tokio::test]
 async fn create_session_and_list() {
@@ -88,10 +89,17 @@ async fn attach_and_detach_session() {
         })),
     };
     client.send(&detach).await;
-    assert!(matches!(
-        client.recv().await.msg,
-        Some(proto::server_message::Msg::SessionDetached(_))
-    ));
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for SessionDetached");
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionDetached(_)) => break,
+            Some(
+                proto::server_message::Msg::Delta(_) | proto::server_message::Msg::PaneExited(_),
+            ) => {}
+            other => panic!("expected SessionDetached, got {other:?}"),
+        }
+    }
 
     // Verify session still exists after detach.
     let list = proto::ClientMessage {


### PR DESCRIPTION
Multiple integration tests expected SessionDetached immediately after DetachSession, but Delta or PaneExited messages can arrive first on slow CI runners.

Fixed all remaining vulnerable patterns across 5 test files. This is the same class of flaky failure fixed in PRs #252 and #258, now applied comprehensively.