### PR TITLE
refactor: replace terminal_uuids().contains() with contains_terminal()

### DIFF
--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1913,7 +1913,7 @@ impl Window {
         let session_idx = state
             .sessions
             .iter()
-            .position(|s| s.layout.terminal_uuids().contains(&terminal_uuid.to_string()));
+            .position(|s| s.layout.contains_terminal(terminal_uuid));
 
         if let Some(idx) = session_idx {
             let at_limit = state.sessions[idx]
@@ -1997,7 +1997,7 @@ impl Window {
             let session_idx = state
                 .sessions
                 .iter()
-                .position(|s| s.layout.terminal_uuids().contains(&terminal_uuid.to_string()));
+                .position(|s| s.layout.contains_terminal(terminal_uuid));
             let Some(idx) = session_idx else { return };
 
             if state.sessions[idx].uses_managed_runtime()
@@ -2378,7 +2378,7 @@ impl Window {
         let session = state
             .sessions
             .iter()
-            .find(|s| s.input_sync && s.layout.terminal_uuids().contains(&source_uuid.to_string()));
+            .find(|s| s.input_sync && s.layout.contains_terminal(source_uuid));
         let Some(session) = session else { return };
         let uuids = session.layout.terminal_uuids();
         drop(state);

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1910,10 +1910,8 @@ impl Window {
 
         let mut state = imp.state.borrow_mut();
 
-        let session_idx = state
-            .sessions
-            .iter()
-            .position(|s| s.layout.contains_terminal(terminal_uuid));
+        let session_idx =
+            state.sessions.iter().position(|s| s.layout.contains_terminal(terminal_uuid));
 
         if let Some(idx) = session_idx {
             let at_limit = state.sessions[idx]
@@ -1994,10 +1992,8 @@ impl Window {
 
         let action = {
             let mut state = imp.state.borrow_mut();
-            let session_idx = state
-                .sessions
-                .iter()
-                .position(|s| s.layout.contains_terminal(terminal_uuid));
+            let session_idx =
+                state.sessions.iter().position(|s| s.layout.contains_terminal(terminal_uuid));
             let Some(idx) = session_idx else { return };
 
             if state.sessions[idx].uses_managed_runtime()
@@ -2375,10 +2371,8 @@ impl Window {
 
     fn forward_input(&self, source_uuid: &str, text: &str) {
         let state = self.imp().state.borrow();
-        let session = state
-            .sessions
-            .iter()
-            .find(|s| s.input_sync && s.layout.contains_terminal(source_uuid));
+        let session =
+            state.sessions.iter().find(|s| s.input_sync && s.layout.contains_terminal(source_uuid));
         let Some(session) = session else { return };
         let uuids = session.layout.terminal_uuids();
         drop(state);


### PR DESCRIPTION
## What changed

Replaced the 3 remaining `terminal_uuids().contains(&uuid.to_string())` calls in `window/mod.rs` with the dedicated `contains_terminal(uuid)` predicate.

## Why

`terminal_uuids()` collects all UUIDs into a `Vec` then does a linear scan. `contains_terminal()` does an early-exit tree walk — same semantics, less allocation, and reads more clearly.

## Call sites replaced

1. `split_terminal()` — finding which session owns the terminal to split
2. `close_terminal()` — finding which session owns the terminal to close
3. `forward_input()` — finding the input-sync session for broadcast

## Manual verification

Pure refactor — behavior is identical. The `contains_terminal` predicate has its own unit test (`contains_terminal_works`) and is already used in 10+ other call sites.

## Tests run

- `cargo test -p rttx --lib`: 330 passed
- `bash .github/scripts/run-clippy.sh`: clean
- `bash .github/scripts/run-quality-tests.sh`: all pass

No new tests needed — this is a mechanical replacement with an already-tested predicate.

Fixes #89