### PR TITLE
fix(sidebar): icon shape encodes type, color encodes state

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -369,32 +369,44 @@ pub struct ConnectionIcon {
     pub tooltip: &'static str,
 }
 
-/// Returns the connection icon for a workspace row. Always returns an icon.
+/// Returns the connection icon for a workspace row.
+///
+/// Shape encodes workspace type (constant for the lifetime of the row):
+/// - Local managed: `computer-symbolic`
+/// - Remote managed: `network-server-symbolic`
+/// - Direct (no daemon): `utilities-terminal-symbolic`
+///
+/// Color encodes connection state (changes dynamically):
+/// - `dim-label`: normal / connecting
+/// - `accent`: connected (remote) or recovered
+/// - `warning`: disconnected
+/// - `error`: blocked
 #[must_use]
 pub const fn connection_icon(
     endpoint: &RuntimeEndpoint,
     status: &ConnectionStatus,
+    managed: bool,
 ) -> ConnectionIcon {
-    let (icon_name, css_class, tooltip) = match status {
-        ConnectionStatus::Connected => {
-            if matches!(endpoint, RuntimeEndpoint::Local) {
-                ("computer-symbolic", "dim-label", "Local workspace")
-            } else {
-                ("network-server-symbolic", "accent", "Connected to remote host")
-            }
+    let icon_name = if managed {
+        match endpoint {
+            RuntimeEndpoint::Local => "computer-symbolic",
+            RuntimeEndpoint::Remote { .. } => "network-server-symbolic",
         }
-        ConnectionStatus::Recovered => ("emblem-ok-symbolic", "accent", "Connection recovered"),
-        ConnectionStatus::Disconnected => {
-            ("network-offline-symbolic", "warning", "Disconnected from runtime")
-        }
-        ConnectionStatus::Blocked(_) => ("network-offline-symbolic", "error", "Connection blocked"),
-        _ => {
-            if matches!(endpoint, RuntimeEndpoint::Local) {
-                ("content-loading-symbolic", "dim-label", "Connecting to local runtime")
-            } else {
-                ("network-server-symbolic", "dim-label", "Connecting to remote host")
-            }
-        }
+    } else {
+        "utilities-terminal-symbolic"
+    };
+    let (css_class, tooltip) = match status {
+        ConnectionStatus::Connected => match endpoint {
+            RuntimeEndpoint::Local => ("dim-label", "Local workspace"),
+            RuntimeEndpoint::Remote { .. } => ("accent", "Connected to remote host"),
+        },
+        ConnectionStatus::Recovered => ("accent", "Connection recovered"),
+        ConnectionStatus::Disconnected => ("warning", "Disconnected from runtime"),
+        ConnectionStatus::Blocked(_) => ("error", "Connection blocked"),
+        _ => match endpoint {
+            RuntimeEndpoint::Local => ("dim-label", "Connecting to local runtime"),
+            RuntimeEndpoint::Remote { .. } => ("dim-label", "Connecting to remote host"),
+        },
     };
     ConnectionIcon { icon_name, css_class, tooltip }
 }
@@ -717,73 +729,100 @@ mod tests {
 
     #[test]
     fn connection_icon_computer_for_local_connected() {
-        let icon = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
+        let icon = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, true);
         assert_eq!(icon.icon_name, "computer-symbolic");
         assert_eq!(icon.css_class, "dim-label");
     }
 
     #[test]
-    fn connection_icon_shown_for_local_non_connected() {
+    fn connection_icon_shape_constant_for_local_managed() {
         let ep = RuntimeEndpoint::Local;
-        let icon = connection_icon(&ep, &ConnectionStatus::Disconnected);
-        assert_eq!(icon.css_class, "warning");
-
-        let icon = connection_icon(&ep, &ConnectionStatus::Recovered);
-        assert_eq!(icon.css_class, "accent");
-
-        let icon =
-            connection_icon(&ep, &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable));
-        assert_eq!(icon.css_class, "error");
-
-        let icon = connection_icon(&ep, &ConnectionStatus::Connecting);
-        assert_eq!(icon.css_class, "dim-label");
-    }
-
-    #[test]
-    fn connection_icon_accent_for_remote_connected() {
-        let ep = RuntimeEndpoint::Remote { host: "h".into() };
-        let icon = connection_icon(&ep, &ConnectionStatus::Connected);
-        assert_eq!(icon.icon_name, "network-server-symbolic");
-        assert_eq!(icon.css_class, "accent");
-    }
-
-    #[test]
-    fn connection_icon_dim_for_remote_connecting() {
-        let ep = RuntimeEndpoint::Remote { host: "h".into() };
         for status in [
-            ConnectionStatus::Starting,
+            ConnectionStatus::Connected,
+            ConnectionStatus::Disconnected,
+            ConnectionStatus::Recovered,
+            ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable),
             ConnectionStatus::Connecting,
-            ConnectionStatus::Reconnecting { attempt: 1, retry_in_secs: 5 },
         ] {
-            let icon = connection_icon(&ep, &status);
-            assert_eq!(icon.icon_name, "network-server-symbolic");
-            assert_eq!(icon.css_class, "dim-label");
+            let icon = connection_icon(&ep, &status, true);
+            assert_eq!(icon.icon_name, "computer-symbolic", "shape must not change with status");
         }
     }
 
     #[test]
-    fn connection_icon_warning_for_remote_disconnected() {
-        let ep = RuntimeEndpoint::Remote { host: "h".into() };
-        let icon = connection_icon(&ep, &ConnectionStatus::Disconnected);
-        assert_eq!(icon.icon_name, "network-offline-symbolic");
-        assert_eq!(icon.css_class, "warning");
+    fn connection_icon_color_for_local_managed() {
+        let ep = RuntimeEndpoint::Local;
+        assert_eq!(connection_icon(&ep, &ConnectionStatus::Connected, true).css_class, "dim-label");
+        assert_eq!(connection_icon(&ep, &ConnectionStatus::Recovered, true).css_class, "accent");
+        assert_eq!(
+            connection_icon(&ep, &ConnectionStatus::Disconnected, true).css_class,
+            "warning"
+        );
+        assert_eq!(
+            connection_icon(
+                &ep,
+                &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable),
+                true
+            )
+            .css_class,
+            "error"
+        );
+        assert_eq!(
+            connection_icon(&ep, &ConnectionStatus::Connecting, true).css_class,
+            "dim-label"
+        );
     }
 
     #[test]
-    fn connection_icon_error_for_remote_blocked() {
+    fn connection_icon_shape_constant_for_remote() {
         let ep = RuntimeEndpoint::Remote { host: "h".into() };
-        let icon =
-            connection_icon(&ep, &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied));
-        assert_eq!(icon.icon_name, "network-offline-symbolic");
-        assert_eq!(icon.css_class, "error");
+        for status in [
+            ConnectionStatus::Connected,
+            ConnectionStatus::Disconnected,
+            ConnectionStatus::Recovered,
+            ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
+            ConnectionStatus::Connecting,
+            ConnectionStatus::Starting,
+            ConnectionStatus::Reconnecting { attempt: 1, retry_in_secs: 5 },
+        ] {
+            let icon = connection_icon(&ep, &status, true);
+            assert_eq!(
+                icon.icon_name, "network-server-symbolic",
+                "shape must not change with status"
+            );
+        }
     }
 
     #[test]
-    fn connection_icon_accent_for_remote_recovered() {
+    fn connection_icon_color_for_remote() {
         let ep = RuntimeEndpoint::Remote { host: "h".into() };
-        let icon = connection_icon(&ep, &ConnectionStatus::Recovered);
-        assert_eq!(icon.icon_name, "emblem-ok-symbolic");
-        assert_eq!(icon.css_class, "accent");
+        assert_eq!(connection_icon(&ep, &ConnectionStatus::Connected, true).css_class, "accent");
+        assert_eq!(connection_icon(&ep, &ConnectionStatus::Recovered, true).css_class, "accent");
+        assert_eq!(
+            connection_icon(&ep, &ConnectionStatus::Disconnected, true).css_class,
+            "warning"
+        );
+        assert_eq!(
+            connection_icon(
+                &ep,
+                &ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied),
+                true
+            )
+            .css_class,
+            "error"
+        );
+        assert_eq!(
+            connection_icon(&ep, &ConnectionStatus::Connecting, true).css_class,
+            "dim-label"
+        );
+    }
+
+    #[test]
+    fn connection_icon_direct_uses_terminal_icon() {
+        let ep = RuntimeEndpoint::Local;
+        let icon = connection_icon(&ep, &ConnectionStatus::Connected, false);
+        assert_eq!(icon.icon_name, "utilities-terminal-symbolic");
+        assert_eq!(icon.css_class, "dim-label");
     }
 
     #[test]
@@ -791,19 +830,19 @@ mod tests {
         let remote = RuntimeEndpoint::Remote { host: "h".into() };
         let local = RuntimeEndpoint::Local;
 
-        let connected = connection_icon(&remote, &ConnectionStatus::Connected);
+        let connected = connection_icon(&remote, &ConnectionStatus::Connected, true);
         assert_eq!(connected.tooltip, "Connected to remote host");
 
-        let disconnected = connection_icon(&remote, &ConnectionStatus::Disconnected);
+        let disconnected = connection_icon(&remote, &ConnectionStatus::Disconnected, true);
         assert_eq!(disconnected.tooltip, "Disconnected from runtime");
 
-        let connecting_local = connection_icon(&local, &ConnectionStatus::Connecting);
+        let connecting_local = connection_icon(&local, &ConnectionStatus::Connecting, true);
         assert_eq!(connecting_local.tooltip, "Connecting to local runtime");
 
-        let connecting_remote = connection_icon(&remote, &ConnectionStatus::Connecting);
+        let connecting_remote = connection_icon(&remote, &ConnectionStatus::Connecting, true);
         assert_eq!(connecting_remote.tooltip, "Connecting to remote host");
 
-        let local_connected = connection_icon(&local, &ConnectionStatus::Connected);
+        let local_connected = connection_icon(&local, &ConnectionStatus::Connected, true);
         assert_eq!(local_connected.tooltip, "Local workspace");
     }
 

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -847,6 +847,24 @@ mod tests {
     }
 
     #[test]
+    fn connection_icon_shape_never_changes_with_status_regression() {
+        let local = RuntimeEndpoint::Local;
+        let remote = RuntimeEndpoint::Remote { host: "h".into() };
+        let statuses = [
+            ConnectionStatus::Connected,
+            ConnectionStatus::Disconnected,
+            ConnectionStatus::Recovered,
+            ConnectionStatus::Connecting,
+            ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable),
+        ];
+        for s in &statuses {
+            assert_eq!(connection_icon(&local, s, true).icon_name, "computer-symbolic");
+            assert_eq!(connection_icon(&remote, s, true).icon_name, "network-server-symbolic");
+            assert_eq!(connection_icon(&local, s, false).icon_name, "utilities-terminal-symbolic");
+        }
+    }
+
+    #[test]
     fn workspace_connection_summary_local_returns_empty_without_pane_info() {
         assert!(workspace_connection_summary(&RuntimeEndpoint::Local, None).is_empty());
     }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -480,7 +480,11 @@ impl Window {
         } else {
             ConnectionStatus::Connected
         };
