### PR TITLE
feat: propagate light/dark mode to daemon panes via COLORFGBG

### DIFF
--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -293,11 +293,13 @@ impl DaemonConnection {
         &mut self,
         session_id: Uuid,
         cwd: Option<String>,
+        dark_background: Option<bool>,
     ) -> Result<Uuid, DaemonError> {
         let msg = proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: uuid_to_bytes(session_id),
                 cwd,
+                dark_background,
             })),
         };
         self.send(&msg).await?;

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -96,6 +96,7 @@ enum EndpointCommand {
         runtime_id: String,
         layout_terminal_uuid: String,
         cwd: Option<String>,
+        dark_background: bool,
     },
     ClosePane {
         workspace_id: String,
@@ -205,12 +206,14 @@ impl EndpointConnectionManager {
         runtime_id: &str,
         layout_terminal_uuid: &str,
         cwd: Option<String>,
+        dark_background: bool,
     ) {
         let _ = self.endpoint_handle(endpoint).send(EndpointCommand::CreatePane {
             workspace_id: workspace_id.to_string(),
             runtime_id: runtime_id.to_string(),
             layout_terminal_uuid: layout_terminal_uuid.to_string(),
             cwd,
+            dark_background,
         });
     }
 
@@ -451,6 +454,7 @@ impl EndpointActor {
                             runtime_id,
                             layout_terminal_uuid,
                             cwd: None,
+                            dark_background: true,
                         });
                     } else {
                         self.emit_status(&workspace_id, ConnectionStatus::Connected);
@@ -459,7 +463,13 @@ impl EndpointActor {
                     self.emit_status(&workspace_id, ConnectionStatus::Connected);
                 }
             }
-            EndpointCommand::CreatePane { workspace_id, runtime_id, layout_terminal_uuid, cwd } => {
+            EndpointCommand::CreatePane {
+                workspace_id,
+                runtime_id,
+                layout_terminal_uuid,
+                cwd,
+                dark_background,
+            } => {
                 if let Err(problem) = self.ensure_connected(&workspace_id).await {
                     self.emit_error(
                         &workspace_id,
@@ -482,6 +492,7 @@ impl EndpointActor {
                     msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                         session_id: rttx_proto::uuid_to_bytes(runtime_uuid),
                         cwd,
+                        dark_background: Some(dark_background),
                     })),
                 };
                 if let Err(error) = self.send_message(&msg).await {

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1899,6 +1899,7 @@ impl Window {
                         runtime_id,
                         &new_terminal_uuid,
                         source_cwd,
+                        adw::StyleManager::default().is_dark(),
                     );
                 }
             }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -360,6 +360,7 @@ impl Window {
                     &request.runtime_id,
                     &request.layout_terminal_uuid,
                     request.cwd.clone(),
+                    adw::StyleManager::default().is_dark(),
                 );
             }
         }

--- a/protocols/rttx-proto/proto/rttx.proto
+++ b/protocols/rttx-proto/proto/rttx.proto
@@ -45,6 +45,7 @@ message TerminateSession {
 message CreatePane {
     bytes session_id = 1;
     optional string cwd = 2;
+    optional bool dark_background = 3;
 }
 
 message ClosePane {

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -169,6 +169,7 @@ mod tests {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: session_id.clone(),
                     cwd: None,
+                    dark_background: None,
                 })),
             },
             proto::ClientMessage {
@@ -369,5 +370,28 @@ mod tests {
         let mut buf = BytesMut::new();
         buf.put_u32_le(MAX_MESSAGE_SIZE + 1);
         assert!(matches!(decode_frame::<proto::Hello>(&mut buf), Err(FrameError::TooLarge(_))));
+    }
+
+    #[test]
+    fn create_pane_dark_background_roundtrip() {
+        let session_id = uuid_to_bytes(uuid::Uuid::new_v4());
+
+        for dark in [Some(true), Some(false), None] {
+            let msg = proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+                    session_id: session_id.clone(),
+                    cwd: Some("/tmp".into()),
+                    dark_background: dark,
+                })),
+            };
+            let mut buf = BytesMut::new();
+            encode_frame(&msg, &mut buf).unwrap();
+            let decoded: proto::ClientMessage = decode_frame(&mut buf).unwrap();
+            if let Some(proto::client_message::Msg::CreatePane(cp)) = decoded.msg {
+                assert_eq!(cp.dark_background, dark);
+            } else {
+                panic!("expected CreatePane");
+            }
+        }
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -151,7 +151,10 @@ impl Server {
                 if let Some(parent) = hist.parent() {
                     let _ = std::fs::create_dir_all(parent);
                 }
-                let env = vec![("HISTFILE".into(), hist.to_string_lossy().into_owned())];
+                let env = vec![
+                    ("HISTFILE".into(), hist.to_string_lossy().into_owned()),
+                    ("COLORFGBG".into(), "15;0".into()),
+                ];
                 let config = PaneSpawnConfig { command: vec![], cwd, env, cols, rows };
                 s.engine.spawn_pane(pane_id, &config)
             };
