### PR TITLE
feat(sidebar): move connection icon to prefix, always show, drop Local subtitle

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -369,18 +369,19 @@ pub struct ConnectionIcon {
     pub tooltip: &'static str,
 }
 
-/// Returns the connection icon for a workspace row, or `None` for local endpoints.
+/// Returns the connection icon for a workspace row. Always returns an icon.
 #[must_use]
 pub const fn connection_icon(
     endpoint: &RuntimeEndpoint,
     status: &ConnectionStatus,
-) -> Option<ConnectionIcon> {
+) -> ConnectionIcon {
     let (icon_name, css_class, tooltip) = match status {
         ConnectionStatus::Connected => {
             if matches!(endpoint, RuntimeEndpoint::Local) {
-                return None;
+                ("computer-symbolic", "dim-label", "Local workspace")
+            } else {
+                ("network-server-symbolic", "accent", "Connected to remote host")
             }
-            ("network-server-symbolic", "accent", "Connected to remote host")
         }
         ConnectionStatus::Recovered => ("emblem-ok-symbolic", "accent", "Connection recovered"),
         ConnectionStatus::Disconnected => {
@@ -395,7 +396,7 @@ pub const fn connection_icon(
             }
         }
     };
-    Some(ConnectionIcon { icon_name, css_class, tooltip })
+    ConnectionIcon { icon_name, css_class, tooltip }
 }
 
 #[must_use]
