### PR TITLE
fix: pass source pane CWD to daemon when splitting managed panes

### DIFF
--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -289,10 +289,15 @@ impl DaemonConnection {
     }
 
     /// Create a pane in a session and return the new pane UUID.
-    pub async fn create_pane(&mut self, session_id: Uuid) -> Result<Uuid, DaemonError> {
+    pub async fn create_pane(
+        &mut self,
+        session_id: Uuid,
+        cwd: Option<String>,
+    ) -> Result<Uuid, DaemonError> {
         let msg = proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: uuid_to_bytes(session_id),
+                cwd,
             })),
         };
         self.send(&msg).await?;

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -95,6 +95,7 @@ enum EndpointCommand {
         workspace_id: String,
         runtime_id: String,
         layout_terminal_uuid: String,
+        cwd: Option<String>,
     },
     ClosePane {
         workspace_id: String,
@@ -203,11 +204,13 @@ impl EndpointConnectionManager {
         endpoint: &RuntimeEndpoint,
         runtime_id: &str,
         layout_terminal_uuid: &str,
+        cwd: Option<String>,
     ) {
         let _ = self.endpoint_handle(endpoint).send(EndpointCommand::CreatePane {
             workspace_id: workspace_id.to_string(),
             runtime_id: runtime_id.to_string(),
             layout_terminal_uuid: layout_terminal_uuid.to_string(),
+            cwd,
         });
     }
 
@@ -447,6 +450,7 @@ impl EndpointActor {
                             workspace_id,
                             runtime_id,
                             layout_terminal_uuid,
+                            cwd: None,
                         });
                     } else {
                         self.emit_status(&workspace_id, ConnectionStatus::Connected);
@@ -455,7 +459,7 @@ impl EndpointActor {
                     self.emit_status(&workspace_id, ConnectionStatus::Connected);
                 }
             }
-            EndpointCommand::CreatePane { workspace_id, runtime_id, layout_terminal_uuid } => {
+            EndpointCommand::CreatePane { workspace_id, runtime_id, layout_terminal_uuid, cwd } => {
                 if let Err(problem) = self.ensure_connected(&workspace_id).await {
                     self.emit_error(
                         &workspace_id,
@@ -477,6 +481,7 @@ impl EndpointActor {
                 let msg = proto::ClientMessage {
                     msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                         session_id: rttx_proto::uuid_to_bytes(runtime_uuid),
+                        cwd,
                     })),
                 };
                 if let Err(error) = self.send_message(&msg).await {

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1898,6 +1898,7 @@ impl Window {
                         &session_state.runtime.endpoint,
                         runtime_id,
                         &new_terminal_uuid,
+                        source_cwd,
                     );
                 }
             }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -359,6 +359,7 @@ impl Window {
                     &request.endpoint,
                     &request.runtime_id,
                     &request.layout_terminal_uuid,
+                    request.cwd.clone(),
                 );
             }
         }

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -52,6 +52,7 @@ pub struct ManagedPaneCreateRequest {
     pub endpoint: RuntimeEndpoint,
     pub runtime_id: String,
     pub layout_terminal_uuid: String,
+    pub cwd: Option<String>,
 }
 
 /// Pure outcome of reconciling a daemon endpoint event against app state.
@@ -117,11 +118,13 @@ impl WindowState {
                 transition.pane_snapshot_restores = snapshot_restores;
 
                 for layout_terminal_uuid in panes_to_create {
+                    let cwd = session_state.layout.terminal_cwd(&layout_terminal_uuid);
                     transition.pane_create_requests.push(ManagedPaneCreateRequest {
                         workspace_id: workspace_id.clone(),
                         endpoint: session_state.runtime.endpoint.clone(),
                         runtime_id: runtime_id.clone(),
                         layout_terminal_uuid,
+                        cwd,
                     });
                 }
             }
@@ -1044,6 +1047,7 @@ mod tests {
                 endpoint: RuntimeEndpoint::Local,
                 runtime_id: runtime_id.clone(),
                 layout_terminal_uuid: second_terminal_uuid,
+                cwd: None,
             }],
         );
         assert_eq!(
@@ -1335,6 +1339,35 @@ mod tests {
             session.layout.terminal_cwd(layout_uuid).as_deref(),
             Some("/new/project"),
             "layout CWD must be updated from snapshot during workspace opened"
+        );
+    }
+
+    /// Pane create requests must carry the layout node's CWD. #297.
+    #[test]
+    fn reconcile_workspace_opened_propagates_layout_cwd_to_pane_create_request() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let existing_uuid = uuid::Uuid::new_v4().to_string();
+        let new_uuid = uuid::Uuid::new_v4().to_string();
+        let mut state = window_state(vec![managed_session(
+            "ws-1",
+            "Workspace",
+            hsplit(term(&existing_uuid), term_full(&new_uuid, "/srv/project", "Shell")),
+        )]);
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(
+                &runtime_id,
+                vec![pane_snapshot(&existing_uuid, "Shell", "/home", b"")],
+            ),
+        });
+
+        assert_eq!(transition.pane_create_requests.len(), 1);
+        assert_eq!(
+            transition.pane_create_requests[0].cwd.as_deref(),
+            Some("/srv/project"),
+            "pane create request must carry layout CWD"
         );
     }
 }

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -887,3 +887,67 @@ fn ctrl_arrow_encodes_with_modifier_param() {
         Some(b"\x1b[1;5D".as_slice()),
     );
 }