@@ -460,7 +463,12 @@ impl Server {
                     if let Some(parent) = hist.parent() {
                         let _ = std::fs::create_dir_all(parent);
                     }
-                    let env = vec![("HISTFILE".into(), hist.to_string_lossy().into_owned())];
+                    let colorfgbg =
+                        if req.dark_background.unwrap_or(true) { "15;0" } else { "0;15" };
+                    let env = vec![
+                        ("HISTFILE".into(), hist.to_string_lossy().into_owned()),
+                        ("COLORFGBG".into(), colorfgbg.into()),
+                    ];
                     let cwd = req.cwd;
                     let config = PaneSpawnConfig { command: vec![], cwd, env, cols: 80, rows: 24 };
                     s.engine.spawn_pane(pane_id, &config)

--- a/services/rttx-server/tests/client_lifecycle.rs
+++ b/services/rttx-server/tests/client_lifecycle.rs
@@ -43,6 +43,7 @@ async fn reconnect_restores_scrollback() {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
                 cwd: None,
+                dark_background: None,
             })),
         })
         .await;
@@ -216,6 +217,7 @@ async fn restart_preserves_session_count_and_scrollback() {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
                 cwd: None,
+                dark_background: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/colorfgbg.rs
+++ b/services/rttx-server/tests/colorfgbg.rs
@@ -1,0 +1,131 @@
+mod common;
+
+use common::{TestClient, start_test_server};
+use rttx_proto::proto;
+use std::time::Duration;
+
+/// Helper: create a pane with explicit `dark_background`, return `pane_id`.
+async fn create_pane_with_appearance(
+    client: &mut TestClient,
+    session_id: &[u8],
+    dark_background: Option<bool>,
+) -> Vec<u8> {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+                session_id: session_id.to_vec(),
+                cwd: None,
+                dark_background,
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::PaneCreated(pc)) => return pc.pane_id,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected PaneCreated, got {other:?}"),
+        }
+    }
+}
+
+/// Read PTY output until `needle` is found or timeout.
+async fn read_until(client: &mut TestClient, needle: &str, timeout: Duration) -> String {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut output = String::new();
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(delta)) = msg.msg
+        {
+            output.push_str(&String::from_utf8_lossy(&delta.data));
+            if output.contains(needle) {
+                return output;
+            }
+        }
+    }
+    output
+}
+
+/// Send input and drain snapshot first.
+async fn attach_and_send(client: &mut TestClient, session_id: &[u8], pane_id: &[u8], input: &[u8]) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+                session_id: session_id.to_vec(),
+                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(_)) => break,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    }
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Input(proto::Input {
+                session_id: session_id.to_vec(),
+                pane_id: pane_id.to_vec(),
+                data: input.to_vec(),
+            })),
+        })
+        .await;
+}
+
+/// Dark background pane must have COLORFGBG=15;0.
+#[tokio::test]
+async fn create_pane_dark_sets_colorfgbg() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let session_id =
+        common::create_session(&mut client, "dark-test", proto::RuntimePolicy::Persistent).await;
+
+    let pane_id = create_pane_with_appearance(&mut client, &session_id, Some(true)).await;
+    attach_and_send(&mut client, &session_id, &pane_id, b"echo $COLORFGBG\n").await;
+
+    let output = read_until(&mut client, "15;0", Duration::from_secs(5)).await;
+    assert!(output.contains("15;0"), "dark pane must have COLORFGBG=15;0, got: {output}");
+}
+
+/// Light background pane must have COLORFGBG=0;15.
+#[tokio::test]
+async fn create_pane_light_sets_colorfgbg() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let session_id =
+        common::create_session(&mut client, "light-test", proto::RuntimePolicy::Persistent).await;
+
+    let pane_id = create_pane_with_appearance(&mut client, &session_id, Some(false)).await;
+    attach_and_send(&mut client, &session_id, &pane_id, b"echo $COLORFGBG\n").await;
+
+    let output = read_until(&mut client, "0;15", Duration::from_secs(5)).await;
+    assert!(output.contains("0;15"), "light pane must have COLORFGBG=0;15, got: {output}");
+}
+
+/// Omitting `dark_background` (None) defaults to dark (15;0).
+#[tokio::test]
+async fn create_pane_default_assumes_dark() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let session_id =
+        common::create_session(&mut client, "default-test", proto::RuntimePolicy::Persistent).await;
+
+    let pane_id = create_pane_with_appearance(&mut client, &session_id, None).await;
+    attach_and_send(&mut client, &session_id, &pane_id, b"echo $COLORFGBG\n").await;
+
+    let output = read_until(&mut client, "15;0", Duration::from_secs(5)).await;
+    assert!(
+        output.contains("15;0"),
+        "pane without dark_background must default to dark (15;0), got: {output}"
+    );
+}

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -237,6 +237,7 @@ pub async fn create_pane_with_cwd(
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.to_vec(),
                 cwd,
+                dark_background: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/gui_restore_flow.rs
+++ b/services/rttx-server/tests/gui_restore_flow.rs
@@ -43,6 +43,7 @@ async fn gui_restore_flow_no_duplicates() {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: sid.clone(),
                     cwd: None,
+                    dark_background: None,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/inventory.rs
+++ b/services/rttx-server/tests/inventory.rs
@@ -32,6 +32,7 @@ async fn list_sessions_includes_runtime_inventory_metadata() {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
                 cwd: None,
+                dark_background: None,
             })),
         })
         .await;
