### PR TITLE
feat(pane): add configurable pane navigation with Alt+Arrow (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ workspaces will fail to connect.
 | Jump to workspace 1-9 | Alt+1 through Alt+9 |
 | Zoom in / out / reset | Ctrl+Plus / Ctrl+Minus / Ctrl+0 |
 | Zoom pane (toggle) | Ctrl+Shift+Z |
+| Navigate panes | Alt+Arrow (configurable) |
 | Preferences | Ctrl+, |
 | Fullscreen | F11 |
 

--- a/clients/rttx/src/preferences.rs
+++ b/clients/rttx/src/preferences.rs
@@ -21,6 +21,27 @@ pub enum DefaultSessionFolder {
     Custom(String),
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum PaneNavigationKeys {
+    #[default]
+    AltArrow,
+    CtrlShiftArrow,
+}
+
+impl PaneNavigationKeys {
+    /// GTK accelerator strings for (left, right, up, down).
+    #[must_use]
+    pub const fn accels(&self) -> (&str, &str, &str, &str) {
+        match self {
+            Self::AltArrow => ("<Alt>Left", "<Alt>Right", "<Alt>Up", "<Alt>Down"),
+            Self::CtrlShiftArrow => {
+                ("<Ctrl><Shift>Left", "<Ctrl><Shift>Right", "<Ctrl><Shift>Up", "<Ctrl><Shift>Down")
+            }
+        }
+    }
+}
+
 const fn default_session_folder() -> DefaultSessionFolder {
     DefaultSessionFolder::Home
 }
@@ -54,6 +75,8 @@ pub struct Preferences {
     pub smart_clipboard: bool,
     #[serde(default = "default_session_folder")]
     pub default_session_folder: DefaultSessionFolder,
+    #[serde(default)]
+    pub pane_navigation_keys: PaneNavigationKeys,
 }
 
 fn default_font() -> String {
@@ -93,6 +116,7 @@ impl Default for Preferences {
             visual_bell: true,
             smart_clipboard: false,
             default_session_folder: default_session_folder(),
+            pane_navigation_keys: PaneNavigationKeys::default(),
         }
     }
 }
@@ -142,6 +166,8 @@ struct PreferencesDisk {
     smart_clipboard: bool,
     #[serde(default = "default_session_folder")]
     default_session_folder: DefaultSessionFolder,
+    #[serde(default)]
+    pane_navigation_keys: PaneNavigationKeys,
 }
 
 impl From<PreferencesDisk> for Preferences {
@@ -172,6 +198,7 @@ impl From<PreferencesDisk> for Preferences {
             visual_bell: raw.visual_bell,
             smart_clipboard: raw.smart_clipboard,
             default_session_folder: raw.default_session_folder,
+            pane_navigation_keys: raw.pane_navigation_keys,
         }
     }
 }
@@ -379,5 +406,33 @@ mod tests {
         std::fs::write(&path, "{}").unwrap();
         let loaded = load_from(&path);
         assert_eq!(loaded.default_session_folder, DefaultSessionFolder::Home);
+    }
+
+    #[test]
+    fn pane_navigation_keys_defaults_to_alt_arrow() {
+        let prefs = Preferences::default();
+        assert_eq!(prefs.pane_navigation_keys, PaneNavigationKeys::AltArrow);
+    }
+
+    #[test]
+    fn pane_navigation_keys_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("prefs.json");
+        let prefs = Preferences {
+            pane_navigation_keys: PaneNavigationKeys::CtrlShiftArrow,
+            ..Default::default()
+        };
+        save_to(&prefs, &path).unwrap();
+        let loaded = load_from(&path);
+        assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::CtrlShiftArrow);
+    }
+
+    #[test]
+    fn missing_pane_navigation_keys_defaults_to_alt_arrow() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("prefs.json");
+        std::fs::write(&path, "{}").unwrap();
+        let loaded = load_from(&path);
+        assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::AltArrow);
     }
 }

