### PR TITLE
fix(server): trim stale prompt tails on daemon restart

### DIFF
--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -85,6 +85,24 @@ impl PaneScreen {
     }
 }
 
+/// Return restart-safe scrollback bytes for a reconstructed pane.
+///
+/// A daemon restart destroys the old PTY, so the last unterminated line from
+/// the previous shell cannot be resumed safely. Keeping it would cause the new
+/// shell prompt to be appended onto stale prompt/editing state, producing
+/// duplicated prompts and corrupted command lines after reconstruction.
+#[must_use]
+pub fn restart_safe_scrollback(data: &[u8]) -> &[u8] {
+    if data.last().is_some_and(|byte| matches!(byte, b'\n' | b'\r')) {
+        return data;
+    }
+
+    match data.iter().rposition(|&byte| matches!(byte, b'\n' | b'\r')) {
+        Some(index) => &data[..=index],
+        None => &[],
+    }
+}
+
 impl vte::Perform for ScreenPerformer {
     fn print(&mut self, c: char) {
         self.cursor_col += 1;
@@ -258,5 +276,25 @@ mod tests {
         screen.feed(b"\r\n\r\n\r\n"); // row 3
         screen.feed(b"\x1b[2A"); // up 2 → row 1
         assert_eq!(screen.cursor_position().0, 1);
+    }
+
+    #[test]
+    fn restart_safe_scrollback_keeps_complete_lines() {
+        assert_eq!(restart_safe_scrollback(b"line 1\r\nline 2\r\n"), b"line 1\r\nline 2\r\n");
+    }
+
+    #[test]
+    fn restart_safe_scrollback_drops_unterminated_active_line() {
+        assert_eq!(restart_safe_scrollback(b"line 1\r\nPROMPT> "), b"line 1\r\n");
+    }
+
+    #[test]
+    fn restart_safe_scrollback_drops_prompt_only_state() {
+        assert_eq!(restart_safe_scrollback(b"PROMPT> "), b"");
+    }
+
+    #[test]
+    fn restart_safe_scrollback_uses_last_carriage_return_as_boundary() {
+        assert_eq!(restart_safe_scrollback(b"status\rpartial"), b"status\r");
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -10,6 +10,7 @@ use crate::ipc::{ClientConnection, Listener};
 use crate::os::OsInterface;
 use crate::pane::Pane;
 use crate::protocol;
+use crate::screen::restart_safe_scrollback;
 use crate::serialization::{self, ServerState, default_state_path, load_state, write_state_atomic};
 use crate::session::{
     AttachError, AttachMode, AttachOutcome, DetachOutcome, DetachReason, RuntimePolicy, Session,
@@ -109,12 +110,21 @@ impl Server {
                     {
                         match std::fs::read(log_path) {
                             Ok(data) => {
+                                let restart_safe = restart_safe_scrollback(&data);
                                 tracing::info!(
                                     "Replaying {} bytes of scrollback for pane {}",
-                                    data.len(),
+                                    restart_safe.len(),
                                     pane.id
                                 );
-                                pane.screen.feed(&data);
+                                pane.screen.feed(restart_safe);
+                                if restart_safe.len() != data.len()
+                                    && let Err(e) = std::fs::write(log_path, restart_safe)
+                                {
+                                    tracing::error!(
+                                        "Failed to rewrite restart-safe scrollback for pane {}: {e}",
+                                        pane.id
+                                    );
+                                }
                             }
                             Err(e) => {
                                 tracing::error!(

--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -155,6 +155,16 @@ async fn resize_pane(
     }
 }
 
+fn pane_scrollback(snapshot: &proto::Snapshot, pane_id: &[u8]) -> Vec<u8> {
+    snapshot
+        .panes
+        .iter()
+        .find(|pane| pane.pane_id == pane_id)
+        .expect("pane missing from snapshot")
+        .scrollback
+        .clone()
+}
+
 async fn reattach_snapshot_bytes(
     client: &mut TestClient,
     session_id: &[u8],
@@ -190,17 +200,59 @@ async fn reattach_snapshot_bytes(
             other => panic!("expected Snapshot, got {other:?}"),
         }
     };
-    snapshot
-        .panes
-        .iter()
-        .find(|pane| pane.pane_id == pane_id)
-        .expect("pane missing from snapshot")
-        .scrollback
-        .clone()
+    pane_scrollback(&snapshot, pane_id)
 }
 
 async fn snapshot_scrollback(client: &mut TestClient, session_id: &[u8], pane_id: &[u8]) -> String {
     normalize_scrollback(&reattach_snapshot_bytes(client, session_id, pane_id).await)
+}
+
+async fn attach_snapshot_bytes(
+    client: &mut TestClient,
+    session_id: &[u8],
+    pane_id: &[u8],
+) -> Vec<u8> {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+                session_id: session_id.to_vec(),
+                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+            })),
+        })
+        .await;
+    let snapshot = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(snapshot)) => break snapshot,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    };
+    pane_scrollback(&snapshot, pane_id)
+}
+
+async fn attach_and_collect_prompt(
+    client: &mut TestClient,
+    session_id: &[u8],
+    pane_id: &[u8],
+) -> String {
+    let mut output = attach_snapshot_bytes(client, session_id, pane_id).await;
+    if String::from_utf8_lossy(&output).contains(PROMPT) {
+        return normalize_scrollback(&output);
+    }
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        if let Some(message) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(delta)) = message.msg
+        {
+            output.extend(delta.data);
+            if String::from_utf8_lossy(&output).contains(PROMPT) {
+                return normalize_scrollback(&output);
+            }
+        }
+    }
+
+    panic!("shell prompt did not arrive after reattach");
 }
 
 async fn send_input(client: &mut TestClient, session_id: &[u8], pane_id: &[u8], data: &[u8]) {
@@ -351,4 +403,54 @@ async fn formatted_output_survives_reattach_and_allows_follow_up_input() {
     );
 
     shutdown_server(&mut client, &mut server_child).await;
+}
+
+#[test]
+fn graceful_restart_does_not_fossilize_stale_prompt_lines() {
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (socket_path, mut server_child) = start_binary_server(&tmp).await;
+
+        let mut client = TestClient::connect(&socket_path).await;
+        let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+        wait_for_prompt(&mut client).await;
+
+        send_input(&mut client, &session_id, &pane_id, b"echo cycle-0\r").await;
+        wait_for_prompt(&mut client).await;
+        shutdown_server(&mut client, &mut server_child).await;
+
+        let (socket_path, mut server_child) = start_binary_server(&tmp).await;
+        let mut client = TestClient::connect(&socket_path).await;
+        client.handshake().await;
+
+        let first_restart = attach_and_collect_prompt(&mut client, &session_id, &pane_id).await;
+        assert!(
+            !first_restart.contains("PROMPT> PROMPT> "),
+            "first restart should not replay stacked prompts.\nscrollback:\n{first_restart:?}"
+        );
+
+        send_input(&mut client, &session_id, &pane_id, b"echo cycle-1\r").await;
+        wait_for_prompt(&mut client).await;
+        shutdown_server(&mut client, &mut server_child).await;
+
+        let (socket_path, mut server_child) = start_binary_server(&tmp).await;
+        let mut client = TestClient::connect(&socket_path).await;
+        client.handshake().await;
+
+        let second_restart = attach_and_collect_prompt(&mut client, &session_id, &pane_id).await;
+        assert!(
+            !second_restart.contains("PROMPT> PROMPT> "),
+            "repeated graceful restarts must not fossilize stale prompt tails.\nscrollback:\n{second_restart:?}"
+        );
+        assert!(
+            second_restart.contains("cycle-0\n") && second_restart.contains("cycle-1\n"),
+            "restored scrollback should retain completed command output across restarts.\nscrollback:\n{second_restart:?}"
+        );
+        assert!(
+            second_restart.ends_with(PROMPT),
+            "restored shell should end on a single live prompt after restart.\nscrollback:\n{second_restart:?}"
+        );
+
+        shutdown_server(&mut client, &mut server_child).await;
+    });
 }


### PR DESCRIPTION
## Summary
- trim the unterminated prompt/editing tail from persisted scrollback during daemon reconstruction
- rewrite the reconstructed scrollback log to the restart-safe bytes so repeated graceful restarts do not compound stale prompts
- add a real daemon regression that restarts twice and verifies reconstructed scrollback ends on one clean prompt

## Testing
- bash .github/scripts/run-quality-tests.sh