### PR TITLE
feat(cli): add rttx-server status command

### DIFF
--- a/services/rttx-server/src/ipc.rs
+++ b/services/rttx-server/src/ipc.rs
@@ -284,4 +284,13 @@ mod tests {
         let sock_path = tmp.path().join("rttx-server.sock");
         assert!(!sock_path.exists(), "socket must not exist in empty dir");
     }
+
+    /// Status command uses `is_server_running` to check daemon availability. #271.
+    #[test]
+    fn is_server_running_returns_false_for_nonexistent_path() {
+        let tmp = TempDir::new().unwrap();
+        let sock_path = tmp.path().join("rttx-server.sock");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert!(!rt.block_on(is_server_running(&sock_path)));
+    }
 }

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -31,6 +31,8 @@ enum Command {
     },
     /// Stop the running daemon
     Stop,
+    /// Show daemon status and active runtimes
+    Status,
     /// Serve one client over stdin/stdout (for SSH)
     AttachStdio,
 }
@@ -41,6 +43,7 @@ fn main() -> anyhow::Result<()> {
     match cli.command.unwrap_or(Command::Start { foreground: false }) {
         Command::Start { foreground } => start(foreground),
         Command::Stop => stop(),
+        Command::Status => status(),
         Command::AttachStdio => attach_stdio(),
     }
 }
@@ -177,6 +180,109 @@ fn stop() -> anyhow::Result<()> {
         println!("Shutdown signal sent");
         Ok(())
     })
+}
+
+fn status() -> anyhow::Result<()> {
+    use bytes::BytesMut;
+    use rttx_proto::{decode_frame, encode_frame};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let os = UnixOs;
+    let socket_path = os.runtime_dir().join("rttx-server.sock");
+
+    println!("rttx-server {}", env!("CARGO_PKG_VERSION"));
+    println!("Socket: {}", socket_path.display());
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        if !ipc::is_server_running(&socket_path).await {
+            println!("Status: not running");
+            return Ok(());
+        }
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path).await?;
+        let mut buf = BytesMut::new();
+        let mut read_buf = BytesMut::with_capacity(8192);
+
+        // Hello.
+        let hello = proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Hello(proto::Hello {
+                protocol_version: rttx_proto::PROTOCOL_VERSION,
+                client_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
+            })),
+        };
+        encode_frame(&hello, &mut buf)?;
+        stream.write_all(&buf).await?;
+        stream.flush().await?;
+
+        // Read HelloAck.
+        loop {
+            stream.read_buf(&mut read_buf).await?;
+            if decode_frame::<proto::ServerMessage>(&mut read_buf).is_ok() {
+                break;
+            }
+        }
+
+        // ListSessions.
+        buf.clear();
+        let list = proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
+        };
+        encode_frame(&list, &mut buf)?;
+        stream.write_all(&buf).await?;
+        stream.flush().await?;
+
+        // Read SessionList.
+        let resp: proto::ServerMessage = loop {
+            stream.read_buf(&mut read_buf).await?;
+            match decode_frame::<proto::ServerMessage>(&mut read_buf) {
+                Ok(msg) => break msg,
+                Err(rttx_proto::FrameError::Incomplete) => {}
+                Err(e) => anyhow::bail!("decode error: {e}"),
+            }
+        };
+
+        if let Some(proto::server_message::Msg::SessionList(sl)) = resp.msg {
+            println!("Status: running");
+            println!("Runtimes: {}", sl.sessions.len());
+
+            let total_panes: usize = sl.sessions.iter().map(|s| s.panes.len()).sum();
+            let total_clients: u32 = sl.sessions.iter().map(|s| s.attached_client_count).sum();
+            println!("Panes: {total_panes}");
+            println!("Connected clients: {total_clients}");
+
+            if !sl.sessions.is_empty() {
+                println!();
+                println!(
+                    "{:<38} {:<20} {:<12} {:<6} {:<8}",
+                    "ID", "NAME", "POLICY", "PANES", "CLIENTS"
+                );
+                for session in &sl.sessions {
+                    let id = rttx_proto::bytes_to_uuid(&session.id)
+                        .map_or_else(|_| "?".into(), |u| u.to_string());
+                    let policy = match proto::RuntimePolicy::try_from(session.policy) {
+                        Ok(proto::RuntimePolicy::Persistent) => "persistent",
+                        Ok(proto::RuntimePolicy::Ephemeral) => "ephemeral",
+                        _ => "unknown",
+                    };
+                    println!(
+                        "{:<38} {:<20} {:<12} {:<6} {:<8}",
+                        id,
+                        truncate(&session.name, 20),
+                        policy,
+                        session.panes.len(),
+                        session.attached_client_count,
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    })
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max { s.to_string() } else { format!("{}…", &s[..max - 1]) }
 }
 
 /// Check if a daemon is running by reading the PID file and probing the process.

--- a/services/rttx-server/tests/stdio_transport.rs
+++ b/services/rttx-server/tests/stdio_transport.rs
@@ -175,3 +175,22 @@ fn attach_stdio_requires_running_daemon() {
         "error should mention missing socket, got: {stderr}"
     );
 }
+
+/// The status command must show version and socket path even when daemon is not running.
+#[test]
+fn status_command_shows_not_running_when_no_daemon() {
+    let bin = env!("CARGO_BIN_EXE_rttx-server");
+    let tmp = tempfile::TempDir::new().unwrap();
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+
+    let output = std::process::Command::new(bin)
+        .arg("status")
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .output()
+        .expect("failed to run status");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("rttx-server"), "must show version line");
+    assert!(stdout.contains("not running"), "must report not running");
+}


### PR DESCRIPTION
Add `rttx-server status` command for daemon troubleshooting and monitoring.

## What it does

Connects to the daemon socket, queries `ListSessions`, and displays:
- Version, socket path
- Running/not running status
- Number of runtimes, panes, connected clients
- Table of active runtimes with ID, name, policy, pane count, client count

## Example output

```
rttx-server 0.1.0
Socket: /run/user/1000/rttx-server/v1/rttx-server.sock
Status: running
Runtimes: 2
Panes: 5
Connected clients: 1

ID                                     NAME                 POLICY       PANES  CLIENTS
d7d04564-b2bf-4302-9495-e65c4df12ac6   Workspace 1          persistent   3      1
a1b2c3d4-e5f6-7890-abcd-ef1234567890   Remote Work          persistent   2      0
```

When daemon is not running:
```
rttx-server 0.1.0
Socket: /run/user/1000/rttx-server/v1/rttx-server.sock
Status: not running
```

## Related issues created

- #272 `rttx-server list` — detailed runtime listing
- #273 `rttx-server info <id>` — single runtime details
- #274 `rttx-server logs` — tail daemon logs
- #275 `rttx-server config` — show paths and settings
- #276 `rttx-server kill <id>` — terminate a runtime

## Tests run

- `cargo test -p rttx-server --tests` — all pass
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- clippy, fmt — clean
- Manual: `cargo run -p rttx-server -- status` verified against running daemon

Fixes #271