### PR TITLE
feat(build): include git commit hash in version strings

### DIFF
--- a/clients/rttx/build.rs
+++ b/clients/rttx/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+fn main() {
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+}

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1084,7 +1084,7 @@ impl Window {
         about.set_transient_for(Some(self));
         about.set_application_name(config::display_name());
         about.set_application_icon(config::icon_name());
-        about.set_version(env!("CARGO_PKG_VERSION"));
+        about.set_version(&format!("{} ({})", env!("CARGO_PKG_VERSION"), env!("GIT_HASH")));
         about.set_developer_name(config::DEVELOPER_NAME);
         about.set_developers(&[config::DEVELOPER_NAME]);
         about.set_website(config::PROJECT_WEBSITE);

--- a/services/rttx-server/build.rs
+++ b/services/rttx-server/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+fn main() {
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+}

--- a/services/rttx-server/src/ipc.rs
+++ b/services/rttx-server/src/ipc.rs
@@ -293,4 +293,12 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         assert!(!rt.block_on(is_server_running(&sock_path)));
     }
+
+    /// `GIT_HASH` env var must be set by `build.rs` for version tracking.
+    #[test]
+    fn git_hash_env_is_set_at_build_time() {
+        let hash = env!("GIT_HASH");
+        // Hash may be empty in non-git builds (tarballs), but must be set.
+        assert!(hash.len() <= 40, "git hash should be at most 40 chars");
+    }
 }

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::EnvFilter;
 #[derive(Parser)]
 #[command(
     name = "rttx-server",
-    version,
+    version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")"),
     about = "Daemon runtime service for the rttx terminal emulator"
 )]
 struct Cli {
@@ -190,7 +190,7 @@ fn status() -> anyhow::Result<()> {
     let os = UnixOs;
     let socket_path = os.runtime_dir().join("rttx-server.sock");
 
-    println!("rttx-server {}", env!("CARGO_PKG_VERSION"));
+    println!("rttx-server {} ({})", env!("CARGO_PKG_VERSION"), env!("GIT_HASH"));
     println!("Socket: {}", socket_path.display());
 
     let rt = tokio::runtime::Runtime::new()?;

--- a/services/rttx-server/tests/stdio_transport.rs
+++ b/services/rttx-server/tests/stdio_transport.rs
@@ -194,3 +194,14 @@ fn status_command_shows_not_running_when_no_daemon() {
     assert!(stdout.contains("rttx-server"), "must show version line");
     assert!(stdout.contains("not running"), "must report not running");
 }
+
+/// Version string must include git hash. Regression for version tracking.
+#[test]
+fn version_includes_git_hash() {
+    let bin = env!("CARGO_BIN_EXE_rttx-server");
+    let output =
+        std::process::Command::new(bin).arg("--version").output().expect("failed to run --version");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("rttx-server"), "must show binary name");
+    assert!(stdout.contains('('), "must include git hash in parens");
+}


### PR DESCRIPTION
Both the GUI client and daemon now show the git commit hash in their version strings.

**Daemon:**
```
$ rttx-server --version
rttx-server 0.1.0 (f334566)

$ rttx-server status
rttx-server 0.1.0 (f334566)
Socket: ...
```

**GUI:** About dialog shows `0.1.0 (f334566)`

Implementation: `build.rs` in each package runs `git rev-parse --short HEAD` and sets `GIT_HASH` env var. Falls back to empty string if git is unavailable (e.g. Flatpak builds from tarball).