+
+/// Split pane CWD must propagate through reconciliation pane create requests. #297.
+#[test]
+fn split_pane_cwd_propagates_through_reconciliation_create_request() {
+    use rttx::daemon_bridge::EndpointEvent;
+    use rttx::runtime::WorkspacePolicy;
+    use rttx::session::*;
+
+    let first_uuid = uuid::Uuid::new_v4().to_string();
+    let second_uuid = uuid::Uuid::new_v4().to_string();
+    let runtime_id = uuid::Uuid::new_v4().to_string();
+
+    // Build a managed workspace with two panes, second has a CWD from a prior split.
+    let layout = LayoutNode::Split {
+        orientation: SplitOrientation::Horizontal,
+        ratio: 0.5,
+        first: Box::new(LayoutNode::Terminal {
+            uuid: first_uuid.clone(),
+            profile: None,
+            cwd: None,
+            custom_title: None,
+        }),
+        second: Box::new(LayoutNode::Terminal {
+            uuid: second_uuid,
+            profile: None,
+            cwd: Some("/srv/project".into()),
+            custom_title: None,
+        }),
+    };
+
+    let mut session =
+        SessionState::new_managed_local("Workspace".into(), WorkspacePolicy::Persistent, None);
+    session.layout = layout;
+
+    let mut state = WindowState { sessions: vec![session], ..Default::default() };
+
+    // Simulate daemon reporting only the first pane exists.
+    let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+        workspace_id: state.sessions[0].uuid.clone(),
+        runtime_id: runtime_id.clone(),
+        snapshot: rttx_proto::proto::Snapshot {
+            session_id: rttx_proto::uuid_to_bytes(runtime_id.parse().unwrap()),
+            panes: vec![rttx_proto::proto::PaneSnapshot {
+                pane_id: rttx_proto::uuid_to_bytes(first_uuid.parse().unwrap()),
+                title: "Shell".into(),
+                cwd: "/home".into(),
+                scrollback: vec![],
+                cols: 80,
+                rows: 24,
+                exit_status: None,
+            }],
+            revision: 0,
+            current_client_role: 0,
+        },
+    });
+
+    // The second pane should be requested with the layout CWD.
+    assert_eq!(transition.pane_create_requests.len(), 1);
+    assert_eq!(
+        transition.pane_create_requests[0].cwd.as_deref(),
+        Some("/srv/project"),
+        "reconciliation must carry layout CWD to pane create request"
+    );
+}

--- a/protocols/rttx-proto/proto/rttx.proto
+++ b/protocols/rttx-proto/proto/rttx.proto
@@ -44,6 +44,7 @@ message TerminateSession {
 
 message CreatePane {
     bytes session_id = 1;
+    optional string cwd = 2;
 }
 
 message ClosePane {

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -168,6 +168,7 @@ mod tests {
             proto::ClientMessage {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: session_id.clone(),
+                    cwd: None,
                 })),
             },
             proto::ClientMessage {

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -461,8 +461,8 @@ impl Server {
                         let _ = std::fs::create_dir_all(parent);
                     }
                     let env = vec![("HISTFILE".into(), hist.to_string_lossy().into_owned())];
-                    let config =
-                        PaneSpawnConfig { command: vec![], cwd: None, env, cols: 80, rows: 24 };
+                    let cwd = req.cwd;
+                    let config = PaneSpawnConfig { command: vec![], cwd, env, cols: 80, rows: 24 };
                     s.engine.spawn_pane(pane_id, &config)
                 };
 

--- a/services/rttx-server/tests/client_lifecycle.rs
+++ b/services/rttx-server/tests/client_lifecycle.rs
@@ -42,6 +42,7 @@ async fn reconnect_restores_scrollback() {
         c.send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
+                cwd: None,
             })),
         })
         .await;
