### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "prost",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/clients/rttx/Cargo.toml
+++ b/clients/rttx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rttx"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 description = "A tiling terminal emulator for GNOME"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.1.0',
+  version: '0.2.0',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -1,5 +1,5 @@
 Name:           rttx
-Version:        0.1.0
+Version:        0.2.0
 Release:        1%{?dist}
 Summary:        A tiling terminal emulator for GNOME
 

--- a/protocols/rttx-proto/Cargo.toml
+++ b/protocols/rttx-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rttx-proto"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 

--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rttx-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 


### PR DESCRIPTION
Bump all package versions from 0.1.0 to 0.2.0:
- `clients/rttx/Cargo.toml`
- `services/rttx-server/Cargo.toml`
- `protocols/rttx-proto/Cargo.toml`
- `meson.build`
- `packaging/rttx/rttx.spec`

Verified: `rttx-server --version` → `rttx-server 0.2.0 (d43e6c8)`