### PR TITLE
docs: update RFC status to reflect current implementation

### DIFF
--- a/designs/RFC-002-adwaita-modernization.md
+++ b/designs/RFC-002-adwaita-modernization.md
@@ -116,17 +116,18 @@ adw::ApplicationWindow
 ### SessionRow widget tree
 
 ```text
-adw::ActionRow
-├── prefix: gtk4::Stack "indicator"
-│     ├── page "idle":   gtk4::Image  (color dot, CSS class)
-│     └── page "active": gtk4::Spinner
+adw::ActionRow  (.session-row)
+├── prefix: gtk4::Image  (connection icon — always visible)
+├── prefix: gtk4::Label  (position number 1–9)
 ├── [title]    — session name  (ActionRow built-in)
-├── [subtitle] — activity text (ActionRow built-in)
+├── [subtitle] — pane info or host · pane info (ActionRow built-in)
 └── suffix:
-      ├── gtk4::Label  (terminal count badge)
-      ├── gtk4::Button ("document-edit-symbolic", rename trigger)
-      └── gtk4::Button ("window-close-symbolic", flat circular)
+      └── gtk4::Button ("window-close-symbolic" or "view-more-symbolic" for managed)
 ```
+
+Activity is indicated by CSS classes on the row itself (no extra widgets):
+- `.session-activity-active` — 3px accent left bar with pulse animation
+- `.session-activity-idle` — 3px accent left bar, static, 45% opacity
 
 ### Session color data model
 
