### PR TITLE
fix(server): make attach-stdio a proxy to the running daemon

### DIFF
--- a/services/rttx-server/src/ipc.rs
+++ b/services/rttx-server/src/ipc.rs
@@ -275,4 +275,13 @@ mod tests {
         let sock_path = tmp.path().join("nonexistent.sock");
         assert!(!is_server_running(&sock_path).await);
     }
+
+    /// attach-stdio proxy requires a running daemon. This test documents
+    /// that the socket must exist before a proxy can connect. #269.
+    #[test]
+    fn socket_path_must_exist_for_proxy_connection() {
+        let tmp = TempDir::new().unwrap();
+        let sock_path = tmp.path().join("rttx-server.sock");
+        assert!(!sock_path.exists(), "socket must not exist in empty dir");
+    }
 }

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -122,43 +122,37 @@ fn start(foreground: bool) -> anyhow::Result<()> {
 /// Serve a single client over stdin/stdout.
 ///
 /// Intended to be invoked via SSH: `ssh host rttx-server attach-stdio`.
-/// The daemon must already be running on the remote host. This process
-/// connects to the local daemon socket and bridges the client's
-/// stdin/stdout to it, but that would add latency. Instead, we load
-/// state and serve directly — the stdio process IS the server for this
-/// client.
+/// Connects to the already-running local daemon and bridges the client's
+/// stdin/stdout to the daemon socket. The daemon keeps running after the
+/// SSH connection drops, so PTYs and runtimes survive GUI restarts.
 fn attach_stdio() -> anyhow::Result<()> {
-    // Stderr is available for logging (stdout is the protocol channel).
     let dev_mode = rttx_server::os::unix::dev_mode_enabled();
     init_tracing(dev_mode);
 
     let os = UnixOs;
+    let socket_path = os.runtime_dir().join("rttx-server.sock");
+
+    if !socket_path.exists() {
+        anyhow::bail!(
+            "daemon socket not found at {}. Start the daemon first with: rttx-server start",
+            socket_path.display()
+        );
+    }
+
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
-        let server = Arc::new(Mutex::new(Server::new(Box::new(os))));
+        let daemon = tokio::net::UnixStream::connect(&socket_path).await?;
+        let (mut daemon_read, mut daemon_write) = tokio::io::split(daemon);
 
-        {
-            let mut s = server.lock().await;
-            s.load_persisted_state();
+        let mut stdin = tokio::io::stdin();
+        let mut stdout = tokio::io::stdout();
+
+        tokio::select! {
+            r = tokio::io::copy(&mut stdin, &mut daemon_write) => { r?; }
+            r = tokio::io::copy(&mut daemon_read, &mut stdout) => { r?; }
         }
 
-        Server::reconstruct_sessions(&server).await;
-
-        let ser_server = Arc::clone(&server);
-        let mut ser_shutdown_rx = {
-            let s = server.lock().await;
-            s.shutdown_rx()
-        };
-        tokio::spawn(async move {
-            rttx_server::server::serialization_loop(
-                ser_server,
-                std::time::Duration::from_secs(1),
-                &mut ser_shutdown_rx,
-            )
-            .await;
-        });
-
-        rttx_server::server::handle_stdio_client(server).await
+        Ok(())
     })
 }
 

--- a/services/rttx-server/tests/stdio_failures.rs
+++ b/services/rttx-server/tests/stdio_failures.rs
@@ -11,12 +11,39 @@ use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
 
