### PR TITLE
refactor(terminal): remove disconnection banner from persistent panes

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -289,16 +289,10 @@ pub fn advance_connection_status(
     }
 }
 
-/// UI-facing connection banner configuration.
+/// UI-facing connection state for pane headers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectionPresentation {
     pub header_label: String,
-    pub banner_title: String,
-    pub banner_body: String,
-    pub banner_visible: bool,
-    pub show_retry: bool,
-    pub show_close: bool,
-    pub show_edit_connection: bool,
     pub input_enabled: bool,
 }
 
@@ -358,53 +352,11 @@ pub fn present_workspace_actions(
     }
 }
 
-/// Render a connection state into user-facing copy and control visibility.
+/// Render a connection state into pane header label and input availability.
 #[must_use]
-pub fn present_connection_status(
-    endpoint: &RuntimeEndpoint,
-    status: &ConnectionStatus,
-) -> ConnectionPresentation {
-    let endpoint_label = match endpoint {
-        RuntimeEndpoint::Local => "local daemon".to_string(),
-        RuntimeEndpoint::Remote { host } => host.clone(),
-    };
-    let show_edit_connection = matches!(endpoint, RuntimeEndpoint::Remote { .. })
-        && matches!(status, ConnectionStatus::Blocked(_));
-
-    let (banner_title, banner_body, banner_visible, show_retry, show_close) = match status {
-        ConnectionStatus::Starting
-        | ConnectionStatus::Connecting
-        | ConnectionStatus::Connected
-        | ConnectionStatus::Recovered => (String::new(), String::new(), false, false, false),
-        ConnectionStatus::Reconnecting { attempt, retry_in_secs } => (
-            format!("Reconnecting in {retry_in_secs}s"),
-            format!(
-                "The runtime connection dropped. rttx will retry automatically (attempt {attempt})."
-            ),
-            true,
-            true,
-            true,
-        ),
-        ConnectionStatus::Blocked(problem) => {
-            (format!("Action required for {endpoint_label}"), problem.label(), true, true, true)
-        }
-        ConnectionStatus::Disconnected => (
-            format!("Disconnected from {endpoint_label}"),
-            "The runtime is unavailable right now.".into(),
-            true,
-            true,
-            true,
-        ),
-    };
-
+pub fn present_connection_status(status: &ConnectionStatus) -> ConnectionPresentation {
     ConnectionPresentation {
         header_label: status.short_label(),
-        banner_title,
-        banner_body,
-        banner_visible,
-        show_retry,
-        show_close,
-        show_edit_connection,
         input_enabled: status.accepts_input(),
     }
 }
@@ -614,53 +566,37 @@ mod tests {
     }
 
     #[test]
-    fn connection_presentation_hides_banner_for_compact_states() {
-        let presentation =
-            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
-        assert!(!presentation.banner_visible);
-        assert!(presentation.input_enabled);
-        assert!(!presentation.show_retry);
+    fn connection_presentation_header_and_input_for_connected_states() {
+        let connected =
+            present_connection_status(&ConnectionStatus::Connected);
+        assert_eq!(connected.header_label, "Connected");
+        assert!(connected.input_enabled);
 
         let recovered =
-            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Recovered);
-        assert!(!recovered.banner_visible);
+            present_connection_status(&ConnectionStatus::Recovered);
         assert_eq!(recovered.header_label, "Connected");
-
-        let connecting =
-            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connecting);
-        assert!(!connecting.banner_visible);
+        assert!(recovered.input_enabled);
     }
 
     #[test]
