### PR TITLE
feat: smart workspace auto-naming from CWD and hostname

### DIFF
--- a/clients/rttx/src/session/state.rs
+++ b/clients/rttx/src/session/state.rs
@@ -113,6 +113,8 @@ pub struct SessionState {
     pub color: SessionColor,
     #[serde(default)]
     pub zoomed_terminal_uuid: Option<String>,
+    #[serde(default)]
+    pub user_renamed: bool,
 }
 
 impl SessionState {
@@ -145,6 +147,7 @@ impl SessionState {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         }
     }
 
@@ -191,6 +194,7 @@ impl SessionState {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         }
     }
 }
@@ -291,6 +295,23 @@ impl SessionState {
     }
 }
 
+/// Derive a workspace name from the endpoint and working directory.
+///
+/// Returns `None` when no meaningful name can be derived.
+#[must_use]
+pub fn auto_name_for_workspace(endpoint: &RuntimeEndpoint, cwd: Option<&str>) -> Option<String> {
+    if let RuntimeEndpoint::Remote { host } = endpoint {
+        let short = host.split('@').next_back().unwrap_or(host);
+        let short = short.split('.').next().unwrap_or(short);
+        if !short.is_empty() {
+            return Some(short.to_string());
+        }
+    }
+    let path = cwd?;
+    let name = std::path::Path::new(path).file_name()?.to_str()?;
+    if name.is_empty() { None } else { Some(name.to_string()) }
+}
+
 const fn default_left_sidebar_width() -> i32 {
     220
 }
@@ -381,6 +402,7 @@ mod tests {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         };
         let json = serde_json::to_string(&session).unwrap();
         let restored: SessionState = serde_json::from_str(&json).unwrap();
@@ -640,6 +662,7 @@ mod tests {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         };
         session.layout = session.layout.remove_terminal("t2").unwrap();
         session.prune_recovery();
@@ -661,6 +684,7 @@ mod tests {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         };
         session.normalize_active_terminal();
         assert_eq!(session.active_terminal_uuid.as_deref(), Some("t1"));
@@ -694,6 +718,7 @@ mod tests {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         };
         let json = serde_json::to_string(&session).unwrap();
         let restored: SessionState = serde_json::from_str(&json).unwrap();
@@ -812,5 +837,64 @@ mod module_boundary_tests {
         let classes: std::collections::HashSet<_> =
             SessionColor::ALL.iter().map(|c| c.css_class()).collect();
         assert_eq!(classes.len(), 8);
+    }
+
+    #[test]
+    fn auto_name_from_cwd_uses_basename() {
+        let ep = RuntimeEndpoint::Local;
+        assert_eq!(
+            auto_name_for_workspace(&ep, Some("/home/user/projects/rttx")),
+            Some("rttx".into())
+        );
+    }
+
+    #[test]
+    fn auto_name_from_remote_uses_short_hostname() {
+        let ep = RuntimeEndpoint::Remote { host: "etf@nucbox.local".into() };
+        assert_eq!(auto_name_for_workspace(&ep, None), Some("nucbox".into()));
+    }
+
+    #[test]
+    fn auto_name_remote_without_user_prefix() {
+        let ep = RuntimeEndpoint::Remote { host: "builder.example.com".into() };
+        assert_eq!(auto_name_for_workspace(&ep, None), Some("builder".into()));
+    }
+
+    #[test]
+    fn auto_name_remote_ignores_cwd() {
+        let ep = RuntimeEndpoint::Remote { host: "etf@nucbox".into() };
+        assert_eq!(auto_name_for_workspace(&ep, Some("/home/etf/work")), Some("nucbox".into()));
+    }
+
+    #[test]
+    fn auto_name_returns_none_for_local_without_cwd() {
+        assert_eq!(auto_name_for_workspace(&RuntimeEndpoint::Local, None), None);
+    }
+
+    #[test]
+    fn auto_name_returns_none_for_root_path() {
+        assert_eq!(auto_name_for_workspace(&RuntimeEndpoint::Local, Some("/")), None);
+    }
+
+    #[test]
+    fn auto_name_home_directory() {
+        let ep = RuntimeEndpoint::Local;
+        assert_eq!(auto_name_for_workspace(&ep, Some("/home/user")), Some("user".into()));
+    }
+
+    #[test]
+    fn user_renamed_defaults_to_false_on_deserialize() {
+        let json = r#"{"uuid":"u","name":"Test","layout":{"Terminal":{"uuid":"t"}}}"#;
+        let session: SessionState = serde_json::from_str(json).unwrap();
+        assert!(!session.user_renamed);
+    }
+
+    #[test]
+    fn user_renamed_roundtrips_through_serde() {
+        let mut session = SessionState::new("Test".into());
+        session.user_renamed = true;
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: SessionState = serde_json::from_str(&json).unwrap();
+        assert!(restored.user_renamed);
     }
 }

