### PR TITLE
fix(sidebar): show full CWD path and running command in subtitle

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -401,10 +401,8 @@ pub const fn connection_icon(
 
 /// Build a structured subtitle for a workspace row.
 ///
-/// Format: `[connection ·] [user@host ·] leaf-path`
-/// - For remote managed: `host · leaf-path`
-/// - For local managed: `leaf-path`
-/// - For direct: `user@host · leaf-path` or just `leaf-path`
+/// - Local: pane info (full path, optional command)
+/// - Remote: `host · pane-info`
 #[must_use]
 pub fn workspace_connection_summary(
     endpoint: &RuntimeEndpoint,
@@ -423,25 +421,38 @@ pub fn workspace_connection_summary(
     }
 }
 
-/// Extract a compact pane description for the sidebar subtitle.
+/// Build a pane description for the sidebar subtitle.
 ///
-/// Prioritizes the CWD leaf folder. Only falls back to the VTE title when
-/// no CWD is available and the title carries useful information (not a
-/// generic shell name or "Terminal (persistent)" noise).
+/// Shows the full CWD path (tilde-collapsed). When the VTE title carries
+/// useful info (a running command, not a generic shell name), it is
+/// appended after a newline so both path and command are visible.
 #[must_use]
 pub fn pane_description(title: Option<&str>, cwd: Option<&str>) -> Option<String> {
-    // Prefer CWD leaf — this is always meaningful.
-    if let Some(leaf) = cwd.and_then(|c| {
-        let name = c.rsplit('/').find(|s| !s.is_empty()).unwrap_or(c);
-        if name.is_empty() { None } else { Some(name.to_string()) }
-    }) {
-        return Some(leaf);
+    let path = cwd.map(|c| collapse_home(c.trim()));
+    let useful_title = title.map(str::trim).filter(|t| !t.is_empty() && !is_generic_title(t));
+
+    match (path, useful_title) {
+        (Some(p), Some(t)) if !p.is_empty() => Some(format!("{p}\n{t}")),
+        (Some(p), _) if !p.is_empty() => Some(p),
+        (_, Some(t)) => Some(t.to_string()),
+        _ => None,
     }
-    // Fall back to title only if it's not generic noise.
-    if let Some(t) = title.map(str::trim).filter(|t| !t.is_empty() && !is_generic_title(t)) {
-        return Some(t.to_string());
+}
+
+/// Collapse `/home/<user>/…` to `~/…`.
+fn collapse_home(path: &str) -> String {
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = home.to_string_lossy();
+        if let Some(rest) = path.strip_prefix(home.as_ref()) {
+            if rest.is_empty() {
+                return "~".into();
+            }
+            if rest.starts_with('/') {
+                return format!("~{rest}");
+            }
+        }
     }
-    None
+    path.to_string()
 }
 
 /// Returns true for VTE titles that carry no useful information.
@@ -662,11 +673,16 @@ mod tests {
     }
 
     #[test]
-    fn pane_description_prefers_cwd_over_title() {
-        assert_eq!(
-            pane_description(Some("vim main.rs"), Some("/home/user/project")),
-            Some("project".into())
-        );
+    fn pane_description_shows_full_path_and_command() {
+        // Full path + useful title → both on separate lines.
+        let desc = pane_description(Some("vim main.rs"), Some("/tmp/project"));
+        assert_eq!(desc, Some("/tmp/project\nvim main.rs".into()));
+    }
+
+    #[test]
+    fn pane_description_path_only_when_title_is_generic() {
+        let desc = pane_description(Some("bash"), Some("/tmp/project"));
+        assert_eq!(desc, Some("/tmp/project".into()));
     }
 
     #[test]
@@ -682,9 +698,8 @@ mod tests {
     }
 
     #[test]
-    fn pane_description_falls_back_to_cwd_basename() {
-        assert_eq!(pane_description(None, Some("/home/user/project")), Some("project".into()));
-        assert_eq!(pane_description(None, Some("/home/user/project/")), Some("project".into()));
+    fn pane_description_shows_full_cwd() {
+        assert_eq!(pane_description(None, Some("/tmp/project")), Some("/tmp/project".into()));
         assert_eq!(pane_description(None, Some("/")), Some("/".into()));
     }
 

--- a/clients/rttx/src/sidebar.rs
+++ b/clients/rttx/src/sidebar.rs
@@ -81,7 +81,7 @@ mod imp {
             obj.add_prefix(&self.position_label);
             obj.add_suffix(&self.close_button);
 
-            obj.set_subtitle_lines(1);
+            obj.set_subtitle_lines(2);
             obj.add_css_class("session-row");
         }
     }
@@ -498,6 +498,6 @@ mod tests {
         require_display!();
         let row = SessionRow::new("s1", "Session");
         assert!(row.has_css_class("session-row"));
-        assert_eq!(row.subtitle_lines(), 1);
+        assert_eq!(row.subtitle_lines(), 2);
     }
 }

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -828,9 +828,11 @@ fn workspace_connection_summary_contains_no_status_text() {
 fn pane_description_extracts_compact_label() {
     use rttx::runtime::pane_description;
 
-    // CWD leaf is preferred over title.
-    assert_eq!(pane_description(Some("vim"), Some("/home/user")), Some("user".into()));
-    assert_eq!(pane_description(None, Some("/home/user/project")), Some("project".into()));
+    // Full CWD + useful title → both shown.
+    assert!(pane_description(Some("vim"), Some("/tmp/work")).unwrap().contains("/tmp/work"));
+    assert!(pane_description(Some("vim"), Some("/tmp/work")).unwrap().contains("vim"));
+    // Full CWD shown, generic title filtered.
+    assert_eq!(pane_description(Some("bash"), Some("/tmp/work")), Some("/tmp/work".into()));
     // Title used only when no CWD and title is not generic.
     assert_eq!(pane_description(Some("vim"), None), Some("vim".into()));
     // Generic titles are filtered.
@@ -838,18 +840,18 @@ fn pane_description_extracts_compact_label() {
     assert_eq!(pane_description(None, None), None);
 }
 
-/// Contract: pane_description filters generic VTE titles and prefers CWD.
+/// Contract: pane_description filters generic VTE titles and shows full path.
 ///
 /// Prevents 'Terminal (persistent)' and shell names from appearing in the
-/// sidebar subtitle. CWD leaf folder is always preferred when available.
+/// sidebar subtitle. Full CWD path is always shown when available.
 #[test]
 fn pane_description_subtitle_structure_regression() {
     use rttx::runtime::{RuntimeEndpoint, pane_description, workspace_connection_summary};
 
-    // CWD leaf preferred over any title.
+    // Full path shown, generic title filtered.
     assert_eq!(
-        pane_description(Some("Terminal (persistent)"), Some("/home/user/rttx")),
-        Some("rttx".into())
+        pane_description(Some("Terminal (persistent)"), Some("/tmp/rttx")),
+        Some("/tmp/rttx".into())
     );
     // Generic titles filtered when no CWD.
     assert_eq!(pane_description(Some("Terminal (persistent)"), None), None);
@@ -858,10 +860,13 @@ fn pane_description_subtitle_structure_regression() {
     assert_eq!(pane_description(Some("htop"), None), Some("htop".into()));
 
     // Local subtitle is just the pane info.
-    assert_eq!(workspace_connection_summary(&RuntimeEndpoint::Local, Some("rttx")), "rttx");
+    assert_eq!(
+        workspace_connection_summary(&RuntimeEndpoint::Local, Some("/tmp/rttx")),
+        "/tmp/rttx"
+    );
     // Remote subtitle includes host.
     let remote = RuntimeEndpoint::Remote { host: "dev-box".into() };
-    assert_eq!(workspace_connection_summary(&remote, Some("rttx")), "dev-box · rttx");
+    assert_eq!(workspace_connection_summary(&remote, Some("/tmp/rttx")), "dev-box · /tmp/rttx");
     assert_eq!(workspace_connection_summary(&remote, None), "dev-box");
 }
 

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -870,6 +870,25 @@ fn pane_description_subtitle_structure_regression() {
     assert_eq!(workspace_connection_summary(&remote, None), "dev-box");
 }
 
+/// Contract: pane_description shows full path with running command on second line.
+///
+/// Prevents regression to leaf-only or title-only subtitle.
+#[test]
+fn pane_description_full_path_and_command_regression() {
+    use rttx::runtime::pane_description;
+
+    // Full path + command → two lines.
+    let desc = pane_description(Some("htop"), Some("/tmp/work")).unwrap();
+    assert!(desc.contains("/tmp/work"), "must show full path");
+    assert!(desc.contains("htop"), "must show running command");
+    assert!(desc.contains('\n'), "path and command on separate lines");
+
+    // Generic title → path only, no second line.
+    let desc = pane_description(Some("bash"), Some("/tmp/work")).unwrap();
+    assert!(!desc.contains('\n'), "generic title should not add a line");
+    assert_eq!(desc, "/tmp/work");
+}
+
 /// Contract: ConnectionPresentation contains only header_label and input_enabled.
 ///
 /// The banner fields were removed in #305. The pane header status label and


### PR DESCRIPTION
## What changed

Subtitle now shows the full CWD path (tilde-collapsed) and the running command when useful, instead of just the leaf folder name.

### Before
```
rttx          (just leaf folder, no path context)
```

### After
```
~/projects/rttx                    (full path, idle)
~/projects/rttx                    (full path + command)
vim main.rs
builder · ~/src/rttx              (remote + full path)
```

### Details
- `pane_description` shows full CWD (tilde-collapsed via `collapse_home`)
- When VTE title is a useful command (not bash/zsh/fish/Terminal), it appears on a second line
- `SessionRow.subtitle_lines` increased from 1 to 2
- Generic VTE titles still filtered

## Tests
- Updated unit tests for full-path behavior
- Updated `gtk_boundary_contracts` integration tests
- All pass: `cargo test --workspace`, clippy, quality

## Manual verification
`RTTX_DEV_MODE=1 cargo run -p rttx`, open workspaces, run commands — subtitle shows full path and running command on two lines.

Refs #331