### PR TITLE
fix(server): set COLORTERM=truecolor in daemon-spawned PTYs

### DIFF
--- a/services/rttx-server/src/pty.rs
+++ b/services/rttx-server/src/pty.rs
@@ -61,7 +61,7 @@ impl Pty {
         if let Some(ref cwd) = config.cwd {
             cmd = cmd.current_dir(cwd);
         }
-        cmd = cmd.env("TERM", "xterm-256color");
+        cmd = cmd.env("TERM", "xterm-256color").env("COLORTERM", "truecolor");
         for (key, val) in &config.env {
             cmd = cmd.env(key, val);
         }
@@ -130,4 +130,33 @@ impl Pty {
 /// Determine the user's default shell.
 fn default_shell() -> String {
     std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawned_pty_child_inherits_colorterm() {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        rt.block_on(async {
+            let config = PtyConfig {
+                command: vec!["/bin/sh".into(), "-c".into(), "sleep 60".into()],
+                ..PtyConfig::default()
+            };
+            let mut pty = Pty::spawn(Uuid::new_v4(), &config).expect("spawn must succeed");
+            let pid = pty.pid().expect("child must be running");
+            let environ = std::fs::read_to_string(format!("/proc/{pid}/environ"))
+                .expect("read /proc environ");
+            assert!(
+                environ.contains("COLORTERM=truecolor"),
+                "PTY child must have COLORTERM=truecolor in its environment"
+            );
+            assert!(
+                environ.contains("TERM=xterm-256color"),
+                "PTY child must have TERM=xterm-256color in its environment"
+            );
+            pty.kill().expect("kill must succeed");
+        });
+    }
 }

--- a/services/rttx-server/tests/pty_basic.rs
+++ b/services/rttx-server/tests/pty_basic.rs
@@ -50,6 +50,40 @@ async fn pty_resize() {
     pty.kill().expect("kill failed");
 }
 
+#[test]
+fn pty_sets_colorterm_truecolor() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        let config = PtyConfig {
+            command: vec!["/bin/sh".into(), "-c".into(), "echo COLORTERM=$COLORTERM".into()],
+            cwd: None,
+            env: Vec::new(),
+            cols: 80,
+            rows: 24,
+        };
+        let mut pty = Pty::spawn(Uuid::new_v4(), &config).expect("failed to spawn PTY");
+
+        let mut output = Vec::new();
+        let mut buf = [0u8; 1024];
+
+        for _ in 0..50 {
+            match pty.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => output.extend_from_slice(&buf[..n]),
+            }
+            if output.windows(b"COLORTERM=truecolor".len()).any(|w| w == b"COLORTERM=truecolor") {
+                break;
+            }
+        }
+
+        let text = String::from_utf8_lossy(&output);
+        assert!(
+            text.contains("COLORTERM=truecolor"),
+            "PTY must set COLORTERM=truecolor for consistent CLI color support, got: {text}"
+        );
+    });
+}
+
 #[tokio::test]
 async fn pty_exit_status() {
     let config = PtyConfig {


### PR DESCRIPTION
## Summary
- Set `COLORTERM=truecolor` alongside `TERM=xterm-256color` in `Pty::spawn()` so all daemon-backed panes consistently advertise truecolor support
- Without this, `COLORTERM` was inherited from the daemon's environment, causing inconsistent CLI app behavior between local and remote workspaces (e.g. Gemini CLI using basic ANSI locally but unreadable 24-bit RGB colors remotely on light backgrounds)

## Manual verification
1. Open rttx with a light theme (Daybreak)
2. Create a local persistent workspace and a remote persistent workspace
3. Run `echo $COLORTERM` in both — should show `truecolor` in both
4. Run a truecolor-aware CLI app (e.g. Gemini CLI) in both — colors should be consistent

## Tests added
- `pty_sets_colorterm_truecolor` in `services/rttx-server/tests/pty_basic.rs` — verifies the spawned PTY shell sees `COLORTERM=truecolor`

## Tests run
- `cargo build --workspace` ✅
- `cargo test -p rttx-server --test pty_basic` ✅ (4/4 pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (except pre-existing `list_sessions_includes_runtime_inventory_metadata` failure on mainline)

Fixes #280