### PR TITLE
fix: replace PID-based single-instance check with flock

### DIFF
--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -55,7 +55,7 @@ serde_json = "1"
 
 # Process management
 daemonize = "0.5"
-nix = { version = "0.29", features = ["signal"] }
+nix = { version = "0.29", features = ["fs"] }
 signal-hook = { version = "0.3", features = ["iterator"] }
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 

--- a/services/rttx-server/src/lib.rs
+++ b/services/rttx-server/src/lib.rs
@@ -10,3 +10,4 @@ pub mod screen;
 pub mod serialization;
 pub mod server;
 pub mod session;
+pub mod single_instance;

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -60,17 +60,23 @@ fn start(foreground: bool) -> anyhow::Result<()> {
 
     let os = UnixOs;
     let runtime_dir = os.runtime_dir();
+    let lock_path = runtime_dir.join("rttx-server.lock");
     let pid_path = runtime_dir.join("rttx-server.pid");
 
-    // Check if already running via PID file.
-    if is_running_via_pid(&pid_path) {
-        let mode = if dev_mode { "rttx-server (dev)" } else { "rttx-server" };
-        eprintln!("{mode} is already running");
-        std::process::exit(1);
-    }
+    // Acquire the single-instance lock before any other initialization.
+    // The lock is inherited across fork (daemonize) and held until process exit.
+    let _instance_guard =
+        match rttx_server::single_instance::SingleInstanceGuard::try_acquire(&lock_path) {
+            Ok(guard) => guard,
+            Err(rttx_server::single_instance::SingleInstanceError::AlreadyRunning) => {
+                let mode = if dev_mode { "rttx-server (dev)" } else { "rttx-server" };
+                eprintln!("{mode} is already running");
+                std::process::exit(1);
+            }
+            Err(e) => return Err(e.into()),
+        };
 
     if !foreground {
-        std::fs::create_dir_all(&runtime_dir)?;
         let daemon = daemonize::Daemonize::new().pid_file(&pid_path).working_directory(".");
 
         match daemon.start() {
@@ -89,7 +95,7 @@ fn start(foreground: bool) -> anyhow::Result<()> {
         tracing::debug!(runtime_dir = %runtime_dir.display(), cache_dir = %os.cache_dir().display());
     }
 
-    // Write PID file in foreground mode too (daemonize writes it in daemon mode).
+    // Write PID file in foreground mode (daemonize writes it in daemon mode).
     if foreground {
         std::fs::create_dir_all(&runtime_dir)?;
         std::fs::write(&pid_path, std::process::id().to_string())?;
@@ -117,7 +123,7 @@ fn start(foreground: bool) -> anyhow::Result<()> {
         rttx_server::server::run(server).await
     });
 
-    // Cleanup PID file on normal exit.
+    // Cleanup PID file on normal exit. Lock file is cleaned up by guard drop.
     let _ = std::fs::remove_file(&pid_path);
     result
 }
@@ -283,18 +289,6 @@ fn status() -> anyhow::Result<()> {
 
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max { s.to_string() } else { format!("{}…", &s[..max - 1]) }
-}
-
-/// Check if a daemon is running by reading the PID file and probing the process.
-fn is_running_via_pid(pid_path: &std::path::Path) -> bool {
-    let Ok(contents) = std::fs::read_to_string(pid_path) else {
-        return false;
-    };
-    let Ok(pid) = contents.trim().parse::<i32>() else {
-        return false;
-    };
-    // Check if the process exists by sending signal 0.
-    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
 }
 
 async fn handle_signals(server: Arc<Mutex<Server>>) {

--- a/services/rttx-server/src/single_instance.rs
+++ b/services/rttx-server/src/single_instance.rs
@@ -1,0 +1,109 @@
+//! Flock-based single-instance enforcement for `rttx-server`.
+//!
+//! Acquires an exclusive advisory lock on a lock file in the runtime directory.
+//! The lock is held for the process lifetime and released automatically on drop
+//! (or process exit/crash). A second instance attempting to acquire the lock
+//! fails immediately with [`AlreadyRunning`].
+
+use nix::fcntl::{Flock, FlockArg};
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Held for the lifetime of the daemon process. Dropping it releases the lock.
+#[derive(Debug)]
+pub struct SingleInstanceGuard {
+    _lock: Flock<File>,
+    path: PathBuf,
+}
+
+impl SingleInstanceGuard {
+    /// Try to acquire the single-instance lock.
+    ///
+    /// Creates the lock file if it does not exist. Returns the guard on success,
+    /// or [`AlreadyRunning`] if another instance holds the lock.
+    pub fn try_acquire(lock_path: &Path) -> Result<Self, SingleInstanceError> {
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let file = File::options().create(true).truncate(false).write(true).open(lock_path)?;
+
+        let lock = Flock::lock(file, FlockArg::LockExclusiveNonblock).map_err(|(_, errno)| {
+            if errno == nix::errno::Errno::EWOULDBLOCK {
+                SingleInstanceError::AlreadyRunning
+            } else {
+                SingleInstanceError::Io(io::Error::from_raw_os_error(errno as i32))
+            }
+        })?;
+
+        Ok(Self { _lock: lock, path: lock_path.to_owned() })
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SingleInstanceError {
+    #[error("another instance is already running")]
+    AlreadyRunning,
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_instance_acquires_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("test.lock");
+        let guard = SingleInstanceGuard::try_acquire(&lock_path);
+        assert!(guard.is_ok(), "first instance should acquire the lock");
+        assert!(lock_path.exists());
+    }
+
+    #[test]
+    fn second_instance_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("test.lock");
+        let _first = SingleInstanceGuard::try_acquire(&lock_path).unwrap();
+        let second = SingleInstanceGuard::try_acquire(&lock_path);
+        assert!(
+            matches!(second, Err(SingleInstanceError::AlreadyRunning)),
+            "second instance should get AlreadyRunning"
+        );
+    }
+
+    #[test]
+    fn lock_released_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("test.lock");
+        {
+            let _guard = SingleInstanceGuard::try_acquire(&lock_path).unwrap();
+        }
+        // After drop, a new instance should succeed.
+        let guard = SingleInstanceGuard::try_acquire(&lock_path);
+        assert!(guard.is_ok(), "lock should be available after first guard is dropped");
+    }
+
+    #[test]
+    fn creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("nested").join("dir").join("test.lock");
+        let guard = SingleInstanceGuard::try_acquire(&lock_path);
+        assert!(guard.is_ok(), "should create parent dirs and acquire lock");
+    }
+
+    #[test]
+    fn guard_reports_lock_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("test.lock");
+        let guard = SingleInstanceGuard::try_acquire(&lock_path).unwrap();
+        assert_eq!(guard.path(), lock_path);
+    }
+}