@@ -214,6 +215,7 @@ async fn restart_preserves_session_count_and_scrollback() {
         c.send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
+                cwd: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -223,10 +223,20 @@ pub async fn attach_ro(client: &mut TestClient, session_id: &[u8]) -> proto::Sna
 
 /// Create a pane, draining interleaved Deltas until `PaneCreated` arrives.
 pub async fn create_pane(client: &mut TestClient, session_id: &[u8]) -> Vec<u8> {
+    create_pane_with_cwd(client, session_id, None).await
+}
+
+/// Create a pane with an optional CWD, draining interleaved Deltas until `PaneCreated` arrives.
+pub async fn create_pane_with_cwd(
+    client: &mut TestClient,
+    session_id: &[u8],
+    cwd: Option<String>,
+) -> Vec<u8> {
     client
         .send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.to_vec(),
+                cwd,
             })),
         })
         .await;

--- a/services/rttx-server/tests/gui_restore_flow.rs
+++ b/services/rttx-server/tests/gui_restore_flow.rs
@@ -42,6 +42,7 @@ async fn gui_restore_flow_no_duplicates() {
             c.send(&proto::ClientMessage {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: sid.clone(),
+                    cwd: None,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/inventory.rs
+++ b/services/rttx-server/tests/inventory.rs
@@ -31,6 +31,7 @@ async fn list_sessions_includes_runtime_inventory_metadata() {
         .send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
+                cwd: None,
             })),
         })
         .await;
@@ -178,6 +179,7 @@ async fn list_sessions_marks_restored_runtime_and_panes_as_reconstructed() {
             .send(&proto::ClientMessage {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: session_id.clone(),
+                    cwd: None,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/make_pane_persistent.rs
+++ b/services/rttx-server/tests/make_pane_persistent.rs
@@ -51,6 +51,7 @@ async fn make_pane_persistent_flow() {
     c.send(&proto::ClientMessage {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.clone(),
+            cwd: None,
         })),
     })
     .await;

--- a/services/rttx-server/tests/negative_protocol.rs
+++ b/services/rttx-server/tests/negative_protocol.rs
@@ -147,6 +147,7 @@ async fn create_pane_in_nonexistent_session_returns_error() {
     let msg = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: bogus_uuid(),
+            cwd: None,
         })),
     };
     client.send(&msg).await;
@@ -352,6 +353,7 @@ async fn attach_and_create_pane(client: &mut TestClient, session_id: &[u8]) -> V
     let msg = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.to_vec(),
+            cwd: None,
         })),
     };
     client.send(&msg).await;

--- a/services/rttx-server/tests/ownership.rs
+++ b/services/rttx-server/tests/ownership.rs
@@ -127,6 +127,7 @@ async fn read_only_attach_cannot_mutate_runtime() {
         .send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
+                cwd: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/ownership_races.rs
+++ b/services/rttx-server/tests/ownership_races.rs
@@ -66,6 +66,7 @@ async fn readers_observe_pane_created_push() {
         .send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
+                cwd: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/pty_io.rs
+++ b/services/rttx-server/tests/pty_io.rs
@@ -27,6 +27,7 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
     let create_pane = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.clone(),
+            cwd: None,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/reconstruction.rs
+++ b/services/rttx-server/tests/reconstruction.rs
@@ -38,6 +38,7 @@ async fn reconstruct_session_after_restart() {
         let create_pane = proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
+                cwd: None,
             })),
         };
         client.send(&create_pane).await;
@@ -160,6 +161,7 @@ async fn reconstruct_session_respawns_shell_in_last_reported_cwd() {
             .send(&proto::ClientMessage {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: session_id.clone(),
+                    cwd: None,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/revisions.rs
+++ b/services/rttx-server/tests/revisions.rs
@@ -48,6 +48,7 @@ async fn mutation_acks_return_monotonic_runtime_revisions() {
         .send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
+                cwd: None,
             })),
         })
         .await;
@@ -173,6 +174,7 @@ async fn runtime_revision_survives_restart_and_attach_advances_it() {
             .send(&proto::ClientMessage {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: session_id.clone(),
+                    cwd: None,
                 })),
             })
             .await;
