### PR TITLE
fix: darken Daybreak bright ANSI colors for WCAG AA contrast

### DIFF
--- a/clients/rttx/src/color_scheme.rs
+++ b/clients/rttx/src/color_scheme.rs
@@ -114,7 +114,7 @@ pub fn builtin_color_schemes() -> Vec<ColorScheme> {
     ];
     const DAYBREAK: [&str; 16] = [
         "#2B2F36", "#B2472F", "#2F6B3C", "#8A6318", "#2F5FAE", "#7B4CB0", "#1E6F79", "#687281",
-        "#768090", "#CC5A3C", "#3F7D4D", "#A97A1F", "#4B7BD0", "#9562C7", "#2B8791", "#37414F",
+        "#666F7E", "#B94D31", "#3F7D4D", "#8F681A", "#376CCB", "#8C54C2", "#277982", "#37414F",
     ];
 
     vec![
@@ -364,9 +364,11 @@ mod tests {
         );
 
         for (index, color) in scheme.palette_rgba().iter().enumerate() {
+            let ratio = contrast_ratio(color, &background);
             assert!(
-                contrast_ratio(color, &background) >= 3.5,
-                "palette slot {index} lost too much contrast against the light background"
+                ratio >= 4.5,
+                "palette slot {index} has contrast {ratio:.2} against the light background, \
+                 WCAG AA requires at least 4.5:1"
             );
         }
     }


### PR DESCRIPTION
## What changed

Darkened the bright ANSI palette colors (slots 8–14) in the Daybreak light theme to meet WCAG AA 4.5:1 contrast ratio against the `#FAF7F0` background. Each color was adjusted by reducing lightness while preserving hue.

## Why

The bright palette colors had contrast ratios between 3.5:1 and 4.0:1, making colored CLI output (e.g. Gemini CLI, cargo colored output) hard to read on the light background.

| Slot | Name | Before | After | Old ratio | New ratio |
|------|------|--------|-------|-----------|-----------|
| 8 | Bright Black | `#768090` | `#666F7E` | 3.73 | 4.74 |
| 9 | Bright Red | `#CC5A3C` | `#B94D31` | 3.85 | 4.71 |
| 11 | Bright Yellow | `#A97A1F` | `#8F681A` | 3.57 | 4.71 |
| 12 | Bright Blue | `#4B7BD0` | `#376CCB` | 3.89 | 4.71 |
| 13 | Bright Magenta | `#9562C7` | `#8C54C2` | 4.05 | 4.72 |
| 14 | Bright Cyan | `#2B8791` | `#277982` | 3.94 | 4.74 |

Slots 10 (Bright Green) and 15 (Bright White) already met the threshold and were not changed.

## Manual verification

1. Set terminal theme to Rttx Daybreak (light)
2. Run `ls --color=auto` or any CLI with ANSI colors
3. All colored text should be clearly readable against the light background

## Tests

- Tightened `builtin_light_scheme_palette_stays_readable_for_cli_apps` threshold from 3.5 to 4.5 (WCAG AA)
- Test fails on the old colors, passes on the new ones

## Tests run

- `cargo test -p rttx --lib`: 330 passed
- `cargo test -p rttx-server --lib`: 67 passed
- `bash .github/scripts/run-clippy.sh`: clean
- `bash .github/scripts/run-quality-tests.sh`: all pass

Fixes #267