### PR TITLE
fix(terminal): forward F-keys to PTY in managed panes

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -110,6 +110,18 @@ fn encode_terminal_key_input(
         gtk4::gdk::Key::Delete | gtk4::gdk::Key::KP_Delete => Some(b"\x1b[3~".to_vec()),
         gtk4::gdk::Key::Page_Up | gtk4::gdk::Key::KP_Page_Up => Some(b"\x1b[5~".to_vec()),
         gtk4::gdk::Key::Page_Down | gtk4::gdk::Key::KP_Page_Down => Some(b"\x1b[6~".to_vec()),
+        gtk4::gdk::Key::F1 => Some(b"\x1bOP".to_vec()),
+        gtk4::gdk::Key::F2 => Some(b"\x1bOQ".to_vec()),
+        gtk4::gdk::Key::F3 => Some(b"\x1bOR".to_vec()),
+        gtk4::gdk::Key::F4 => Some(b"\x1bOS".to_vec()),
+        gtk4::gdk::Key::F5 => Some(b"\x1b[15~".to_vec()),
+        gtk4::gdk::Key::F6 => Some(b"\x1b[17~".to_vec()),
+        gtk4::gdk::Key::F7 => Some(b"\x1b[18~".to_vec()),
+        gtk4::gdk::Key::F8 => Some(b"\x1b[19~".to_vec()),
+        gtk4::gdk::Key::F9 => Some(b"\x1b[20~".to_vec()),
+        gtk4::gdk::Key::F10 => Some(b"\x1b[21~".to_vec()),
+        gtk4::gdk::Key::F11 => Some(b"\x1b[23~".to_vec()),
+        gtk4::gdk::Key::F12 => Some(b"\x1b[24~".to_vec()),
         _ => {
             let ch = key.to_unicode()?;
             if ctrl {
@@ -384,6 +396,57 @@ mod tests {
             ),
             TerminalKeyAction::CopySelection
         );
+    }
+
+    /// F-keys must produce xterm escape sequences for managed terminals. #293.
+    #[test]
+    fn fkeys_produce_escape_sequences() {
+        let expected: &[(gtk4::gdk::Key, &[u8])] = &[
+            (gtk4::gdk::Key::F1, b"\x1bOP"),
+            (gtk4::gdk::Key::F2, b"\x1bOQ"),
+            (gtk4::gdk::Key::F3, b"\x1bOR"),
+            (gtk4::gdk::Key::F4, b"\x1bOS"),
+            (gtk4::gdk::Key::F5, b"\x1b[15~"),
+            (gtk4::gdk::Key::F6, b"\x1b[17~"),
+            (gtk4::gdk::Key::F7, b"\x1b[18~"),
+            (gtk4::gdk::Key::F8, b"\x1b[19~"),
+            (gtk4::gdk::Key::F9, b"\x1b[20~"),
+            (gtk4::gdk::Key::F10, b"\x1b[21~"),
+            (gtk4::gdk::Key::F11, b"\x1b[23~"),
+            (gtk4::gdk::Key::F12, b"\x1b[24~"),
+        ];
+        for (key, seq) in expected {
+            let result = encode_terminal_key_input(*key, gtk4::gdk::ModifierType::empty());
+            assert_eq!(
+                result.as_deref(),
+                Some(*seq as &[u8]),
+                "F-key {key:?} should produce escape sequence"
+            );
+        }
+    }
+
+    /// F-keys must be forwarded to PTY in managed mode, not dropped. #293.
+    #[test]
+    fn managed_terminal_forwards_fkeys_to_pty() {
+        let action = terminal_key_action(
+            TerminalInputBackend::Managed,
+            gtk4::gdk::Key::F1,
+            gtk4::gdk::ModifierType::empty(),
+            false,
+            false,
+        );
+        assert!(
+            matches!(action, TerminalKeyAction::ForwardToPty(_)),
+            "F1 must be ForwardToPty in managed mode, got {action:?}"
+        );
+    }
+
+    /// Alt+F-key must prepend ESC to the F-key sequence. #293.
+    #[test]
+    fn alt_fkey_prepends_escape() {
+        let result =
+            encode_terminal_key_input(gtk4::gdk::Key::F2, gtk4::gdk::ModifierType::ALT_MASK);
+        assert_eq!(result.as_deref(), Some(b"\x1b\x1bOQ" as &[u8]));
     }
 }
 

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -4,6 +4,16 @@ pub mod links;
 pub mod persistent_widget;
 pub mod widget;
 
+/// Test-only re-export of `encode_terminal_key_input`.
+#[doc(hidden)]
+#[must_use]
+pub fn encode_terminal_key_input_for_test(
+    key: gtk4::gdk::Key,
+    state: gtk4::gdk::ModifierType,
+) -> Option<Vec<u8>> {
+    encode_terminal_key_input(key, state)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TerminalInputBackend {
     Direct,

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -850,3 +850,24 @@ fn connection_status_lifecycle_is_deterministic() {
     );
     assert!(matches!(s, ConnectionStatus::Blocked(_)));
 }
+
+/// F-keys must produce xterm escape sequences for managed terminals. Regression for #293.
+#[test]
+fn managed_fkeys_encode_to_escape_sequences() {
+    use rttx::terminal::encode_terminal_key_input_for_test;
+
+    let fkeys = [
+        (gtk4::gdk::Key::F1, b"\x1bOP".as_slice()),
+        (gtk4::gdk::Key::F5, b"\x1b[15~".as_slice()),
+        (gtk4::gdk::Key::F10, b"\x1b[21~".as_slice()),
+        (gtk4::gdk::Key::F12, b"\x1b[24~".as_slice()),
+    ];
+    for (key, expected) in fkeys {
+        let result = encode_terminal_key_input_for_test(key, gtk4::gdk::ModifierType::empty());
+        assert_eq!(
+            result.as_deref(),
+            Some(expected),
+            "F-key {key:?} must encode to escape sequence"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

F-keys (F1-F12) don't work in terminal applications (htop F10 quit, mc F-key menus, vim help) when using daemon-backed (managed) panes. The keys are silently dropped.

## Root cause

`encode_terminal_key_input` in `terminal/mod.rs` was missing F1-F12 key encodings. For managed panes, the key controller intercepts all keys and encodes them as byte sequences to forward to the daemon PTY. F-keys fell through to `key.to_unicode()` which returns `None`, causing the function to return `None` → `PassThrough` → the key is lost (VTE doesn't have a PTY for managed panes).

## Fix

Add standard xterm F-key escape sequences:
- F1-F4: SS3 format (`ESC O P/Q/R/S`)
- F5-F12: CSI tilde format (`ESC [ 15~/17~/18~/19~/20~/21~/23~/24~`)

Alt+F-key combinations work automatically via the existing Alt prefix logic.

## Manual verification

1. Open a managed workspace, run `htop`
2. Press F10 — htop should quit
3. Run `mc`, press F5/F8/F10 — file operations should work
4. Press F1 in bash — help should appear

## Tests added

- `fkeys_produce_escape_sequences` — verifies all 12 F-key encodings
- `managed_terminal_forwards_fkeys_to_pty` — verifies F1 produces `ForwardToPty` in managed mode
- `alt_fkey_prepends_escape` — verifies Alt+F2 prepends ESC

## Tests run

- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- `bash .github/scripts/run-clippy.sh` — clean
- `cargo fmt` — clean

Fixes #293