### PR TITLE
fix(sidebar): replace text status labels with icons

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -374,37 +374,32 @@ pub const fn connection_icon(
     endpoint: &RuntimeEndpoint,
     status: &ConnectionStatus,
 ) -> Option<ConnectionIcon> {
-    if matches!(endpoint, RuntimeEndpoint::Local) {
-        return None;
-    }
     let (icon_name, css_class) = match status {
-        ConnectionStatus::Connected | ConnectionStatus::Recovered => {
+        ConnectionStatus::Connected => {
+            if matches!(endpoint, RuntimeEndpoint::Local) {
+                return None;
+            }
             ("network-server-symbolic", "accent")
         }
+        ConnectionStatus::Recovered => ("emblem-ok-symbolic", "accent"),
         ConnectionStatus::Disconnected => ("network-offline-symbolic", "warning"),
         ConnectionStatus::Blocked(_) => ("network-offline-symbolic", "error"),
-        _ => ("network-server-symbolic", "dim-label"),
+        _ => {
+            if matches!(endpoint, RuntimeEndpoint::Local) {
+                ("content-loading-symbolic", "dim-label")
+            } else {
+                ("network-server-symbolic", "dim-label")
+            }
+        }
     };
     Some(ConnectionIcon { icon_name, css_class })
 }
 
 #[must_use]
-pub fn workspace_connection_summary(
-    endpoint: &RuntimeEndpoint,
-    status: &ConnectionStatus,
-    pane_count: usize,
-) -> String {
-    let endpoint_label = match endpoint {
-        RuntimeEndpoint::Local => "Local".to_string(),
-        RuntimeEndpoint::Remote { host } => host.clone(),
-    };
-
-    let base = match status {
-        ConnectionStatus::Connected => match endpoint {
-            RuntimeEndpoint::Local => "Local runtime".into(),
-            RuntimeEndpoint::Remote { .. } => endpoint_label,
-        },
-        _ => format!("{endpoint_label} · {}", status.label()),
+pub fn workspace_connection_summary(endpoint: &RuntimeEndpoint, pane_count: usize) -> String {
+    let base = match endpoint {
+        RuntimeEndpoint::Local => "Local runtime",
+        RuntimeEndpoint::Remote { host } => host.as_str(),
     };
 
     if pane_count == 1 {
@@ -599,24 +594,23 @@ mod tests {
     #[test]
     fn workspace_connection_summary_includes_pane_count() {
         assert_eq!(
-            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, 3),
+            workspace_connection_summary(&RuntimeEndpoint::Local, 3),
             "Local runtime · 3 panes"
         );
         assert_eq!(
-            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, 1),
+            workspace_connection_summary(&RuntimeEndpoint::Local, 1),
             "Local runtime · 1 pane"
         );
         assert_eq!(
-            workspace_connection_summary(&RuntimeEndpoint::Local, &ConnectionStatus::Recovered, 2),
-            "Local · Recovered · 2 panes"
+            workspace_connection_summary(&RuntimeEndpoint::Local, 2),
+            "Local runtime · 2 panes"
         );
         assert_eq!(
             workspace_connection_summary(
                 &RuntimeEndpoint::Remote { host: "builder.example".into() },
-                &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
                 1,
             ),
-            "builder.example · Action Required: Permission denied · 1 pane"
+            "builder.example · 1 pane"
         );
     }
 
@@ -624,31 +618,39 @@ mod tests {
     fn workspace_connection_summary_for_connected_remote_stays_compact() {
         let endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
 
-        assert_eq!(
-            workspace_connection_summary(&endpoint, &ConnectionStatus::Connected, 1),
-            "builder.example · 1 pane"
-        );
-        assert_eq!(
-            workspace_connection_summary(&endpoint, &ConnectionStatus::Disconnected, 2),
-            "builder.example · Disconnected · 2 panes"
-        );
+        assert_eq!(workspace_connection_summary(&endpoint, 1), "builder.example · 1 pane");
+        assert_eq!(workspace_connection_summary(&endpoint, 2), "builder.example · 2 panes");
     }
 
     #[test]
     fn workspace_connection_summary_pane_count_singular_plural() {
         let ep = RuntimeEndpoint::Local;
-        let status = ConnectionStatus::Connected;
-        assert!(workspace_connection_summary(&ep, &status, 1).ends_with("1 pane"));
-        assert!(workspace_connection_summary(&ep, &status, 2).ends_with("2 panes"));
-        assert!(workspace_connection_summary(&ep, &status, 10).ends_with("10 panes"));
+        assert!(workspace_connection_summary(&ep, 1).ends_with("1 pane"));
+        assert!(workspace_connection_summary(&ep, 2).ends_with("2 panes"));
+        assert!(workspace_connection_summary(&ep, 10).ends_with("10 panes"));
     }
 
     #[test]
-    fn connection_icon_none_for_local() {
+    fn connection_icon_none_for_local_connected() {
         assert!(connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected).is_none());
-        assert!(
-            connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Disconnected).is_none()
-        );
+    }
+
+    #[test]
+    fn connection_icon_shown_for_local_non_connected() {
+        let ep = RuntimeEndpoint::Local;
+        let icon = connection_icon(&ep, &ConnectionStatus::Disconnected).unwrap();
+        assert_eq!(icon.css_class, "warning");
+
+        let icon = connection_icon(&ep, &ConnectionStatus::Recovered).unwrap();
+        assert_eq!(icon.css_class, "accent");
+
+        let icon =
+            connection_icon(&ep, &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable))
+                .unwrap();
+        assert_eq!(icon.css_class, "error");
+
+        let icon = connection_icon(&ep, &ConnectionStatus::Connecting).unwrap();
+        assert_eq!(icon.css_class, "dim-label");
     }
 
     #[test]
@@ -695,7 +697,7 @@ mod tests {
     fn connection_icon_accent_for_remote_recovered() {
         let ep = RuntimeEndpoint::Remote { host: "h".into() };
         let icon = connection_icon(&ep, &ConnectionStatus::Recovered).unwrap();
-        assert_eq!(icon.icon_name, "network-server-symbolic");
+        assert_eq!(icon.icon_name, "emblem-ok-symbolic");
         assert_eq!(icon.css_class, "accent");
     }
 

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -2230,13 +2230,7 @@ impl Window {
                 return;
             };
             if session.uses_managed_runtime() {
-                let status = imp
-                    .workspace_connection_status
-                    .borrow()
-                    .get(session_uuid)
-                    .cloned()
-                    .unwrap_or(ConnectionStatus::Connecting);
-                workspace_connection_summary(&session.runtime.endpoint, &status, count)
+                workspace_connection_summary(&session.runtime.endpoint, count)
             } else if count == 1 {
                 "1 pane".to_string()
             } else {
@@ -5815,10 +5809,11 @@ mod tests {
 
         let row = session_row_for_uuid(&window, &session_state.uuid);
         let subtitle = row.subtitle().map(|value| value.to_string());
-        assert_eq!(subtitle.as_deref(), Some("Local · Recovered"));
+        assert_eq!(subtitle.as_deref(), Some("Local runtime · 1 pane"));
+        assert!(row.imp().connection_icon.is_visible());
         assert!(
-            !subtitle.as_deref().is_some_and(|value| value.contains("Persistent")),
-            "workspace row status should no longer include the policy label"
+            !subtitle.as_deref().is_some_and(|value| value.contains("Recovered")),
+            "status text should be conveyed by icon, not subtitle"
         );
 
         window.close();

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -532,7 +532,6 @@ impl Window {
         };
         let summary = workspace_connection_summary(
             &session.runtime.endpoint,
-            status,
             session.layout.terminal_count(),
         );
         let icon = connection_icon(&session.runtime.endpoint, status);

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -784,8 +784,7 @@ fn workspace_connection_summary_contains_no_status_text() {
 
     for (ep, count) in [(&local, 1), (&local, 3), (&remote, 1), (&remote, 2)] {
         let summary = workspace_connection_summary(ep, count);
-        for keyword in ["Recovered", "Disconnected", "Action Required", "Reconnecting", "Blocked"]
-        {
+        for keyword in ["Recovered", "Disconnected", "Action Required", "Reconnecting", "Blocked"] {
             assert!(
                 !summary.contains(keyword),
                 "subtitle should not contain status text '{keyword}': {summary}"

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -721,35 +721,27 @@ fn old_state_without_zoom_field_deserializes_cleanly() {
 /// correct.
 #[test]
 fn workspace_connection_summary_includes_pane_count_in_subtitle() {
-    use rttx::runtime::{ConnectionStatus, RuntimeEndpoint, workspace_connection_summary};
+    use rttx::runtime::{RuntimeEndpoint, workspace_connection_summary};
 
     let local = RuntimeEndpoint::Local;
     let remote = RuntimeEndpoint::Remote { host: "dev@host".into() };
 
-    assert!(
-        workspace_connection_summary(&local, &ConnectionStatus::Connected, 3).ends_with("3 panes")
-    );
-    assert!(
-        workspace_connection_summary(&local, &ConnectionStatus::Connected, 1).ends_with("1 pane")
-    );
-    assert!(
-        workspace_connection_summary(&remote, &ConnectionStatus::Connected, 2).ends_with("2 panes")
-    );
-    assert!(
-        workspace_connection_summary(&remote, &ConnectionStatus::Disconnected, 1)
-            .contains("1 pane")
-    );
+    assert!(workspace_connection_summary(&local, 3).ends_with("3 panes"));
+    assert!(workspace_connection_summary(&local, 1).ends_with("1 pane"));
+    assert!(workspace_connection_summary(&remote, 2).ends_with("2 panes"));
+    assert!(workspace_connection_summary(&remote, 1).contains("1 pane"));
 }
 
 /// Contract: connection_icon returns None for local, Some for remote endpoints.
 ///
-/// The sidebar row must show a connection icon only for remote workspaces.
-/// The icon and CSS class must change based on connection status.
+/// The sidebar row shows a connection icon for non-connected states (any endpoint)
+/// and for remote endpoints when connected. Local+Connected returns None.
 #[test]
 fn connection_icon_distinguishes_local_from_remote() {
     use rttx::runtime::{ConnectionStatus, RuntimeEndpoint, connection_icon};
 
     assert!(connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected).is_none());
+    assert!(connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Disconnected).is_some());
 
     let remote = RuntimeEndpoint::Remote { host: "h".into() };
     let connected = connection_icon(&remote, &ConnectionStatus::Connected).unwrap();

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -752,6 +752,48 @@ fn connection_icon_distinguishes_local_from_remote() {
     assert_ne!(connected.icon_name, disconnected.icon_name);
 }
 
+/// Contract: local endpoints show status icons for non-Connected states.
+///
+/// Before #329, local endpoints never showed connection icons. Now they show
+/// icons for Disconnected, Recovered, Blocked, and transient states so the
+/// sidebar subtitle can stay clean (endpoint + pane count only).
+#[test]
+fn connection_icon_shown_for_local_non_connected_states() {
+    use rttx::runtime::{ConnectionProblem, ConnectionStatus, RuntimeEndpoint, connection_icon};
+
+    let local = RuntimeEndpoint::Local;
+    assert!(connection_icon(&local, &ConnectionStatus::Connected).is_none());
+    assert!(connection_icon(&local, &ConnectionStatus::Disconnected).is_some());
+    assert!(connection_icon(&local, &ConnectionStatus::Recovered).is_some());
+    assert!(
+        connection_icon(&local, &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable))
+            .is_some()
+    );
+    assert!(connection_icon(&local, &ConnectionStatus::Connecting).is_some());
+}
+
+/// Contract: workspace_connection_summary never contains status text.
+///
+/// Status is conveyed by the connection icon, not the subtitle string.
+#[test]
+fn workspace_connection_summary_contains_no_status_text() {
+    use rttx::runtime::{RuntimeEndpoint, workspace_connection_summary};
+
+    let local = RuntimeEndpoint::Local;
+    let remote = RuntimeEndpoint::Remote { host: "h".into() };
+
+    for (ep, count) in [(&local, 1), (&local, 3), (&remote, 1), (&remote, 2)] {
+        let summary = workspace_connection_summary(ep, count);
+        for keyword in ["Recovered", "Disconnected", "Action Required", "Reconnecting", "Blocked"]
+        {
+            assert!(
+                !summary.contains(keyword),
+                "subtitle should not contain status text '{keyword}': {summary}"
+            );
+        }
+    }
+}
+
 /// Contract: ConnectionPresentation contains only header_label and input_enabled.
 ///
 /// The banner fields were removed in #305. The pane header status label and


### PR DESCRIPTION
## What changed

Replaced verbose text status labels in sidebar workspace subtitles ("Recovered", "Disconnected", "Action Required: ...", "Reconnecting in Ns") with connection status icons.

Before: `Local · Recovered · 2 panes`
After: `Local runtime · 2 panes` + ✓ icon (accent)

Before: `Local · Disconnected · 1 pane`
After: `Local runtime · 1 pane` + ⚠ icon (warning)

## Why

Status text was noisy in the compact sidebar. Icons convey the same information more efficiently and consistently with the existing remote endpoint icon pattern.

## Changes

- `connection_icon()` now returns status icons for local endpoints when status ≠ Connected
  - Connected (local): no icon (normal state)
  - Recovered: `emblem-ok-symbolic` (accent)
  - Disconnected: `network-offline-symbolic` (warning)
  - Blocked: `network-offline-symbolic` (error)
  - Starting/Connecting/Reconnecting (local): `content-loading-symbolic` (dim-label)
  - Starting/Connecting/Reconnecting (remote): `network-server-symbolic` (dim-label) — unchanged
- `workspace_connection_summary()` simplified to just endpoint + pane count (status parameter removed)
- Net -12 lines

## Manual verification

1. Launch rttx with a managed workspace
2. Disconnect the daemon (`rttx-server stop`)
3. Verify the sidebar shows a warning icon instead of "Disconnected" text
4. Restart the daemon — verify the icon changes to accent checkmark during recovery
5. Verify the subtitle stays clean: just endpoint + pane count

## Tests added/updated

- `connection_icon_none_for_local_connected` — local+Connected still returns None
- `connection_icon_shown_for_local_non_connected` — local Disconnected/Recovered/Blocked/Connecting all return appropriate icons
- `connection_icon_accent_for_remote_recovered` — updated to expect `emblem-ok-symbolic`
- Updated `workspace_connection_summary` tests to expect no status text
- Updated GTK boundary contract `connection_icon_distinguishes_local_from_remote` to assert local Disconnected returns Some
- Updated `recovered_workspace_uses_compact_sidebar_status_without_banner` to verify icon visible + no status text in subtitle

## Tests run

- `cargo test -p rttx --lib`: 328 passed
- `cargo test -p rttx-server --lib`: 67 passed
- `bash .github/scripts/run-clippy.sh`: clean
- `bash .github/scripts/run-quality-tests.sh`: all pass

Fixes #329