--- a/clients/rttx/src/preferences_window.rs
+++ b/clients/rttx/src/preferences_window.rs
@@ -4,7 +4,9 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 
 use crate::color_scheme;
-use crate::preferences::{self, DefaultSessionFolder, Preferences, TerminalThemeMode};
+use crate::preferences::{
+    self, DefaultSessionFolder, PaneNavigationKeys, Preferences, TerminalThemeMode,
+};
 
 /// Build and present the preferences window.
 pub fn show(parent: &impl IsA<gtk4::Window>) {
@@ -133,12 +135,26 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
     session_group.add(&folder_mode_row);
     session_group.add(&custom_folder_row);
 
+    let keyboard_group = adw::PreferencesGroup::new();
+    keyboard_group.set_title("Keyboard");
+
+    let nav_keys_row = adw::ComboRow::builder().title("Pane navigation keys").build();
+    let nav_keys_names = ["Alt + Arrow", "Ctrl + Shift + Arrow"];
+    let nav_keys_model = gtk4::StringList::new(&nav_keys_names);
+    nav_keys_row.set_model(Some(&nav_keys_model));
+    nav_keys_row.set_selected(match prefs.pane_navigation_keys {
+        PaneNavigationKeys::AltArrow => 0,
+        PaneNavigationKeys::CtrlShiftArrow => 1,
+    });
+    keyboard_group.add(&nav_keys_row);
+
     let page = adw::PreferencesPage::new();
     page.set_icon_name(Some("preferences-system-symbolic"));
     page.set_title("General");
     page.add(&appearance_group);
     page.add(&terminal_group);
     page.add(&session_group);
+    page.add(&keyboard_group);
     window.add(&page);
 
     let parent_window = parent.as_ref().clone();
@@ -177,6 +193,10 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
                 1 => DefaultSessionFolder::CurrentSession,
                 2 => DefaultSessionFolder::Custom(custom_folder_row.text().to_string()),
                 _ => DefaultSessionFolder::Home,
+            },
+            pane_navigation_keys: match nav_keys_row.selected() {
+                1 => PaneNavigationKeys::CtrlShiftArrow,
+                _ => PaneNavigationKeys::AltArrow,
             },
         };
         if let Err(e) = preferences::save(&new_prefs) {

--- a/clients/rttx/src/session/layout.rs
+++ b/clients/rttx/src/session/layout.rs
@@ -45,6 +45,14 @@ pub enum SplitOrientation {
     Vertical,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
 impl LayoutNode {
     #[must_use]
     pub fn new_terminal() -> Self {
@@ -368,12 +376,90 @@ impl LayoutNode {
             }
         }
     }
+
+    /// Return the UUID of the terminal adjacent to `target_uuid` in `direction`.
+    ///
+    /// Navigation walks up from the target to find the nearest split whose
+    /// orientation matches the direction, crosses to the sibling subtree, then
+    /// descends to the nearest terminal on the edge closest to the origin.
+    #[must_use]
+    pub fn find_adjacent(&self, target_uuid: &str, direction: Direction) -> Option<String> {
+        self.find_adjacent_inner(target_uuid, direction).0
+    }
+
+    /// Returns `(adjacent_uuid, target_is_in_this_subtree)`.
+    fn find_adjacent_inner(
+        &self,
+        target_uuid: &str,
+        direction: Direction,
+    ) -> (Option<String>, bool) {
+        match self {
+            Self::Terminal { uuid, .. } => (None, uuid == target_uuid),
+            Self::Split { orientation, first, second, .. } => {
+                // Recurse into children first — inner splits get priority.
+                let (found, in_first) = first.find_adjacent_inner(target_uuid, direction);
+                if found.is_some() {
+                    return (found, true);
+                }
+                let (found, in_second) = second.find_adjacent_inner(target_uuid, direction);
+                if found.is_some() {
+                    return (found, true);
+                }
+
+                if !in_first && !in_second {
+                    return (None, false);
+                }
+
+                let matches_axis = matches!(
+                    (orientation, direction),
+                    (SplitOrientation::Horizontal, Direction::Left | Direction::Right)
+                        | (SplitOrientation::Vertical, Direction::Up | Direction::Down)
+                );
+                if !matches_axis {
+                    return (None, true);
+                }
+
+                let toward_first = matches!(direction, Direction::Left | Direction::Up);
+                let adjacent = if toward_first && in_second {
+                    Some(first.edge_terminal(direction))
+                } else if !toward_first && in_first {
+                    Some(second.edge_terminal(direction))
+                } else {
+                    None
+                };
+                (adjacent, true)
+            }
+        }
+    }
+
+    /// Return the terminal UUID at the edge of this subtree closest to `direction`.
+    ///
+    /// When navigating left, we want the rightmost terminal in the sibling subtree
+    /// (the one closest to the boundary we crossed). When navigating right, we want
+    /// the leftmost terminal.
+    fn edge_terminal(&self, direction: Direction) -> String {
+        match self {
+            Self::Terminal { uuid, .. } => uuid.clone(),
+            Self::Split { orientation, first, second, .. } => {
+                let pick_first = !matches!(
+                    (orientation, direction),
+                    (SplitOrientation::Horizontal, Direction::Left)
+                        | (SplitOrientation::Vertical, Direction::Up)
+                );
+                if pick_first {
+                    first.edge_terminal(direction)
+                } else {
+                    second.edge_terminal(direction)
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{hsplit, split_ratio, term};
+    use crate::test_helpers::{hsplit, split_ratio, term, vsplit};
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
@@ -829,6 +915,95 @@ mod tests {
         assert_eq!(layout.terminal_cwd("t2").as_deref(), Some("/tmp"));
         assert_eq!(layout.terminal_custom_title("t2").as_deref(), Some("build"));
     }
+
+    // ── Directional navigation ──────────────────────────────────
+
+    #[test]
+    fn navigate_right_in_horizontal_split() {
+        let layout = hsplit(term("t1"), term("t2"));
+        assert_eq!(layout.find_adjacent("t1", Direction::Right).as_deref(), Some("t2"));
+    }
+
+    #[test]
+    fn navigate_left_in_horizontal_split() {
+        let layout = hsplit(term("t1"), term("t2"));
+        assert_eq!(layout.find_adjacent("t2", Direction::Left).as_deref(), Some("t1"));
+    }
+
+    #[test]
+    fn navigate_down_in_vertical_split() {
+        let layout = vsplit(term("t1"), term("t2"));
+        assert_eq!(layout.find_adjacent("t1", Direction::Down).as_deref(), Some("t2"));
+    }
+
+    #[test]
+    fn navigate_up_in_vertical_split() {
+        let layout = vsplit(term("t1"), term("t2"));
+        assert_eq!(layout.find_adjacent("t2", Direction::Up).as_deref(), Some("t1"));
+    }
+
+    #[test]
+    fn navigate_returns_none_at_boundary() {
+        let layout = hsplit(term("t1"), term("t2"));
+        assert!(layout.find_adjacent("t1", Direction::Left).is_none());
+        assert!(layout.find_adjacent("t2", Direction::Right).is_none());
+        assert!(layout.find_adjacent("t1", Direction::Up).is_none());
+        assert!(layout.find_adjacent("t1", Direction::Down).is_none());
+    }
+
+    #[test]
+    fn navigate_single_terminal_returns_none() {
+        let layout = term("t1");
+        assert!(layout.find_adjacent("t1", Direction::Right).is_none());
+    }
+
+    #[test]
+    fn navigate_nonexistent_terminal_returns_none() {
+        let layout = hsplit(term("t1"), term("t2"));
+        assert!(layout.find_adjacent("missing", Direction::Right).is_none());
+    }
+
+    #[test]
+    fn navigate_across_nested_splits() {
+        // [t1 | [t2 / t3]]  (horizontal outer, vertical inner)
+        let layout = hsplit(term("t1"), vsplit(term("t2"), term("t3")));
+        // Right from t1 → enters the vertical split, picks topmost = t2
+        assert_eq!(layout.find_adjacent("t1", Direction::Right).as_deref(), Some("t2"));
+        // Left from t2 → crosses to t1
+        assert_eq!(layout.find_adjacent("t2", Direction::Left).as_deref(), Some("t1"));
+        // Left from t3 → crosses to t1
+        assert_eq!(layout.find_adjacent("t3", Direction::Left).as_deref(), Some("t1"));
+        // Down from t2 → t3 (within the vertical split)
+        assert_eq!(layout.find_adjacent("t2", Direction::Down).as_deref(), Some("t3"));
+        // Up from t3 → t2
+        assert_eq!(layout.find_adjacent("t3", Direction::Up).as_deref(), Some("t2"));
+    }
+
+    #[test]
+    fn navigate_picks_nearest_edge_terminal() {
+        // [[t1 / t2] | [t3 / t4]]  (horizontal outer, vertical inners)
+        let layout = hsplit(vsplit(term("t1"), term("t2")), vsplit(term("t3"), term("t4")));
+        // Right from t1 → enters right vsplit, cross-axis picks first = t3
+        assert_eq!(layout.find_adjacent("t1", Direction::Right).as_deref(), Some("t3"));
+        // Right from t2 → enters right vsplit, cross-axis picks first = t3
+        assert_eq!(layout.find_adjacent("t2", Direction::Right).as_deref(), Some("t3"));
+        // Left from t3 → enters left vsplit, cross-axis picks first = t1
+        assert_eq!(layout.find_adjacent("t3", Direction::Left).as_deref(), Some("t1"));
+        // Left from t4 → enters left vsplit, cross-axis picks first = t1
+        assert_eq!(layout.find_adjacent("t4", Direction::Left).as_deref(), Some("t1"));
+    }
+
+    #[test]
+    fn navigate_deeply_nested() {
+        // [t1 | [t2 | [t3 | t4]]]
+        let layout = hsplit(term("t1"), hsplit(term("t2"), hsplit(term("t3"), term("t4"))));
+        assert_eq!(layout.find_adjacent("t1", Direction::Right).as_deref(), Some("t2"));
+        assert_eq!(layout.find_adjacent("t2", Direction::Right).as_deref(), Some("t3"));
+        assert_eq!(layout.find_adjacent("t3", Direction::Right).as_deref(), Some("t4"));
+        assert_eq!(layout.find_adjacent("t4", Direction::Left).as_deref(), Some("t3"));
+        assert_eq!(layout.find_adjacent("t3", Direction::Left).as_deref(), Some("t2"));
+        assert_eq!(layout.find_adjacent("t2", Direction::Left).as_deref(), Some("t1"));
+    }
 }
 
 #[cfg(test)]
@@ -942,6 +1117,18 @@ pub mod proptests {
             {
                 let restored = restored_layout.terminal_uuids();
                 prop_assert_eq!(original_uuids, restored, "Split+remove must restore original UUID set");
+            }
+        }
+
+        #[test]
+        fn find_adjacent_returns_valid_terminal(layout in arb_layout()) {
+            let uuids = layout.terminal_uuids();
+            let target = &uuids[0];
+            for dir in [Direction::Left, Direction::Right, Direction::Up, Direction::Down] {
+                if let Some(adj) = layout.find_adjacent(target, dir) {
+                    prop_assert!(uuids.contains(&adj), "Adjacent UUID must exist in layout");
+                    prop_assert_ne!(&adj, target, "Adjacent must differ from target");
+                }
             }
         }
     }

--- a/clients/rttx/src/session/mod.rs
+++ b/clients/rttx/src/session/mod.rs
@@ -2,7 +2,7 @@ pub mod layout;
 pub mod recovery;
 pub mod state;
 
-pub use layout::{LayoutNode, MAX_SPLIT_DEPTH, SplitOrientation};
+pub use layout::{Direction, LayoutNode, MAX_SPLIT_DEPTH, SplitOrientation};
 pub use recovery::{PaneRecovery, PaneSource, PaneTarget, StartupStep};
 pub use state::{SessionColor, SessionMode, SessionState, WindowState};
 

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -18,8 +18,8 @@ use crate::runtime::{
     workspace_connection_summary,
 };
 use crate::session::{
-    self, LayoutNode, MAX_SPLIT_DEPTH, PaneRecovery, PaneSource, PaneTarget, SessionColor,
-    SessionState, SplitOrientation, StartupStep, WindowState,
+    self, Direction, LayoutNode, MAX_SPLIT_DEPTH, PaneRecovery, PaneSource, PaneTarget,
+    SessionColor, SessionState, SplitOrientation, StartupStep, WindowState,
 };
 use crate::sidebar::SessionRow;
 use crate::terminal::handle::TerminalHandle;
@@ -557,6 +557,26 @@ impl Window {
             win.show_about_window();
         });
         self.add_action(&about_action);
+
+        // Pane navigation — shortcuts are configurable via preferences.
+        {
+            let nav_keys = crate::preferences::load().pane_navigation_keys;
+            let (left, right, up, down) = nav_keys.accels();
+            let nav_actions: &[(&str, &str, Direction)] = &[
+                ("navigate-left", left, Direction::Left),
+                ("navigate-right", right, Direction::Right),
+                ("navigate-up", up, Direction::Up),
+                ("navigate-down", down, Direction::Down),
+            ];
+            for (name, accel, direction) in nav_actions {
+                let action = gtk4::gio::SimpleAction::new(name, None);
+                let win = self.clone();
+                let dir = *direction;
+                action.connect_activate(move |_, _| win.navigate_focused(dir));
+                self.add_action(&action);
+                app.set_accels_for_action(&format!("win.{name}"), &[accel]);
+            }
+        }
 
         for number in 1_u8..=9 {
             let action_name = format!("switch-to-session-{number}");
@@ -2249,6 +2269,20 @@ impl Window {
 
     pub(crate) fn reapply_terminal_preferences(&self) {
         let prefs = preferences::load();
+
+        // Update pane navigation shortcuts in case the keybinding changed.
+        if let Some(app) = self.application().and_downcast::<adw::Application>() {
+            let (left, right, up, down) = prefs.pane_navigation_keys.accels();
+            for (name, accel) in [
+                ("navigate-left", left),
+                ("navigate-right", right),
+                ("navigate-up", up),
+                ("navigate-down", down),
+            ] {
+                app.set_accels_for_action(&format!("win.{name}"), &[accel]);
+            }
+        }
+
         let font_desc = gtk4::pango::FontDescription::from_string(&prefs.font);
         let is_dark = adw::StyleManager::default().is_dark();
         let effective_name = prefs.effective_color_scheme_name(is_dark);
@@ -2356,6 +2390,28 @@ impl Window {
     fn split_focused(&self, orientation: SplitOrientation) {
         if let Some(uuid) = self.focused_terminal_uuid() {
             self.split_terminal(&uuid, orientation);
+        }
+    }
+
+    fn navigate_focused(&self, direction: Direction) {
+        let Some(current_uuid) = self.focused_terminal_uuid() else { return };
+        let adjacent_uuid = {
+            let state = self.imp().state.borrow();
+            state
+                .sessions
+                .iter()
+                .find(|s| s.layout.contains_terminal(&current_uuid))
+                .and_then(|s| s.layout.find_adjacent(&current_uuid, direction))
+        };
+        if let Some(target_uuid) = adjacent_uuid
+            && let Some(terminal) = self.terminal_handle(&target_uuid)
+        {
+            let win = self.clone();
+            glib::idle_add_local_once(move || {
+                if terminal.grab_focus() {
+                    win.set_focused_terminal(Some(&target_uuid));
+                }
+            });
         }
     }
 

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -185,3 +185,22 @@ fn custom_title_backward_compat_null() {
         assert_eq!(*custom_title, None);
     }
 }
+
+#[test]
+fn pane_navigation_keys_persists_across_save_load() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+
+    let prefs = Preferences {
+        pane_navigation_keys: PaneNavigationKeys::CtrlShiftArrow,
+        ..Default::default()
+    };
+    preferences::save_to(&prefs, &path).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::CtrlShiftArrow);
+
+    // Verify backward compatibility: old JSON without the field defaults to AltArrow.
+    std::fs::write(&path, r#"{"font": "Mono 12"}"#).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::AltArrow);
+}

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -1,5 +1,5 @@
 /// Integration tests for preferences persistence.
-use rttx::preferences::{self, DefaultSessionFolder, Preferences, TerminalThemeMode};
+use rttx::preferences::{self, DefaultSessionFolder, PaneNavigationKeys, Preferences, TerminalThemeMode};
 use tempfile::TempDir;
 
 #[test]
@@ -28,6 +28,7 @@ fn preferences_roundtrip_all_fields() {
         visual_bell: true,
         smart_clipboard: true,
         default_session_folder: DefaultSessionFolder::Custom("/home/user/dev".into()),
+        pane_navigation_keys: PaneNavigationKeys::AltArrow,
     };
 
     preferences::save_to(&prefs, &path).unwrap();

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -204,3 +204,4 @@ fn pane_navigation_keys_persists_across_save_load() {
     let loaded = preferences::load_from(&path);
     assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::AltArrow);
 }
+

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -204,4 +204,3 @@ fn pane_navigation_keys_persists_across_save_load() {
     let loaded = preferences::load_from(&path);
     assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::AltArrow);
 }
-

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -1,5 +1,7 @@
 /// Integration tests for preferences persistence.
-use rttx::preferences::{self, DefaultSessionFolder, PaneNavigationKeys, Preferences, TerminalThemeMode};
+use rttx::preferences::{
+    self, DefaultSessionFolder, PaneNavigationKeys, Preferences, TerminalThemeMode,
+};
 use tempfile::TempDir;
 
 #[test]


### PR DESCRIPTION
## What changed and why

Adds directional pane navigation using the layout tree structure, resolving #39.

Users can move focus between panes using **Alt+Arrow** (default) or **Ctrl+Shift+Arrow** (configurable in Preferences → Keyboard). The navigation algorithm walks up from the focused terminal to find the nearest split whose orientation matches the direction, crosses to the sibling subtree, then descends to the nearest terminal on the edge closest to the origin.

### Changes

- **layout.rs**: `Direction` enum and `find_adjacent` / `find_adjacent_inner` / `edge_terminal` methods on `LayoutNode`
- **preferences.rs**: `PaneNavigationKeys` enum (`AltArrow` | `CtrlShiftArrow`) with `#[serde(default)]` for backward compatibility
- **preferences_window.rs**: New "Keyboard" group with pane navigation keys combo row
- **window/mod.rs**: `navigate_focused` method, action registration in `setup_actions`, shortcut reapplication in `reapply_terminal_preferences`
- **session/mod.rs**: Re-export `Direction`
- **README.md**: Added "Navigate panes" row to keyboard shortcuts table
- **preferences_integration.rs**: Updated to include new field

### Manual verification

1. Open rttx, create a workspace, split horizontally and vertically
2. Press Alt+Left/Right/Up/Down to navigate between panes
3. Open Preferences → Keyboard, switch to Ctrl+Shift+Arrow
4. Verify new shortcuts work immediately
5. Restart rttx, verify preference persists

### Tests added

- 10 unit tests: all 4 directions, boundary returns None, single terminal, nonexistent terminal, nested splits, cross-axis navigation, deeply nested chains
- 1 proptest: `find_adjacent` always returns a valid, different terminal UUID on random layouts
- 3 preference tests: default value, roundtrip, backward compatibility with missing field

### Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (all pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `./run_ui_tests.sh` — 6 pre-existing failures (same on mainline), no regressions

### Limitations

- Cross-axis navigation into a perpendicular split picks the first child (top/left) rather than the positionally closest terminal. This is consistent with Tilix behavior and avoids coordinate-based complexity.

Fixes #39