### PR TITLE
feat(sidebar): add connection status icon to workspace row

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -751,11 +751,9 @@ mod tests {
     #[test]
     fn connection_icon_error_for_remote_blocked() {
         let ep = RuntimeEndpoint::Remote { host: "h".into() };
-        let icon = connection_icon(
-            &ep,
-            &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
-        )
-        .unwrap();
+        let icon =
+            connection_icon(&ep, &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied))
+                .unwrap();
         assert_eq!(icon.icon_name, "network-offline-symbolic");
         assert_eq!(icon.css_class, "error");
     }

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -409,7 +409,33 @@ pub fn present_connection_status(
     }
 }
 
-/// Render a compact workspace-row summary for connection state.
+/// Icon and CSS class for the sidebar connection status indicator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionIcon {
+    pub icon_name: &'static str,
+    pub css_class: &'static str,
+}
+
+/// Returns the connection icon for a workspace row, or `None` for local endpoints.
+#[must_use]
+pub const fn connection_icon(
+    endpoint: &RuntimeEndpoint,
+    status: &ConnectionStatus,
+) -> Option<ConnectionIcon> {
+    if matches!(endpoint, RuntimeEndpoint::Local) {
+        return None;
+    }
+    let (icon_name, css_class) = match status {
+        ConnectionStatus::Connected | ConnectionStatus::Recovered => {
+            ("network-server-symbolic", "accent")
+        }
+        ConnectionStatus::Disconnected => ("network-offline-symbolic", "warning"),
+        ConnectionStatus::Blocked(_) => ("network-offline-symbolic", "error"),
+        _ => ("network-server-symbolic", "dim-label"),
+    };
+    Some(ConnectionIcon { icon_name, css_class })
+}
+
 #[must_use]
 pub fn workspace_connection_summary(
     endpoint: &RuntimeEndpoint,
@@ -682,6 +708,64 @@ mod tests {
         assert!(workspace_connection_summary(&ep, &status, 1).ends_with("1 pane"));
         assert!(workspace_connection_summary(&ep, &status, 2).ends_with("2 panes"));
         assert!(workspace_connection_summary(&ep, &status, 10).ends_with("10 panes"));
+    }
+
+    #[test]
+    fn connection_icon_none_for_local() {
+        assert!(connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected).is_none());
+        assert!(
+            connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Disconnected).is_none()
+        );
+    }
+
+    #[test]
+    fn connection_icon_accent_for_remote_connected() {
+        let ep = RuntimeEndpoint::Remote { host: "h".into() };
+        let icon = connection_icon(&ep, &ConnectionStatus::Connected).unwrap();
+        assert_eq!(icon.icon_name, "network-server-symbolic");
+        assert_eq!(icon.css_class, "accent");
+    }
+
+    #[test]
+    fn connection_icon_dim_for_remote_connecting() {
+        let ep = RuntimeEndpoint::Remote { host: "h".into() };
+        for status in [
+            ConnectionStatus::Starting,
+            ConnectionStatus::Connecting,
+            ConnectionStatus::Reconnecting { attempt: 1, retry_in_secs: 5 },
+        ] {
+            let icon = connection_icon(&ep, &status).unwrap();
+            assert_eq!(icon.icon_name, "network-server-symbolic");
+            assert_eq!(icon.css_class, "dim-label");
+        }
+    }
+
+    #[test]
+    fn connection_icon_warning_for_remote_disconnected() {
+        let ep = RuntimeEndpoint::Remote { host: "h".into() };
+        let icon = connection_icon(&ep, &ConnectionStatus::Disconnected).unwrap();
+        assert_eq!(icon.icon_name, "network-offline-symbolic");
+        assert_eq!(icon.css_class, "warning");
+    }
+
+    #[test]
+    fn connection_icon_error_for_remote_blocked() {
+        let ep = RuntimeEndpoint::Remote { host: "h".into() };
+        let icon = connection_icon(
+            &ep,
+            &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
+        )
+        .unwrap();
+        assert_eq!(icon.icon_name, "network-offline-symbolic");
+        assert_eq!(icon.css_class, "error");
+    }
+
+    #[test]
+    fn connection_icon_accent_for_remote_recovered() {
+        let ep = RuntimeEndpoint::Remote { host: "h".into() };
+        let icon = connection_icon(&ep, &ConnectionStatus::Recovered).unwrap();
+        assert_eq!(icon.icon_name, "network-server-symbolic");
+        assert_eq!(icon.css_class, "accent");
     }
 
     #[test]

