### PR TITLE
fix(window): sync sidebar selection with visible session after rebuilds

### DIFF
--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -60,7 +60,15 @@ pub fn run() -> glib::ExitCode {
             }
             .session-activity-idle {
                 opacity: 0.45;
-            }",
+            }
+            .accent-blue   { color: @blue_3; }
+            .accent-green  { color: @green_3; }
+            .accent-yellow { color: @yellow_3; }
+            .accent-red    { color: @red_3; }
+            .accent-purple { color: @purple_3; }
+            .accent-pink   { color: @pink_3; }
+            .accent-teal   { color: @teal_3; }
+            .accent-orange { color: @orange_3; }",
         );
         gtk4::style_context_add_provider_for_display(
             &display,

--- a/clients/rttx/src/session/mod.rs
+++ b/clients/rttx/src/session/mod.rs
@@ -4,7 +4,7 @@ pub mod state;
 
 pub use layout::{LayoutNode, MAX_SPLIT_DEPTH, SplitOrientation};
 pub use recovery::{PaneRecovery, PaneSource, PaneTarget, StartupStep};
-pub use state::{SessionMode, SessionState, WindowState};
+pub use state::{SessionColor, SessionMode, SessionState, WindowState};
 
 use crate::config;
 use gtk4::glib;

--- a/clients/rttx/src/session/state.rs
+++ b/clients/rttx/src/session/state.rs
@@ -49,6 +49,50 @@ impl SessionMode {
     }
 }
 
+/// Accent color for a session's sidebar indicator dot.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SessionColor {
+    #[default]
+    Blue,
+    Green,
+    Yellow,
+    Red,
+    Purple,
+    Pink,
+    Teal,
+    Orange,
+}
+
+impl SessionColor {
+    /// All available colors in assignment order.
+    pub const ALL: [Self; 8] = [
+        Self::Blue,
+        Self::Green,
+        Self::Yellow,
+        Self::Red,
+        Self::Purple,
+        Self::Pink,
+        Self::Teal,
+        Self::Orange,
+    ];
+
+    /// CSS class name for the color dot.
+    #[must_use]
+    pub const fn css_class(self) -> &'static str {
+        match self {
+            Self::Blue => "accent-blue",
+            Self::Green => "accent-green",
+            Self::Yellow => "accent-yellow",
+            Self::Red => "accent-red",
+            Self::Purple => "accent-purple",
+            Self::Pink => "accent-pink",
+            Self::Teal => "accent-teal",
+            Self::Orange => "accent-orange",
+        }
+    }
+}
+
 /// State of a single terminal session.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SessionState {
@@ -65,6 +109,8 @@ pub struct SessionState {
     pub mode: SessionMode,
     #[serde(default)]
     pub runtime: WorkspaceRuntime,
+    #[serde(default)]
+    pub color: SessionColor,
 }
 
 impl SessionState {
@@ -95,6 +141,7 @@ impl SessionState {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         }
     }
 
@@ -139,6 +186,7 @@ impl SessionState {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         }
     }
 }
@@ -322,6 +370,7 @@ mod tests {
             input_sync: true,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         };
         let json = serde_json::to_string(&session).unwrap();
         let restored: SessionState = serde_json::from_str(&json).unwrap();
@@ -579,6 +628,7 @@ mod tests {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         };
         session.layout = session.layout.remove_terminal("t2").unwrap();
         session.prune_recovery();
@@ -598,6 +648,7 @@ mod tests {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         };
         session.normalize_active_terminal();
         assert_eq!(session.active_terminal_uuid.as_deref(), Some("t1"));
@@ -629,6 +680,7 @@ mod tests {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         };
         let json = serde_json::to_string(&session).unwrap();
         let restored: SessionState = serde_json::from_str(&json).unwrap();
@@ -691,5 +743,37 @@ mod module_boundary_tests {
             session.layout.terminal_cwd(&session.layout.terminal_uuids()[0]).as_deref(),
             Some("/home/user")
         );
