### PR TITLE
fix(server): cap on-disk scrollback log at 10 MB per pane

### DIFF
--- a/.github/scripts/check_runtime_behavior_policy.py
+++ b/.github/scripts/check_runtime_behavior_policy.py
@@ -53,7 +53,7 @@ BEHAVIOR_TEST_PATTERNS = (
     "services/rttx-server/tests/**/*.rs",
 )
 
-RUST_TEST_DECLARATION = re.compile(r"^\s*(#\[(test|should_panic)\]|proptest!\s*)")
+RUST_TEST_DECLARATION = re.compile(r"^\s*(#\[(test|should_panic|tokio::test)\]|proptest!\s*)")
 PYTHON_TEST_DECLARATION = re.compile(r"^\s*def test_[A-Za-z0-9_]*\s*\(")
 
 

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -14,6 +14,9 @@ use uuid::Uuid;
 /// Default scrollback byte limit per pane (10 MB).
 const DEFAULT_MAX_SCROLLBACK: usize = 10 * 1024 * 1024;
 
+/// Default on-disk scrollback log byte limit per pane (10 MB).
+const DEFAULT_MAX_SCROLLBACK_LOG: u64 = 10 * 1024 * 1024;
+
 /// Runtime state of a single pane.
 pub struct Pane {
     /// Unique pane identifier.
@@ -73,8 +76,9 @@ impl Pane {
 
     /// Flush pending scrollback bytes to the log file on disk.
     ///
-    /// Appends only the bytes received since the last flush. Sets the
-    /// `scrollback_log_path` on the pane for persistence metadata.
+    /// Appends only the bytes received since the last flush. If the file
+    /// exceeds `DEFAULT_MAX_SCROLLBACK_LOG` bytes after appending, the file
+    /// is truncated to keep only the tail.
     pub fn flush_scrollback(
         &mut self,
         cache_dir: &Path,
@@ -92,7 +96,14 @@ impl Pane {
         let mut file = std::fs::OpenOptions::new().create(true).append(true).open(&path)?;
         file.write_all(&self.pending_flush)?;
         self.pending_flush.clear();
-        self.scrollback_log_path = Some(path);
+        self.scrollback_log_path = Some(path.clone());
+
+        // Cap the file size.
+        let meta = std::fs::metadata(&path)?;
+        if meta.len() > DEFAULT_MAX_SCROLLBACK_LOG {
+            truncate_log_tail(&path, DEFAULT_MAX_SCROLLBACK_LOG)?;
+        }
+
         Ok(())
     }
 
@@ -143,6 +154,17 @@ impl Pane {
             rows: self.rows,
         }
     }
+}
+
+/// Truncate a log file to keep only the last `max_bytes` bytes.
+///
+/// Reads the tail, rewrites the file. This is `O(max_bytes)` but runs at most
+/// once per flush cycle and only when the file exceeds the cap.
+fn truncate_log_tail(path: &Path, max_bytes: u64) -> Result<(), std::io::Error> {
+    let data = std::fs::read(path)?;
+    let keep_from = data.len().saturating_sub(max_bytes as usize);
+    std::fs::write(path, &data[keep_from..])?;
+    Ok(())
 }
 
 /// Serializable pane state for disk persistence.
@@ -277,5 +299,36 @@ mod tests {
     fn effective_cwd_returns_none_without_pid_or_osc7() {
         let pane = Pane::new(Uuid::new_v4(), 80, 24);
         assert!(pane.effective_cwd().is_none());
+    }
+
+    #[test]
+    fn flush_scrollback_caps_file_size() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let session_id = Uuid::new_v4();
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+
+        // Write more than DEFAULT_MAX_SCROLLBACK_LOG in multiple flushes.
+        let chunk = vec![b'A'; 4 * 1024 * 1024]; // 4 MB
+        for _ in 0..4 {
+            pane.feed_output(&chunk);
+            pane.flush_scrollback(tmp.path(), session_id).unwrap();
+        }
+        // 4 * 4 MB = 16 MB written, cap is 10 MB.
+        let log_path = pane.scrollback_log_path.as_ref().unwrap();
+        let size = std::fs::metadata(log_path).unwrap().len();
+        assert!(
+            size <= DEFAULT_MAX_SCROLLBACK_LOG,
+            "scrollback log {size} bytes exceeds cap {DEFAULT_MAX_SCROLLBACK_LOG}"
+        );
+        assert!(size > 0, "scrollback log should not be empty");
+    }
+
+    #[test]
+    fn truncate_log_tail_keeps_end() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.log");
+        std::fs::write(&path, b"AAABBBCCC").unwrap();
+        truncate_log_tail(&path, 3).unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"CCC");
     }
 }

--- a/services/rttx-server/tests/scrollback.rs
+++ b/services/rttx-server/tests/scrollback.rs
@@ -98,3 +98,84 @@ async fn scrollback_flushed_to_disk_after_serialization_tick() {
     let content = std::fs::read_to_string(&log_files[0]).unwrap();
     assert!(content.contains(marker), "expected '{marker}' in scrollback log, got: {content}");
 }
+
+#[tokio::test]
+async fn scrollback_log_capped_at_max_size() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+            name: "cap-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    let create_pane = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            session_id: session_id.clone(),
+            cwd: None,
+            dark_background: None,
+        })),
+    };
+    client.send(&create_pane).await;
+    let pane_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+            session_id: session_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+    client.drain(Duration::from_millis(500)).await;
+
+    // Generate ~12 MB of output via a shell command.
+    let input = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            session_id: session_id.clone(),
+            pane_id: pane_id.clone(),
+            data: b"head -c 12000000 /dev/zero | tr '\\0' 'A'\n".to_vec(),
+        })),
+    };
+    client.send(&input).await;
+
+    // Wait for command to finish + serialization ticks to flush and cap.
+    tokio::time::sleep(Duration::from_secs(8)).await;
+
+    // Find the scrollback log file.
+    let scrollback_dir = tmp.path().join("cache").join("scrollback");
+    let mut log_files = Vec::new();
+    for session_dir in std::fs::read_dir(&scrollback_dir).unwrap() {
+        let session_dir = session_dir.unwrap().path();
+        if session_dir.is_dir() {
+            for entry in std::fs::read_dir(&session_dir).unwrap() {
+                let entry = entry.unwrap().path();
+                if entry.extension().is_some_and(|ext| ext == "log") {
+                    log_files.push(entry);
+                }
+            }
+        }
+    }
+
+    assert!(!log_files.is_empty(), "expected at least one scrollback log");
+
+    let size = std::fs::metadata(&log_files[0]).unwrap().len();
+    let max = 10 * 1024 * 1024_u64; // 10 MB
+    assert!(size <= max, "scrollback log is {size} bytes, exceeds {max} byte cap");
+}


### PR DESCRIPTION
## Problem

Scrollback log files (`scrollback/<session>/<pane>.log`) were append-only with no size limit. A pane producing continuous output would grow the log indefinitely.

## Fix

After each flush, if the file exceeds 10 MB, truncate to keep only the tail. Same cap as the in-memory Screen buffer.

## Tests
- `flush_scrollback_caps_file_size`: writes 16 MB across 4 flushes, verifies file stays ≤ 10 MB
- `truncate_log_tail_keeps_end`: unit test for the truncation function

Fixes #361