### PR TITLE
fix(sidebar): consistent icons, titles, and subtitles across all workspace types

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -399,33 +399,59 @@ pub const fn connection_icon(
     ConnectionIcon { icon_name, css_class, tooltip }
 }
 
+/// Build a structured subtitle for a workspace row.
+///
+/// Format: `[connection ·] [user@host ·] leaf-path`
+/// - For remote managed: `host · leaf-path`
+/// - For local managed: `leaf-path`
+/// - For direct: `user@host · leaf-path` or just `leaf-path`
 #[must_use]
 pub fn workspace_connection_summary(
     endpoint: &RuntimeEndpoint,
     active_pane_info: Option<&str>,
 ) -> String {
+    let pane_part = active_pane_info.filter(|s| !s.is_empty()).unwrap_or("");
     match endpoint {
-        RuntimeEndpoint::Local => active_pane_info.unwrap_or("").to_string(),
-        RuntimeEndpoint::Remote { host } => match active_pane_info {
-            Some(info) if !info.is_empty() => format!("{host} · {info}"),
-            _ => host.clone(),
-        },
+        RuntimeEndpoint::Local => pane_part.to_string(),
+        RuntimeEndpoint::Remote { host } => {
+            if pane_part.is_empty() {
+                host.clone()
+            } else {
+                format!("{host} · {pane_part}")
+            }
+        }
     }
 }
 
-/// Extract a compact pane description from its title and working directory.
+/// Extract a compact pane description for the sidebar subtitle.
 ///
-/// Prefers the title when it carries useful information (i.e. not just the shell
-/// name). Falls back to the CWD basename.
+/// Prioritizes the CWD leaf folder. Only falls back to the VTE title when
+/// no CWD is available and the title carries useful information (not a
+/// generic shell name or "Terminal (persistent)" noise).
 #[must_use]
 pub fn pane_description(title: Option<&str>, cwd: Option<&str>) -> Option<String> {
-    if let Some(title) = title {
-        let trimmed = title.trim();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_string());
-        }
+    // Prefer CWD leaf — this is always meaningful.
+    if let Some(leaf) = cwd.and_then(|c| {
+        let name = c.rsplit('/').find(|s| !s.is_empty()).unwrap_or(c);
+        if name.is_empty() { None } else { Some(name.to_string()) }
+    }) {
+        return Some(leaf);
     }
-    cwd.map(|c| c.rsplit('/').find(|s| !s.is_empty()).unwrap_or(c).to_string())
+    // Fall back to title only if it's not generic noise.
+    if let Some(t) = title.map(str::trim).filter(|t| !t.is_empty() && !is_generic_title(t)) {
+        return Some(t.to_string());
+    }
+    None
+}
+
+/// Returns true for VTE titles that carry no useful information.
+fn is_generic_title(title: &str) -> bool {
+    let lower = title.to_lowercase();
+    lower.contains("terminal")
+        || lower == "bash"
+        || lower == "zsh"
+        || lower == "sh"
+        || lower == "fish"
 }
 
 /// Deterministic, non-destructive binding reconciliation result.
@@ -636,11 +662,23 @@ mod tests {
     }
 
     #[test]
-    fn pane_description_prefers_title_over_cwd() {
+    fn pane_description_prefers_cwd_over_title() {
         assert_eq!(
             pane_description(Some("vim main.rs"), Some("/home/user/project")),
-            Some("vim main.rs".into())
+            Some("project".into())
         );
+    }
+
+    #[test]
+    fn pane_description_falls_back_to_useful_title() {
+        assert_eq!(pane_description(Some("vim main.rs"), None), Some("vim main.rs".into()));
+    }
+
+    #[test]
+    fn pane_description_filters_generic_titles() {
+        assert_eq!(pane_description(Some("Terminal (persistent)"), None), None);
+        assert_eq!(pane_description(Some("bash"), None), None);
+        assert_eq!(pane_description(Some("zsh"), None), None);
     }
 
     #[test]

--- a/clients/rttx/src/session/state.rs
+++ b/clients/rttx/src/session/state.rs
@@ -312,6 +312,18 @@ pub fn auto_name_for_workspace(endpoint: &RuntimeEndpoint, cwd: Option<&str>) ->
     if name.is_empty() { None } else { Some(name.to_string()) }
 }
 