--- a/services/rttx-server/tests/single_instance.rs
+++ b/services/rttx-server/tests/single_instance.rs
@@ -1,0 +1,35 @@
+//! Integration tests for flock-based single-instance enforcement.
+
+use rttx_server::single_instance::{SingleInstanceError, SingleInstanceGuard};
+
+#[test]
+fn concurrent_acquisition_rejects_second() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock_path = dir.path().join("rttx-server.lock");
+
+    let first = SingleInstanceGuard::try_acquire(&lock_path).unwrap();
+    let second = SingleInstanceGuard::try_acquire(&lock_path);
+
+    assert!(
+        matches!(&second, Err(SingleInstanceError::AlreadyRunning)),
+        "second acquisition must fail with AlreadyRunning, got: {second:?}"
+    );
+
+    drop(first);
+
+    // After the first guard is dropped, acquisition should succeed again.
+    let third = SingleInstanceGuard::try_acquire(&lock_path);
+    assert!(third.is_ok(), "third acquisition should succeed after first is dropped");
+}
+
+#[test]
+fn stale_lock_file_does_not_block() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock_path = dir.path().join("rttx-server.lock");
+
+    // Create a lock file without holding a lock (simulates stale file after crash).
+    std::fs::write(&lock_path, "").unwrap();
+
+    let guard = SingleInstanceGuard::try_acquire(&lock_path);
+    assert!(guard.is_ok(), "stale lock file should not prevent acquisition");
+}


### PR DESCRIPTION
## What changed and why

Replaced the racy PID-file-based single-instance check with `flock(2)` on a dedicated lock file.

**Root cause**: The PID file check had a race window — between reading the PID file and writing a new one, a second instance could pass the check. When the GUI's reconnect loop spawned `rttx-server start` every 5 seconds and the server was slow to start (replaying large scrollback), multiple server processes accumulated, each loading scrollback into memory, causing OOM.

**Fix**: Acquire an exclusive advisory lock (`flock(LOCK_EX | LOCK_NB)`) on `rttx-server.lock` before any initialization, including daemonize. The lock is inherited across fork and held for the process lifetime. A second instance fails immediately with `EWOULDBLOCK`.

## Changes

- New `single_instance` module with `SingleInstanceGuard` wrapping `nix::fcntl::Flock<File>`
- `main.rs`: replaced `is_running_via_pid` with flock guard acquired before daemonize
- Removed `is_running_via_pid` function entirely
- PID file kept for informational purposes (`status` command, daemonize)
- `nix` feature changed from `signal` to `fs` (signal was only used by the removed function)

## Manual verification

```bash
# Start server in foreground
RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground &

# Try to start a second instance — should fail immediately
RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground
# Expected: "rttx-server (dev) is already running"

# Kill the first instance
kill %1

# Start again — should succeed (lock released on exit)
RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground
```

## Tests added

**Unit tests** (5 in `single_instance.rs`):
- `first_instance_acquires_lock`
- `second_instance_is_rejected`
- `lock_released_on_drop`
- `creates_parent_directories`
- `guard_reports_lock_path`

**Integration tests** (2 in `tests/single_instance.rs`):
- `concurrent_acquisition_rejects_second` — acquire, reject second, drop first, acquire third
- `stale_lock_file_does_not_block` — pre-existing lock file without held lock doesn't prevent startup

## Tests run

- `cargo fmt --check` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `cargo test -p rttx-server --lib` ✅ (74 tests)
- `cargo test -p rttx-server --tests` ✅ (all integration tests)
- Runtime behavior gate: not triggered (server-side change)

## Limitations

- The flock is inherited across `fork()` (used by daemonize). This is correct behavior — the grandchild process inherits the lock. However, if daemonize ever changes to use `posix_spawn` or `exec` with `O_CLOEXEC`, the lock would be lost. This is unlikely given daemonize's design.

Fixes #370