@@ -263,6 +265,7 @@ async fn failed_close_pane_returns_error_without_revision_change() {
         .send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
+                cwd: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/runtime_policy.rs
+++ b/services/rttx-server/tests/runtime_policy.rs
@@ -152,7 +152,10 @@ async fn ephemeral_runtime_is_not_restored_after_restart() {
 
         client
             .send(&proto::ClientMessage {
-                msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane { session_id })),
+                msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+                    session_id,
+                    cwd: None,
+                })),
             })
             .await;
         assert!(matches!(

--- a/services/rttx-server/tests/scrollback.rs
+++ b/services/rttx-server/tests/scrollback.rs
@@ -30,6 +30,7 @@ async fn scrollback_flushed_to_disk_after_serialization_tick() {
     let create_pane = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.clone(),
+            cwd: None,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/session_lifecycle.rs
+++ b/services/rttx-server/tests/session_lifecycle.rs
@@ -141,6 +141,7 @@ async fn create_and_close_pane() {
     let create_pane = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.clone(),
+            cwd: None,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -87,6 +87,7 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
         .send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
+                cwd: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/split_cwd.rs
+++ b/services/rttx-server/tests/split_cwd.rs
@@ -1,0 +1,102 @@
+mod common;
+
+use common::{TestClient, create_pane_with_cwd, start_test_server};
+use rttx_proto::proto;
+use std::time::Duration;
+
+/// Pane created with a CWD should spawn its shell in that directory. #297.
+#[tokio::test]
+async fn create_pane_with_cwd_spawns_in_target_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+            name: "cwd-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    let target_dir = std::env::temp_dir();
+    let canonical_target =
+        std::fs::canonicalize(&target_dir).unwrap_or_else(|_| target_dir.clone());
+    let target_str = canonical_target.to_string_lossy().to_string();
+
+    let pane_id = create_pane_with_cwd(&mut client, &session_id, Some(target_str.clone())).await;
+
+    // Attach to receive output.
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+            session_id: session_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+
+    // Drain the snapshot.
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(_)) => break,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    }
+
+    // Send `pwd` and read output.
+    let input = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            session_id: session_id.clone(),
+            pane_id: pane_id.clone(),
+            data: b"pwd\n".to_vec(),
+        })),
+    };
+    client.send(&input).await;
+
+    // Collect output until we see the target directory.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut output = String::new();
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(delta)) = msg.msg
+        {
+            output.push_str(&String::from_utf8_lossy(&delta.data));
+            if output.contains(&target_str) {
+                return; // Success
+            }
+        }
+    }
+    panic!(
+        "pwd output did not contain target directory {target_str:?} within timeout.\nOutput: {output}"
+    );
+}
+
+/// Pane created without CWD should still work (spawns in default directory). #297.
+#[tokio::test]
+async fn create_pane_without_cwd_uses_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+            name: "no-cwd-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    // Should not panic — None CWD is valid.
+    let _pane_id = create_pane_with_cwd(&mut client, &session_id, None).await;
+}


### PR DESCRIPTION
## Problem

When splitting a pane in a managed (daemon-backed) session, the new pane starts in `$HOME` instead of inheriting the source pane's working directory. Affects both local and remote daemon-backed workspaces.

## Root cause

The `CreatePane` protobuf message had no `cwd` field. The GUI correctly read the source pane's CWD and stored it in the layout node, but never transmitted it to the daemon. The daemon spawned every new pane with `cwd: None`, defaulting to `$HOME`.

## What changed

1. **Proto**: Added `optional string cwd = 2` to `CreatePane` message
2. **Client**: Thread CWD through `daemon_bridge::create_pane()` → `EndpointCommand::CreatePane` → wire message
3. **Server**: Use `req.cwd` in `PaneSpawnConfig` when spawning the pane
4. **Reconciliation**: `ManagedPaneCreateRequest` now carries the layout node's CWD, so panes created after reconnect also inherit the persisted CWD

The proto field is `optional`, so old clients that omit it get the existing default-directory behavior (backward compatible).

## Manual verification

1. Start rttx in dev mode with daemon: `RTTX_DEV_MODE=1 cargo run -p rttx`
2. Open a managed workspace, `cd /tmp`
3. Split horizontally (Ctrl+Shift+E)
4. The new pane should start in `/tmp`, not `$HOME`

## Tests added

- **`create_pane_with_cwd_spawns_in_target_directory`** — server integration test: creates a pane with CWD, sends `pwd`, verifies output contains the target directory
- **`create_pane_without_cwd_uses_default`** — server integration test: creates a pane without CWD, verifies it doesn't panic
- **`reconcile_workspace_opened_propagates_layout_cwd_to_pane_create_request`** — unit test: verifies that workspace reconciliation carries layout-node CWD into pane create requests

## Tests run

- `cargo test -p rttx --lib` — 288 passed
- `cargo test -p rttx-server --lib` — 63 passed
- `cargo test -p rttx-server --tests` — all passed (including new split_cwd tests)
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — 0 failures
- `cargo build -p rttx && ./run_ui_tests.sh` — same 5 pre-existing failures as mainline (not caused by this change)

## Note on local (direct) panes

For local (non-daemon) panes, CWD inheritance already works via VTE's OSC 7 tracking in `split_terminal_in_place`. This PR only fixes the managed pane path.

Fixes #297