### PR TITLE
fix(sidebar): show only CWD path in subtitle, never VTE title

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -423,20 +423,19 @@ pub fn workspace_connection_summary(
 
 /// Build a pane description for the sidebar subtitle.
 ///
-/// Shows the full CWD path (tilde-collapsed). When the VTE title carries
-/// useful info (a running command, not a generic shell name), it is
-/// appended after a newline so both path and command are visible.
+/// Shows the full CWD path (tilde-collapsed). When no CWD is available,
+/// falls back to the VTE title if it carries useful info (not a generic
+/// shell name or prompt-set `user@host:path`).
 #[must_use]
 pub fn pane_description(title: Option<&str>, cwd: Option<&str>) -> Option<String> {
     let path = cwd.map(|c| collapse_home(c.trim()));
-    let useful_title = title.map(str::trim).filter(|t| !t.is_empty() && !is_generic_title(t));
-
-    match (path, useful_title) {
-        (Some(p), Some(t)) if !p.is_empty() => Some(format!("{p}\n{t}")),
-        (Some(p), _) if !p.is_empty() => Some(p),
-        (_, Some(t)) => Some(t.to_string()),
-        _ => None,
+    if let Some(ref p) = path
+        && !p.is_empty()
+    {
+        return Some(p.clone());
     }
+    // No CWD — fall back to title if useful.
+    title.map(str::trim).filter(|t| !t.is_empty() && !is_generic_title(t)).map(String::from)
 }
 
 /// Collapse `/home/<user>/…` to `~/…`.
@@ -674,15 +673,22 @@ mod tests {
 
     #[test]
     fn pane_description_shows_full_path_and_command() {
-        // Full path + useful title → both on separate lines.
+        // CWD always wins — title is ignored when CWD is available.
         let desc = pane_description(Some("vim main.rs"), Some("/tmp/project"));
-        assert_eq!(desc, Some("/tmp/project\nvim main.rs".into()));
+        assert_eq!(desc, Some("/tmp/project".into()));
     }
 
     #[test]
     fn pane_description_path_only_when_title_is_generic() {
         let desc = pane_description(Some("bash"), Some("/tmp/project"));
         assert_eq!(desc, Some("/tmp/project".into()));
+    }
+
+    #[test]
+    fn pane_description_prompt_title_ignored_when_cwd_present() {
+        // Shell prompt sets VTE title to user@host:path — always redundant.
+        let desc = pane_description(Some("yalovyyi@host:~/work"), Some("/home/yalovyyi/work"));
+        assert!(!desc.as_deref().unwrap_or("").contains('@'));
     }
 
     #[test]

--- a/clients/rttx/src/sidebar.rs
+++ b/clients/rttx/src/sidebar.rs
@@ -81,7 +81,7 @@ mod imp {
             obj.add_prefix(&self.position_label);
             obj.add_suffix(&self.close_button);
 
-            obj.set_subtitle_lines(2);
+            obj.set_subtitle_lines(1);
             obj.add_css_class("session-row");
         }
     }

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -887,6 +887,21 @@ fn pane_description_full_path_and_command_regression() {
 }
 
 /// Contract: ConnectionPresentation contains only header_label and input_enabled.
+/// Contract: prompt-set VTE titles never appear in subtitle when CWD is available.
+#[test]
+fn pane_description_never_shows_prompt_title_with_cwd() {
+    use rttx::runtime::pane_description;
+
+    // user@host:path prompt title — always redundant with CWD.
+    assert_eq!(
+        pane_description(Some("user@host:~/work"), Some("/home/user/work")),
+        Some("/home/user/work".into())
+    );
+    // Even a "useful" title is ignored when CWD is present.
+    assert_eq!(pane_description(Some("vim"), Some("/tmp/project")), Some("/tmp/project".into()));
+}
+
+/// Contract: ConnectionPresentation contains only header_label and input_enabled.
 ///
 /// The banner fields were removed in #305. The pane header status label and
 /// input gating are the only remaining presentation concerns.

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -828,10 +828,9 @@ fn workspace_connection_summary_contains_no_status_text() {
 fn pane_description_extracts_compact_label() {
     use rttx::runtime::pane_description;
 
-    // Full CWD + useful title → both shown.
-    assert!(pane_description(Some("vim"), Some("/tmp/work")).unwrap().contains("/tmp/work"));
-    assert!(pane_description(Some("vim"), Some("/tmp/work")).unwrap().contains("vim"));
-    // Full CWD shown, generic title filtered.
+    // CWD always wins — title ignored when CWD present.
+    assert_eq!(pane_description(Some("vim"), Some("/tmp/work")), Some("/tmp/work".into()));
+    // Generic title filtered.
     assert_eq!(pane_description(Some("bash"), Some("/tmp/work")), Some("/tmp/work".into()));
     // Title used only when no CWD and title is not generic.
     assert_eq!(pane_description(Some("vim"), None), Some("vim".into()));
@@ -870,22 +869,20 @@ fn pane_description_subtitle_structure_regression() {
     assert_eq!(workspace_connection_summary(&remote, None), "dev-box");
 }
 
-/// Contract: pane_description shows full path with running command on second line.
+/// Contract: pane_description shows CWD only, title never leaks into subtitle.
 ///
-/// Prevents regression to leaf-only or title-only subtitle.
+/// Prevents prompt-set VTE titles (user@host:path) from appearing.
 #[test]
 fn pane_description_full_path_and_command_regression() {
     use rttx::runtime::pane_description;
 
-    // Full path + command → two lines.
+    // CWD present → only path shown, title ignored entirely.
     let desc = pane_description(Some("htop"), Some("/tmp/work")).unwrap();
-    assert!(desc.contains("/tmp/work"), "must show full path");
-    assert!(desc.contains("htop"), "must show running command");
-    assert!(desc.contains('\n'), "path and command on separate lines");
+    assert_eq!(desc, "/tmp/work");
+    assert!(!desc.contains('\n'), "no multi-line subtitle");
 
-    // Generic title → path only, no second line.
-    let desc = pane_description(Some("bash"), Some("/tmp/work")).unwrap();
-    assert!(!desc.contains('\n'), "generic title should not add a line");
+    // Prompt-set title ignored when CWD present.
+    let desc = pane_description(Some("user@host:~/work"), Some("/tmp/work")).unwrap();
     assert_eq!(desc, "/tmp/work");
 }
 


### PR DESCRIPTION
## Problem

The VTE title (set by shell prompt via OSC 0/2) was leaking into the sidebar subtitle, producing garbage like:

```
~/Workspace
yalovyyi@u5fe00e26b31e5:
~/Workspace
```

The shell prompt sets the VTE title to `user@host:path`, which is always redundant when we already have the CWD from OSC 7.

## Fix

`pane_description` now shows only the tilde-collapsed CWD path. The VTE title is completely ignored when CWD is available. It's only used as a last-resort fallback when the shell doesn't support OSC 7 (no CWD reported), and even then generic titles (bash, zsh, Terminal) are filtered.

`subtitle_lines` reverted from 2 to 1.

## Result
```
~/Workspace/other/rttx     (clean, single line)
builder · ~/src             (remote, clean)
```

## Tests
- Updated unit tests and integration tests
- All pass: cargo test, clippy, quality

Fixes #331