--- a/clients/rttx/src/test_helpers.rs
+++ b/clients/rttx/src/test_helpers.rs
@@ -76,6 +76,7 @@ pub fn session(id: &str, name: &str, layout: LayoutNode) -> SessionState {
         runtime: WorkspaceRuntime::default(),
         color: SessionColor::default(),
         zoomed_terminal_uuid: None,
+        user_renamed: false,
     }
 }
 
@@ -127,6 +128,7 @@ pub fn managed_session_with_runtime(
         },
         color: SessionColor::default(),
         zoomed_terminal_uuid: None,
+        user_renamed: false,
     };
     session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
     session.sync_legacy_mode_from_runtime();

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -984,6 +984,7 @@ impl Window {
                 return;
             };
             session.name = new_name.to_string();
+            session.user_renamed = true;
         }
 
         let mut idx = 0;
@@ -2808,6 +2809,7 @@ mod tests {
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
+                    user_renamed: false,
                 },
                 SessionState {
                     uuid: "s2".into(),
@@ -2820,6 +2822,7 @@ mod tests {
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
+                    user_renamed: false,
                 },
             ],
             ..WindowState::default()
@@ -2866,6 +2869,7 @@ mod tests {
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
+                user_renamed: false,
             }],
             ..WindowState::default()
         };
@@ -2905,6 +2909,7 @@ mod tests {
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
+                user_renamed: false,
             }],
             ..WindowState::default()
         };
@@ -2932,6 +2937,7 @@ mod tests {
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
+                    user_renamed: false,
                 },
                 SessionState {
                     uuid: "s2".into(),
@@ -2949,6 +2955,7 @@ mod tests {
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
+                    user_renamed: false,
                 },
             ],
             ..WindowState::default()
@@ -3530,6 +3537,7 @@ mod tests {
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
+                user_renamed: false,
             }],
             ..WindowState::default()
         };
@@ -4422,6 +4430,7 @@ mod tests {
         window.save_state();
         let saved_state = session::load_window_state();
         assert_eq!(saved_state.sessions[0].name, "Renamed Session");
+        assert!(saved_state.sessions[0].user_renamed);
 
         window.close();
     }
@@ -5731,6 +5740,7 @@ mod tests {
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
+                    user_renamed: false,
                 },
                 SessionState {
                     uuid: second_uuid.clone(),
@@ -5743,6 +5753,7 @@ mod tests {
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
+                    user_renamed: false,
                 },
             ],
             ..WindowState::default()
@@ -6139,5 +6150,72 @@ mod tests {
 
         window.close();
         crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+    }