@@ -135,14 +136,13 @@ adw::ActionRow
 pub enum SessionColor { #[default] Blue, Green, Yellow, Red, Purple, Pink, Teal, Orange }
 ```
 
-Each variant maps to an Adwaita accent CSS variable (`@blue_3`, `@green_3`, …) applied as a
-CSS class on the indicator dot image.
+Each variant maps to an Adwaita accent CSS variable (`@blue_3`, `@green_3`, …).
 
 ### Activity detection
 
 VTE fires `window_title_changed` when the shell updates its title (shells do this when starting
-a command). A 5-second debounce timer resets the activity state. The sidebar spinner starts on
-title change and stops after debounce. The timer closure captures a weak window reference to
+a command). A debounce timer resets the activity state. The accent bar appears on
+title change and fades to idle after the debounce. The timer closure captures a weak reference to
 avoid crashes when sessions are closed before the timer fires.
 
 ---
@@ -153,7 +153,7 @@ avoid crashes when sessions are closed before the timer fires.
 | --- | --- |
 | G1 — HIG window chrome | `adw::ToolbarView` replaces `gtk4::Box` wrapper |
 | G2 — Two-tier notifications | `adw::Toast` for focused-window/background-session; `gio::Notification` when unfocused |
-| G3 — SessionRow as ActionRow | Full rewrite with indicator stack, spinner, color dot, rename popover |
+| G3 — SessionRow as ActionRow | Full rewrite with connection icon prefix, accent bar activity, managed actions |
 
 ---
 
@@ -163,11 +163,12 @@ avoid crashes when sessions are closed before the timer fires.
 - [x] **Two-tier notifications** — Implement `terminal_is_in_visible_session`; update `notify_process_completed`
 - [x] **SessionRow base** — Rewrite as `adw::ActionRow` subclass
 - [x] **Session renaming** — Inline popover with `adw::EntryRow`
-- [x] **Activity indicator** — Wire `window_title_changed` signal; debounce timer; spinner vs dot
+- [x] **Activity indicator** — Accent bar via CSS `box-shadow` with pulse animation; replaces earlier spinner/dot design
 - [x] **Session color coding** — Assign colors on creation; CSS classes; color picker UI deferred (NG2)
+- [x] **Connection icon** — Always-visible prefix icon: `computer-symbolic` (local), `network-server-symbolic` (remote), state-specific icons for disconnected/blocked/connecting
 
 ---
 
 ## Open Questions
 
-- [ ] **Q1** — Should the color dot use `circle-filled-symbolic` (stock icon) or a 10×10 CSS-drawn circle via a custom icon? The stock icon scales with the font; the CSS approach gives precise sizing control.
+All resolved.

--- a/designs/RFC-003-testing-strategy.md
+++ b/designs/RFC-003-testing-strategy.md
@@ -176,8 +176,6 @@ non-main threads).
 - **GAP2** — Add more real client+daemon restart/reconcile coverage now that both live in one repo
 - **GAP3** — Expand daemon adversarial tests: malformed protocol input, persistence failure
   injection, race-heavy ownership, stress/load, and leak-oriented lifecycle loops
-- **GAP4** — Add the deferred nightly AT-SPI job so accessibility-level UI regressions run
-  continuously in GitHub Actions
 
 ---
 
@@ -201,9 +199,9 @@ non-main threads).
 - [x] Activity indicator timer regression coverage
 - [x] Nested split ratio restore regression coverage
 - [x] Runtime-affecting PR gate requiring pure-state plus behavior-layer evidence
+- [x] AT-SPI behavioral UI tests running in CI on every PR (Weston headless)
 - [ ] Deterministic plain-harness GTK execution
 - [ ] Deeper client+daemon restart/reconcile integration coverage
 - [ ] Expanded daemon adversarial test matrix
-- [ ] Nightly AT-SPI GitHub Actions job
 
 ---

--- a/designs/RFC-007-session-recovery.md
+++ b/designs/RFC-007-session-recovery.md
@@ -2,7 +2,7 @@
 
 | Field         | Value                   |
 |---------------|-------------------------|
-| Status        | Accepted                |
+| Status        | Accepted (L1–L2 implemented; L3–L4 superseded by RFC-013) |
 | Author(s)     | Illya Yalovyy           |
 | Supersedes    | —                       |
 | Superseded by | —                       |

--- a/designs/RFC-010-maintainability-refactor.md
+++ b/designs/RFC-010-maintainability-refactor.md
@@ -400,7 +400,7 @@ seams already exist.
 - [x] **Step 3** — Share direct/managed terminal shortcut policy and add regression coverage (`#187`, `#201`) *(prerequisite: Step 2)*
 - [ ] **Step 4** — Add black-box client+daemon GTK integration coverage for restore/restart/selection sync (`#185`) *(prerequisite: Steps 1–3 can land incrementally)*
 - [ ] **Step 5** — Fix terminal retry/title-sync lifecycle and remaining low-risk correctness cleanup *(prerequisite: Step 2)*
-- [ ] **Step 6** — Split `window.rs` into `build`, `actions`, `runtime`, `sessions`, `recovery`, and `sidebars` modules (`#98`, `#204` partial) *(prerequisite: Steps 1–5)*
+- [x] **Step 6** — Split `window.rs` into module directory with `actions`, `runtime`, `sidebar`, `terminal`, `dialogs`, `input` modules (`#98`, `#204`) — `mod.rs` still large but core concerns are separated
 - [x] **Step 7** — Split `session/layout.rs` into layout tree, state, and recovery modules (`#101`, `#205`) *(prerequisite: Step 6)*
 - [x] **Step 8** — Tighten the terminal widget API and finish or remove inactive search UI (`#24`, `#221`) *(prerequisite: Step 7)*
 - [x] **Step 9** — Promote daemon-backed stability coverage into routine CI gating (`#109`→`#220`, `#147`→`#209`, `#153`→`#219`) *(prerequisite: Step 4)*

--- a/designs/RFC-012-ci-cd-pipeline.md
+++ b/designs/RFC-012-ci-cd-pipeline.md
@@ -267,10 +267,10 @@ quality pipeline simple and fast. It will run on a schedule (nightly) rather tha
 
 - [ ] **W1** — Add `[package.metadata.deb]` to `Cargo.toml` for `cargo-deb`
 - [ ] **W2** — Add `[package.metadata.generate-rpm]` to `Cargo.toml` for `cargo-generate-rpm`
-- [ ] **W3** — Create `.github/workflows/quality.yml` — fmt, clippy, test, manifest validation
-- [ ] **W4** — Create `.github/workflows/release.yml` — scaffold with build-flatpak, build-deb, build-rpm, github-release, copr-submit jobs
-- [ ] **W5** — Set `COPR_API_TOKEN` as a repository secret
-- [ ] **W6** — Validate Flatpak runtime caching on first release run; tune cache key
-- [ ] **W7** — Add nightly `ui-tests.yml` job for AT-SPI2 suite once weston headless setup is worked out
+- [x] **W3** — Create `.github/workflows/quality.yml` — fmt, clippy, test, manifest validation
+- [x] **W4** — Create `.github/workflows/release.yml` — scaffold with build-flatpak, build-deb, build-rpm, github-release, copr-submit jobs
+- [x] **W5** — Set `COPR_API_TOKEN` as a repository secret
+- [x] **W6** — Validate Flatpak runtime caching on first release run; tune cache key
+- [x] **W7** — AT-SPI behavioral UI tests running in CI on every PR via Weston headless compositor
 
 ---

--- a/designs/RFC-013-persistent-host-sessions.md
+++ b/designs/RFC-013-persistent-host-sessions.md
@@ -282,28 +282,28 @@ where replayable context is useful.
 
 ## Development Plan
 
-1. **Terminology and doc cleanup**
-   Align product docs on `Workspace`, `Runtime`, `Endpoint`, `Policy`, and the no-fallback rule.
-2. **Endpoint connection manager**
-   Replace synchronous bridge calls with an endpoint-scoped async manager and a pure connection
-   state machine.
-3. **Workspace/runtime binding model**
-   Persist stable ids and a binding map so restore and reconcile do not depend on layout position.
-4. **Homogeneous workspace policy**
-   Enforce one endpoint and one runtime policy per workspace while allowing mixed workspaces in the
-   same window.
-5. **Explicit connection UX**
-   Add `Connecting`, `Reconnecting`, `Blocked`, and `Recovered` UI states with one control surface
-   per workspace in the tab/sidebar row.
-6. **Shared terminal abstraction**
-   Make search, zoom, copy, paste, cwd/title tracking, and notifications operate through one
-   terminal abstraction for all managed workspaces.
-7. **Authoritative workspace lifecycle**
-   Make `Close Workspace` destructive and final, keep attach explicit, and demote or remove
-   advanced daemon lifecycle actions from the normal close flow.
-8. **Test strategy**
-   Push most workflow logic into pure reducer/state-machine tests; keep GTK tests for wiring and
-   widget contracts only.
+1. **Terminology and doc cleanup** ✅
+   Product docs aligned on `Workspace`, `Runtime`, `Endpoint`, `Policy`, and the no-fallback rule.
+2. **Endpoint connection manager** — partially done
+   `runtime.rs` holds pure connection-state logic; `workspace_state.rs` owns managed-workspace
+   transitions. Full async manager extraction remains.
+3. **Workspace/runtime binding model** ✅
+   Stable ids and binding map persist; restore and reconcile do not depend on layout position.
+4. **Homogeneous workspace policy** ✅
+   One endpoint and one runtime policy per workspace enforced.
+5. **Explicit connection UX** ✅
+   `Connecting`, `Reconnecting`, `Blocked`, and `Recovered` UI states with connection icon in
+   sidebar prefix and state-specific icons/colors.
+6. **Shared terminal abstraction** ✅
+   `terminal/handle.rs` provides unified search, zoom, copy, paste, cwd/title tracking for both
+   direct and managed terminals.
+7. **Authoritative workspace lifecycle** ✅
+   `Close Workspace` is destructive and final (#192). Attach is explicit (#194). Advanced daemon
+   lifecycle actions removed from normal close flow (#195).
+8. **Test strategy** — partially done
+   Pure state tests in `runtime.rs` and `workspace_state.rs`. Runtime behavior gate enforces
+   coverage on every PR. GTK integration tests cover wiring and widget contracts. Deeper
+   client+daemon end-to-end coverage remains a gap.
 
 ---
 
@@ -324,12 +324,16 @@ implementation:
 
 ## Backlog
 
-1. `#191` — Simplify managed workspace lifecycle UX: close means gone, attach is explicit, tabs own reconnect state
-2. `#192` — Make `Close Workspace` destructive for managed runtimes and suppress inventory resurrection
-3. `#194` — Add explicit `Attach to Existing Runtime` flow and stop implicit attach during `New Workspace`
-4. `#195` — Remove terminate/detach from the normal managed workspace close flow
-5. `#196` — Move managed reconnect and connection actions from panes to workspace tabs
-6. `#193` — Add regression coverage for managed workspace close, attach, and reconnect UX
+All original backlog items have been completed:
+
+1. ~~`#191` — Simplify managed workspace lifecycle UX~~ ✅
+2. ~~`#192` — Make `Close Workspace` destructive for managed runtimes~~ ✅
+3. ~~`#194` — Add explicit `Attach to Existing Runtime` flow~~ ✅
+4. ~~`#195` — Remove terminate/detach from normal close flow~~ ✅
+5. ~~`#196` — Move managed reconnect/connection actions from panes to workspace tabs~~ ✅
+6. ~~`#193` — Add regression coverage for managed workspace close, attach, and reconnect UX~~ ✅
+
+Remaining work tracked in RFC-010 (Steps 1, 2, 4) and test issues #318, #319.
 
 ---
 


### PR DESCRIPTION
Docs-only update bringing 6 RFCs in line with the actual codebase.

### Changes

| RFC | Update |
|-----|--------|
| RFC-002 (Adwaita) | SessionRow widget tree updated for accent bar + connection icon prefix. All dev items done. Q1 resolved. |
| RFC-003 (Testing) | AT-SPI CI marked done (runs on every PR). GAP4 removed. |
| RFC-007 (Recovery) | Status updated: L3–L4 superseded by RFC-013. |
| RFC-010 (Refactor) | Step 6 (window module split) marked done. |
| RFC-012 (CI/CD) | W3–W7 marked done. |
| RFC-013 (Daemon) | 6/8 dev plan items done. All 6 backlog issues closed. |

No code changes.