### PR TITLE
feat(sidebar): show active pane command/path in subtitle

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -396,17 +396,34 @@ pub const fn connection_icon(
 }
 
 #[must_use]
-pub fn workspace_connection_summary(endpoint: &RuntimeEndpoint, pane_count: usize) -> String {
+pub fn workspace_connection_summary(
+    endpoint: &RuntimeEndpoint,
+    active_pane_info: Option<&str>,
+) -> String {
     let base = match endpoint {
         RuntimeEndpoint::Local => "Local runtime",
         RuntimeEndpoint::Remote { host } => host.as_str(),
     };
 
-    if pane_count == 1 {
-        format!("{base} · 1 pane")
-    } else {
-        format!("{base} · {pane_count} panes")
+    match active_pane_info {
+        Some(info) if !info.is_empty() => format!("{base} · {info}"),
+        _ => base.to_string(),
     }
+}
+
+/// Extract a compact pane description from its title and working directory.
+///
+/// Prefers the title when it carries useful information (i.e. not just the shell
+/// name). Falls back to the CWD basename.
+#[must_use]
+pub fn pane_description(title: Option<&str>, cwd: Option<&str>) -> Option<String> {
+    if let Some(title) = title {
+        let trimmed = title.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    cwd.map(|c| c.rsplit('/').find(|s| !s.is_empty()).unwrap_or(c).to_string())
 }
 
 /// Deterministic, non-destructive binding reconciliation result.
@@ -592,42 +609,52 @@ mod tests {
     }
 
     #[test]
-    fn workspace_connection_summary_includes_pane_count() {
+    fn workspace_connection_summary_with_pane_info() {
         assert_eq!(
-            workspace_connection_summary(&RuntimeEndpoint::Local, 3),
-            "Local runtime · 3 panes"
+            workspace_connection_summary(&RuntimeEndpoint::Local, Some("vim main.rs")),
+            "Local runtime · vim main.rs"
         );
+        assert_eq!(workspace_connection_summary(&RuntimeEndpoint::Local, None), "Local runtime");
         assert_eq!(
-            workspace_connection_summary(&RuntimeEndpoint::Local, 1),
-            "Local runtime · 1 pane"
-        );
-        assert_eq!(
-            workspace_connection_summary(&RuntimeEndpoint::Local, 2),
-            "Local runtime · 2 panes"
+            workspace_connection_summary(&RuntimeEndpoint::Local, Some("")),
+            "Local runtime"
         );
         assert_eq!(
             workspace_connection_summary(
                 &RuntimeEndpoint::Remote { host: "builder.example".into() },
-                1,
+                Some("~/src"),
             ),
-            "builder.example · 1 pane"
+            "builder.example · ~/src"
         );
     }
 
     #[test]
-    fn workspace_connection_summary_for_connected_remote_stays_compact() {
+    fn workspace_connection_summary_for_remote_endpoint() {
         let endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
 
-        assert_eq!(workspace_connection_summary(&endpoint, 1), "builder.example · 1 pane");
-        assert_eq!(workspace_connection_summary(&endpoint, 2), "builder.example · 2 panes");
+        assert_eq!(workspace_connection_summary(&endpoint, Some("bash")), "builder.example · bash");
+        assert_eq!(workspace_connection_summary(&endpoint, None), "builder.example");
     }
 
     #[test]
-    fn workspace_connection_summary_pane_count_singular_plural() {
-        let ep = RuntimeEndpoint::Local;
-        assert!(workspace_connection_summary(&ep, 1).ends_with("1 pane"));
-        assert!(workspace_connection_summary(&ep, 2).ends_with("2 panes"));
-        assert!(workspace_connection_summary(&ep, 10).ends_with("10 panes"));
+    fn pane_description_prefers_title_over_cwd() {
+        assert_eq!(
+            pane_description(Some("vim main.rs"), Some("/home/user/project")),
+            Some("vim main.rs".into())
+        );
+    }
+
+    #[test]
+    fn pane_description_falls_back_to_cwd_basename() {
+        assert_eq!(pane_description(None, Some("/home/user/project")), Some("project".into()));
+        assert_eq!(pane_description(None, Some("/home/user/project/")), Some("project".into()));
+        assert_eq!(pane_description(None, Some("/")), Some("/".into()));
+    }
+
+    #[test]
+    fn pane_description_none_when_no_info() {
+        assert_eq!(pane_description(None, None), None);
+        assert_eq!(pane_description(Some(""), None), None);
     }
 
     #[test]

--- a/clients/rttx/src/sidebar.rs
+++ b/clients/rttx/src/sidebar.rs
@@ -303,15 +303,15 @@ mod tests {
 
     #[test]
     #[ignore = "requires isolated GTK harness"]
-    fn session_row_subtitle_shows_pane_count() {
+    fn session_row_subtitle_shows_pane_info() {
         require_display!();
 
         let row = SessionRow::new("session-1", "Session 1");
-        row.set_subtitle("Local runtime · 3 panes");
-        assert_eq!(row.subtitle().unwrap().as_str(), "Local runtime · 3 panes");
+        row.set_subtitle("Local runtime · vim main.rs");
+        assert_eq!(row.subtitle().unwrap().as_str(), "Local runtime · vim main.rs");
 
-        row.set_subtitle("1 pane");
-        assert_eq!(row.subtitle().unwrap().as_str(), "1 pane");
+        row.set_subtitle("Local runtime");
+        assert_eq!(row.subtitle().unwrap().as_str(), "Local runtime");
     }
 
     #[test]

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -14,8 +14,8 @@ use crate::config;
 use crate::preferences::{self, Preferences};
 use crate::runtime::{
     ConnectionPresentation, ConnectionStatus, RuntimeEndpoint, WorkspaceActionPresentation,
-    WorkspacePolicy, connection_icon, present_connection_status, present_workspace_actions,
-    workspace_connection_summary,
+    WorkspacePolicy, connection_icon, pane_description, present_connection_status,
+    present_workspace_actions, workspace_connection_summary,
 };
 use crate::session::{
     self, Direction, LayoutNode, MAX_SPLIT_DEPTH, PaneRecovery, PaneSource, PaneTarget,
@@ -740,7 +740,7 @@ impl Window {
 
         imp.session_stack.add_named(&content, Some(&session_state.uuid));
         session::schedule_initial_paned_ratios(&content, &session_state.layout);
-        self.update_sidebar_count(&session_state.uuid, session_state.layout.terminal_count());
+        self.refresh_sidebar_subtitle(&session_state.uuid);
         self.renumber_session_rows();
 
         if auto_connect_managed && session_state.uses_managed_runtime() {
@@ -1022,11 +1022,21 @@ impl Window {
         let focus_controller = gtk4::EventControllerFocus::new();
         focus_controller.connect_enter(move |_| {
             win.set_focused_terminal(Some(&uuid));
-            let mut state = win.imp().state.borrow_mut();
-            if let Some(session) =
-                state.sessions.iter_mut().find(|session| session.layout.contains_terminal(&uuid))
-            {
-                session.active_terminal_uuid = Some(uuid.clone());
+            let session_uuid = {
+                let mut state = win.imp().state.borrow_mut();
+                let session = state
+                    .sessions
+                    .iter_mut()
+                    .find(|session| session.layout.contains_terminal(&uuid));
+                if let Some(session) = session {
+                    session.active_terminal_uuid = Some(uuid.clone());
+                    Some(session.uuid.clone())
+                } else {
+                    None
+                }
+            };
+            if let Some(session_uuid) = session_uuid {
+                win.refresh_sidebar_subtitle(&session_uuid);
             }
         });
         term.vte().add_controller(focus_controller);
@@ -1046,6 +1056,12 @@ impl Window {
         let uuid = term.uuid();
         term.vte().connect_contents_changed(move |_| {
             win.mark_session_activity(&uuid);
+        });
+
+        let win = self.clone();
+        let uuid = term.uuid();
+        term.vte().connect_window_title_changed(move |_| {
+            win.refresh_sidebar_subtitle_if_active(&uuid);
         });
 
         let drag_source = gtk4::DragSource::new();
@@ -1932,7 +1948,7 @@ impl Window {
                     &new_terminal_uuid,
                     orientation,
                 ) {
-                    self.update_sidebar_count(&session_uuid, session_state.layout.terminal_count());
+                    self.refresh_sidebar_subtitle(&session_uuid);
                 } else {
                     self.rebuild_session_content(&session_uuid, &session_state);
                 }
@@ -2064,7 +2080,7 @@ impl Window {
             session::schedule_initial_paned_ratios(&content, &session_state.layout);
         }
 
-        self.update_sidebar_count(session_uuid, session_state.layout.terminal_count());
+        self.refresh_sidebar_subtitle(session_uuid);
         self.sync_sidebar_to_visible_session();
     }
 
@@ -2222,19 +2238,23 @@ impl Window {
         imp.terminals.borrow_mut().remove(uuid);
     }
 
-    fn update_sidebar_count(&self, session_uuid: &str, count: usize) {
+    fn refresh_sidebar_subtitle(&self, session_uuid: &str) {
         let imp = self.imp();
         let subtitle = {
             let state = imp.state.borrow();
             let Some(session) = state.sessions.iter().find(|s| s.uuid == session_uuid) else {
                 return;
             };
+            let endpoint = &session.runtime.endpoint;
+            let active_uuid = session.active_terminal_uuid.as_deref();
+            let pane_info = active_uuid.and_then(|uuid| {
+                let handle = self.terminal_handle(uuid)?;
+                pane_description(Some(&handle.title()), handle.current_directory().as_deref())
+            });
             if session.uses_managed_runtime() {
-                workspace_connection_summary(&session.runtime.endpoint, count)
-            } else if count == 1 {
-                "1 pane".to_string()
+                workspace_connection_summary(endpoint, pane_info.as_deref())
             } else {
-                format!("{count} panes")
+                pane_info.unwrap_or_default()
             }
         };
         let mut idx = 0;
@@ -2246,6 +2266,20 @@ impl Window {
                 return;
             }
             idx += 1;
+        }
+    }
+
+    fn refresh_sidebar_subtitle_if_active(&self, terminal_uuid: &str) {
+        let session_uuid = {
+            let state = self.imp().state.borrow();
+            state
+                .sessions
+                .iter()
+                .find(|s| s.active_terminal_uuid.as_deref() == Some(terminal_uuid))
+                .map(|s| s.uuid.clone())
+        };
+        if let Some(session_uuid) = session_uuid {
+            self.refresh_sidebar_subtitle(&session_uuid);
         }
     }
 
@@ -5809,7 +5843,7 @@ mod tests {
 
         let row = session_row_for_uuid(&window, &session_state.uuid);
         let subtitle = row.subtitle().map(|value| value.to_string());
-        assert_eq!(subtitle.as_deref(), Some("Local runtime · 1 pane"));
+        assert_eq!(subtitle.as_deref(), Some("Local runtime · Terminal (persistent)"));
         assert!(row.imp().connection_icon.is_visible());
         assert!(
             !subtitle.as_deref().is_some_and(|value| value.contains("Recovered")),

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -525,15 +525,13 @@ impl Window {
         workspace_id: &str,
         status: &ConnectionStatus,
     ) {
+        self.refresh_sidebar_subtitle(workspace_id);
+
         let state = self.imp().state.borrow();
         let Some(session) = state.sessions.iter().find(|session| session.uuid == workspace_id)
         else {
             return;
         };
-        let summary = workspace_connection_summary(
-            &session.runtime.endpoint,
-            session.layout.terminal_count(),
-        );
         let icon = connection_icon(&session.runtime.endpoint, status);
         drop(state);
 
@@ -544,7 +542,6 @@ impl Window {
                 row.child().and_then(|child| child.downcast::<SessionRow>().ok())
                 && session_row.uuid() == workspace_id
             {
-                session_row.set_subtitle(&summary);
                 session_row.set_connection_icon(icon.as_ref());
                 break;
             }
@@ -636,10 +633,12 @@ impl Window {
                 if pane.custom_title().is_none() {
                     pane.set_title(&title_changed.title);
                 }
+                self.refresh_sidebar_subtitle_if_active(&layout_terminal_uuid);
             }
             Msg::CwdChanged(cwd_changed) => {
                 pane.set_current_directory(Some(&cwd_changed.cwd));
                 self.maybe_auto_rename_workspace(&workspace_id, Some(&cwd_changed.cwd));
+                self.refresh_sidebar_subtitle_if_active(&layout_terminal_uuid);
             }
             Msg::PaneExited(exited) => {
                 let visible_session = self.imp().session_stack.visible_child_name();

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -714,22 +714,21 @@ fn old_state_without_zoom_field_deserializes_cleanly() {
     assert!(state.sessions[0].zoomed_terminal_uuid.is_none());
 }
 
-/// Contract: workspace_connection_summary includes pane count in subtitle text.
+/// Contract: workspace_connection_summary shows endpoint and optional pane info.
 ///
-/// The sidebar row subtitle must always contain the pane count so users can see
-/// how many panes a workspace has without expanding it. Singular/plural must be
-/// correct.
+/// The sidebar row subtitle shows the endpoint label and, when available, the
+/// active pane's command or path.
 #[test]
-fn workspace_connection_summary_includes_pane_count_in_subtitle() {
+fn workspace_connection_summary_shows_endpoint_and_pane_info() {
     use rttx::runtime::{RuntimeEndpoint, workspace_connection_summary};
 
     let local = RuntimeEndpoint::Local;
     let remote = RuntimeEndpoint::Remote { host: "dev@host".into() };
 
-    assert!(workspace_connection_summary(&local, 3).ends_with("3 panes"));
-    assert!(workspace_connection_summary(&local, 1).ends_with("1 pane"));
-    assert!(workspace_connection_summary(&remote, 2).ends_with("2 panes"));
-    assert!(workspace_connection_summary(&remote, 1).contains("1 pane"));
+    assert_eq!(workspace_connection_summary(&local, Some("vim")), "Local runtime · vim");
+    assert_eq!(workspace_connection_summary(&local, None), "Local runtime");
+    assert_eq!(workspace_connection_summary(&remote, Some("~/src")), "dev@host · ~/src");
+    assert_eq!(workspace_connection_summary(&remote, None), "dev@host");
 }
 
 /// Contract: connection_icon returns None for local, Some for remote endpoints.
@@ -782,8 +781,10 @@ fn workspace_connection_summary_contains_no_status_text() {
     let local = RuntimeEndpoint::Local;
     let remote = RuntimeEndpoint::Remote { host: "h".into() };
 
-    for (ep, count) in [(&local, 1), (&local, 3), (&remote, 1), (&remote, 2)] {
-        let summary = workspace_connection_summary(ep, count);
+    for (ep, info) in
+        [(&local, Some("bash")), (&local, None), (&remote, Some("vim")), (&remote, None)]
+    {
+        let summary = workspace_connection_summary(ep, info);
         for keyword in ["Recovered", "Disconnected", "Action Required", "Reconnecting", "Blocked"] {
             assert!(
                 !summary.contains(keyword),
@@ -791,6 +792,18 @@ fn workspace_connection_summary_contains_no_status_text() {
             );
         }
     }
+}
+
+/// Contract: pane_description extracts a compact label from title and CWD.
+///
+/// The sidebar subtitle uses this to show what the active pane is doing.
+#[test]
+fn pane_description_extracts_compact_label() {
+    use rttx::runtime::pane_description;
+
+    assert_eq!(pane_description(Some("vim"), Some("/home/user")), Some("vim".into()));
+    assert_eq!(pane_description(None, Some("/home/user/project")), Some("project".into()));
+    assert_eq!(pane_description(None, None), None);
 }
 
 /// Contract: ConnectionPresentation contains only header_label and input_enabled.


### PR DESCRIPTION
## What changed

Replaced the static pane count in the sidebar subtitle with the active pane's title or working directory.

Before: `Local runtime · 2 panes`
After: `Local runtime · vim main.rs` or `Local runtime · ~/projects/rttx`

The subtitle now dynamically reflects what the focused pane is doing, which is more useful than a pane count that users can already see in the workspace content area.

## Why

The pane count was not very useful information. Showing the active command or path gives users immediate context about what each workspace is doing, especially when switching between workspaces.

## Changes

- `workspace_connection_summary()` takes an optional pane info string instead of a pane count
- New `pane_description()` extracts a compact label from the pane's title and CWD (prefers title, falls back to CWD basename)
- New `refresh_sidebar_subtitle()` replaces `update_sidebar_count()` — reads the active pane's title/CWD
- New `refresh_sidebar_subtitle_if_active()` — only refreshes if the given terminal is the active pane
- Subtitle updates on: focus change, TitleChanged, CwdChanged, connection status change, split, and close
- Direct terminals also refresh subtitle on VTE `window_title_changed` signal

## Manual verification steps

1. Launch rttx, create a workspace
2. Verify the subtitle shows the shell name or CWD
3. Run a command (e.g. `vim`) — subtitle should update to show the command
4. Split the workspace, focus different panes — subtitle should update to show the focused pane's info
5. Connect to a remote host — subtitle should show `hostname · command`

## Tests added

- `workspace_connection_summary_with_pane_info` — endpoint + pane info formatting
- `workspace_connection_summary_for_remote_endpoint` — remote endpoint formatting
- `pane_description_prefers_title_over_cwd` — title takes priority
- `pane_description_falls_back_to_cwd_basename` — CWD basename extraction
- `pane_description_none_when_no_info` — graceful None handling
- Updated boundary contracts: `workspace_connection_summary_shows_endpoint_and_pane_info`, `workspace_connection_summary_contains_no_status_text`, `pane_description_extracts_compact_label`
- Updated sidebar widget test and recovered workspace status test

## Tests run

- `cargo test -p rttx --lib`: 330 passed
- `cargo test -p rttx-server --lib`: 67 passed
- `bash .github/scripts/run-clippy.sh`: clean
- `bash .github/scripts/run-quality-tests.sh`: all pass
- Runtime behavior gate: pass (no runtime-affecting changes)

## Follow-ups

- Multi-line subtitle (mentioned in issue) could be explored if single-line ellipsis proves insufficient

Fixes #331