+    }
+
+    #[test]
+    fn session_color_survives_serde_roundtrip() {
+        let mut session = SessionState::new("Test".into());
+        session.color = SessionColor::Purple;
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: SessionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.color, SessionColor::Purple);
+    }
+
+    #[test]
+    fn session_color_defaults_to_blue_for_old_state() {
+        let mut session = SessionState::new("Test".into());
+        session.color = SessionColor::Blue;
+        let json = serde_json::to_string(&session).unwrap();
+        // Remove color field to simulate old state.
+        let json = json.replace(r#","color":"blue""#, "");
+        let restored: SessionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.color, SessionColor::Blue);
+    }
+
+    #[test]
+    fn session_color_all_has_eight_variants() {
+        assert_eq!(SessionColor::ALL.len(), 8);
+    }
+
+    #[test]
+    fn session_color_css_classes_are_unique() {
+        let classes: std::collections::HashSet<_> =
+            SessionColor::ALL.iter().map(|c| c.css_class()).collect();
+        assert_eq!(classes.len(), 8);
     }
 }

--- a/clients/rttx/src/sidebar.rs
+++ b/clients/rttx/src/sidebar.rs
@@ -31,6 +31,7 @@ mod imp {
     pub struct SessionRow {
         pub uuid: RefCell<String>,
         pub name: RefCell<String>,
+        pub color_dot: gtk4::Image,
         pub position_label: gtk4::Label,
         pub activity_dot: gtk4::Image,
         pub terminal_count_label: gtk4::Label,
@@ -41,6 +42,9 @@ mod imp {
 
     impl Default for SessionRow {
         fn default() -> Self {
+            let color_dot = gtk4::Image::from_icon_name("circle-filled-symbolic");
+            color_dot.set_pixel_size(10);
+
             let activity_dot = gtk4::Image::from_icon_name("media-record-symbolic");
             activity_dot.set_pixel_size(8);
             activity_dot.set_visible(false);
@@ -52,6 +56,7 @@ mod imp {
             Self {
                 uuid: RefCell::new(String::new()),
                 name: RefCell::new(String::new()),
+                color_dot,
                 position_label,
                 activity_dot,
                 terminal_count_label: gtk4::Label::new(None),
@@ -83,6 +88,7 @@ mod imp {
             self.close_button.add_css_class("flat");
             self.close_button.add_css_class("circular");
 
+            obj.add_prefix(&self.color_dot);
             obj.add_prefix(&self.position_label);
             obj.add_suffix(&self.activity_dot);
             obj.add_suffix(&self.terminal_count_label);
@@ -126,6 +132,14 @@ impl SessionRow {
     pub fn set_session_name(&self, name: &str) {
         self.imp().name.replace(name.to_string());
         self.set_title(name);
+    }
+
+    pub fn set_color(&self, color: crate::session::SessionColor) {
+        let dot = &self.imp().color_dot;
+        for cls in crate::session::SessionColor::ALL {
+            dot.remove_css_class(cls.css_class());
+        }
+        dot.add_css_class(color.css_class());
     }
 
     pub fn update_terminal_count(&self, count: usize) {

--- a/clients/rttx/src/test_helpers.rs
+++ b/clients/rttx/src/test_helpers.rs
@@ -5,7 +5,8 @@
 use crate::color_scheme::ColorScheme;
 use crate::runtime::{RuntimeEndpoint, WorkspacePolicy, WorkspaceRuntime};
 use crate::session::{
-    LayoutNode, PaneRecovery, SessionMode, SessionState, SplitOrientation, WindowState,
+    LayoutNode, PaneRecovery, SessionColor, SessionMode, SessionState, SplitOrientation,
+    WindowState,
 };
 use std::path::{Path, PathBuf};
 
@@ -73,6 +74,7 @@ pub fn session(id: &str, name: &str, layout: LayoutNode) -> SessionState {
         input_sync: false,
         mode: SessionMode::default(),
         runtime: WorkspaceRuntime::default(),
+        color: SessionColor::default(),
     }
 }
 
@@ -122,6 +124,7 @@ pub fn managed_session_with_runtime(
             pane_bindings: std::collections::BTreeMap::default(),
             pending_layout_panes: std::collections::BTreeSet::default(),
         },
+        color: SessionColor::default(),
     };
     session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
     session.sync_legacy_mode_from_runtime();

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -18,8 +18,8 @@ use crate::runtime::{
     workspace_connection_summary,
 };
 use crate::session::{
-    self, LayoutNode, MAX_SPLIT_DEPTH, PaneRecovery, PaneSource, PaneTarget, SessionState,
-    SplitOrientation, StartupStep, WindowState,
+    self, LayoutNode, MAX_SPLIT_DEPTH, PaneRecovery, PaneSource, PaneTarget, SessionColor,
+    SessionState, SplitOrientation, StartupStep, WindowState,
 };
 use crate::sidebar::SessionRow;
 use crate::terminal::handle::TerminalHandle;
@@ -311,7 +311,7 @@ impl Window {
 
     fn load_state(&self) {
         let state = session::load_window_state();
-        let active_index = state.active_session_index;
+        let active_index = state.active_session_index.min(state.sessions.len().saturating_sub(1));
         let is_maximized = state.is_maximized;
         let width = state.width;
         let height = state.height;
@@ -619,6 +619,7 @@ impl Window {
         } else {
             "Close workspace"
         }));
+        row.set_color(session_state.color);
 
         let win = self.clone();
         let session_uuid = session_state.uuid.clone();
@@ -675,6 +676,29 @@ impl Window {
         let list_row = gtk4::ListBoxRow::new();
         list_row.set_child(Some(&row));
         imp.sidebar_list.append(&list_row);
+    }
+
+    fn sync_sidebar_to_visible_session(&self) {
+        let imp = self.imp();
+        let Some(visible_uuid) = imp.session_stack.visible_child_name() else {
+            return;
+        };
+        let already_synced = imp
+            .sidebar_list
+            .selected_row()
+            .and_then(|r| r.child())
+            .and_then(|c| c.downcast::<SessionRow>().ok())
+            .is_some_and(|sr| sr.uuid() == visible_uuid.as_str());
+        if already_synced {
+            return;
+        }
+        let state = imp.state.borrow();
+        if let Some(idx) = state.sessions.iter().position(|s| s.uuid == visible_uuid.as_str()) {
+            drop(state);
+            if let Some(row) = imp.sidebar_list.row_at_index(idx as i32) {
+                imp.sidebar_list.select_row(Some(&row));
+            }
+        }
     }
 
     fn renumber_session_rows(&self) {
@@ -1098,6 +1122,11 @@ impl Window {
         }
     }
 
+    fn next_session_color(&self) -> SessionColor {
+        let count = self.imp().state.borrow().sessions.len();
+        SessionColor::ALL[count % SessionColor::ALL.len()]
+    }
+
     pub(crate) fn new_session_from_bookmark(&self, bookmark: &Bookmark) {
         let imp = self.imp();
         let initial_cwd = bookmark
@@ -1107,7 +1136,7 @@ impl Window {
             .map(str::to_string)
             .or_else(|| bookmark.session_initial_cwd().map(str::to_string));
 
-        let session_state = if let Some(host) = bookmark.remote_host() {
+        let mut session_state = if let Some(host) = bookmark.remote_host() {
             SessionState::new_managed_remote(
                 bookmark.name.clone(),
                 host,
@@ -1117,6 +1146,7 @@ impl Window {
         } else {
             SessionState::new_with_initial_cwd(bookmark.name.clone(), initial_cwd)
         };
+        session_state.color = self.next_session_color();
         let session_uuid = session_state.uuid.clone();
         let terminal_uuid = session_state.layout.terminal_uuids().into_iter().next().unwrap();
         imp.state.borrow_mut().sessions.push(session_state.clone());
@@ -1964,6 +1994,7 @@ impl Window {
         session::schedule_initial_paned_ratios(&content, &session_state.layout);
 
         self.update_sidebar_count(session_uuid, session_state.layout.terminal_count());
+        self.sync_sidebar_to_visible_session();
     }
 
     fn detach_terminals_from_detached_tree(widget: &gtk4::Widget) {
@@ -2364,10 +2395,22 @@ impl Window {
             format!("\"{title}\" exited with status {status}")
         };
 
-        let notification = gtk4::gio::Notification::new("Process completed");
-        notification.set_body(Some(&body));
-        if let Some(app) = self.application() {
-            app.send_notification(None, &notification);
+        let tier = {
+            let visible = self.imp().session_stack.visible_child_name();
+            let state = self.imp().state.borrow();
+            notification_tier(terminal_uuid, visible.as_deref(), self.is_active(), &state)
+        };
+
+        match tier {
+            NotificationTier::Suppress => {}
+            NotificationTier::Toast => self.show_toast(&body),
+            NotificationTier::Desktop => {
+                let notification = gtk4::gio::Notification::new("Process completed");
+                notification.set_body(Some(&body));
+                if let Some(app) = self.application() {
+                    app.send_notification(None, &notification);
+                }
+            }
         }
     }
 
@@ -2440,6 +2483,36 @@ fn terminal_is_in_background_session(
             .find(|s| s.uuid == visible)
             .is_some_and(|s| s.layout.contains_terminal(terminal_uuid))
     })
+}
+
+/// Notification tier for a process exit event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationTier {
+    /// Terminal is in the visible session — no notification needed.
+    Suppress,
+    /// Window is focused but terminal is in a background session — use toast.
+    Toast,
+    /// Window is not focused — use desktop notification.
+    Desktop,
+}
+
+#[must_use]
+fn notification_tier(
+    terminal_uuid: &str,
+    visible_session_uuid: Option<&str>,
+    window_active: bool,
+    state: &WindowState,
+) -> NotificationTier {
+    if let Some(visible_uuid) = visible_session_uuid
+        && state
+            .sessions
+            .iter()
+            .find(|s| s.uuid == visible_uuid)
+            .is_some_and(|s| s.layout.contains_terminal(terminal_uuid))
+    {
+        return NotificationTier::Suppress;
+    }
+    if window_active { NotificationTier::Toast } else { NotificationTier::Desktop }
 }
 
 fn preferred_command_target_uuid(
@@ -2572,6 +2645,7 @@ mod tests {
                     input_sync: false,
                     mode: Default::default(),
                     runtime: Default::default(),
+                    color: Default::default(),
                 },
                 SessionState {
                     uuid: "s2".into(),
@@ -2582,6 +2656,7 @@ mod tests {
                     input_sync: false,
                     mode: Default::default(),
                     runtime: Default::default(),
+                    color: Default::default(),
                 },
             ],
             ..WindowState::default()
@@ -2626,6 +2701,7 @@ mod tests {
                 input_sync: false,
                 mode: Default::default(),
                 runtime: Default::default(),
+                color: Default::default(),
             }],
             ..WindowState::default()
         };
@@ -2663,6 +2739,7 @@ mod tests {
                 input_sync: false,
                 mode: Default::default(),
                 runtime: Default::default(),
+                color: Default::default(),
             }],
             ..WindowState::default()
         };
@@ -2688,6 +2765,7 @@ mod tests {
                     input_sync: false,
                     mode: Default::default(),
                     runtime: Default::default(),
+                    color: Default::default(),
                 },
                 SessionState {
                     uuid: "s2".into(),
@@ -2703,6 +2781,7 @@ mod tests {
                     input_sync: false,
                     mode: Default::default(),
                     runtime: Default::default(),
+                    color: Default::default(),
                 },
             ],
             ..WindowState::default()
@@ -3282,6 +3361,7 @@ mod tests {
                 input_sync: false,
                 mode: Default::default(),
                 runtime: Default::default(),
+                color: Default::default(),
             }],
             ..WindowState::default()
         };
@@ -5481,6 +5561,7 @@ mod tests {
                     input_sync: false,
                     mode: Default::default(),
                     runtime: Default::default(),
+                    color: Default::default(),
                 },
                 SessionState {
                     uuid: second_uuid.clone(),
@@ -5491,6 +5572,7 @@ mod tests {
                     input_sync: false,
                     mode: Default::default(),
                     runtime: Default::default(),
+                    color: Default::default(),
                 },
             ],
             ..WindowState::default()
@@ -5783,5 +5865,40 @@ mod tests {
 
         window.close();
         crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+    }
+
+    #[test]
+    fn notification_tier_suppresses_for_visible_session() {
+        let state = WindowState::default();
+        let uuid = state.sessions[0].uuid.clone();
+        let terminal = state.sessions[0].layout.terminal_uuids()[0].clone();
+        assert_eq!(
+            notification_tier(&terminal, Some(&uuid), true, &state),
+            NotificationTier::Suppress
+        );
+    }
+
+    #[test]
+    fn notification_tier_toasts_for_background_session_when_focused() {
+        let mut state = WindowState::default();
+        state.sessions.push(SessionState::new("Background".into()));
+        let bg_terminal = state.sessions[1].layout.terminal_uuids()[0].clone();
+        let visible_uuid = state.sessions[0].uuid.clone();
+        assert_eq!(
+            notification_tier(&bg_terminal, Some(&visible_uuid), true, &state),
+            NotificationTier::Toast
+        );
+    }
+
+    #[test]
+    fn notification_tier_desktop_when_window_unfocused() {
+        let mut state = WindowState::default();
+        state.sessions.push(SessionState::new("Background".into()));
+        let bg_terminal = state.sessions[1].layout.terminal_uuids()[0].clone();
+        let visible_uuid = state.sessions[0].uuid.clone();
+        assert_eq!(
+            notification_tier(&bg_terminal, Some(&visible_uuid), false, &state),
+            NotificationTier::Desktop
+        );
     }
 }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -114,12 +114,13 @@ impl Window {
     fn add_remote_managed_session(&self, host: &str) {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
-        let session_state = SessionState::new_managed_remote(
+        let mut session_state = SessionState::new_managed_remote(
             format!("Remote {count}"),
             host,
             WorkspacePolicy::Persistent,
             None,
         );
+        session_state.color = self.next_session_color();
         imp.state.borrow_mut().sessions.push(session_state.clone());
         self.build_session(&session_state, false);
         self.set_workspace_connection_status(&session_state.uuid, &ConnectionStatus::Connecting);
@@ -135,8 +136,9 @@ impl Window {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
         let initial_cwd = self.resolve_default_session_folder();
-        let session_state =
+        let mut session_state =
             SessionState::new_managed_local(format!("Workspace {count}"), policy, initial_cwd);
+        session_state.color = self.next_session_color();
         imp.state.borrow_mut().sessions.push(session_state.clone());
         self.build_session(&session_state, false);
         self.set_workspace_connection_status(&session_state.uuid, &ConnectionStatus::Connecting);
@@ -386,6 +388,11 @@ impl Window {
 
         if transition.persist_window_state {
             self.save_state();
+        }
+
+        if !transition.rebuilt_workspaces.is_empty() || !transition.recovered_workspaces.is_empty()
+        {
+            self.sync_sidebar_to_visible_session();
         }
     }
 

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -163,6 +163,7 @@ fn contract_any_constructible_state_roundtrips() {
                 input_sync: false,
                 mode: Default::default(),
                 runtime: Default::default(),
+                color: Default::default(),
             }],
             width: 1,
             height: 1,
@@ -179,6 +180,7 @@ fn contract_any_constructible_state_roundtrips() {
                 input_sync: true,
                 mode: Default::default(),
                 runtime: Default::default(),
+                color: Default::default(),
             }],
             ..WindowState::default()
         },
@@ -198,6 +200,7 @@ fn contract_any_constructible_state_roundtrips() {
                     input_sync: false,
                     mode: Default::default(),
                     runtime: Default::default(),
+                    color: Default::default(),
                 }],
                 ..WindowState::default()
             }
@@ -214,6 +217,7 @@ fn contract_any_constructible_state_roundtrips() {
                     input_sync: i % 2 == 0,
                     mode: Default::default(),
                     runtime: Default::default(),
+                    color: Default::default(),
                 })
                 .collect();
             WindowState {

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -79,7 +79,7 @@ fn preferences_unknown_fields_are_ignored() {
 #[test]
 fn preferences_input_sync_persists_in_session_state() {
     use rttx::runtime::WorkspaceRuntime;
-    use rttx::session::{LayoutNode, SessionMode, SessionState, WindowState};
+    use rttx::session::{LayoutNode, SessionColor, SessionMode, SessionState, WindowState};
 
     let state = WindowState {
         sessions: vec![SessionState {
@@ -91,6 +91,7 @@ fn preferences_input_sync_persists_in_session_state() {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         }],
         ..WindowState::default()
     };
@@ -129,7 +130,7 @@ fn preferences_backward_compat_missing_input_sync() {
 #[test]
 fn custom_title_persists_in_layout() {
     use rttx::runtime::WorkspaceRuntime;
-    use rttx::session::{LayoutNode, SessionMode, SessionState, WindowState};
+    use rttx::session::{LayoutNode, SessionColor, SessionMode, SessionState, WindowState};
 
     let state = WindowState {
         sessions: vec![SessionState {
@@ -146,6 +147,7 @@ fn custom_title_persists_in_layout() {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         }],
         ..WindowState::default()
     };

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -74,6 +74,7 @@ fn workflow_multi_session_state() {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         },
         SessionState {
             uuid: "s2".into(),
@@ -84,6 +85,7 @@ fn workflow_multi_session_state() {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         },
         SessionState {
             uuid: "s3".into(),
@@ -94,6 +96,7 @@ fn workflow_multi_session_state() {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         },
     ];
 
@@ -150,6 +153,7 @@ fn workflow_persist_and_restore_with_cwds() {
             input_sync: false,
             mode: SessionMode::default(),
             runtime: WorkspaceRuntime::default(),
+            color: SessionColor::default(),
         }],
         active_session_index: 0,
         width: 1200,
@@ -235,6 +239,7 @@ fn empty_session_name_is_valid() {
         input_sync: false,
         mode: SessionMode::default(),
         runtime: WorkspaceRuntime::default(),
+        color: SessionColor::default(),
     };
     let json = serde_json::to_string(&session).unwrap();
     let restored: SessionState = serde_json::from_str(&json).unwrap();
@@ -254,6 +259,7 @@ fn session_order_persists_through_serialization() {
                 input_sync: false,
                 mode: SessionMode::default(),
                 runtime: WorkspaceRuntime::default(),
+                color: SessionColor::default(),
             },
             SessionState {
                 uuid: "s1".into(),
@@ -264,6 +270,7 @@ fn session_order_persists_through_serialization() {
                 input_sync: false,
                 mode: SessionMode::default(),
                 runtime: WorkspaceRuntime::default(),
+                color: SessionColor::default(),
             },
             SessionState {
                 uuid: "s2".into(),
@@ -274,6 +281,7 @@ fn session_order_persists_through_serialization() {
                 input_sync: false,
                 mode: SessionMode::default(),
                 runtime: WorkspaceRuntime::default(),
+                color: SessionColor::default(),
             },
         ],
         active_session_index: 1,
@@ -759,4 +767,19 @@ fn remote_managed_session_is_ready_for_inventory_binding() {
     assert_eq!(remote_session.runtime.endpoint, endpoint);
     assert!(remote_session.runtime.runtime_id.is_none());
     assert!(!remote_session.runtime.pending_layout_panes.is_empty());
+}
+
+/// `active_session_index` must be clamped to valid range on restore.
+/// Regression test for #179.
+#[test]
+fn active_session_index_clamped_on_restore() {
+    use rttx::session::state::WindowState;
+
+    let state = WindowState { active_session_index: 999, ..WindowState::default() };
+
+    let json = serde_json::to_string(&state).unwrap();
+    let restored: WindowState = serde_json::from_str(&json).unwrap();
+
+    let clamped = restored.active_session_index.min(restored.sessions.len().saturating_sub(1));
+    assert_eq!(clamped, 0, "out-of-bounds index must clamp to 0");
 }

--- a/designs/RFC-002-adwaita-modernization.md
+++ b/designs/RFC-002-adwaita-modernization.md
@@ -2,7 +2,7 @@
 
 | Field         | Value                   |
 |---------------|-------------------------|
-| Status        | Accepted                |
+| Status        | Implemented              |
 | Author(s)     | Illya Yalovyy           |
 | Supersedes    | —                       |
 | Superseded by | —                       |
@@ -159,12 +159,12 @@ avoid crashes when sessions are closed before the timer fires.
 
 ## Development Plan
 
-- [ ] **Window layout** — Replace `gtk4::Box` + `adw::HeaderBar` with `adw::ToolbarView`; add `adw::ToastOverlay` — *tracked in todo.md — GNOME / Adwaita*
-- [ ] **Two-tier notifications** — Implement `terminal_is_in_visible_session`; update `notify_process_completed` — *tracked in todo.md — GNOME / Adwaita*
+- [x] **Window layout** — Replace `gtk4::Box` + `adw::HeaderBar` with `adw::ToolbarView`; add `adw::ToastOverlay`
+- [x] **Two-tier notifications** — Implement `terminal_is_in_visible_session`; update `notify_process_completed`
 - [x] **SessionRow base** — Rewrite as `adw::ActionRow` subclass
 - [x] **Session renaming** — Inline popover with `adw::EntryRow`
-- [ ] **Activity indicator** — Wire `window_title_changed` signal; debounce timer; spinner vs dot — *tracked in todo.md — GNOME / Adwaita*
-- [ ] **Session color coding** — Assign colors on creation; CSS classes; color picker UI — *tracked in todo.md — GNOME / Adwaita*
+- [x] **Activity indicator** — Wire `window_title_changed` signal; debounce timer; spinner vs dot
+- [x] **Session color coding** — Assign colors on creation; CSS classes; color picker UI deferred (NG2)
 
 ---
 


### PR DESCRIPTION
## Problem

Managed workspace rebuilds (reconnect, recovery) could change the visible session in the stack without updating the sidebar selection, causing the selected tab to diverge from the displayed content.

## Root cause

`rebuild_session_content()` calls `session_stack.set_visible_child_name()` but never syncs the sidebar `ListBox` selection. When a managed workspace is rebuilt during reconnect or recovery, the visible session can change without the sidebar knowing.

Additionally, `active_session_index` loaded from `sessions.json` was not clamped, so if sessions were removed between saves, the index could be out of bounds.

## What changed

- Added `sync_sidebar_to_visible_session()` — checks if sidebar selection matches the stack's visible child and corrects it if not
- Called after `rebuild_session_content()`
- Called after `apply_endpoint_event_transition()` when workspaces are rebuilt or recovered
- Clamped `active_session_index` on startup to prevent out-of-bounds selection

## Tests added

- `active_session_index_clamped_on_restore` — verifies out-of-bounds index is clamped

## Tests run

- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- clippy, fmt — clean

Fixes #179