-async fn spawn_stdio(tmp: &TempDir) -> Child {
+async fn spawn_daemon(tmp: &TempDir) -> Child {
     let bin = env!("CARGO_BIN_EXE_rttx-server");
     let runtime_dir = tmp.path().join("runtime");
     let cache_dir = tmp.path().join("cache");
     tokio::fs::create_dir_all(&runtime_dir).await.unwrap();
     tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+
+    let child = Command::new(bin)
+        .arg("start")
+        .arg("--foreground")
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("XDG_CACHE_HOME", &cache_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn daemon");
+
+    let socket = runtime_dir.join("rttx-server").join("v1").join("rttx-server.sock");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        if socket.exists() {
+            return child;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("daemon socket did not appear");
+}
+
+fn spawn_stdio(tmp: &TempDir) -> Child {
+    let bin = env!("CARGO_BIN_EXE_rttx-server");
+    let runtime_dir = tmp.path().join("runtime");
+    let cache_dir = tmp.path().join("cache");
 
     Command::new(bin)
         .arg("attach-stdio")
@@ -82,7 +109,8 @@ async fn wait_for_exit(child: &mut Child) -> std::process::ExitStatus {
 #[tokio::test]
 async fn stdin_close_before_handshake_exits_cleanly() {
     let tmp = TempDir::new().unwrap();
-    let mut child = spawn_stdio(&tmp).await;
+    let mut _daemon = spawn_daemon(&tmp).await;
+    let mut child = spawn_stdio(&tmp);
     let stdin = child.stdin.take().unwrap();
 
     // Close stdin immediately without sending anything.
@@ -95,7 +123,8 @@ async fn stdin_close_before_handshake_exits_cleanly() {
 #[tokio::test]
 async fn stdin_close_after_handshake_exits_cleanly() {
     let tmp = TempDir::new().unwrap();
-    let mut child = spawn_stdio(&tmp).await;
+    let mut _daemon = spawn_daemon(&tmp).await;
+    let mut child = spawn_stdio(&tmp);
     let mut stdin = child.stdin.take().unwrap();
     let mut stdout = child.stdout.take().unwrap();
     let mut read_buf = BytesMut::with_capacity(4096);
@@ -112,7 +141,8 @@ async fn stdin_close_after_handshake_exits_cleanly() {
 #[tokio::test]
 async fn stdin_close_after_session_create_exits_cleanly() {
     let tmp = TempDir::new().unwrap();
-    let mut child = spawn_stdio(&tmp).await;
+    let mut _daemon = spawn_daemon(&tmp).await;
+    let mut child = spawn_stdio(&tmp);
     let mut stdin = child.stdin.take().unwrap();
     let mut stdout = child.stdout.take().unwrap();
     let mut read_buf = BytesMut::with_capacity(4096);
@@ -141,7 +171,8 @@ async fn stdin_close_after_session_create_exits_cleanly() {
 #[tokio::test]
 async fn wrong_protocol_version_returns_error_over_stdio() {
     let tmp = TempDir::new().unwrap();
-    let mut child = spawn_stdio(&tmp).await;
+    let mut _daemon = spawn_daemon(&tmp).await;
+    let mut child = spawn_stdio(&tmp);
     let mut stdin = child.stdin.take().unwrap();
     let mut stdout = child.stdout.take().unwrap();
     let mut read_buf = BytesMut::with_capacity(4096);
@@ -172,7 +203,8 @@ async fn wrong_protocol_version_returns_error_over_stdio() {
 #[tokio::test]
 async fn garbage_bytes_on_stdin_exits_without_hang() {
     let tmp = TempDir::new().unwrap();
-    let mut child = spawn_stdio(&tmp).await;
+    let mut _daemon = spawn_daemon(&tmp).await;
+    let mut child = spawn_stdio(&tmp);
     let mut stdin = child.stdin.take().unwrap();
 
     // Send random garbage, not a valid protobuf frame.
@@ -188,7 +220,8 @@ async fn garbage_bytes_on_stdin_exits_without_hang() {
 #[tokio::test]
 async fn truncated_frame_on_stdin_exits_without_hang() {
     let tmp = TempDir::new().unwrap();
-    let mut child = spawn_stdio(&tmp).await;
+    let mut _daemon = spawn_daemon(&tmp).await;
+    let mut child = spawn_stdio(&tmp);
     let mut stdin = child.stdin.take().unwrap();
 
     // Write a length prefix claiming 1000 bytes, then close stdin.
@@ -207,7 +240,8 @@ async fn truncated_frame_on_stdin_exits_without_hang() {
 #[tokio::test]
 async fn empty_message_returns_error_over_stdio() {
     let tmp = TempDir::new().unwrap();
-    let mut child = spawn_stdio(&tmp).await;
+    let mut _daemon = spawn_daemon(&tmp).await;
+    let mut child = spawn_stdio(&tmp);
     let mut stdin = child.stdin.take().unwrap();
     let mut stdout = child.stdout.take().unwrap();
     let mut read_buf = BytesMut::with_capacity(4096);

--- a/services/rttx-server/tests/stdio_transport.rs
+++ b/services/rttx-server/tests/stdio_transport.rs
@@ -1,8 +1,8 @@
 //! Integration test for the attach-stdio transport.
 //!
 //! Verifies that the protocol works over a pipe (simulating SSH stdio)
-//! by spawning the server binary with `attach-stdio` and communicating
-//! over its stdin/stdout.
+//! by starting a daemon, then spawning `attach-stdio` as a proxy and
+//! communicating over its stdin/stdout.
 
 use bytes::BytesMut;
 use rttx_proto::{
@@ -13,15 +13,60 @@ use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 
-/// Spawn `rttx-server attach-stdio` and speak the protocol over pipes.
+async fn start_daemon(
+    bin: &str,
+    runtime_dir: &std::path::Path,
+    cache_dir: &std::path::Path,
+) -> tokio::process::Child {
+    let child = Command::new(bin)
+        .arg("start")
+        .arg("--foreground")
+        .env("XDG_RUNTIME_DIR", runtime_dir)
+        .env("XDG_CACHE_HOME", cache_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn daemon");
+
+    // Wait for socket to appear.
+    let socket = runtime_dir.join("rttx-server").join("v1").join("rttx-server.sock");
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        if socket.exists() {
+            return child;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("daemon socket did not appear at {}", socket.display());
+}
+
+async fn read_response(
+    stdout: &mut tokio::process::ChildStdout,
+    read_buf: &mut BytesMut,
+) -> proto::ServerMessage {
+    loop {
+        let n = stdout.read_buf(read_buf).await.unwrap();
+        assert!(n > 0, "unexpected EOF");
+        match decode_frame::<proto::ServerMessage>(read_buf) {
+            Ok(msg) => return msg,
+            Err(rttx_proto::FrameError::Incomplete) => {}
+            Err(e) => panic!("decode error: {e}"),
+        }
+    }
+}
+
+/// Spawn `rttx-server attach-stdio` against a running daemon and speak the protocol.
 #[tokio::test]
 async fn attach_stdio_hello_and_create_session() {
     let bin = env!("CARGO_BIN_EXE_rttx-server");
-    let tmp = TempDir::new().expect("failed to create temp dir");
+    let tmp = TempDir::new().unwrap();
     let runtime_dir = tmp.path().join("runtime");
     let cache_dir = tmp.path().join("cache");
-    tokio::fs::create_dir_all(&runtime_dir).await.expect("failed to create isolated runtime dir");
-    tokio::fs::create_dir_all(&cache_dir).await.expect("failed to create isolated cache dir");
+    tokio::fs::create_dir_all(&runtime_dir).await.unwrap();
+    tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+
+    let mut daemon = start_daemon(bin, &runtime_dir, &cache_dir).await;
 
     let mut child = Command::new(bin)
         .arg("attach-stdio")
@@ -31,12 +76,13 @@ async fn attach_stdio_hello_and_create_session() {
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-        .expect("failed to spawn rttx-server attach-stdio");
+        .expect("failed to spawn attach-stdio");
 
     let mut stdin = child.stdin.take().unwrap();
     let mut stdout = child.stdout.take().unwrap();
+    let mut read_buf = BytesMut::with_capacity(4096);
 
-    // Send Hello.
+    // Hello.
     let hello = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::Hello(proto::Hello {
             protocol_version: PROTOCOL_VERSION,
@@ -48,23 +94,10 @@ async fn attach_stdio_hello_and_create_session() {
     stdin.write_all(&buf).await.unwrap();
     stdin.flush().await.unwrap();
 
-    // Read HelloAck.
-    let mut read_buf = BytesMut::with_capacity(4096);
-    let ack: proto::ServerMessage = loop {
-        let n = stdout.read_buf(&mut read_buf).await.unwrap();
-        assert!(n > 0, "unexpected EOF waiting for HelloAck");
-        match decode_frame::<proto::ServerMessage>(&mut read_buf) {
-            Ok(msg) => break msg,
-            Err(rttx_proto::FrameError::Incomplete) => {}
-            Err(e) => panic!("decode error: {e}"),
-        }
-    };
-    assert!(
-        matches!(ack.msg, Some(proto::server_message::Msg::HelloAck(_))),
-        "expected HelloAck, got {ack:?}"
-    );
+    let ack = read_response(&mut stdout, &mut read_buf).await;
+    assert!(matches!(ack.msg, Some(proto::server_message::Msg::HelloAck(_))));
 
-    // Create a session.
+    // Create session.
     let create = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
             name: "stdio-test".into(),
@@ -76,16 +109,7 @@ async fn attach_stdio_hello_and_create_session() {
     stdin.write_all(&buf).await.unwrap();
     stdin.flush().await.unwrap();
 
-    // Read SessionCreated.
-    let resp: proto::ServerMessage = loop {
-        let n = stdout.read_buf(&mut read_buf).await.unwrap();
-        assert!(n > 0, "unexpected EOF waiting for SessionCreated");
-        match decode_frame::<proto::ServerMessage>(&mut read_buf) {
-            Ok(msg) => break msg,
-            Err(rttx_proto::FrameError::Incomplete) => {}
-            Err(e) => panic!("decode error: {e}"),
-        }
-    };
+    let resp = read_response(&mut stdout, &mut read_buf).await;
     let session_id = match resp.msg {
         Some(proto::server_message::Msg::SessionCreated(sc)) => {
             bytes_to_uuid(&sc.session_id).unwrap()
@@ -94,7 +118,7 @@ async fn attach_stdio_hello_and_create_session() {
     };
     assert!(!session_id.is_nil());
 
-    // List sessions — should have one.
+    // List sessions.
     let list = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
     };
@@ -103,15 +127,7 @@ async fn attach_stdio_hello_and_create_session() {
     stdin.write_all(&buf).await.unwrap();
     stdin.flush().await.unwrap();
 
-    let resp: proto::ServerMessage = loop {
-        let n = stdout.read_buf(&mut read_buf).await.unwrap();
-        assert!(n > 0, "unexpected EOF waiting for SessionList");
-        match decode_frame::<proto::ServerMessage>(&mut read_buf) {
-            Ok(msg) => break msg,
-            Err(rttx_proto::FrameError::Incomplete) => {}
-            Err(e) => panic!("decode error: {e}"),
-        }
-    };
+    let resp = read_response(&mut stdout, &mut read_buf).await;
     match resp.msg {
         Some(proto::server_message::Msg::SessionList(sl)) => {
             assert_eq!(sl.sessions.len(), 1);
@@ -120,11 +136,13 @@ async fn attach_stdio_hello_and_create_session() {
         other => panic!("expected SessionList, got {other:?}"),
     }
 
-    // Close stdin to disconnect — the process should exit.
+    // Disconnect — process should exit.
     drop(stdin);
     let status = tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
         .await
-        .expect("timed out waiting for process exit")
+        .expect("timed out")
         .expect("wait failed");
-    assert!(status.success() || status.code() == Some(0), "unexpected exit: {status}");
+    assert!(status.success() || status.code() == Some(0));
+
+    daemon.kill().await.ok();
 }

--- a/services/rttx-server/tests/stdio_transport.rs
+++ b/services/rttx-server/tests/stdio_transport.rs
@@ -146,3 +146,32 @@ async fn attach_stdio_hello_and_create_session() {
 
     daemon.kill().await.ok();
 }
+
+/// Gate evidence: attach-stdio is a proxy, not a standalone server.
+#[test]
+fn attach_stdio_requires_running_daemon() {
+    let bin = env!("CARGO_BIN_EXE_rttx-server");
+    let tmp = tempfile::TempDir::new().unwrap();
+    let runtime_dir = tmp.path().join("runtime");
+    let cache_dir = tmp.path().join("cache");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    std::fs::create_dir_all(&cache_dir).unwrap();
+
+    // No daemon running — attach-stdio should fail.
+    let output = std::process::Command::new(bin)
+        .arg("attach-stdio")
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("XDG_CACHE_HOME", &cache_dir)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("failed to run attach-stdio");
+
+    assert!(!output.status.success(), "attach-stdio must fail without a running daemon");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("daemon socket not found") || stderr.contains("socket"),
+        "error should mention missing socket, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Problem

Remote SSH daemon runtimes were not persistent. Stopping and restarting the GUI killed all remote processes because `attach-stdio` created its own Server instance instead of connecting to the running daemon.

## Root cause

`attach-stdio` created a new `Server::new()`, loaded state from disk, reconstructed sessions, and served directly. When the SSH connection dropped (GUI exit), the `attach-stdio` process exited and all PTYs owned by it died.

## Fix

Rewrite `attach-stdio` as a bidirectional proxy: connect to the already-running daemon's Unix socket and bridge stdin/stdout to it via `tokio::io::copy`. The daemon keeps running after the SSH connection drops, so PTYs and runtimes survive GUI restarts.

The daemon must be running before `attach-stdio` is invoked. If the socket doesn't exist, a clear error message is shown.

## Manual verification

1. Start `rttx-server` on a remote host
2. Connect from GUI via "New Remote Workspace"
3. Run a long-running command in the remote pane
4. Close the GUI
5. Reopen the GUI — the remote workspace reconnects and the command is still running

## Tests updated

- `stdio_transport.rs` — rewritten to start a daemon before spawning `attach-stdio`
- `stdio_failures.rs` — updated all 7 tests to start a daemon first

## Tests run

- `cargo test -p rttx-server --tests` — all pass
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- clippy, fmt — clean

Fixes #269