-        let icon = connection_icon(&session_state.runtime.endpoint, &initial_status);
+        let icon = connection_icon(
+            &session_state.runtime.endpoint,
+            &initial_status,
+            session_state.uses_managed_runtime(),
+        );
         row.set_connection_icon(&icon);
 
         if session_state.uses_managed_runtime() {

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -531,7 +531,8 @@ impl Window {
         else {
             return;
         };
-        let icon = connection_icon(&session.runtime.endpoint, status);
+        let icon =
+            connection_icon(&session.runtime.endpoint, status, session.uses_managed_runtime());
         drop(state);
 
         let list = &self.imp().sidebar_list;

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -740,20 +740,34 @@ fn workspace_connection_summary_shows_endpoint_and_pane_info() {
 fn connection_icon_always_returns_icon() {
     use rttx::runtime::{ConnectionStatus, RuntimeEndpoint, connection_icon};
 
-    let local_connected = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected);
+    let local_connected =
+        connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, true);
     assert_eq!(local_connected.icon_name, "computer-symbolic");
 
     let local_disconnected =
-        connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Disconnected);
+        connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Disconnected, true);
     assert_eq!(local_disconnected.css_class, "warning");
+    // Shape stays constant regardless of state.
+    assert_eq!(local_disconnected.icon_name, "computer-symbolic");
 
     let remote = RuntimeEndpoint::Remote { host: "h".into() };
