### PR TITLE
feat(sidebar): move pane count from suffix to subtitle

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -414,18 +414,25 @@ pub fn present_connection_status(
 pub fn workspace_connection_summary(
     endpoint: &RuntimeEndpoint,
     status: &ConnectionStatus,
+    pane_count: usize,
 ) -> String {
     let endpoint_label = match endpoint {
         RuntimeEndpoint::Local => "Local".to_string(),
         RuntimeEndpoint::Remote { host } => host.clone(),
     };
 
-    match status {
+    let base = match status {
         ConnectionStatus::Connected => match endpoint {
             RuntimeEndpoint::Local => "Local runtime".into(),
             RuntimeEndpoint::Remote { .. } => endpoint_label,
         },
         _ => format!("{endpoint_label} · {}", status.label()),
+    };
+
+    if pane_count == 1 {
+        format!("{base} · 1 pane")
+    } else {
+        format!("{base} · {pane_count} panes")
     }
 }
 
@@ -631,21 +638,26 @@ mod tests {
     }
 
     #[test]
-    fn workspace_connection_summary_omits_policy_and_keeps_recovery_compact() {
+    fn workspace_connection_summary_includes_pane_count() {
         assert_eq!(
-            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Connected),
-            "Local runtime"
+            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, 3),
+            "Local runtime · 3 panes"
         );
         assert_eq!(
-            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Recovered),
-            "Local · Recovered"
+            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, 1),
+            "Local runtime · 1 pane"
+        );
+        assert_eq!(
+            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Recovered, 2),
+            "Local · Recovered · 2 panes"
         );
         assert_eq!(
             workspace_connection_summary(
                 &RuntimeEndpoint::Remote { host: "builder.example".into() },
                 &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
+                1,
             ),
-            "builder.example · Action Required: Permission denied"
+            "builder.example · Action Required: Permission denied · 1 pane"
         );
     }
 
@@ -654,12 +666,12 @@ mod tests {
         let endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
 
         assert_eq!(
-            workspace_connection_summary(&endpoint, &ConnectionStatus::Connected),
-            "builder.example"
+            workspace_connection_summary(&endpoint, &ConnectionStatus::Connected, 1),
+            "builder.example · 1 pane"
         );
         assert_eq!(
-            workspace_connection_summary(&endpoint, &ConnectionStatus::Disconnected),
-            "builder.example · Disconnected"
+            workspace_connection_summary(&endpoint, &ConnectionStatus::Disconnected, 2),
+            "builder.example · Disconnected · 2 panes"
         );
     }
 

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -676,6 +676,15 @@ mod tests {
     }
 
     #[test]
