### PR TITLE
fix(gui): prevent unbounded daemon process spawning on reconnect

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -1684,4 +1684,15 @@ mod tests {
         actor_task.abort();
         let _ = actor_task.await;
     }
+
+    #[test]
+    fn daemon_start_attempted_flag_defaults_to_false() {
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx);
+        assert!(
+            !actor.daemon_start_attempted,
+            "new actor must not have daemon_start_attempted set"
+        );
+    }
 }

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -318,6 +318,8 @@ struct EndpointActor {
     reconnect_attempt: u32,
     heartbeat: HeartbeatMonitor,
     heartbeat_deadline: Instant,
+    /// Prevents spawning multiple daemon processes during reconnect loops.
+    daemon_start_attempted: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -388,6 +390,7 @@ impl EndpointActor {
             reconnect_attempt: 0,
             heartbeat: HeartbeatMonitor::default(),
             heartbeat_deadline: new_heartbeat_deadline(),
+            daemon_start_attempted: false,
         }
     }
 
@@ -1040,10 +1043,13 @@ impl EndpointActor {
         match &self.endpoint {
             RuntimeEndpoint::Local => {
                 let socket_path = default_socket_path();
-                if !socket_path.exists() {
+                if !socket_path.exists() && !self.daemon_start_attempted {
+                    self.daemon_start_attempted = true;
                     Self::start_local_daemon(&socket_path).await?;
                 }
                 self.connection = Some(DaemonConnection::connect(&socket_path).await?);
+                // Connection succeeded — allow future start attempts if daemon dies again.
+                self.daemon_start_attempted = false;
             }
             RuntimeEndpoint::Remote { host } => {
                 let (connection, ssh_handle) = DaemonConnection::connect_ssh(host).await?;
@@ -1063,9 +1069,16 @@ impl EndpointActor {
         if crate::config::is_development() {
             command.env("RTTX_DEV_MODE", "1");
         }
-        let _ = command.status().await?;
 
-        for _ in 0..30 {
+        // Spawn and wait for the parent process to exit (it daemonizes by forking).
+        let status = command.status().await?;
+        if !status.success() {
+            return Err(DaemonError::Io(std::io::Error::other(format!(
+                "daemon exited with {status}"
+            ))));
+        }
+
+        for _ in 0..50 {
             if socket_path.exists() {
                 return Ok(());
             }
@@ -1374,6 +1387,7 @@ mod tests {
             reconnect_attempt: 0,
             heartbeat: HeartbeatMonitor::default(),
             heartbeat_deadline: new_heartbeat_deadline(),
+            daemon_start_attempted: false,
         }
     }
 
@@ -1470,6 +1484,7 @@ mod tests {
             reconnect_attempt: 0,
             heartbeat: HeartbeatMonitor::default(),
             heartbeat_deadline: new_heartbeat_deadline(),
+            daemon_start_attempted: false,
         };
         (actor, event_rx)
     }

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -931,3 +931,18 @@ fn connection_presentation_has_no_banner_fields() {
     assert_eq!(p.header_label, "Connected");
     assert!(p.input_enabled);
 }
+
+/// Contract: daemon_binary returns a non-empty string suitable for Command::new.
+///
+/// The GUI uses this to auto-start the daemon. If it returned an empty string,
+/// Command::new would fail silently and the reconnect loop could spawn garbage.
+#[test]
+fn daemon_binary_is_non_empty() {
+    use rttx::daemon::daemon_binary;
+    let binary = daemon_binary();
+    assert!(!binary.is_empty(), "daemon_binary must return a non-empty name");
+    assert!(
+        !binary.contains('/'),
+        "daemon_binary should be a bare name resolved via PATH, not an absolute path"
+    );
+}


### PR DESCRIPTION
## Root cause

When the local daemon dies and the socket disappears, the GUI's reconnect loop spawns a new `rttx-server start` every 5 seconds. If the spawned server is incompatible or slow to start (replaying large scrollback), the socket never appears, and the next cycle spawns another process. This creates dozens of orphaned server processes, each loading scrollback into memory, causing OOM within minutes.

## Repro

1. Install rttx-server in two locations (e.g. `~/.local/bin` and `/usr/local/bin`)
2. Kill the daemon and delete the binary from the first location
3. The GUI finds the second (incompatible) binary on `$PATH` and spawns it repeatedly

## Fix

- `daemon_start_attempted` flag: spawn the daemon at most once per connection lifecycle. Resets only after successful connection.
- Check daemon exit status instead of ignoring it.
- Increased socket wait from 3s to 5s.

## Impact

Eliminates the OOM scenario from unbounded process spawning. The GUI will try once to start the daemon, and if it fails, subsequent reconnect cycles only attempt to connect to the socket (not spawn new processes).