+
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn auto_rename_updates_sidebar_when_not_user_renamed() {
+        require_display!();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+        crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+        let app =
+            adw::Application::builder().application_id("com.illya.rttx.auto-rename-tests").build();
+        app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+        let window = Window::new(&app);
+        let session_uuid = {
+            let state = window.imp().state.borrow();
+            state.sessions[0].uuid.clone()
+        };
+
+        window.maybe_auto_rename_workspace(&session_uuid, Some("/home/user/projects/rttx"));
+
+        {
+            let state = window.imp().state.borrow();
+            assert_eq!(state.sessions[0].name, "rttx");
+            assert!(!state.sessions[0].user_renamed);
+        }
+
+        let row = window.imp().sidebar_list.row_at_index(0).expect("row exists");
+        let session_row =
+            row.child().and_then(|child| child.downcast::<SessionRow>().ok()).expect("SessionRow");
+        assert_eq!(session_row.session_name(), "rttx");
+
+        window.close();
+    }
+
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn auto_rename_skipped_after_manual_rename() {
+        require_display!();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+        crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+        let app = adw::Application::builder()
+            .application_id("com.illya.rttx.auto-rename-sticky-tests")
+            .build();
+        app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+        let window = Window::new(&app);
+        let session_uuid = {
+            let state = window.imp().state.borrow();
+            state.sessions[0].uuid.clone()
+        };
+
+        window.rename_session(&session_uuid, "My Custom Name");
+        window.maybe_auto_rename_workspace(&session_uuid, Some("/home/user/projects/rttx"));
+
+        {
+            let state = window.imp().state.borrow();
+            assert_eq!(state.sessions[0].name, "My Custom Name");
+            assert!(state.sessions[0].user_renamed);
+        }
+
+        window.close();
     }
 }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -114,12 +114,11 @@ impl Window {
     fn add_remote_managed_session(&self, host: &str) {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
-        let mut session_state = SessionState::new_managed_remote(
-            format!("Remote {count}"),
-            host,
-            WorkspacePolicy::Persistent,
-            None,
-        );
+        let endpoint = RuntimeEndpoint::Remote { host: host.to_string() };
+        let name = crate::session::state::auto_name_for_workspace(&endpoint, None)
+            .unwrap_or_else(|| format!("Remote {count}"));
+        let mut session_state =
+            SessionState::new_managed_remote(name, host, WorkspacePolicy::Persistent, None);
         session_state.color = self.next_session_color();
         imp.state.borrow_mut().sessions.push(session_state.clone());
         self.build_session(&session_state, false);
@@ -136,8 +135,12 @@ impl Window {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
         let initial_cwd = self.resolve_default_session_folder();
-        let mut session_state =
-            SessionState::new_managed_local(format!("Workspace {count}"), policy, initial_cwd);
+        let name = crate::session::state::auto_name_for_workspace(
+            &RuntimeEndpoint::Local,
+            initial_cwd.as_deref(),
+        )
+        .unwrap_or_else(|| format!("Workspace {count}"));
+        let mut session_state = SessionState::new_managed_local(name, policy, initial_cwd);
         session_state.color = self.next_session_color();
         imp.state.borrow_mut().sessions.push(session_state.clone());
         self.build_session(&session_state, false);
@@ -637,6 +640,7 @@ impl Window {
             }
             Msg::CwdChanged(cwd_changed) => {
                 pane.set_current_directory(Some(&cwd_changed.cwd));
+                self.maybe_auto_rename_workspace(&workspace_id, Some(&cwd_changed.cwd));
             }
             Msg::PaneExited(exited) => {
                 let visible_session = self.imp().session_stack.visible_child_name();
@@ -757,5 +761,40 @@ impl Window {
 
         self.set_workspace_connection_status(workspace_id, &ConnectionStatus::Connecting);
         self.connect_managed_workspace(&session_state);
+    }
+
+    pub(super) fn maybe_auto_rename_workspace(&self, workspace_id: &str, cwd: Option<&str>) {
+        let mut state = self.imp().state.borrow_mut();
+        let Some(session) = state.sessions.iter_mut().find(|s| s.uuid == workspace_id) else {
+            return;
+        };
+        if session.user_renamed {
+            return;
+        }
+        let Some(new_name) =
+            crate::session::state::auto_name_for_workspace(&session.runtime.endpoint, cwd)
+        else {
+            return;
+        };
+        if session.name == new_name {
+            return;
+        }
+        session.name.clone_from(&new_name);
+        drop(state);
+        self.update_sidebar_row_name(workspace_id, &new_name);
+    }
+
+    fn update_sidebar_row_name(&self, session_uuid: &str, name: &str) {
+        let mut idx = 0;
+        while let Some(row) = self.imp().sidebar_list.row_at_index(idx) {
+            if let Some(session_row) =
+                row.child().and_then(|child| child.downcast::<SessionRow>().ok())
+                && session_row.uuid() == session_uuid
+            {
+                session_row.set_session_name(name);
+                return;
+            }
+            idx += 1;
+        }
     }
 }

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -165,6 +165,7 @@ fn contract_any_constructible_state_roundtrips() {
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
+                user_renamed: false,
             }],
             width: 1,
             height: 1,
@@ -183,6 +184,7 @@ fn contract_any_constructible_state_roundtrips() {
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
+                user_renamed: false,
             }],
             ..WindowState::default()
         },
@@ -204,6 +206,7 @@ fn contract_any_constructible_state_roundtrips() {
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
+                    user_renamed: false,
                 }],
                 ..WindowState::default()
             }
@@ -222,6 +225,7 @@ fn contract_any_constructible_state_roundtrips() {
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
+                    user_renamed: false,
                 })
                 .collect();
             WindowState {
@@ -683,6 +687,7 @@ fn zoom_state_survives_serialization_roundtrip() {
             runtime: Default::default(),
             color: Default::default(),
             zoomed_terminal_uuid: Some("t1".into()),
+            user_renamed: false,
         }],
         ..Default::default()
     };

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -96,6 +96,7 @@ fn preferences_input_sync_persists_in_session_state() {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         }],
         ..WindowState::default()
     };
@@ -153,6 +154,7 @@ fn custom_title_persists_in_layout() {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         }],
         ..WindowState::default()
     };

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -76,6 +76,7 @@ fn workflow_multi_session_state() {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         },
         SessionState {
             uuid: "s2".into(),
@@ -88,6 +89,7 @@ fn workflow_multi_session_state() {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         },
         SessionState {
             uuid: "s3".into(),
@@ -100,6 +102,7 @@ fn workflow_multi_session_state() {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         },
     ];
 
@@ -158,6 +161,7 @@ fn workflow_persist_and_restore_with_cwds() {
             runtime: WorkspaceRuntime::default(),
             color: SessionColor::default(),
             zoomed_terminal_uuid: None,
+            user_renamed: false,
         }],
         active_session_index: 0,
         width: 1200,