@@ -403,14 +404,12 @@ pub fn workspace_connection_summary(
     endpoint: &RuntimeEndpoint,
     active_pane_info: Option<&str>,
 ) -> String {
-    let base = match endpoint {
-        RuntimeEndpoint::Local => "Local",
-        RuntimeEndpoint::Remote { host } => host.as_str(),
-    };
-
-    match active_pane_info {
-        Some(info) if !info.is_empty() => format!("{base} · {info}"),
-        _ => base.to_string(),
+    match endpoint {
+        RuntimeEndpoint::Local => active_pane_info.unwrap_or("").to_string(),
+        RuntimeEndpoint::Remote { host } => match active_pane_info {
+            Some(info) if !info.is_empty() => format!("{host} · {info}"),
+            _ => host.clone(),
+        },
     }
 }
 
@@ -615,10 +614,10 @@ mod tests {
     fn workspace_connection_summary_with_pane_info() {
         assert_eq!(
             workspace_connection_summary(&RuntimeEndpoint::Local, Some("vim main.rs")),
-            "Local · vim main.rs"
+            "vim main.rs"
         );
-        assert_eq!(workspace_connection_summary(&RuntimeEndpoint::Local, None), "Local");
-        assert_eq!(workspace_connection_summary(&RuntimeEndpoint::Local, Some("")), "Local");
+        assert_eq!(workspace_connection_summary(&RuntimeEndpoint::Local, None), "");
+        assert_eq!(workspace_connection_summary(&RuntimeEndpoint::Local, Some("")), "");
         assert_eq!(
             workspace_connection_summary(
                 &RuntimeEndpoint::Remote { host: "builder.example".into() },
@@ -658,32 +657,33 @@ mod tests {
     }
 
     #[test]
-    fn connection_icon_none_for_local_connected() {
-        assert!(connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected).is_none());
+    fn connection_icon_computer_for_local_connected() {
+        let icon = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
+        assert_eq!(icon.icon_name, "computer-symbolic");
+        assert_eq!(icon.css_class, "dim-label");
     }
 
     #[test]
     fn connection_icon_shown_for_local_non_connected() {
         let ep = RuntimeEndpoint::Local;
-        let icon = connection_icon(&ep, &ConnectionStatus::Disconnected).unwrap();
+        let icon = connection_icon(&ep, &ConnectionStatus::Disconnected);
         assert_eq!(icon.css_class, "warning");
 
-        let icon = connection_icon(&ep, &ConnectionStatus::Recovered).unwrap();
+        let icon = connection_icon(&ep, &ConnectionStatus::Recovered);
         assert_eq!(icon.css_class, "accent");
 
         let icon =
-            connection_icon(&ep, &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable))
-                .unwrap();
+            connection_icon(&ep, &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable));
         assert_eq!(icon.css_class, "error");
 
-        let icon = connection_icon(&ep, &ConnectionStatus::Connecting).unwrap();
+        let icon = connection_icon(&ep, &ConnectionStatus::Connecting);
         assert_eq!(icon.css_class, "dim-label");
     }
 
     #[test]
     fn connection_icon_accent_for_remote_connected() {
         let ep = RuntimeEndpoint::Remote { host: "h".into() };
-        let icon = connection_icon(&ep, &ConnectionStatus::Connected).unwrap();
+        let icon = connection_icon(&ep, &ConnectionStatus::Connected);
         assert_eq!(icon.icon_name, "network-server-symbolic");
         assert_eq!(icon.css_class, "accent");
     }
@@ -696,7 +696,7 @@ mod tests {
             ConnectionStatus::Connecting,
             ConnectionStatus::Reconnecting { attempt: 1, retry_in_secs: 5 },
         ] {
-            let icon = connection_icon(&ep, &status).unwrap();
+            let icon = connection_icon(&ep, &status);
             assert_eq!(icon.icon_name, "network-server-symbolic");
             assert_eq!(icon.css_class, "dim-label");
         }
@@ -705,7 +705,7 @@ mod tests {
     #[test]
     fn connection_icon_warning_for_remote_disconnected() {
         let ep = RuntimeEndpoint::Remote { host: "h".into() };
-        let icon = connection_icon(&ep, &ConnectionStatus::Disconnected).unwrap();
+        let icon = connection_icon(&ep, &ConnectionStatus::Disconnected);
         assert_eq!(icon.icon_name, "network-offline-symbolic");
         assert_eq!(icon.css_class, "warning");
     }
@@ -714,8 +714,7 @@ mod tests {
     fn connection_icon_error_for_remote_blocked() {
         let ep = RuntimeEndpoint::Remote { host: "h".into() };
         let icon =
-            connection_icon(&ep, &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied))
-                .unwrap();
+            connection_icon(&ep, &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied));
         assert_eq!(icon.icon_name, "network-offline-symbolic");
         assert_eq!(icon.css_class, "error");
     }
@@ -723,7 +722,7 @@ mod tests {
     #[test]
     fn connection_icon_accent_for_remote_recovered() {
         let ep = RuntimeEndpoint::Remote { host: "h".into() };
-        let icon = connection_icon(&ep, &ConnectionStatus::Recovered).unwrap();
+        let icon = connection_icon(&ep, &ConnectionStatus::Recovered);
         assert_eq!(icon.icon_name, "emblem-ok-symbolic");
         assert_eq!(icon.css_class, "accent");
     }
@@ -733,17 +732,25 @@ mod tests {
         let remote = RuntimeEndpoint::Remote { host: "h".into() };
         let local = RuntimeEndpoint::Local;
 
-        let connected = connection_icon(&remote, &ConnectionStatus::Connected).unwrap();
+        let connected = connection_icon(&remote, &ConnectionStatus::Connected);
         assert_eq!(connected.tooltip, "Connected to remote host");
 
-        let disconnected = connection_icon(&remote, &ConnectionStatus::Disconnected).unwrap();
+        let disconnected = connection_icon(&remote, &ConnectionStatus::Disconnected);
         assert_eq!(disconnected.tooltip, "Disconnected from runtime");
 
-        let connecting_local = connection_icon(&local, &ConnectionStatus::Connecting).unwrap();
+        let connecting_local = connection_icon(&local, &ConnectionStatus::Connecting);
         assert_eq!(connecting_local.tooltip, "Connecting to local runtime");
 
-        let connecting_remote = connection_icon(&remote, &ConnectionStatus::Connecting).unwrap();
+        let connecting_remote = connection_icon(&remote, &ConnectionStatus::Connecting);
         assert_eq!(connecting_remote.tooltip, "Connecting to remote host");
+
+        let local_connected = connection_icon(&local, &ConnectionStatus::Connected);
+        assert_eq!(local_connected.tooltip, "Local workspace");
+    }
+
+    #[test]
+    fn workspace_connection_summary_local_returns_empty_without_pane_info() {
+        assert!(workspace_connection_summary(&RuntimeEndpoint::Local, None).is_empty());
     }
 
     #[test]

--- a/clients/rttx/src/sidebar.rs
+++ b/clients/rttx/src/sidebar.rs
@@ -43,7 +43,6 @@ mod imp {
         fn default() -> Self {
             let connection_icon = gtk4::Image::new();
             connection_icon.set_pixel_size(16);
-            connection_icon.set_visible(false);
 
             let activity_dot = gtk4::Image::from_icon_name("media-record-symbolic");
             activity_dot.set_pixel_size(8);
@@ -84,8 +83,8 @@ mod imp {
             self.close_button.add_css_class("flat");
             self.close_button.add_css_class("circular");
 
+            obj.add_prefix(&self.connection_icon);
             obj.add_prefix(&self.position_label);
-            obj.add_suffix(&self.connection_icon);
             obj.add_suffix(&self.activity_dot);
             obj.add_suffix(&self.close_button);
 
@@ -131,21 +130,15 @@ impl SessionRow {
         self.set_title(name);
     }
 
-    pub fn set_connection_icon(&self, icon: Option<&crate::runtime::ConnectionIcon>) {
+    pub fn set_connection_icon(&self, icon: &crate::runtime::ConnectionIcon) {
         const ICON_CSS_CLASSES: &[&str] = &["accent", "dim-label", "warning", "error"];
         let widget = &self.imp().connection_icon;
         for cls in ICON_CSS_CLASSES {
             widget.remove_css_class(cls);
         }
-        if let Some(icon) = icon {
-            widget.set_icon_name(Some(icon.icon_name));
-            widget.add_css_class(icon.css_class);
-            widget.set_tooltip_text(Some(icon.tooltip));
-            widget.set_visible(true);
-        } else {
-            widget.set_tooltip_text(None);
-            widget.set_visible(false);
-        }
+        widget.set_icon_name(Some(icon.icon_name));
+        widget.add_css_class(icon.css_class);
+        widget.set_tooltip_text(Some(icon.tooltip));
     }
 
     fn set_activity_state_internal(&self, state: ActivityState) {
@@ -302,24 +295,24 @@ mod tests {
         require_display!();
 
         let row = SessionRow::new("session-1", "Session 1");
-        row.set_subtitle("Local · vim main.rs");
-        assert_eq!(row.subtitle().unwrap().as_str(), "Local · vim main.rs");
+        row.set_subtitle("vim main.rs");
+        assert_eq!(row.subtitle().unwrap().as_str(), "vim main.rs");
 
-        row.set_subtitle("Local");
-        assert_eq!(row.subtitle().unwrap().as_str(), "Local");
+        row.set_subtitle("");
+        assert_eq!(row.subtitle().unwrap().as_str(), "");
     }
 
     #[test]
     #[ignore = "requires isolated GTK harness"]
-    fn connection_icon_hidden_by_default() {
+    fn connection_icon_visible_by_default() {
         require_display!();
         let row = SessionRow::new("s1", "Session");
-        assert!(!row.imp().connection_icon.is_visible());
+        assert!(row.imp().connection_icon.is_visible());
     }
 
     #[test]
     #[ignore = "requires isolated GTK harness"]
-    fn connection_icon_shows_and_hides() {
+    fn connection_icon_shows_and_updates() {
         require_display!();
         let row = SessionRow::new("s1", "Session");
 
@@ -328,14 +321,21 @@ mod tests {
             css_class: "accent",
             tooltip: "Connected to remote host",
         };
-        row.set_connection_icon(Some(&icon));
+        row.set_connection_icon(&icon);
         assert!(row.imp().connection_icon.is_visible());
         assert_eq!(row.imp().connection_icon.icon_name().unwrap(), "network-server-symbolic");
         assert!(row.imp().connection_icon.has_css_class("accent"));
 
-        row.set_connection_icon(None);
-        assert!(!row.imp().connection_icon.is_visible());
+        let local = crate::runtime::ConnectionIcon {
+            icon_name: "computer-symbolic",
+            css_class: "dim-label",
+            tooltip: "Local workspace",
+        };
+        row.set_connection_icon(&local);
+        assert!(row.imp().connection_icon.is_visible());
+        assert_eq!(row.imp().connection_icon.icon_name().unwrap(), "computer-symbolic");
         assert!(!row.imp().connection_icon.has_css_class("accent"));
+        assert!(row.imp().connection_icon.has_css_class("dim-label"));
     }
 
     #[test]
@@ -349,7 +349,7 @@ mod tests {
             css_class: "accent",
             tooltip: "Connected to remote host",
         };
-        row.set_connection_icon(Some(&connected));
+        row.set_connection_icon(&connected);
         assert!(row.imp().connection_icon.has_css_class("accent"));
 
         let disconnected = crate::runtime::ConnectionIcon {
@@ -357,7 +357,7 @@ mod tests {
             css_class: "warning",
             tooltip: "Disconnected from runtime",
         };
-        row.set_connection_icon(Some(&disconnected));
+        row.set_connection_icon(&disconnected);
         assert!(!row.imp().connection_icon.has_css_class("accent"));
         assert!(row.imp().connection_icon.has_css_class("warning"));
         assert_eq!(row.imp().connection_icon.icon_name().unwrap(), "network-offline-symbolic");
@@ -462,7 +462,7 @@ mod tests {
 
     #[test]
     #[ignore = "requires isolated GTK harness"]
-    fn connection_icon_tooltip_set_and_cleared() {
+    fn connection_icon_tooltip_updates() {
         require_display!();
         let row = SessionRow::new("s1", "Session");
 
@@ -471,14 +471,19 @@ mod tests {
             css_class: "accent",
             tooltip: "Connected to remote host",
         };
-        row.set_connection_icon(Some(&icon));
+        row.set_connection_icon(&icon);
         assert_eq!(
             row.imp().connection_icon.tooltip_text().unwrap().as_str(),
             "Connected to remote host"
         );
 
-        row.set_connection_icon(None);
-        assert!(row.imp().connection_icon.tooltip_text().is_none());
+        let local = crate::runtime::ConnectionIcon {
+            icon_name: "computer-symbolic",
+            css_class: "dim-label",
+            tooltip: "Local workspace",
+        };
+        row.set_connection_icon(&local);
+        assert_eq!(row.imp().connection_icon.tooltip_text().unwrap().as_str(), "Local workspace");
     }
 
     #[test]

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -542,7 +542,7 @@ impl Window {
                 row.child().and_then(|child| child.downcast::<SessionRow>().ok())
                 && session_row.uuid() == workspace_id
             {
-                session_row.set_connection_icon(icon.as_ref());
+                session_row.set_connection_icon(&icon);
                 break;
             }
             idx += 1;

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3052,7 +3052,7 @@ fn recovered_workspace_uses_compact_sidebar_status_without_banner() {
 
     let row = session_row_for_uuid(&window, &session_state.uuid);
     let subtitle = row.subtitle().map(|value| value.to_string());
-    assert_eq!(subtitle.as_deref(), Some("Local · Terminal (persistent)"));
+    assert_eq!(subtitle.as_deref(), Some("Terminal (persistent)"));
     assert!(row.imp().connection_icon.is_visible());
     assert!(
         !subtitle.as_deref().is_some_and(|value| value.contains("Recovered")),

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -714,10 +714,11 @@ fn old_state_without_zoom_field_deserializes_cleanly() {
     assert!(state.sessions[0].zoomed_terminal_uuid.is_none());
 }
 
-/// Contract: workspace_connection_summary shows endpoint and optional pane info.
+/// Contract: workspace_connection_summary shows just pane info for local,
+/// host · pane info for remote.
 ///
-/// The sidebar row subtitle shows the endpoint label and, when available, the
-/// active pane's command or path.
+/// The sidebar row subtitle shows the active pane's command or path for local
+/// workspaces, and host · pane info for remote workspaces.
 #[test]
 fn workspace_connection_summary_shows_endpoint_and_pane_info() {
     use rttx::runtime::{RuntimeEndpoint, workspace_connection_summary};
@@ -725,53 +726,37 @@ fn workspace_connection_summary_shows_endpoint_and_pane_info() {
     let local = RuntimeEndpoint::Local;
     let remote = RuntimeEndpoint::Remote { host: "dev@host".into() };
 
-    assert_eq!(workspace_connection_summary(&local, Some("vim")), "Local · vim");
-    assert_eq!(workspace_connection_summary(&local, None), "Local");
+    assert_eq!(workspace_connection_summary(&local, Some("vim")), "vim");
+    assert_eq!(workspace_connection_summary(&local, None), "");
     assert_eq!(workspace_connection_summary(&remote, Some("~/src")), "dev@host · ~/src");
     assert_eq!(workspace_connection_summary(&remote, None), "dev@host");
 }
 
-/// Contract: connection_icon returns None for local, Some for remote endpoints.
+/// Contract: connection_icon always returns an icon for every endpoint/status.
 ///
-/// The sidebar row shows a connection icon for non-connected states (any endpoint)
-/// and for remote endpoints when connected. Local+Connected returns None.
+/// Local connected gets computer-symbolic, remote connected gets network-server-symbolic,
+/// and error/warning states get appropriate icons.
 #[test]
-fn connection_icon_distinguishes_local_from_remote() {
+fn connection_icon_always_returns_icon() {
     use rttx::runtime::{ConnectionStatus, RuntimeEndpoint, connection_icon};
 
-    assert!(connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected).is_none());
-    assert!(connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Disconnected).is_some());
+    let local_connected = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
+    assert_eq!(local_connected.icon_name, "computer-symbolic");
+
+    let local_disconnected =
+        connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Disconnected);
+    assert_eq!(local_disconnected.css_class, "warning");
 
     let remote = RuntimeEndpoint::Remote { host: "h".into() };
-    let connected = connection_icon(&remote, &ConnectionStatus::Connected).unwrap();
+    let connected = connection_icon(&remote, &ConnectionStatus::Connected);
     assert_eq!(connected.css_class, "accent");
 
-    let disconnected = connection_icon(&remote, &ConnectionStatus::Disconnected).unwrap();
+    let disconnected = connection_icon(&remote, &ConnectionStatus::Disconnected);
     assert_eq!(disconnected.css_class, "warning");
     assert_ne!(connected.icon_name, disconnected.icon_name);
 }
 
-/// Contract: local endpoints show status icons for non-Connected states.
-///
-/// Before #329, local endpoints never showed connection icons. Now they show
-/// icons for Disconnected, Recovered, Blocked, and transient states so the
-/// sidebar subtitle can stay clean (endpoint + pane count only).
-#[test]
-fn connection_icon_shown_for_local_non_connected_states() {
-    use rttx::runtime::{ConnectionProblem, ConnectionStatus, RuntimeEndpoint, connection_icon};
-
-    let local = RuntimeEndpoint::Local;
-    assert!(connection_icon(&local, &ConnectionStatus::Connected).is_none());
-    assert!(connection_icon(&local, &ConnectionStatus::Disconnected).is_some());
-    assert!(connection_icon(&local, &ConnectionStatus::Recovered).is_some());
-    assert!(
-        connection_icon(&local, &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable))
-            .is_some()
-    );
-    assert!(connection_icon(&local, &ConnectionStatus::Connecting).is_some());
-}
-
-/// Contract: every visible connection icon carries a non-empty tooltip.
+/// Contract: every connection icon carries a non-empty tooltip.
 ///
 /// Tooltips differentiate connection state from activity state in the sidebar.
 #[test]
@@ -785,18 +770,32 @@ fn connection_icon_always_has_tooltip() {
         (&remote, ConnectionStatus::Connected),
         (&remote, ConnectionStatus::Disconnected),
         (&remote, ConnectionStatus::Connecting),
+        (&local, ConnectionStatus::Connected),
         (&local, ConnectionStatus::Disconnected),
         (&local, ConnectionStatus::Connecting),
         (&remote, ConnectionStatus::Recovered),
         (&remote, ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied)),
     ] {
-        if let Some(icon) = connection_icon(endpoint, &status) {
-            assert!(
-                !icon.tooltip.is_empty(),
-                "connection_icon for {status:?} should have a non-empty tooltip"
-            );
-        }
+        let icon = connection_icon(endpoint, &status);
+        assert!(
+            !icon.tooltip.is_empty(),
+            "connection_icon for {status:?} should have a non-empty tooltip"
+        );
     }
+}
+
+/// Contract: local workspace subtitle contains no endpoint prefix.
+///
+/// The connection icon in the prefix communicates local vs remote,
+/// so the subtitle should contain only pane info.
+#[test]
+fn workspace_connection_summary_local_has_no_prefix() {
+    use rttx::runtime::{RuntimeEndpoint, workspace_connection_summary};
+
+    let local = RuntimeEndpoint::Local;
+    let summary = workspace_connection_summary(&local, Some("vim"));
+    assert!(!summary.contains("Local"), "local subtitle should not contain 'Local' prefix");
+    assert_eq!(summary, "vim");
 }
 
 /// Contract: workspace_connection_summary never contains status text.


### PR DESCRIPTION
## What changed

1. **Connection icon moved to prefix** (left side of row, before position label)
2. **Always visible** — no more hiding for local connected workspaces:
   - Local connected: `computer-symbolic` (dim)
   - Remote connected: `network-server-symbolic` (accent)
   - Disconnected: `network-offline-symbolic` (warning)
   - Blocked: `network-offline-symbolic` (error)
   - Connecting: `content-loading-symbolic` or `network-server-symbolic` (dim)
3. **Removed 'Local' subtitle prefix** — local workspaces show just the pane info (e.g. `vim main.rs`). Remote keeps `host · pane_info`.

## Why

The connection icon in the prefix already communicates local vs remote, making the subtitle prefix redundant. Always showing the icon gives every row a consistent visual anchor.

## API changes

- `connection_icon()` now returns `ConnectionIcon` instead of `Option<ConnectionIcon>`
- `set_connection_icon()` takes `&ConnectionIcon` instead of `Option<&ConnectionIcon>`
- `workspace_connection_summary()` returns empty string for local with no pane info

## Tests updated

- `connection_icon_computer_for_local_connected` — new test for local icon
- `connection_icon_tooltips_describe_state` — added local connected tooltip
- `connection_icon_always_returns_icon` — replaces old distinguishes/shown tests
- `connection_icon_visible_by_default` — replaces hidden_by_default
- `connection_icon_shows_and_updates` — replaces shows_and_hides
- `connection_icon_tooltip_updates` — replaces tooltip_set_and_cleared
- All workspace_connection_summary tests updated for new format

## Tests run

- `cargo test --workspace`: 338 passed, 85 ignored
- `bash .github/scripts/run-clippy.sh`: clean
- `bash .github/scripts/run-quality-tests.sh`: all pass
- `cargo fmt --check`: clean

Fixes #352