+    fn workspace_connection_summary_pane_count_singular_plural() {
+        let ep = RuntimeEndpoint::Local;
+        let status = ConnectionStatus::Connected;
+        assert!(workspace_connection_summary(&ep, &status, 1).ends_with("1 pane"));
+        assert!(workspace_connection_summary(&ep, &status, 2).ends_with("2 panes"));
+        assert!(workspace_connection_summary(&ep, &status, 10).ends_with("10 panes"));
+    }
+
+    #[test]
     fn workspace_actions_for_attached_managed_workspace_shows_destructive_close() {
         let presentation = present_workspace_actions(Some(WorkspacePolicy::Persistent), true, 2);
 

--- a/clients/rttx/src/sidebar.rs
+++ b/clients/rttx/src/sidebar.rs
@@ -34,7 +34,6 @@ mod imp {
         pub color_dot: gtk4::Image,
         pub position_label: gtk4::Label,
         pub activity_dot: gtk4::Image,
-        pub terminal_count_label: gtk4::Label,
         pub close_button: gtk4::Button,
         pub activity_state: Cell<ActivityState>,
         pub idle_transition_source: RefCell<Option<glib::SourceId>>,
@@ -59,7 +58,6 @@ mod imp {
                 color_dot,
                 position_label,
                 activity_dot,
-                terminal_count_label: gtk4::Label::new(None),
                 close_button: gtk4::Button::from_icon_name("window-close-symbolic"),
                 activity_state: Cell::new(ActivityState::None),
                 idle_transition_source: RefCell::new(None),
@@ -82,16 +80,12 @@ mod imp {
             obj.set_selectable(true);
             obj.set_title_lines(1);
 
-            self.terminal_count_label.add_css_class("dim-label");
-            self.terminal_count_label.add_css_class("caption");
-
             self.close_button.add_css_class("flat");
             self.close_button.add_css_class("circular");
 
             obj.add_prefix(&self.color_dot);
             obj.add_prefix(&self.position_label);
             obj.add_suffix(&self.activity_dot);
-            obj.add_suffix(&self.terminal_count_label);
             obj.add_suffix(&self.close_button);
         }
     }
@@ -110,12 +104,11 @@ glib::wrapper! {
 
 impl SessionRow {
     #[must_use]
-    pub fn new(uuid: &str, name: &str, terminal_count: usize) -> Self {
+    pub fn new(uuid: &str, name: &str) -> Self {
         let obj: Self = glib::Object::builder().build();
         obj.imp().uuid.replace(uuid.to_string());
         obj.imp().name.replace(name.to_string());
         obj.set_title(name);
-        obj.update_terminal_count(terminal_count);
         obj
     }
 
@@ -140,10 +133,6 @@ impl SessionRow {
             dot.remove_css_class(cls.css_class());
         }
         dot.add_css_class(color.css_class());
-    }
-
-    pub fn update_terminal_count(&self, count: usize) {
-        self.imp().terminal_count_label.set_label(&format!("{count}"));
     }
 
     fn set_activity_state_internal(&self, state: ActivityState) {
@@ -270,26 +259,36 @@ mod tests {
     fn session_row_is_an_action_row() {
         require_display!();
 
-        let row = SessionRow::new("session-1", "Session 1", 3);
+        let row = SessionRow::new("session-1", "Session 1");
 
         assert!(row.is::<adw::ActionRow>());
         assert!(row.is::<gtk4::ListBoxRow>());
         assert_eq!(row.title().as_str(), "Session 1");
-        assert_eq!(row.imp().terminal_count_label.label().as_str(), "3");
     }
 
     #[test]
     #[ignore = "requires isolated GTK harness"]
-    fn session_row_updates_title_and_count() {
+    fn session_row_updates_title() {
         require_display!();
 
-        let row = SessionRow::new("session-1", "Session 1", 1);
+        let row = SessionRow::new("session-1", "Session 1");
         row.set_session_name("Renamed");
-        row.update_terminal_count(5);
 
         assert_eq!(row.session_name(), "Renamed");
         assert_eq!(row.title().as_str(), "Renamed");
-        assert_eq!(row.imp().terminal_count_label.label().as_str(), "5");
+    }
+
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn session_row_subtitle_shows_pane_count() {
+        require_display!();
+
+        let row = SessionRow::new("session-1", "Session 1");
+        row.set_subtitle("Local runtime · 3 panes");
+        assert_eq!(row.subtitle().unwrap().as_str(), "Local runtime · 3 panes");
+
+        row.set_subtitle("1 pane");
+        assert_eq!(row.subtitle().unwrap().as_str(), "1 pane");
     }
 
     #[test]
@@ -297,7 +296,7 @@ mod tests {
     fn activity_indicator_toggles() {
         require_display!();
 
-        let row = SessionRow::new("s1", "Session", 1);
+        let row = SessionRow::new("s1", "Session");
         assert_eq!(row.activity_state(), ActivityState::None);
         assert!(!row.has_activity(), "activity should be off initially");
 
@@ -321,7 +320,7 @@ mod tests {
     fn repeated_activity_refreshes_idle_timer() {
         require_display!();
 
-        let row = SessionRow::new("s1", "Session", 1);
+        let row = SessionRow::new("s1", "Session");
 
         row.mark_activity();
         pump_events(ACTIVITY_IDLE_DELAY_MS / 2);
@@ -347,7 +346,7 @@ mod tests {
     fn clear_activity_cancels_pending_idle_transition() {
         require_display!();
 
-        let row = SessionRow::new("s1", "Session", 1);
+        let row = SessionRow::new("s1", "Session");
 
         row.mark_activity();
         assert_eq!(row.activity_state(), ActivityState::Active);
@@ -368,7 +367,7 @@ mod tests {
     fn position_label_shows_number() {
         require_display!();
 
-        let row = SessionRow::new("s1", "Session", 1);
+        let row = SessionRow::new("s1", "Session");
         row.set_position(0);
         assert_eq!(row.position_label_text(), "1");
 
@@ -381,7 +380,7 @@ mod tests {
     fn position_label_hidden_beyond_nine() {
         require_display!();
 
-        let row = SessionRow::new("s1", "Session", 1);
+        let row = SessionRow::new("s1", "Session");
         row.set_position(0);
         assert!(row.imp().position_label.is_visible());
 

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -633,10 +633,7 @@ impl Window {
 
     fn append_session_row(&self, session_state: &SessionState) {
         let imp = self.imp();
-        let row = SessionRow::new(
-            &session_state.uuid,
-            &session_state.name,
-        );
+        let row = SessionRow::new(&session_state.uuid, &session_state.name);
         row.close_button().set_tooltip_text(Some(if session_state.uses_managed_runtime() {
             "Workspace actions"
         } else {

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -636,7 +636,6 @@ impl Window {
         let row = SessionRow::new(
             &session_state.uuid,
             &session_state.name,
-            session_state.layout.terminal_count(),
         );
         row.close_button().set_tooltip_text(Some(if session_state.uses_managed_runtime() {
             "Workspace actions"
@@ -2227,12 +2226,31 @@ impl Window {
 
     fn update_sidebar_count(&self, session_uuid: &str, count: usize) {
         let imp = self.imp();
+        let subtitle = {
+            let state = imp.state.borrow();
+            let Some(session) = state.sessions.iter().find(|s| s.uuid == session_uuid) else {
+                return;
+            };
+            if session.uses_managed_runtime() {
+                let status = imp
+                    .workspace_connection_status
+                    .borrow()
+                    .get(session_uuid)
+                    .cloned()
+                    .unwrap_or(ConnectionStatus::Connecting);
+                workspace_connection_summary(&session.runtime.endpoint, &status, count)
+            } else if count == 1 {
+                "1 pane".to_string()
+            } else {
+                format!("{count} panes")
+            }
+        };
         let mut idx = 0;
         while let Some(row) = imp.sidebar_list.row_at_index(idx) {
             if let Some(session_row) = row.child().and_then(|c| c.downcast::<SessionRow>().ok())
                 && session_row.uuid() == session_uuid
             {
-                session_row.update_terminal_count(count);
+                session_row.set_subtitle(&subtitle);
                 return;
             }
             idx += 1;

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -529,7 +529,11 @@ impl Window {
         else {
             return;
         };
-        let summary = workspace_connection_summary(&session.runtime.endpoint, status);
+        let summary = workspace_connection_summary(
+            &session.runtime.endpoint,
+            status,
+            session.layout.terminal_count(),
+        );
         drop(state);
 
         let list = &self.imp().sidebar_list;

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -708,3 +708,33 @@ fn old_state_without_zoom_field_deserializes_cleanly() {
     let state: WindowState = serde_json::from_str(json).unwrap();
     assert!(state.sessions[0].zoomed_terminal_uuid.is_none());
 }
+
+/// Contract: workspace_connection_summary includes pane count in subtitle text.
+///
+/// The sidebar row subtitle must always contain the pane count so users can see
+/// how many panes a workspace has without expanding it. Singular/plural must be
+/// correct.
+#[test]
+fn workspace_connection_summary_includes_pane_count_in_subtitle() {
+    use rttx::runtime::{
+        workspace_connection_summary, ConnectionStatus, RuntimeEndpoint,
+    };
+
+    let local = RuntimeEndpoint::Local;
+    let remote = RuntimeEndpoint::Remote { host: "dev@host".into() };
+
+    assert!(
+        workspace_connection_summary(&local, &ConnectionStatus::Connected, 3).ends_with("3 panes")
+    );
+    assert!(
+        workspace_connection_summary(&local, &ConnectionStatus::Connected, 1).ends_with("1 pane")
+    );
+    assert!(
+        workspace_connection_summary(&remote, &ConnectionStatus::Connected, 2)
+            .ends_with("2 panes")
+    );
+    assert!(
+        workspace_connection_summary(&remote, &ConnectionStatus::Disconnected, 1)
+            .contains("1 pane")
+    );
+}

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -716,9 +716,7 @@ fn old_state_without_zoom_field_deserializes_cleanly() {
 /// correct.
 #[test]
 fn workspace_connection_summary_includes_pane_count_in_subtitle() {
-    use rttx::runtime::{
-        workspace_connection_summary, ConnectionStatus, RuntimeEndpoint,
-    };
+    use rttx::runtime::{ConnectionStatus, RuntimeEndpoint, workspace_connection_summary};
 
     let local = RuntimeEndpoint::Local;
     let remote = RuntimeEndpoint::Remote { host: "dev@host".into() };
@@ -730,8 +728,7 @@ fn workspace_connection_summary_includes_pane_count_in_subtitle() {
         workspace_connection_summary(&local, &ConnectionStatus::Connected, 1).ends_with("1 pane")
     );
     assert!(
-        workspace_connection_summary(&remote, &ConnectionStatus::Connected, 2)
-            .ends_with("2 panes")
+        workspace_connection_summary(&remote, &ConnectionStatus::Connected, 2).ends_with("2 panes")
     );
     assert!(
         workspace_connection_summary(&remote, &ConnectionStatus::Disconnected, 1)


### PR DESCRIPTION
## What changed and why

The pane count was a dim standalone number in the suffix area of the sidebar row, between the activity dot and the close button. Its purpose was unclear without a tooltip.

This PR moves the pane count into the subtitle line alongside the endpoint/status info:
- "Local runtime · 3 panes"
- "etf@nucbox · 1 pane"
- "Local · Recovered · 2 panes"
- Non-managed workspaces: "1 pane" / "3 panes"

This frees suffix space, gives the count contextual meaning, and reduces visual clutter.

## Changes

- **`runtime.rs`**: Added `pane_count` parameter to `workspace_connection_summary()` — appends "· N panes" (singular for 1)
- **`sidebar.rs`**: Removed `terminal_count_label` from `SessionRow` suffix, removed `update_terminal_count()`, simplified `SessionRow::new()` signature
- **`window/runtime.rs`**: Pass `session.layout.terminal_count()` to `workspace_connection_summary()`
- **`window/mod.rs`**: `update_sidebar_count()` now sets the subtitle — uses `workspace_connection_summary` for managed workspaces, plain "N panes" for non-managed

## Manual verification

1. Open rttx with multiple workspaces
2. Verify subtitle shows "Local runtime · N panes" for managed workspaces
3. Split a pane — subtitle updates to reflect new count
4. Close a pane — subtitle updates
5. Non-managed workspaces show "N panes" in subtitle
6. No number appears in the suffix area anymore

## Tests added

- `workspace_connection_summary_includes_pane_count` — verifies local connected, local recovered, and remote blocked all include pane count with correct singular/plural
- `workspace_connection_summary_for_connected_remote_stays_compact` — updated to verify pane count in remote summaries
- `session_row_subtitle_shows_pane_count` — GTK widget test verifying subtitle can display pane count strings
- Updated all existing `SessionRow` tests to use new 2-arg constructor

## Tests run

- `cargo build` (rttx, rttx-server, rttx-proto) ✅
- `cargo test --workspace` — 309 passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `./run_ui_tests.sh` — same 6 pre-existing failures as mainline ✅

Fixes #303