### PR TITLE
fix: use prefers-color-scheme for sidebar color dots

### DIFF
--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -5,6 +5,63 @@ use libadwaita as adw;
 use crate::config;
 use crate::window::Window;
 
+pub(crate) const APP_CSS: &str = "\
+    .terminal-pane {
+        border-radius: 10px;
+        border: 1px solid alpha(@window_fg_color, 0.10);
+        background: alpha(@view_bg_color, 0.78);
+    }
+    .terminal-pane-active {
+        border-color: alpha(@accent_bg_color, 0.85);
+        background: alpha(@view_bg_color, 0.92);
+    }
+    .terminal-header {
+        padding: 6px 8px;
+        border-top-left-radius: 10px;
+        border-top-right-radius: 10px;
+        border-bottom: 1px solid alpha(@window_fg_color, 0.08);
+        background: alpha(@headerbar_bg_color, 0.72);
+    }
+    .terminal-pane-active .terminal-header {
+        background: alpha(@accent_bg_color, 0.14);
+    }
+    .terminal-scroller {
+        background: transparent;
+    }
+    vte-terminal {
+        margin: 2px 6px;
+    }
+    @keyframes bell-flash {
+        from { background-color: alpha(@warning_color, 0.4); }
+        to   { background-color: transparent; }
+    }
+    .bell-flash {
+        animation: bell-flash 0.15s ease-out;
+    }
+    .session-activity-idle {
+        opacity: 0.45;
+    }
+    @media (prefers-color-scheme: dark) {
+        .accent-blue   { color: @blue_3; }
+        .accent-green  { color: @green_3; }
+        .accent-yellow { color: @yellow_3; }
+        .accent-red    { color: @red_3; }
+        .accent-purple { color: @purple_3; }
+        .accent-pink   { color: @pink_3; }
+        .accent-teal   { color: @teal_3; }
+        .accent-orange { color: @orange_3; }
+    }
+    @media (prefers-color-scheme: light) {
+        .accent-blue   { color: @blue_5; }
+        .accent-green  { color: @green_5; }
+        .accent-yellow { color: @yellow_5; }
+        .accent-red    { color: @red_5; }
+        .accent-purple { color: @purple_5; }
+        .accent-pink   { color: @pink_5; }
+        .accent-teal   { color: @teal_5; }
+        .accent-orange { color: @orange_5; }
+    }";
+
 /// Build and run the application.
 #[must_use]
 pub fn run() -> glib::ExitCode {
@@ -25,51 +82,7 @@ pub fn run() -> glib::ExitCode {
         };
 
         let css = gtk4::CssProvider::new();
-        css.load_from_string(
-            ".terminal-pane {
-                border-radius: 10px;
-                border: 1px solid alpha(@window_fg_color, 0.10);
-                background: alpha(@view_bg_color, 0.78);
-            }
-            .terminal-pane-active {
-                border-color: alpha(@accent_bg_color, 0.85);
-                background: alpha(@view_bg_color, 0.92);
-            }
-            .terminal-header {
-                padding: 6px 8px;
-                border-top-left-radius: 10px;
-                border-top-right-radius: 10px;
-                border-bottom: 1px solid alpha(@window_fg_color, 0.08);
-                background: alpha(@headerbar_bg_color, 0.72);
-            }
-            .terminal-pane-active .terminal-header {
-                background: alpha(@accent_bg_color, 0.14);
-            }
-            .terminal-scroller {
-                background: transparent;
-            }
-            vte-terminal {
-                margin: 2px 6px;
-            }
-            @keyframes bell-flash {
-                from { background-color: alpha(@warning_color, 0.4); }
-                to   { background-color: transparent; }
-            }
-            .bell-flash {
-                animation: bell-flash 0.15s ease-out;
-            }
-            .session-activity-idle {
-                opacity: 0.45;
-            }
-            .accent-blue   { color: @blue_3; }
-            .accent-green  { color: @green_3; }
-            .accent-yellow { color: @yellow_3; }
-            .accent-red    { color: @red_3; }
-            .accent-purple { color: @purple_3; }
-            .accent-pink   { color: @pink_3; }
-            .accent-teal   { color: @teal_3; }
-            .accent-orange { color: @orange_3; }",
-        );
+        css.load_from_string(APP_CSS);
         gtk4::style_context_add_provider_for_display(
             &display,
             &css,

--- a/clients/rttx/src/session/state.rs
+++ b/clients/rttx/src/session/state.rs
@@ -840,6 +840,33 @@ mod module_boundary_tests {
     }
 
     #[test]
+    fn app_css_has_dark_and_light_rules_for_every_color() {
+        let css = crate::application::APP_CSS;
+        assert!(css.contains("prefers-color-scheme: dark"), "missing dark media query");
+        assert!(css.contains("prefers-color-scheme: light"), "missing light media query");
+        for color in SessionColor::ALL {
+            let cls = color.css_class();
+            assert!(
+                css.matches(&format!(".{cls}")).count() >= 2,
+                ".{cls} should appear in both dark and light sections"
+            );
+        }
+    }
+
+    #[test]
+    fn app_css_uses_different_palette_tiers_for_light_and_dark() {
+        let css = crate::application::APP_CSS;
+        // Dark mode uses _3 variants (good contrast on dark backgrounds)
+        assert!(css.contains("dark") && css.contains("@blue_3"));
+        // Light mode uses _5 variants (good contrast on light backgrounds)
+        assert!(css.contains("light") && css.contains("@blue_5"));
+        // Verify no _3 appears after the light query starts
+        let light_start = css.find("prefers-color-scheme: light").unwrap();
+        let light_section = &css[light_start..];
+        assert!(!light_section.contains("_3;"), "light section should not use _3 tier");
+    }
+
+    #[test]
     fn auto_name_from_cwd_uses_basename() {
         let ep = RuntimeEndpoint::Local;
         assert_eq!(


### PR DESCRIPTION
## What changed

Sidebar color dots used Adwaita `_3` palette variants (`@blue_3`, `@green_3`, etc.) which have low contrast on light backgrounds. Switched to `prefers-color-scheme` media queries:

- Dark mode: `_3` variants (unchanged, good contrast on dark backgrounds)
- Light mode: `_5` variants (higher saturation, visible on light backgrounds)

Also extracted the CSS string into a `pub(crate) const APP_CSS` for testability.

## Root cause

The `_3` Adwaita palette tier is designed for dark backgrounds. On light mode, these colors wash out and the dots become nearly invisible.

## Manual verification

1. Launch rttx in light mode (`gsettings set org.gnome.desktop.interface color-scheme prefer-light`)
2. Create multiple workspaces with different colors
3. Verify color dots are clearly visible in the sidebar
4. Switch to dark mode and verify dots are still visible

## Tests added

- `app_css_has_dark_and_light_rules_for_every_color` — verifies every `SessionColor` CSS class appears in both dark and light media query sections
- `app_css_uses_different_palette_tiers_for_light_and_dark` — verifies dark uses `_3` tier and light uses `_5` tier, with no cross-contamination

## Tests run

- `cargo test -p rttx --lib`: 327 passed (325 + 2 new)
- `cargo test -p rttx-server`: 63 passed
- `bash .github/scripts/run-clippy.sh`: clean
- `bash .github/scripts/run-quality-tests.sh`: all pass
- `./run_ui_tests.sh`: 6 pre-existing failures (same on mainline, unrelated to this change)

Fixes #302