@@ -180,6 +181,7 @@ async fn list_sessions_marks_restored_runtime_and_panes_as_reconstructed() {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: session_id.clone(),
                     cwd: None,
+                    dark_background: None,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/make_pane_persistent.rs
+++ b/services/rttx-server/tests/make_pane_persistent.rs
@@ -52,6 +52,7 @@ async fn make_pane_persistent_flow() {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.clone(),
             cwd: None,
+            dark_background: None,
         })),
     })
     .await;

--- a/services/rttx-server/tests/negative_protocol.rs
+++ b/services/rttx-server/tests/negative_protocol.rs
@@ -148,6 +148,7 @@ async fn create_pane_in_nonexistent_session_returns_error() {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: bogus_uuid(),
             cwd: None,
+            dark_background: None,
         })),
     };
     client.send(&msg).await;
@@ -354,6 +355,7 @@ async fn attach_and_create_pane(client: &mut TestClient, session_id: &[u8]) -> V
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.to_vec(),
             cwd: None,
+            dark_background: None,
         })),
     };
     client.send(&msg).await;

--- a/services/rttx-server/tests/ownership.rs
+++ b/services/rttx-server/tests/ownership.rs
@@ -128,6 +128,7 @@ async fn read_only_attach_cannot_mutate_runtime() {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
                 cwd: None,
+                dark_background: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/ownership_races.rs
+++ b/services/rttx-server/tests/ownership_races.rs
@@ -67,6 +67,7 @@ async fn readers_observe_pane_created_push() {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
                 cwd: None,
+                dark_background: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/pty_basic.rs
+++ b/services/rttx-server/tests/pty_basic.rs
@@ -107,3 +107,38 @@ async fn pty_exit_status() {
     let status = pty.wait().await.expect("wait failed");
     assert_eq!(status, 42);
 }
+
+#[test]
+fn pty_propagates_colorfgbg_from_env() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        let config = PtyConfig {
+            command: vec!["/bin/sh".into(), "-c".into(), "echo COLORFGBG=$COLORFGBG".into()],
+            cwd: None,
+            env: vec![("COLORFGBG".into(), "0;15".into())],
+            cols: 80,
+            rows: 24,
+        };
+        let mut pty = Pty::spawn(Uuid::new_v4(), &config).expect("failed to spawn PTY");
+
+        let mut output = Vec::new();
+        let mut buf = [0u8; 1024];
+        let needle = b"COLORFGBG=0;15";
+
+        for _ in 0..50 {
+            match pty.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => output.extend_from_slice(&buf[..n]),
+            }
+            if output.windows(needle.len()).any(|w| w == needle) {
+                break;
+            }
+        }
+
+        let text = String::from_utf8_lossy(&output);
+        assert!(
+            text.contains("COLORFGBG=0;15"),
+            "PTY must propagate COLORFGBG from env config, got: {text}"
+        );
+    });
+}

