### PR TITLE
refactor: replace build_layout_widget positional args with TerminalSpec

### DIFF
--- a/clients/rttx/src/session/mod.rs
+++ b/clients/rttx/src/session/mod.rs
@@ -109,15 +109,27 @@ pub fn capture_paned_ratios(layout: &mut LayoutNode, widget: &gtk4::Widget) {
     }
 }
 
+/// Terminal properties passed to the `build_layout_widget` closure.
+#[derive(Debug)]
+pub struct TerminalSpec<'a> {
+    pub uuid: &'a str,
+    pub cwd: Option<&'a str>,
+    pub profile: Option<&'a str>,
+    pub custom_title: Option<&'a str>,
+}
+
 /// Build a tree of `GtkPaned` widgets matching the `LayoutNode` structure.
 pub fn build_layout_widget<F>(layout: &LayoutNode, make_terminal: &F) -> gtk4::Widget
 where
-    F: Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> gtk4::Widget,
+    F: Fn(TerminalSpec<'_>) -> gtk4::Widget,
 {
     match layout {
-        LayoutNode::Terminal { uuid, cwd, profile, custom_title } => {
-            make_terminal(uuid, cwd.as_deref(), profile.as_deref(), custom_title.as_deref())
-        }
+        LayoutNode::Terminal { uuid, cwd, profile, custom_title } => make_terminal(TerminalSpec {
+            uuid,
+            cwd: cwd.as_deref(),
+            profile: profile.as_deref(),
+            custom_title: custom_title.as_deref(),
+        }),
         LayoutNode::Split { orientation, ratio, first, second } => {
             let gtk_orientation = match orientation {
                 SplitOrientation::Horizontal => gtk4::Orientation::Horizontal,
@@ -399,7 +411,7 @@ mod tests {
         };
 
         let widget =
-            build_layout_widget(&layout, &|uuid, _, _, _| gtk4::Label::new(Some(uuid)).upcast());
+            build_layout_widget(&layout, &|spec| gtk4::Label::new(Some(spec.uuid)).upcast());
 
         let outer = widget.downcast_ref::<gtk4::Paned>().expect("root widget should be a Paned");
         outer.set_size_request(1000, 800);

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -597,16 +597,13 @@ impl Window {
                 custom_title: session_state.layout.terminal_custom_title(zoomed_uuid),
             };
             let win = self.clone();
-            return session::build_layout_widget(
-                &zoomed_layout,
-                &move |uuid, cwd, _, custom_title| {
-                    win.materialize_terminal(session_state, uuid, cwd, custom_title)
-                },
-            );
+            return session::build_layout_widget(&zoomed_layout, &move |spec| {
+                win.materialize_terminal(session_state, spec.uuid, spec.cwd, spec.custom_title)
+            });
         }
         let win = self.clone();
-        session::build_layout_widget(&session_state.layout, &move |uuid, cwd, _, custom_title| {
-            win.materialize_terminal(session_state, uuid, cwd, custom_title)
+        session::build_layout_widget(&session_state.layout, &move |spec| {
+            win.materialize_terminal(session_state, spec.uuid, spec.cwd, spec.custom_title)
         })
     }
 

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -427,13 +427,16 @@ impl Window {
 
         let build_branch = move || {
             if win_weak.upgrade().is_some() {
-                session::build_layout_widget(&branch_layout_clone, &|uuid, _, _, _| {
-                    if uuid == target_uuid_str {
+                session::build_layout_widget(&branch_layout_clone, &|spec| {
+                    if spec.uuid == target_uuid_str {
                         target_clone.clone().upcast()
-                    } else if uuid == new_terminal_uuid_str {
+                    } else if spec.uuid == new_terminal_uuid_str {
                         new_term_clone.clone().upcast()
                     } else {
-                        unreachable!("split branch builder requested unexpected uuid {uuid}");
+                        unreachable!(
+                            "split branch builder requested unexpected uuid {}",
+                            spec.uuid
+                        );
                     }
                 })
             } else {

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -300,9 +300,7 @@ fn build_layout_widget_sets_position_after_allocation() {
         }),
     };
 
-    let widget = build_layout_widget(&layout, &|_uuid, _cwd, _profile, _title| {
-        gtk4::Label::new(Some("terminal")).upcast()
-    });
+    let widget = build_layout_widget(&layout, &|_spec| gtk4::Label::new(Some("terminal")).upcast());
 
     let outer = widget.downcast_ref::<gtk4::Paned>().expect("Root must be Paned");
 
@@ -366,9 +364,7 @@ fn triple_nested_split_all_paneds_nonzero() {
         }),
     };
 
-    let widget = build_layout_widget(&layout, &|_uuid, _cwd, _profile, _title| {
-        gtk4::Label::new(Some("terminal")).upcast()
-    });
+    let widget = build_layout_widget(&layout, &|_spec| gtk4::Label::new(Some("terminal")).upcast());
 
     let root = widget.downcast_ref::<gtk4::Paned>().unwrap();
     root.set_size_request(800, 600);
@@ -635,9 +631,9 @@ fn build_layout_widget_calls_make_terminal_exactly_once_per_uuid() {
     let call_counts: Rc<RefCell<HashMap<String, usize>>> = Rc::new(RefCell::new(HashMap::new()));
     let counts_clone = call_counts.clone();
 
-    build_layout_widget(&layout, &|uuid, _cwd, _profile, _title| {
-        *counts_clone.borrow_mut().entry(uuid.to_string()).or_insert(0) += 1;
-        gtk4::Label::new(Some(uuid)).upcast()
+    build_layout_widget(&layout, &|spec| {
+        *counts_clone.borrow_mut().entry(spec.uuid.to_string()).or_insert(0) += 1;
+        gtk4::Label::new(Some(spec.uuid)).upcast()
     });
 
     let counts = call_counts.borrow();
@@ -816,7 +812,7 @@ fn paned_extreme_but_valid_ratios_produce_nonzero_positions() {
         };
 
         let widget =
-            build_layout_widget(&layout, &|uuid, _, _, _| gtk4::Label::new(Some(uuid)).upcast());
+            build_layout_widget(&layout, &|spec| gtk4::Label::new(Some(spec.uuid)).upcast());
 
         let paned = widget.downcast_ref::<gtk4::Paned>().expect("Root must be Paned");
 
@@ -1564,9 +1560,7 @@ fn paned_ratio_applied_on_realize_not_just_idle() {
         }),
     };
 
-    let widget = build_layout_widget(&layout, &|_uuid, _cwd, _profile, _title| {
-        gtk4::Label::new(Some("terminal")).upcast()
-    });
+    let widget = build_layout_widget(&layout, &|_spec| gtk4::Label::new(Some("terminal")).upcast());
 
     schedule_initial_paned_ratios(&widget, &layout);
 

--- a/clients/rttx/tests/layout_widget_tests.rs
+++ b/clients/rttx/tests/layout_widget_tests.rs
@@ -86,9 +86,9 @@ fn test_build_layout_widget_multiple_splits() {
     };
 
     let created_uuids = std::cell::RefCell::new(Vec::new());
-    let _widget = build_layout_widget(&layout, &|uuid, _, _, _| {
-        created_uuids.borrow_mut().push(uuid.to_string());
-        gtk4::Label::new(Some(uuid)).upcast()
+    let _widget = build_layout_widget(&layout, &|spec| {
+        created_uuids.borrow_mut().push(spec.uuid.to_string());
+        gtk4::Label::new(Some(spec.uuid)).upcast()
     });
 
     let created_uuids = created_uuids.borrow();
@@ -114,13 +114,13 @@ fn test_rebuild_session_content_reuses_terminals() {
         std::cell::RefCell::new(std::collections::HashMap::<String, gtk4::Widget>::new());
 
     let build_widget = |layout: &LayoutNode| {
-        build_layout_widget(layout, &|uuid, _, _, _| {
+        build_layout_widget(layout, &|spec| {
             let mut terms = terminals.borrow_mut();
-            if let Some(existing) = terms.get(uuid) {
+            if let Some(existing) = terms.get(spec.uuid) {
                 return existing.clone();
             }
-            let new_term: gtk4::Widget = gtk4::Label::new(Some(uuid)).upcast();
-            terms.insert(uuid.to_string(), new_term.clone());
+            let new_term: gtk4::Widget = gtk4::Label::new(Some(spec.uuid)).upcast();
+            terms.insert(spec.uuid.to_string(), new_term.clone());
             new_term
         })
     };
@@ -168,7 +168,7 @@ fn test_build_layout_widget_with_parented_terminals() {
         custom_title: None,
     };
 
-    let widget = build_layout_widget(&layout, &|_, _, _, _| {
+    let widget = build_layout_widget(&layout, &|_spec| {
         if t1.parent().is_some() {
             t1.unparent();
         }
@@ -205,8 +205,7 @@ fn test_capture_paned_ratios_reads_position() {
         }),
     };
 
-    let widget =
-        build_layout_widget(&layout, &|uuid, _, _, _| gtk4::Label::new(Some(uuid)).upcast());
+    let widget = build_layout_widget(&layout, &|spec| gtk4::Label::new(Some(spec.uuid)).upcast());
 
     let paned = widget.downcast_ref::<gtk4::Paned>().unwrap();
     paned.set_size_request(800, 600);
@@ -257,8 +256,7 @@ fn test_capture_paned_ratios_nested() {
         }),
     };
 
-    let widget =
-        build_layout_widget(&layout, &|uuid, _, _, _| gtk4::Label::new(Some(uuid)).upcast());
+    let widget = build_layout_widget(&layout, &|spec| gtk4::Label::new(Some(spec.uuid)).upcast());
 
     let outer = widget.downcast_ref::<gtk4::Paned>().unwrap();
     outer.set_size_request(800, 600);
@@ -311,8 +309,7 @@ fn test_apply_paned_ratios_sets_position() {
         }),
     };
 
-    let widget =
-        build_layout_widget(&layout, &|uuid, _, _, _| gtk4::Label::new(Some(uuid)).upcast());
+    let widget = build_layout_widget(&layout, &|spec| gtk4::Label::new(Some(spec.uuid)).upcast());
 
     let paned = widget.downcast_ref::<gtk4::Paned>().unwrap();
     paned.set_size_request(800, 600);
@@ -350,8 +347,7 @@ fn test_scheduled_initial_paned_ratios_apply_once_widget_has_size() {
         }),
     };
 
-    let widget =
-        build_layout_widget(&layout, &|uuid, _, _, _| gtk4::Label::new(Some(uuid)).upcast());
+    let widget = build_layout_widget(&layout, &|spec| gtk4::Label::new(Some(spec.uuid)).upcast());
     session::schedule_initial_paned_ratios(&widget, &layout);
 
     let window = gtk4::Window::new();
@@ -397,8 +393,7 @@ fn test_scheduled_initial_paned_ratios_do_not_clobber_user_resized_ratio() {
         }),
     };
 
-    let widget =
-        build_layout_widget(&layout, &|uuid, _, _, _| gtk4::Label::new(Some(uuid)).upcast());
+    let widget = build_layout_widget(&layout, &|spec| gtk4::Label::new(Some(spec.uuid)).upcast());
     session::schedule_initial_paned_ratios(&widget, &layout);
 
     let window = gtk4::Window::new();
@@ -455,8 +450,7 @@ fn build_layout_widget_does_not_set_magic_paned_position() {
         }),
     };
 
-    let widget =
-        build_layout_widget(&layout, &|uuid, _, _, _| gtk4::Label::new(Some(uuid)).upcast());
+    let widget = build_layout_widget(&layout, &|spec| gtk4::Label::new(Some(spec.uuid)).upcast());
 
     let paned = widget.downcast_ref::<gtk4::Paned>().unwrap();
     // Before realize, position must be 0 (GTK default) — not a magic sentinel.

--- a/clients/rttx/tests/terminal_lifecycle_tests.rs
+++ b/clients/rttx/tests/terminal_lifecycle_tests.rs
@@ -180,9 +180,9 @@ fn test_terminal_rebuild_integrity_simple() {
         Rc::new(RefCell::new(HashMap::new()));
 
     let build_session = |layout: &LayoutNode| {
-        build_layout_widget(layout, &|uuid, _cwd, _profile, _title| {
+        build_layout_widget(layout, &|spec| {
             let mut map = terminals.borrow_mut();
-            if let Some(existing) = map.get(uuid) {
+            if let Some(existing) = map.get(spec.uuid) {
                 let existing = existing.clone();
                 drop(map);
                 if existing.parent().is_some() {
@@ -192,8 +192,8 @@ fn test_terminal_rebuild_integrity_simple() {
             }
 
             let term: TerminalWidget = glib::Object::builder().build();
-            term.set_title(uuid);
-            map.insert(uuid.to_string(), term.clone());
+            term.set_title(spec.uuid);
+            map.insert(spec.uuid.to_string(), term.clone());
             term.upcast()
         })
     };


### PR DESCRIPTION
## What changed

Replaced the 4-positional-argument closure in `build_layout_widget` with a `TerminalSpec` struct:

```rust
// Before
F: Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> gtk4::Widget

// After
pub struct TerminalSpec<'a> {
    pub uuid: &'a str,
    pub cwd: Option<&'a str>,
    pub profile: Option<&'a str>,
    pub custom_title: Option<&'a str>,
}
F: Fn(TerminalSpec<'_>) -> gtk4::Widget
```

## Why

The positional `Option<&str>` arguments were opaque at call sites — callers used `_` for unused fields and it was unclear which position was which. Named fields make the API self-documenting and easier to extend.

## Call sites updated

- `session/mod.rs`: function definition + 1 test
- `window/mod.rs`: 2 call sites in `build_session_content`
- `window/terminal.rs`: 1 call site in `split_terminal_in_place`
- `tests/layout_widget_tests.rs`: 9 call sites
- `tests/gtk_widget_tests.rs`: 6 call sites
- `tests/terminal_lifecycle_tests.rs`: 1 call site

## Tests run

- `cargo test -p rttx --lib`: 330 passed
- `bash .github/scripts/run-clippy.sh`: clean
- `bash .github/scripts/run-quality-tests.sh`: all pass

No new tests needed — pure API refactor with identical semantics.

Fixes #91