### PR TITLE
fix(daemon-bridge): treat ERR_PANE_NOT_FOUND as successful close

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -588,6 +588,20 @@ impl EndpointActor {
                                 runtime_pane_id,
                             });
                         }
+                        Some(proto::server_message::Msg::Error(e)) if e.code == 6 => {
+                            // ERR_PANE_NOT_FOUND: the pane is already gone on the
+                            // daemon, so treat this as a successful close.
+                            log::info!(
+                                "ClosePane for {workspace_id}: pane already removed on daemon, \
+                                 treating as closed"
+                            );
+                            let _ = self.event_tx.send(EndpointEvent::PaneClosed {
+                                workspace_id,
+                                layout_terminal_uuid,
+                                runtime_id,
+                                runtime_pane_id,
+                            });
+                        }
                         Some(proto::server_message::Msg::Error(e)) => {
                             self.handle_command_error(
                                 &workspace_id,
@@ -1323,5 +1337,82 @@ mod tests {
             .expect("split transport should support AttachSession");
         assert_eq!(rttx_proto::bytes_to_uuid(&snapshot.session_id).unwrap(), runtime_id);
         server.await.expect("fake server task should complete");
+    }
+
+    fn make_actor_with_events(
+        reader: DaemonReader,
+        writer: DaemonWriter,
+    ) -> (EndpointActor, mpsc::UnboundedReceiver<EndpointEvent>) {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let actor = EndpointActor {
+            endpoint: RuntimeEndpoint::Local,
+            event_tx,
+            self_tx,
+            cmd_rx,
+            connection: None,
+            reader: Some(reader),
+            writer: Some(writer),
+            ssh_handle: None,
+            tracked_workspaces: HashMap::new(),
+            reconnect_attempt: 0,
+        };
+        (actor, event_rx)
+    }
+
+    #[tokio::test]
+    async fn close_pane_not_found_emits_pane_closed() {
+        let ((reader, writer), mut server_stream) = split_duplex_connection();
+        let (mut actor, mut event_rx) = make_actor_with_events(reader, writer);
+
+        let runtime_id = Uuid::new_v4();
+        let pane_id = Uuid::new_v4();
+        let workspace_id = "ws-1".to_string();
+
+        let server = tokio::spawn(async move {
+            let mut read_buf = BytesMut::new();
+            let request = recv_client_message(&mut server_stream, &mut read_buf).await;
+            match request.msg {
+                Some(proto::client_message::Msg::ClosePane(_)) => {}
+                other => panic!("expected ClosePane, got {other:?}"),
+            }
+            // Respond with ERR_PANE_NOT_FOUND (code 6).
+            send_server_message(
+                &mut server_stream,
+                &proto::ServerMessage {
+                    msg: Some(proto::server_message::Msg::Error(proto::Error {
+                        code: 6,
+                        message: "pane not found".into(),
+                    })),
+                },
+            )
+            .await;
+        });
+
+        actor
+            .handle_command(EndpointCommand::ClosePane {
+                workspace_id: workspace_id.clone(),
+                runtime_id: runtime_id.to_string(),
+                layout_terminal_uuid: "layout-t1".into(),
+                runtime_pane_id: pane_id.to_string(),
+            })
+            .await;
+
+        server.await.expect("fake server task should complete");
+
+        // Must emit PaneClosed, not WorkspaceError.
+        let mut found_pane_closed = false;
+        while let Ok(event) = event_rx.try_recv() {
+            match event {
+                EndpointEvent::PaneClosed { workspace_id: ref ws, .. } if ws == "ws-1" => {
+                    found_pane_closed = true;
+                }
+                EndpointEvent::WorkspaceError { ref detail, .. } => {
+                    panic!("should not emit WorkspaceError, got: {detail}");
+                }
+                _ => {}
+            }
+        }
+        assert!(found_pane_closed, "expected PaneClosed event for pane-not-found response");
     }
 }

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -551,6 +551,20 @@ mod tests {
         );
     }
 
+    /// `ERR_PANE_NOT_FOUND` (code 6) classifies as non-transient `UserActionRequired`.
+    ///
+    /// The `daemon_bridge` handles this specially for `ClosePane` by emitting
+    /// `PaneClosed` instead of blocking the workspace (see #309).
+    #[test]
+    fn classify_pane_not_found_is_non_transient_user_action() {
+        let problem = classify_connection_problem(&DaemonError::ServerError {
+            code: 6,
+            message: "pane not found".into(),
+        });
+        assert!(!problem.is_transient());
+        assert_eq!(problem, ConnectionProblem::UserActionRequired("pane not found".into()));
+    }
+
     #[test]
     fn connection_state_machine_distinguishes_retryable_and_blocked_failures() {
         let reconnecting = advance_connection_status(

--- a/services/rttx-server/tests/negative_protocol.rs
+++ b/services/rttx-server/tests/negative_protocol.rs
@@ -365,3 +365,43 @@ async fn attach_and_create_pane(client: &mut TestClient, session_id: &[u8]) -> V
         other => panic!("expected PaneCreated, got {other:?}"),
     }
 }
+
+/// Closing an already-closed pane must return `ERR_PANE_NOT_FOUND` (code 6).
+///
+/// Regression test for #309: the client must recognise code 6 on `ClosePane`
+/// and treat it as a successful close instead of blocking the workspace.
+#[test]
+fn close_already_closed_pane_returns_pane_not_found() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        let tmp = tempfile::tempdir().unwrap();
+        let (socket_path, _handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&socket_path).await;
+        client.handshake().await;
+
+        let session_id =
+            create_session(&mut client, "test", proto::RuntimePolicy::Persistent).await;
+        attach_session(&mut client, &session_id).await;
+        let pane_id = create_pane(&mut client, &session_id).await;
+
+        // First close succeeds.
+        let close_msg = proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::ClosePane(proto::ClosePane {
+                session_id: session_id.clone(),
+                pane_id: pane_id.clone(),
+            })),
+        };
+        client.send(&close_msg).await;
+        let resp = client.recv_or_timeout().await;
+        match resp.msg {
+            Some(proto::server_message::Msg::PaneClosed(_)) => {}
+            other => panic!("expected PaneClosed on first close, got {other:?}"),
+        }
+
+        // Second close must return ERR_PANE_NOT_FOUND (code 6).
+        client.send(&close_msg).await;
+        let resp = client.recv_or_timeout().await;
+        let err = expect_error(&resp);
+        assert_eq!(err.code, 6, "expected ERR_PANE_NOT_FOUND (6), got code {}", err.code);
+    });
+}


### PR DESCRIPTION
## Problem

When closing a remote pane, if the daemon returns `ERR_PANE_NOT_FOUND` (code 6), the client treats it as a blocking error via `handle_command_error` → `classify_connection_problem` → `ConnectionProblem::UserActionRequired("pane not found")` → `Blocked` state. The pane is never removed from the layout, leaving the user stuck with "Action Required: pane not found" on all panes in the workspace.

## Fix

In the `ClosePane` response handler in `daemon_bridge.rs`, when the server returns `ERR_PANE_NOT_FOUND` (code 6), emit a `PaneClosed` event instead of calling `handle_command_error`. The pane doesn't exist on the daemon, so the GUI should clean it up through the normal pane removal flow.

## Testing

Added `close_pane_not_found_emits_pane_closed` test that:
1. Sends a `ClosePane` command to the endpoint actor
2. Has the fake server respond with `ERR_PANE_NOT_FOUND` (code 6)
3. Verifies that a `PaneClosed` event is emitted (not a `WorkspaceError`)

All checks pass: clippy, quality tests, build.

Closes #309