-    fn connection_presentation_for_reconnecting_remote_shows_countdown_and_controls() {
-        let presentation = present_connection_status(
-            &RuntimeEndpoint::Remote { host: "builder.example".into() },
+    fn connection_presentation_disables_input_for_disconnected_states() {
+        let reconnecting = present_connection_status(
             &ConnectionStatus::Reconnecting { attempt: 2, retry_in_secs: 4 },
         );
+        assert_eq!(reconnecting.header_label, "Retry 4s");
+        assert!(!reconnecting.input_enabled);
 
-        assert_eq!(presentation.header_label, "Retry 4s");
-        assert_eq!(presentation.banner_title, "Reconnecting in 4s");
-        assert!(presentation.banner_body.contains("attempt 2"));
-        assert!(presentation.banner_visible);
-        assert!(presentation.show_retry);
-        assert!(presentation.show_close);
-        assert!(!presentation.show_edit_connection);
-        assert!(!presentation.input_enabled);
-    }
-
-    #[test]
-    fn connection_presentation_for_blocked_remote_allows_editing() {
-        let presentation = present_connection_status(
-            &RuntimeEndpoint::Remote { host: "builder.example".into() },
+        let blocked = present_connection_status(
             &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
         );
+        assert_eq!(blocked.header_label, "Action Required");
+        assert!(!blocked.input_enabled);
 
-        assert!(presentation.banner_visible);
-        assert!(presentation.show_retry);
-        assert!(presentation.show_close);
-        assert!(presentation.show_edit_connection);
-        assert!(!presentation.input_enabled);
-        assert!(presentation.banner_body.contains("Permission denied"));
+        let disconnected = present_connection_status(
+            &ConnectionStatus::Disconnected,
+        );
+        assert_eq!(disconnected.header_label, "Disconnected");
+        assert!(!disconnected.input_enabled);
     }
 
     #[test]

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -567,34 +567,31 @@ mod tests {
 
     #[test]
     fn connection_presentation_header_and_input_for_connected_states() {
-        let connected =
-            present_connection_status(&ConnectionStatus::Connected);
+        let connected = present_connection_status(&ConnectionStatus::Connected);
         assert_eq!(connected.header_label, "Connected");
         assert!(connected.input_enabled);
 
-        let recovered =
-            present_connection_status(&ConnectionStatus::Recovered);
+        let recovered = present_connection_status(&ConnectionStatus::Recovered);
         assert_eq!(recovered.header_label, "Connected");
         assert!(recovered.input_enabled);
     }
 
     #[test]
     fn connection_presentation_disables_input_for_disconnected_states() {
-        let reconnecting = present_connection_status(
-            &ConnectionStatus::Reconnecting { attempt: 2, retry_in_secs: 4 },
-        );
+        let reconnecting = present_connection_status(&ConnectionStatus::Reconnecting {
+            attempt: 2,
+            retry_in_secs: 4,
+        });
         assert_eq!(reconnecting.header_label, "Retry 4s");
         assert!(!reconnecting.input_enabled);
 
-        let blocked = present_connection_status(
-            &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
-        );
+        let blocked = present_connection_status(&ConnectionStatus::Blocked(
+            ConnectionProblem::PermissionDenied,
+        ));
         assert_eq!(blocked.header_label, "Action Required");
         assert!(!blocked.input_enabled);
 
-        let disconnected = present_connection_status(
-            &ConnectionStatus::Disconnected,
-        );
+        let disconnected = present_connection_status(&ConnectionStatus::Disconnected);
         assert_eq!(disconnected.header_label, "Disconnected");
         assert!(!disconnected.input_enabled);
     }

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -888,4 +888,11 @@ mod tests {
         assert_eq!(local.key(), "local");
         assert!(remote.key().contains("host"));
     }
+
+    #[test]
+    fn connection_presentation_for_starting_shows_starting_label() {
+        let p = present_connection_status(&ConnectionStatus::Starting);
+        assert_eq!(p.header_label, "Starting");
+        assert!(!p.input_enabled);
+    }
 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -652,9 +652,10 @@ mod tests {
 
         let pane = PersistentPaneView::new("pane-1", "runtime-1");
 
-        let reconnecting = present_connection_status(
-            &ConnectionStatus::Reconnecting { attempt: 2, retry_in_secs: 4 },
-        );
+        let reconnecting = present_connection_status(&ConnectionStatus::Reconnecting {
+            attempt: 2,
+            retry_in_secs: 4,
+        });
         pane.set_connection_presentation(
             &ConnectionStatus::Reconnecting { attempt: 2, retry_in_secs: 4 },
             &reconnecting,
@@ -662,14 +663,12 @@ mod tests {
         assert_eq!(pane.status_label_text_for_test(), "Retry 4s");
         assert!(!pane.input_enabled_for_test());
 
-        let connected =
-            present_connection_status(&ConnectionStatus::Connected);
+        let connected = present_connection_status(&ConnectionStatus::Connected);
         pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
         assert!(pane.input_enabled_for_test());
         assert_eq!(pane.status_label_text_for_test(), "Connected");
 
-        let recovered =
-            present_connection_status(&ConnectionStatus::Recovered);
+        let recovered = present_connection_status(&ConnectionStatus::Recovered);
         pane.set_connection_presentation(&ConnectionStatus::Recovered, &recovered);
         assert_eq!(pane.status_label_text_for_test(), "Connected");
     }
@@ -844,8 +843,7 @@ mod tests {
             gtk4::gdk::Display::default().expect("display should be available for GTK tests");
         display.clipboard().set_text("managed pasted text");
         pane.feed_output(b"managed copied text\r\n");
-        let connected =
-            present_connection_status(&ConnectionStatus::Connected);
+        let connected = present_connection_status(&ConnectionStatus::Connected);
         pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
 
         let forwarded = Rc::new(RefCell::new(Vec::new()));
@@ -909,8 +907,7 @@ mod tests {
             gtk4::gdk::Display::default().expect("display should be available for GTK tests");
         display.clipboard().set_text("window action paste");
 
-        let connected =
-            present_connection_status(&ConnectionStatus::Connected);
+        let connected = present_connection_status(&ConnectionStatus::Connected);
         pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
 
         let forwarded = Rc::new(RefCell::new(Vec::new()));

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -36,9 +36,6 @@ mod imp {
         pub vte: vte4::Terminal,
         pub terminal_scroller: gtk4::ScrolledWindow,
         pub header: gtk4::Box,
-        pub connection_banner: gtk4::Box,
-        pub connection_title_label: gtk4::Label,
-        pub connection_body_label: gtk4::Label,
         pub title_label: gtk4::Label,
         pub close_button: gtk4::Button,
         pub split_h_button: gtk4::Button,
@@ -63,9 +60,6 @@ mod imp {
                 vte: vte4::Terminal::new(),
                 terminal_scroller: gtk4::ScrolledWindow::new(),
                 header: gtk4::Box::default(),
-                connection_banner: gtk4::Box::default(),
-                connection_title_label: gtk4::Label::default(),
-                connection_body_label: gtk4::Label::default(),
                 title_label: gtk4::Label::default(),
                 close_button: gtk4::Button::default(),
                 split_h_button: gtk4::Button::default(),
@@ -155,26 +149,6 @@ mod imp {
             self.terminal_scroller.set_child(Some(&self.vte));
 
             obj.append(&self.header);
-            self.connection_banner.set_orientation(gtk4::Orientation::Vertical);
-            self.connection_banner.set_spacing(6);
-            self.connection_banner.set_margin_start(8);
-            self.connection_banner.set_margin_end(8);
-            self.connection_banner.set_margin_top(6);
-            self.connection_banner.set_margin_bottom(6);
-            self.connection_banner.add_css_class("toolbar");
-            self.connection_banner.set_visible(false);
-
-            self.connection_title_label.set_xalign(0.0);
-            self.connection_title_label.add_css_class("heading");
-
-            self.connection_body_label.set_xalign(0.0);
-            self.connection_body_label.set_wrap(true);
-            self.connection_body_label.add_css_class("dim-label");
-
-            self.connection_banner.append(&self.connection_title_label);
-            self.connection_banner.append(&self.connection_body_label);
-
-            obj.append(&self.connection_banner);
             obj.append(&self.search_bar);
             obj.append(&self.terminal_scroller);
 
@@ -390,7 +364,7 @@ impl PersistentPaneView {
         self.imp().status_label.set_tooltip_text(Some(&status.label()));
     }
 
-    /// Render the inline connection banner and update input availability.
+    /// Update the pane header status label and input availability.
     pub fn set_connection_presentation(
         &self,
         status: &ConnectionStatus,
@@ -401,9 +375,6 @@ impl PersistentPaneView {
             .set(matches!(status, ConnectionStatus::Connected | ConnectionStatus::Recovered));
         self.imp().status_label.set_label(&presentation.header_label);
         self.imp().status_label.set_tooltip_text(Some(&status.label()));
-        self.imp().connection_title_label.set_label(&presentation.banner_title);
-        self.imp().connection_body_label.set_label(&presentation.banner_body);
-        self.imp().connection_banner.set_visible(presentation.banner_visible);
         self.imp().accepts_input.set(presentation.input_enabled);
     }
 
@@ -610,12 +581,6 @@ impl PersistentPaneView {
 
     #[cfg(test)]
     #[must_use]
-    pub(crate) fn connection_banner_visible_for_test(&self) -> bool {
-        self.imp().connection_banner.is_visible()
-    }
-
-    #[cfg(test)]
-    #[must_use]
     pub(crate) fn input_enabled_for_test(&self) -> bool {
         self.imp().accepts_input.get()
     }
@@ -624,12 +589,6 @@ impl PersistentPaneView {
     #[must_use]
     pub(crate) fn status_label_text_for_test(&self) -> String {
         self.imp().status_label.label().to_string()
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub(crate) fn connection_title_for_test(&self) -> String {
-        self.imp().connection_title_label.label().to_string()
     }
 
     #[cfg(test)]
@@ -651,7 +610,7 @@ impl PersistentPaneView {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::{ConnectionProblem, RuntimeEndpoint, present_connection_status};
+    use crate::runtime::present_connection_status;
     use std::cell::RefCell;
     use std::rc::Rc;
     use std::time::{Duration, Instant};
@@ -688,44 +647,30 @@ mod tests {
 
     #[test]
     #[ignore = "requires isolated GTK harness"]
-    fn connection_presentation_controls_banner_and_input_state() {
+    fn connection_presentation_controls_header_and_input_state() {
         require_display!();
 
         let pane = PersistentPaneView::new("pane-1", "runtime-1");
 
         let reconnecting = present_connection_status(
-            &RuntimeEndpoint::Local,
             &ConnectionStatus::Reconnecting { attempt: 2, retry_in_secs: 4 },
         );
         pane.set_connection_presentation(
             &ConnectionStatus::Reconnecting { attempt: 2, retry_in_secs: 4 },
             &reconnecting,
         );
-
-        assert!(pane.connection_banner_visible_for_test());
         assert_eq!(pane.status_label_text_for_test(), "Retry 4s");
-        assert_eq!(pane.connection_title_for_test(), "Reconnecting in 4s");
         assert!(!pane.input_enabled_for_test());
 
-        let blocked = present_connection_status(
-            &RuntimeEndpoint::Remote { host: "builder.example".into() },
-            &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
-        );
-        pane.set_connection_presentation(
-            &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
-            &blocked,
-        );
-
         let connected =
-            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
+            present_connection_status(&ConnectionStatus::Connected);
         pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
-        assert!(!pane.connection_banner_visible_for_test());
         assert!(pane.input_enabled_for_test());
+        assert_eq!(pane.status_label_text_for_test(), "Connected");
 
         let recovered =
-            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Recovered);
+            present_connection_status(&ConnectionStatus::Recovered);
         pane.set_connection_presentation(&ConnectionStatus::Recovered, &recovered);
-        assert!(!pane.connection_banner_visible_for_test());
         assert_eq!(pane.status_label_text_for_test(), "Connected");
     }
 
@@ -900,7 +845,7 @@ mod tests {
         display.clipboard().set_text("managed pasted text");
         pane.feed_output(b"managed copied text\r\n");
         let connected =
-            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
+            present_connection_status(&ConnectionStatus::Connected);
         pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
 
         let forwarded = Rc::new(RefCell::new(Vec::new()));
@@ -965,7 +910,7 @@ mod tests {
         display.clipboard().set_text("window action paste");
 
         let connected =
-            present_connection_status(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
+            present_connection_status(&ConnectionStatus::Connected);
         pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
 
         let forwarded = Rc::new(RefCell::new(Vec::new()));

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -5360,8 +5360,8 @@ mod tests {
             .cloned()
             .expect("managed pane should be present");
 
-        assert!(pane.connection_banner_visible_for_test());
         assert!(!pane.input_enabled_for_test());
+        assert_eq!(pane.status_label_text_for_test(), "Action Required");
 
         window.close();
         crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
@@ -5799,7 +5799,7 @@ mod tests {
             .get("managed-pane")
             .cloned()
             .expect("managed pane should be present");
-        assert!(!pane.connection_banner_visible_for_test());
+        assert!(pane.input_enabled_for_test());
         assert_eq!(pane.status_label_text_for_test(), "Connected");
 
         let row = session_row_for_uuid(&window, &session_state.uuid);

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -200,8 +200,7 @@ impl Window {
             .get(&session_state.uuid)
             .cloned()
             .unwrap_or(ConnectionStatus::Connecting);
-        let presentation =
-            self.connection_presentation_for_workspace(&session_state.runtime.endpoint, &status);
+        let presentation = self.connection_presentation_for_workspace(&status);
         pane_view.set_connection_presentation(&status, &presentation);
 
         let win = self.clone();
@@ -513,10 +512,9 @@ impl Window {
 
     pub(super) fn connection_presentation_for_workspace(
         &self,
-        endpoint: &RuntimeEndpoint,
         status: &ConnectionStatus,
     ) -> ConnectionPresentation {
-        present_connection_status(endpoint, status)
+        present_connection_status(status)
     }
 
     pub(super) fn refresh_workspace_row_status(
@@ -557,15 +555,15 @@ impl Window {
         workspace_id: &str,
         status: &ConnectionStatus,
     ) {
-        let (endpoint, terminal_uuids) = {
+        let terminal_uuids = {
             let state = self.imp().state.borrow();
             let Some(session) = state.sessions.iter().find(|session| session.uuid == workspace_id)
             else {
                 return;
             };
-            (session.runtime.endpoint.clone(), session.layout.terminal_uuids())
+            session.layout.terminal_uuids()
         };
-        let presentation = self.connection_presentation_for_workspace(&endpoint, status);
+        let presentation = self.connection_presentation_for_workspace(status);
 
         let panes = self.imp().persistent_terminals.borrow();
         for terminal_uuid in terminal_uuids {

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -754,3 +754,20 @@ fn connection_icon_distinguishes_local_from_remote() {
     assert_eq!(disconnected.css_class, "warning");
     assert_ne!(connected.icon_name, disconnected.icon_name);
 }
+
+/// Contract: ConnectionPresentation contains only header_label and input_enabled.
+///
+/// The banner fields were removed in #305. The pane header status label and
+/// input gating are the only remaining presentation concerns.
+#[test]
+fn connection_presentation_has_no_banner_fields() {
+    use rttx::runtime::{ConnectionStatus, present_connection_status};
+
+    let p = present_connection_status(&ConnectionStatus::Disconnected);
+    assert_eq!(p.header_label, "Disconnected");
+    assert!(!p.input_enabled);
+
+    let p = present_connection_status(&ConnectionStatus::Connected);
+    assert_eq!(p.header_label, "Connected");
+    assert!(p.input_enabled);
+}

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1448,7 +1448,6 @@ fn managed_terminal_request_clipboard_paste_delivers_bytes() {
         rttx::terminal::persistent_widget::PersistentPaneView::new("managed-1", "runtime-1");
     let window = present_widget(&managed);
     let connected = rttx::runtime::present_connection_status(
-        &rttx::runtime::RuntimeEndpoint::Local,
         &rttx::runtime::ConnectionStatus::Connected,
     );
     managed.set_connection_presentation(&rttx::runtime::ConnectionStatus::Connected, &connected);

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1447,9 +1447,8 @@ fn managed_terminal_request_clipboard_paste_delivers_bytes() {
     let managed =
         rttx::terminal::persistent_widget::PersistentPaneView::new("managed-1", "runtime-1");
     let window = present_widget(&managed);
-    let connected = rttx::runtime::present_connection_status(
-        &rttx::runtime::ConnectionStatus::Connected,
-    );
+    let connected =
+        rttx::runtime::present_connection_status(&rttx::runtime::ConnectionStatus::Connected);
     managed.set_connection_presentation(&rttx::runtime::ConnectionStatus::Connected, &connected);
 
     let forwarded = Rc::new(RefCell::new(Vec::new()));


### PR DESCRIPTION
## What changed and why

The fat in-pane disconnection banner duplicated status information already shown by the sidebar row connection icon (#304) and subtitle text. It wasted terminal real estate and was visually disruptive.

This PR removes the banner entirely. The pane header status label is preserved as a subtle in-pane indicator showing "Connected", "Retry 4s", "Action Required", "Disconnected", etc.

## Changes

- **`runtime.rs`**: Simplified `ConnectionPresentation` to just `header_label` + `input_enabled`. Simplified `present_connection_status()` to a two-field constructor (removed `endpoint` parameter since it is no longer needed).
- **`persistent_widget.rs`**: Removed `connection_banner`, `connection_title_label`, `connection_body_label` widgets and their construction. Simplified `set_connection_presentation()` to only update header label and input state. Removed `connection_banner_visible_for_test()` and `connection_title_for_test()`.
- **`window/runtime.rs`**: Simplified `connection_presentation_for_workspace()` and `update_all_panes_connection_status()` to no longer pass endpoint.
- **`window/mod.rs`**: Updated tests to assert header label and input state instead of banner visibility.
- **`gtk_widget_tests.rs`**: Updated `present_connection_status` call to new signature.

Net result: -122 lines.

## Manual verification

1. Open rttx with a remote workspace
2. Disconnect SSH — verify no banner appears in the pane
3. Verify the pane header shows "Disconnected" status label
4. Verify the sidebar row shows the disconnected icon and subtitle
5. Reconnect — verify header returns to "Connected"

## Tests added/updated

- Replaced 3 banner-centric `present_connection_status` tests with 2 focused tests: `connection_presentation_header_and_input_for_connected_states` and `connection_presentation_disables_input_for_disconnected_states`
- Updated `connection_presentation_controls_header_and_input_state` GTK widget test (was `connection_presentation_controls_banner_and_input_state`)
- Updated 2 window integration tests to assert `input_enabled_for_test()` and `status_label_text_for_test()` instead of `connection_banner_visible_for_test()`

## Tests run

- `cargo test -p rttx --lib` — 315 passed ✅
- `cargo test -p rttx-server --lib` — 63 passed ✅
- `cargo test -p rttx --test gtk_boundary_contracts` — 26 passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `./run_ui_tests.sh` — same 6 pre-existing failures as mainline ✅

## Depends on

- #304 (sidebar connection status icon) — already merged

Fixes #305