-    let connected = connection_icon(&remote, &ConnectionStatus::Connected);
+    let connected = connection_icon(&remote, &ConnectionStatus::Connected, true);
     assert_eq!(connected.css_class, "accent");
+    assert_eq!(connected.icon_name, "network-server-symbolic");
 
-    let disconnected = connection_icon(&remote, &ConnectionStatus::Disconnected);
+    let disconnected = connection_icon(&remote, &ConnectionStatus::Disconnected, true);
     assert_eq!(disconnected.css_class, "warning");
-    assert_ne!(connected.icon_name, disconnected.icon_name);
+    // Shape stays constant — same icon, different color.
+    assert_eq!(disconnected.icon_name, "network-server-symbolic");
+}
+
+/// Contract: direct (no daemon) workspaces use terminal icon.
+#[test]
+fn connection_icon_direct_uses_terminal_symbolic() {
+    use rttx::runtime::{ConnectionStatus, RuntimeEndpoint, connection_icon};
+
+    let icon = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, false);
+    assert_eq!(icon.icon_name, "utilities-terminal-symbolic");
 }
 
 /// Contract: every connection icon carries a non-empty tooltip.
@@ -776,7 +790,7 @@ fn connection_icon_always_has_tooltip() {
         (&remote, ConnectionStatus::Recovered),
         (&remote, ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied)),
     ] {
-        let icon = connection_icon(endpoint, &status);
+        let icon = connection_icon(endpoint, &status, true);
         assert!(
             !icon.tooltip.is_empty(),
             "connection_icon for {status:?} should have a non-empty tooltip"

--- a/designs/RFC-015-workspace-sidebar-rows.md
+++ b/designs/RFC-015-workspace-sidebar-rows.md
@@ -144,24 +144,30 @@ Rationale:
 
 ### Connection icon (prefix)
 
-Always visible on every row. Determined by endpoint type and connection status.
+Always visible on every row. One icon per row.
 
-| Endpoint | Status | Icon | CSS class | Tooltip |
-|----------|--------|------|-----------|---------|
-| Local | Connected | `computer-symbolic` | `dim-label` | Local workspace |
-| Local | Connecting/Starting | `content-loading-symbolic` | `dim-label` | Connecting… |
-| Local | Recovered | `emblem-ok-symbolic` | `accent` | Connection recovered |
-| Local | Disconnected | `network-offline-symbolic` | `warning` | Disconnected |
-| Local | Blocked | `network-offline-symbolic` | `error` | Connection blocked |
-| Remote | Connected | `network-server-symbolic` | `accent` | Connected to remote host |
-| Remote | Connecting | `network-server-symbolic` | `dim-label` | Connecting… |
-| Remote | Recovered | `emblem-ok-symbolic` | `accent` | Connection recovered |
-| Remote | Disconnected | `network-offline-symbolic` | `warning` | Disconnected |
-| Remote | Blocked | `network-offline-symbolic` | `error` | Connection blocked |
-| Direct (no daemon) | — | `computer-symbolic` | `dim-label` | Local workspace |
+Shape encodes workspace type (constant for the lifetime of the row):
 
-The icon is set in `append_session_row` at creation time and updated by
-`refresh_workspace_row_status` on connection state changes.
+| Workspace type | Icon shape |
+|----------------|------------|
+| Local managed (daemon-backed) | `computer-symbolic` |
+| Remote managed (daemon-backed) | `network-server-symbolic` |
+| Direct (no daemon) | `utilities-terminal-symbolic` |
+
+Color encodes connection state (changes dynamically):
+
+| Status | CSS class | Meaning |
+|--------|-----------|---------|
+| Connected (local) | `dim-label` | Normal, healthy |
+| Connected (remote) | `accent` | Active remote connection |
+| Connecting / Starting | `dim-label` | In progress |
+| Recovered | `accent` | Just reconnected |
+| Disconnected | `warning` | Lost connection |
+| Blocked | `error` | Cannot connect |
+
+The icon shape never changes — you always know what kind of workspace it is at a glance.
+Only the color changes to reflect connection health. Tooltip provides the detail
+(e.g. "Disconnected from runtime", "Connecting to remote host").
 
 ### Title
 


### PR DESCRIPTION
## Problem

Previously the icon shape changed with connection status — disconnected workspaces showed `network-offline-symbolic` regardless of whether they were local or remote. You couldn't tell workspace type at a glance.

## Fix

Single icon per row. Shape = type (constant), color = state (dynamic):

| Type | Shape |
|------|-------|
| Local managed | `computer-symbolic` |
| Remote managed | `network-server-symbolic` |
| Direct (no daemon) | `utilities-terminal-symbolic` |

| State | Color |
|-------|-------|
| Connected (local) | dim |
| Connected (remote) | accent |
| Connecting | dim |
| Recovered | accent |
| Disconnected | warning (yellow) |
| Blocked | error (red) |

Tooltip provides the detail text.

## API change

`connection_icon()` now takes a third parameter `managed: bool` to distinguish direct from managed workspaces.

## Tests
- Rewrote icon tests to verify shape constancy across all states
- Added direct workspace icon test
- Updated integration tests
- All pass: cargo test, clippy, quality

Updates RFC-015.

Refs #331