--- a/clients/rttx/src/sidebar.rs
+++ b/clients/rttx/src/sidebar.rs
@@ -33,6 +33,7 @@ mod imp {
         pub name: RefCell<String>,
         pub color_dot: gtk4::Image,
         pub position_label: gtk4::Label,
+        pub connection_icon: gtk4::Image,
         pub activity_dot: gtk4::Image,
         pub close_button: gtk4::Button,
         pub activity_state: Cell<ActivityState>,
@@ -43,6 +44,10 @@ mod imp {
         fn default() -> Self {
             let color_dot = gtk4::Image::from_icon_name("circle-filled-symbolic");
             color_dot.set_pixel_size(10);
+
+            let connection_icon = gtk4::Image::new();
+            connection_icon.set_pixel_size(16);
+            connection_icon.set_visible(false);
 
             let activity_dot = gtk4::Image::from_icon_name("media-record-symbolic");
             activity_dot.set_pixel_size(8);
@@ -57,6 +62,7 @@ mod imp {
                 name: RefCell::new(String::new()),
                 color_dot,
                 position_label,
+                connection_icon,
                 activity_dot,
                 close_button: gtk4::Button::from_icon_name("window-close-symbolic"),
                 activity_state: Cell::new(ActivityState::None),
@@ -85,6 +91,7 @@ mod imp {
 
             obj.add_prefix(&self.color_dot);
             obj.add_prefix(&self.position_label);
+            obj.add_suffix(&self.connection_icon);
             obj.add_suffix(&self.activity_dot);
             obj.add_suffix(&self.close_button);
         }
@@ -133,6 +140,22 @@ impl SessionRow {
             dot.remove_css_class(cls.css_class());
         }
         dot.add_css_class(color.css_class());
+    }
+
+    pub fn set_connection_icon(&self, icon: Option<&crate::runtime::ConnectionIcon>) {
+        const ICON_CSS_CLASSES: &[&str] = &["accent", "dim-label", "warning", "error"];
+        let widget = &self.imp().connection_icon;
+        for cls in ICON_CSS_CLASSES {
+            widget.remove_css_class(cls);
+        }
+        match icon {
+            Some(icon) => {
+                widget.set_icon_name(Some(icon.icon_name));
+                widget.add_css_class(icon.css_class);
+                widget.set_visible(true);
+            }
+            None => widget.set_visible(false),
+        }
     }
 
     fn set_activity_state_internal(&self, state: ActivityState) {
@@ -289,6 +312,57 @@ mod tests {
 
         row.set_subtitle("1 pane");
         assert_eq!(row.subtitle().unwrap().as_str(), "1 pane");
+    }
+
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn connection_icon_hidden_by_default() {
+        require_display!();
+        let row = SessionRow::new("s1", "Session");
+        assert!(!row.imp().connection_icon.is_visible());
+    }
+
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn connection_icon_shows_and_hides() {
+        require_display!();
+        let row = SessionRow::new("s1", "Session");
+
+        let icon = crate::runtime::ConnectionIcon {
+            icon_name: "network-server-symbolic",
+            css_class: "accent",
+        };
+        row.set_connection_icon(Some(&icon));
+        assert!(row.imp().connection_icon.is_visible());
+        assert_eq!(row.imp().connection_icon.icon_name().unwrap(), "network-server-symbolic");
+        assert!(row.imp().connection_icon.has_css_class("accent"));
+
+        row.set_connection_icon(None);
+        assert!(!row.imp().connection_icon.is_visible());
+        assert!(!row.imp().connection_icon.has_css_class("accent"));
+    }
+
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn connection_icon_switches_css_class() {
+        require_display!();
+        let row = SessionRow::new("s1", "Session");
+
+        let connected = crate::runtime::ConnectionIcon {
+            icon_name: "network-server-symbolic",
+            css_class: "accent",
+        };
+        row.set_connection_icon(Some(&connected));
+        assert!(row.imp().connection_icon.has_css_class("accent"));
+
+        let disconnected = crate::runtime::ConnectionIcon {
+            icon_name: "network-offline-symbolic",
+            css_class: "warning",
+        };
+        row.set_connection_icon(Some(&disconnected));
+        assert!(!row.imp().connection_icon.has_css_class("accent"));
+        assert!(row.imp().connection_icon.has_css_class("warning"));
+        assert_eq!(row.imp().connection_icon.icon_name().unwrap(), "network-offline-symbolic");
     }
 
     #[test]

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -14,7 +14,7 @@ use crate::config;
 use crate::preferences::{self, Preferences};
 use crate::runtime::{
     ConnectionPresentation, ConnectionStatus, RuntimeEndpoint, WorkspaceActionPresentation,
-    WorkspacePolicy, present_connection_status, present_workspace_actions,
+    WorkspacePolicy, connection_icon, present_connection_status, present_workspace_actions,
     workspace_connection_summary,
 };
 use crate::session::{

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -534,6 +534,7 @@ impl Window {
             status,
             session.layout.terminal_count(),
         );
+        let icon = connection_icon(&session.runtime.endpoint, status);
         drop(state);
 
         let list = &self.imp().sidebar_list;
@@ -544,6 +545,7 @@ impl Window {
                 && session_row.uuid() == workspace_id
             {
                 session_row.set_subtitle(&summary);
+                session_row.set_connection_icon(icon.as_ref());
                 break;
             }
             idx += 1;

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -735,3 +735,22 @@ fn workspace_connection_summary_includes_pane_count_in_subtitle() {
             .contains("1 pane")
     );
 }
+
+/// Contract: connection_icon returns None for local, Some for remote endpoints.
+///
+/// The sidebar row must show a connection icon only for remote workspaces.
+/// The icon and CSS class must change based on connection status.
+#[test]
+fn connection_icon_distinguishes_local_from_remote() {
+    use rttx::runtime::{ConnectionStatus, RuntimeEndpoint, connection_icon};
+
+    assert!(connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected).is_none());
+
+    let remote = RuntimeEndpoint::Remote { host: "h".into() };
+    let connected = connection_icon(&remote, &ConnectionStatus::Connected).unwrap();
+    assert_eq!(connected.css_class, "accent");
+
+    let disconnected = connection_icon(&remote, &ConnectionStatus::Disconnected).unwrap();
+    assert_eq!(disconnected.css_class, "warning");
+    assert_ne!(connected.icon_name, disconnected.icon_name);
+}


### PR DESCRIPTION
## What changed and why

There was no at-a-glance visual indicator on the sidebar row showing whether a managed workspace is connected to its daemon. Users had to click into a workspace to discover it was disconnected.

This PR adds a connection status icon to each sidebar row that conveys the connection state for remote workspaces:

- **Local**: no icon (hidden)
- **Remote connected/recovered**: `network-server-symbolic` with `accent` CSS class
- **Remote connecting/starting/reconnecting**: `network-server-symbolic` with `dim-label` CSS class
- **Remote disconnected**: `network-offline-symbolic` with `warning` CSS class
- **Remote blocked**: `network-offline-symbolic` with `error` CSS class

## Changes

- **`runtime.rs`**: Added `ConnectionIcon` struct and `connection_icon()` function that maps `(RuntimeEndpoint, ConnectionStatus)` to an optional icon name + CSS class
- **`sidebar.rs`**: Added `connection_icon` widget to `SessionRow` (suffix area, before activity dot), added `set_connection_icon()` method
- **`window/runtime.rs`**: `refresh_workspace_row_status()` now also updates the connection icon
- **`window/mod.rs`**: Added `connection_icon` to imports

## Manual verification

1. Open rttx and create a remote workspace (SSH)
2. Verify the sidebar row shows a network icon with accent color when connected
3. Disconnect the SSH connection — icon should change to offline/warning
4. Local workspaces should show no connection icon

## Tests added

- 6 unit tests for `connection_icon()` covering all status variants for local and remote endpoints
- 3 GTK widget tests for `set_connection_icon()` (hidden by default, show/hide, CSS class switching)
- 1 boundary contract test verifying local vs remote distinction

## Tests run

- `cargo build` (rttx, rttx-server, rttx-proto) ✅
- `cargo test --lib` — 316 passed ✅
- `cargo test --test gtk_boundary_contracts` — 26 passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (1 pre-existing flaky server test)
- `./run_ui_tests.sh` — same 6 pre-existing failures as mainline ✅

Fixes #304