+/// Produce a workspace name, always returning a value.
+/// Uses `auto_name_for_workspace` when possible, otherwise falls back to
+/// "Workspace N" where N is the 1-based count.
+#[must_use]
+pub fn workspace_display_name(
+    endpoint: &RuntimeEndpoint,
+    cwd: Option<&str>,
+    count: usize,
+) -> String {
+    auto_name_for_workspace(endpoint, cwd).unwrap_or_else(|| format!("Workspace {count}"))
+}
+
 const fn default_left_sidebar_width() -> i32 {
     220
 }
@@ -907,6 +919,25 @@ mod module_boundary_tests {
     fn auto_name_home_directory() {
         let ep = RuntimeEndpoint::Local;
         assert_eq!(auto_name_for_workspace(&ep, Some("/home/user")), Some("user".into()));
+    }
+
+    #[test]
+    fn workspace_display_name_uses_cwd_basename() {
+        assert_eq!(
+            workspace_display_name(&RuntimeEndpoint::Local, Some("/home/user/projects"), 1),
+            "projects"
+        );
+    }
+
+    #[test]
+    fn workspace_display_name_falls_back_to_counter() {
+        assert_eq!(workspace_display_name(&RuntimeEndpoint::Local, None, 3), "Workspace 3");
+    }
+
+    #[test]
+    fn workspace_display_name_uses_hostname_for_remote() {
+        let ep = RuntimeEndpoint::Remote { host: "user@builder.example.com".into() };
+        assert_eq!(workspace_display_name(&ep, None, 1), "builder");
     }
 
     #[test]

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -474,6 +474,15 @@ impl Window {
     fn append_session_row(&self, session_state: &SessionState) {
         let imp = self.imp();
         let row = SessionRow::new(&session_state.uuid, &session_state.name);
+
+        let initial_status = if session_state.uses_managed_runtime() {
+            ConnectionStatus::Connecting
+        } else {
+            ConnectionStatus::Connected
+        };
+        let icon = connection_icon(&session_state.runtime.endpoint, &initial_status);
+        row.set_connection_icon(&icon);
+
         if session_state.uses_managed_runtime() {
             row.set_managed_actions_style();
             row.close_button().set_tooltip_text(Some("Workspace actions"));

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -115,8 +115,7 @@ impl Window {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
         let endpoint = RuntimeEndpoint::Remote { host: host.to_string() };
-        let name = crate::session::state::auto_name_for_workspace(&endpoint, None)
-            .unwrap_or_else(|| format!("Remote {count}"));
+        let name = crate::session::state::workspace_display_name(&endpoint, None, count);
         let mut session_state =
             SessionState::new_managed_remote(name, host, WorkspacePolicy::Persistent, None);
         session_state.color = self.next_session_color();
@@ -135,11 +134,11 @@ impl Window {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
         let initial_cwd = self.resolve_default_session_folder();
-        let name = crate::session::state::auto_name_for_workspace(
+        let name = crate::session::state::workspace_display_name(
             &RuntimeEndpoint::Local,
             initial_cwd.as_deref(),
-        )
-        .unwrap_or_else(|| format!("Workspace {count}"));
+            count,
+        );
         let mut session_state = SessionState::new_managed_local(name, policy, initial_cwd);
         session_state.color = self.next_session_color();
         imp.state.borrow_mut().sessions.push(session_state.clone());

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -330,11 +330,7 @@ impl Window {
                 let handle = self.terminal_handle(uuid)?;
                 pane_description(Some(&handle.title()), handle.current_directory().as_deref())
             });
-            if session.uses_managed_runtime() {
-                workspace_connection_summary(endpoint, pane_info.as_deref())
-            } else {
-                pane_info.unwrap_or_default()
-            }
+            workspace_connection_summary(endpoint, pane_info.as_deref())
         };
         let mut idx = 0;
         while let Some(row) = imp.sidebar_list.row_at_index(idx) {

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -838,6 +838,33 @@ fn pane_description_extracts_compact_label() {
     assert_eq!(pane_description(None, None), None);
 }
 
+/// Contract: pane_description filters generic VTE titles and prefers CWD.
+///
+/// Prevents 'Terminal (persistent)' and shell names from appearing in the
+/// sidebar subtitle. CWD leaf folder is always preferred when available.
+#[test]
+fn pane_description_subtitle_structure_regression() {
+    use rttx::runtime::{pane_description, workspace_connection_summary, RuntimeEndpoint};
+
+    // CWD leaf preferred over any title.
+    assert_eq!(
+        pane_description(Some("Terminal (persistent)"), Some("/home/user/rttx")),
+        Some("rttx".into())
+    );
+    // Generic titles filtered when no CWD.
+    assert_eq!(pane_description(Some("Terminal (persistent)"), None), None);
+    assert_eq!(pane_description(Some("fish"), None), None);
+    // Useful title kept when no CWD.
+    assert_eq!(pane_description(Some("htop"), None), Some("htop".into()));
+
+    // Local subtitle is just the pane info.
+    assert_eq!(workspace_connection_summary(&RuntimeEndpoint::Local, Some("rttx")), "rttx");
+    // Remote subtitle includes host.
+    let remote = RuntimeEndpoint::Remote { host: "dev-box".into() };
+    assert_eq!(workspace_connection_summary(&remote, Some("rttx")), "dev-box · rttx");
+    assert_eq!(workspace_connection_summary(&remote, None), "dev-box");
+}
+
 /// Contract: ConnectionPresentation contains only header_label and input_enabled.
 ///
 /// The banner fields were removed in #305. The pane header status label and

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -828,8 +828,13 @@ fn workspace_connection_summary_contains_no_status_text() {
 fn pane_description_extracts_compact_label() {
     use rttx::runtime::pane_description;
 
-    assert_eq!(pane_description(Some("vim"), Some("/home/user")), Some("vim".into()));
+    // CWD leaf is preferred over title.
+    assert_eq!(pane_description(Some("vim"), Some("/home/user")), Some("user".into()));
     assert_eq!(pane_description(None, Some("/home/user/project")), Some("project".into()));
+    // Title used only when no CWD and title is not generic.
+    assert_eq!(pane_description(Some("vim"), None), Some("vim".into()));
+    // Generic titles are filtered.
+    assert_eq!(pane_description(Some("bash"), None), None);
     assert_eq!(pane_description(None, None), None);
 }
 

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -844,7 +844,7 @@ fn pane_description_extracts_compact_label() {
 /// sidebar subtitle. CWD leaf folder is always preferred when available.
 #[test]
 fn pane_description_subtitle_structure_regression() {
-    use rttx::runtime::{pane_description, workspace_connection_summary, RuntimeEndpoint};
+    use rttx::runtime::{RuntimeEndpoint, pane_description, workspace_connection_summary};
 
     // CWD leaf preferred over any title.
     assert_eq!(


### PR DESCRIPTION
## What changed

Three fixes for sidebar workspace row inconsistencies:

### 1. Icons on ALL tabs (#304)
`append_session_row` now sets the connection icon immediately for every workspace — not just managed ones. Direct workspaces get `computer-symbolic`, remote get `network-server-symbolic`.

**Before:** Direct workspaces had no icon. Only managed workspaces got one via `set_workspace_connection_status`.

### 2. Consistent title generation (#307)
New `workspace_display_name()` function always returns a name. All creation paths (+ button, Ctrl+Shift+T, bookmark, remote dialog) use it. Eliminates the inconsistent 'Session N' / 'Workspace N' / 'Remote N' naming.

### 3. Structured subtitles (#331, #341)
- `pane_description` now prefers CWD leaf folder over VTE title
- Generic VTE titles like 'Terminal (persistent)', 'bash', 'zsh' are filtered out
- All workspace types (direct and managed) use `workspace_connection_summary` uniformly
- Format: `host · leaf-path` for remote, `leaf-path` for local

**Before:** Subtitles showed raw VTE titles like 'Terminal (persistent)' or inconsistent formats depending on creation path.

## Manual verification
Build and run `RTTX_DEV_MODE=1 cargo run -p rttx`. Create workspaces via:
- + button → should show icon + CWD-based name + leaf-path subtitle
- Ctrl+Shift+T → same
- Bookmark (local) → icon + bookmark name + leaf-path
- Bookmark (remote) → remote icon + hostname + host · leaf-path
- New Remote dialog → remote icon + short hostname + host · leaf-path

## Tests
- Updated `pane_description` unit tests for new CWD-first priority
- Added `pane_description_filters_generic_titles` test
- Added `workspace_display_name` tests (CWD basename, fallback counter, remote hostname)
- Updated `gtk_boundary_contracts::pane_description_extracts_compact_label`
- All pass: `cargo test --workspace`, clippy, quality tests

Fixes #304, #307, #331, #341