@@ -245,6 +249,7 @@ fn empty_session_name_is_valid() {
         runtime: WorkspaceRuntime::default(),
         color: SessionColor::default(),
         zoomed_terminal_uuid: None,
+        user_renamed: false,
     };
     let json = serde_json::to_string(&session).unwrap();
     let restored: SessionState = serde_json::from_str(&json).unwrap();
@@ -266,6 +271,7 @@ fn session_order_persists_through_serialization() {
                 runtime: WorkspaceRuntime::default(),
                 color: SessionColor::default(),
                 zoomed_terminal_uuid: None,
+                user_renamed: false,
             },
             SessionState {
                 uuid: "s1".into(),
@@ -278,6 +284,7 @@ fn session_order_persists_through_serialization() {
                 runtime: WorkspaceRuntime::default(),
                 color: SessionColor::default(),
                 zoomed_terminal_uuid: None,
+                user_renamed: false,
             },
             SessionState {
                 uuid: "s2".into(),
@@ -290,6 +297,7 @@ fn session_order_persists_through_serialization() {
                 runtime: WorkspaceRuntime::default(),
                 color: SessionColor::default(),
                 zoomed_terminal_uuid: None,
+                user_renamed: false,
             },
         ],
         active_session_index: 1,
@@ -975,6 +983,7 @@ fn zoom_toggle_sets_and_clears_zoomed_terminal() {
         runtime: WorkspaceRuntime::default(),
         color: SessionColor::default(),
         zoomed_terminal_uuid: None,
+        user_renamed: false,
     };
 
     // Zoom in
@@ -1003,6 +1012,7 @@ fn zoom_state_not_persisted_when_cleared_before_save() {
         runtime: WorkspaceRuntime::default(),
         color: SessionColor::default(),
         zoomed_terminal_uuid: Some("t1".into()),
+        user_renamed: false,
     };
 
     // Simulate save_state clearing zoom
@@ -1026,6 +1036,7 @@ fn zoom_on_single_pane_session_is_noop() {
         runtime: WorkspaceRuntime::default(),
         color: SessionColor::default(),
         zoomed_terminal_uuid: None,
+        user_renamed: false,
     };
 
     // Single pane — zoom should not be set (enforced by toggle_pane_zoom)
@@ -1047,6 +1058,7 @@ fn zoom_preserves_layout_tree_integrity() {
         runtime: WorkspaceRuntime::default(),
         color: SessionColor::default(),
         zoomed_terminal_uuid: None,
+        user_renamed: false,
     };
 
     // Zoom t2


### PR DESCRIPTION
## What changed

Workspaces now auto-derive meaningful names from context instead of generic "Workspace N" / "Remote N" labels:

- **CWD-based**: directory basename (e.g. `~/Projects/rttx` → "rttx")
- **Host-based**: short hostname for remote workspaces (e.g. `etf@nucbox.local` → "nucbox")
- **Sticky manual rename**: once the user renames a workspace, auto-naming stops permanently for that workspace

## Why

Closes #307. Users shouldn't have to manually rename every workspace when the terminal already knows the CWD and hostname.

## Implementation

- `user_renamed: bool` on `SessionState` with `#[serde(default)]` for backward compat
- `auto_name_for_workspace()` pure function: remote → short hostname, local → CWD basename
- `rename_session()` sets `user_renamed = true`
- `CwdChanged` handler calls `maybe_auto_rename_workspace()` to update sidebar
- Workspace creation derives initial name from CWD or hostname

## Tests added

- 9 unit tests for `auto_name_for_workspace()` pure logic (CWD basename, remote hostname, edge cases, serde roundtrip)
- 2 GTK harness integration tests (`auto_rename_updates_sidebar_when_not_user_renamed`, `auto_rename_skipped_after_manual_rename`)
- 1 assertion added to existing `rename_session_updates_sidebar_and_saved_state` test

## Tests run

- `cargo test -p rttx --lib`: 325 passed, 82 ignored (GTK harness)
- `cargo test -p rttx-server --lib`: 63 passed
- `bash .github/scripts/run-clippy.sh`: clean
- `bash .github/scripts/run-quality-tests.sh`: all pass

## Limitations / follow-ups

- Local (non-managed) terminals don't yet propagate VTE `current-directory-uri` changes to the window — auto-naming only triggers on initial CWD for local workspaces, and on `CwdChanged` protocol messages for managed workspaces
- Command-based naming (e.g. "vim", "htop") is deferred per issue description (lower priority, may be noisy)