--- a/services/rttx-server/tests/pty_io.rs
+++ b/services/rttx-server/tests/pty_io.rs
@@ -28,6 +28,7 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.clone(),
             cwd: None,
+            dark_background: None,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/reconstruction.rs
+++ b/services/rttx-server/tests/reconstruction.rs
@@ -39,6 +39,7 @@ async fn reconstruct_session_after_restart() {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
                 cwd: None,
+                dark_background: None,
             })),
         };
         client.send(&create_pane).await;
@@ -162,6 +163,7 @@ async fn reconstruct_session_respawns_shell_in_last_reported_cwd() {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: session_id.clone(),
                     cwd: None,
+                    dark_background: None,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/revisions.rs
+++ b/services/rttx-server/tests/revisions.rs
@@ -49,6 +49,7 @@ async fn mutation_acks_return_monotonic_runtime_revisions() {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
                 cwd: None,
+                dark_background: None,
             })),
         })
         .await;
@@ -175,6 +176,7 @@ async fn runtime_revision_survives_restart_and_attach_advances_it() {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id: session_id.clone(),
                     cwd: None,
+                    dark_background: None,
                 })),
             })
             .await;
@@ -266,6 +268,7 @@ async fn failed_close_pane_returns_error_without_revision_change() {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
                 cwd: None,
+                dark_background: None,
             })),
         })
         .await;

--- a/services/rttx-server/tests/runtime_policy.rs
+++ b/services/rttx-server/tests/runtime_policy.rs
@@ -155,6 +155,7 @@ async fn ephemeral_runtime_is_not_restored_after_restart() {
                 msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                     session_id,
                     cwd: None,
+                    dark_background: None,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/scrollback.rs
+++ b/services/rttx-server/tests/scrollback.rs
@@ -31,6 +31,7 @@ async fn scrollback_flushed_to_disk_after_serialization_tick() {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.clone(),
             cwd: None,
+            dark_background: None,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/session_lifecycle.rs
+++ b/services/rttx-server/tests/session_lifecycle.rs
@@ -142,6 +142,7 @@ async fn create_and_close_pane() {
         msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
             session_id: session_id.clone(),
             cwd: None,
+            dark_background: None,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -88,6 +88,7 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: session_id.clone(),
                 cwd: None,
+                dark_background: None,
             })),
         })
         .await;


### PR DESCRIPTION
## What changed and why

Modern CLI apps (bat, delta, fd, Gemini CLI) use `COLORFGBG` to detect whether the terminal background is light or dark and adapt their color palettes accordingly. Neither rttx nor its daemon previously set this variable, causing unreadable output in light-mode terminals.

This PR extends the protocol so the client can communicate its light/dark state to the daemon, which then sets `COLORFGBG` on spawned PTY shells.

### Changes

1. **Protocol**: Added `optional bool dark_background = 3` to `CreatePane` message. Proto3 optional fields are backward compatible — old clients omit it, old servers ignore it.

2. **Server**: Reads `dark_background` from `CreatePane` and sets `COLORFGBG` env var on PTY spawn:
   - `15;0` for dark background (white fg, black bg)
   - `0;15` for light background (black fg, white bg)
   - Defaults to dark when unset (backward compat + most common case)
   - Reconstructed panes also default to dark (no client connected during reconstruction)

3. **Client**: Sends `adw::StyleManager::default().is_dark()` when creating panes via both the split path and the runtime transition path.

### Manual verification

1. Start rttx in dark mode → open a managed workspace → run `echo $COLORFGBG` → should print `15;0`
2. Switch to light mode → split a pane → run `echo $COLORFGBG` in the new pane → should print `0;15`
3. Run `bat --color=always somefile` in both modes → output should be readable

### Tests added

- `colorfgbg.rs`: 3 integration tests (dark, light, default/None)
- `pty_basic.rs`: 1 test for COLORFGBG env propagation through PTY
- `lib.rs` (proto): 1 roundtrip test for `dark_background` field

### Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

### Limitations

- Existing panes are not updated when the user toggles light/dark mode. Only newly created panes get the correct value. A future enhancement could add an appearance-update message to update running panes.

Fixes #281