### PR TITLE
feat: add auto_start_daemon config property

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -148,18 +148,24 @@ pub struct EndpointConnectionManager {
     rt: tokio::runtime::Runtime,
     endpoints: RefCell<HashMap<String, EndpointHandle>>,
     event_tx: mpsc::UnboundedSender<EndpointEvent>,
+    auto_start_daemon: bool,
 }
 
 impl EndpointConnectionManager {
     /// Create a new endpoint-scoped manager and its event receiver.
-    pub fn new() -> Result<(Self, mpsc::UnboundedReceiver<EndpointEvent>), DaemonError> {
+    pub fn new(
+        auto_start_daemon: bool,
+    ) -> Result<(Self, mpsc::UnboundedReceiver<EndpointEvent>), DaemonError> {
         let rt = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .enable_all()
             .build()
             .map_err(DaemonError::Io)?;
         let (event_tx, event_rx) = mpsc::unbounded_channel();
-        Ok((Self { rt, endpoints: RefCell::new(HashMap::new()), event_tx }, event_rx))
+        Ok((
+            Self { rt, endpoints: RefCell::new(HashMap::new()), event_tx, auto_start_daemon },
+            event_rx,
+        ))
     }
 
     fn endpoint_handle(
@@ -172,8 +178,13 @@ impl EndpointConnectionManager {
         }
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
-        let actor =
-            EndpointActor::new(endpoint.clone(), self.event_tx.clone(), cmd_tx.clone(), cmd_rx);
+        let actor = EndpointActor::new(
+            endpoint.clone(),
+            self.event_tx.clone(),
+            cmd_tx.clone(),
+            cmd_rx,
+            self.auto_start_daemon,
+        );
         self.rt.spawn(actor.run());
         self.endpoints.borrow_mut().insert(key, EndpointHandle { cmd_tx: cmd_tx.clone() });
         cmd_tx
@@ -320,6 +331,7 @@ struct EndpointActor {
     heartbeat_deadline: Instant,
     /// Prevents spawning multiple daemon processes during reconnect loops.
     daemon_start_attempted: bool,
+    auto_start_daemon: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -376,6 +388,7 @@ impl EndpointActor {
         event_tx: mpsc::UnboundedSender<EndpointEvent>,
         self_tx: mpsc::UnboundedSender<EndpointCommand>,
         cmd_rx: mpsc::UnboundedReceiver<EndpointCommand>,
+        auto_start_daemon: bool,
     ) -> Self {
         Self {
             endpoint,
@@ -391,6 +404,7 @@ impl EndpointActor {
             heartbeat: HeartbeatMonitor::default(),
             heartbeat_deadline: new_heartbeat_deadline(),
             daemon_start_attempted: false,
+            auto_start_daemon,
         }
     }
 
@@ -1043,7 +1057,7 @@ impl EndpointActor {
         match &self.endpoint {
             RuntimeEndpoint::Local => {
                 let socket_path = default_socket_path();
-                if !socket_path.exists() && !self.daemon_start_attempted {
+                if !socket_path.exists() && !self.daemon_start_attempted && self.auto_start_daemon {
                     self.daemon_start_attempted = true;
                     Self::start_local_daemon(&socket_path).await?;
                 }
@@ -1388,6 +1402,7 @@ mod tests {
             heartbeat: HeartbeatMonitor::default(),
             heartbeat_deadline: new_heartbeat_deadline(),
             daemon_start_attempted: false,
+            auto_start_daemon: true,
         }
     }
 
@@ -1485,6 +1500,7 @@ mod tests {
             heartbeat: HeartbeatMonitor::default(),
             heartbeat_deadline: new_heartbeat_deadline(),
             daemon_start_attempted: false,
+            auto_start_daemon: true,
         };
         (actor, event_rx)
     }
@@ -1493,7 +1509,7 @@ mod tests {
     fn endpoint_actor_construction_does_not_require_tokio_runtime() {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
         let (self_tx, cmd_rx) = mpsc::unbounded_channel();
-        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx);
+        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true);
         assert!(actor.reader.is_none());
         assert!(actor.writer.is_none());
     }
@@ -1689,10 +1705,18 @@ mod tests {
     fn daemon_start_attempted_flag_defaults_to_false() {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
         let (self_tx, cmd_rx) = mpsc::unbounded_channel();
-        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx);
+        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true);
         assert!(
             !actor.daemon_start_attempted,
             "new actor must not have daemon_start_attempted set"
         );
+    }
+
+    #[test]
+    fn auto_start_daemon_flag_is_stored() {
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, false);
+        assert!(!actor.auto_start_daemon);
     }
 }

--- a/clients/rttx/src/preferences.rs
+++ b/clients/rttx/src/preferences.rs
@@ -77,6 +77,8 @@ pub struct Preferences {
     pub default_session_folder: DefaultSessionFolder,
     #[serde(default)]
     pub pane_navigation_keys: PaneNavigationKeys,
+    #[serde(default = "default_true")]
+    pub auto_start_daemon: bool,
 }
 
 fn default_font() -> String {
@@ -117,6 +119,7 @@ impl Default for Preferences {
             smart_clipboard: false,
             default_session_folder: default_session_folder(),
             pane_navigation_keys: PaneNavigationKeys::default(),
+            auto_start_daemon: true,
         }
     }
 }
@@ -168,6 +171,8 @@ struct PreferencesDisk {
     default_session_folder: DefaultSessionFolder,
     #[serde(default)]
     pane_navigation_keys: PaneNavigationKeys,
+    #[serde(default = "default_true")]
+    auto_start_daemon: bool,
 }
 
 impl From<PreferencesDisk> for Preferences {
@@ -199,6 +204,7 @@ impl From<PreferencesDisk> for Preferences {
             smart_clipboard: raw.smart_clipboard,
             default_session_folder: raw.default_session_folder,
             pane_navigation_keys: raw.pane_navigation_keys,
+            auto_start_daemon: raw.auto_start_daemon,
         }
     }
 }
@@ -267,6 +273,7 @@ mod tests {
         assert!(prefs.scroll_on_keystroke);
         assert!(!prefs.scroll_on_output);
         assert!(!prefs.smart_clipboard);
+        assert!(prefs.auto_start_daemon);
     }
 
     #[test]
@@ -434,5 +441,29 @@ mod tests {
         std::fs::write(&path, "{}").unwrap();
         let loaded = load_from(&path);
         assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::AltArrow);
+    }
+
+    #[test]
+    fn auto_start_daemon_defaults_to_true() {
+        assert!(Preferences::default().auto_start_daemon);
+    }
+
+    #[test]
+    fn auto_start_daemon_roundtrips_false() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("prefs.json");
+        let prefs = Preferences { auto_start_daemon: false, ..Default::default() };
+        save_to(&prefs, &path).unwrap();
+        let loaded = load_from(&path);
+        assert!(!loaded.auto_start_daemon);
+    }
+
+    #[test]
+    fn missing_auto_start_daemon_defaults_to_true() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("prefs.json");
+        std::fs::write(&path, "{}").unwrap();
+        let loaded = load_from(&path);
+        assert!(loaded.auto_start_daemon);
     }
 }

--- a/clients/rttx/src/preferences_window.rs
+++ b/clients/rttx/src/preferences_window.rs
@@ -198,6 +198,7 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
                 1 => PaneNavigationKeys::CtrlShiftArrow,
                 _ => PaneNavigationKeys::AltArrow,
             },
+            auto_start_daemon: prefs.auto_start_daemon,
         };
         if let Err(e) = preferences::save(&new_prefs) {
             log::error!("Failed to save preferences: {e}");

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -157,7 +157,9 @@ impl Window {
             return true;
         }
 
-        match crate::daemon_bridge::EndpointConnectionManager::new() {
+        match crate::daemon_bridge::EndpointConnectionManager::new(
+            crate::preferences::load().auto_start_daemon,
+        ) {
             Ok((manager, rx)) => {
                 self.start_endpoint_event_poller(rx);
                 self.imp().connection_manager.replace(Some(manager));

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -946,3 +946,25 @@ fn daemon_binary_is_non_empty() {
         "daemon_binary should be a bare name resolved via PATH, not an absolute path"
     );
 }
+
+/// Contract: auto_start_daemon defaults to true and survives roundtrip.
+///
+/// Existing preferences files without this field must load with auto-start
+/// enabled (backward compat). Files with it set to false must preserve that.
+#[test]
+fn auto_start_daemon_backward_compat_and_roundtrip() {
+    use rttx::preferences::{Preferences, load_from, save_to};
+
+    let dir = tempfile::tempdir().unwrap();
+
+    // Backward compat: missing field defaults to true.
+    let legacy = dir.path().join("legacy.json");
+    std::fs::write(&legacy, r#"{"font": "Hack 10"}"#).unwrap();
+    assert!(load_from(&legacy).auto_start_daemon);
+
+    // Roundtrip with false.
+    let explicit = dir.path().join("explicit.json");
+    let prefs = Preferences { auto_start_daemon: false, ..Default::default() };
+    save_to(&prefs, &explicit).unwrap();
+    assert!(!load_from(&explicit).auto_start_daemon);
+}

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -31,6 +31,7 @@ fn preferences_roundtrip_all_fields() {
         smart_clipboard: true,
         default_session_folder: DefaultSessionFolder::Custom("/home/user/dev".into()),
         pane_navigation_keys: PaneNavigationKeys::AltArrow,
+        auto_start_daemon: true,
     };
 
     preferences::save_to(&prefs, &path).unwrap();


### PR DESCRIPTION
## What changed and why

Added `auto_start_daemon` boolean to GUI preferences (default: `true`). When set to `false`, the GUI never spawns `rttx-server` on reconnect — it only tries to connect to the existing socket.

This lets users who manage the daemon separately (systemd unit, manual start, or who don't want the GUI spawning processes) disable auto-start entirely.

## How it works

1. `auto_start_daemon` field added to `Preferences` and `PreferencesDisk` with `#[serde(default = "default_true")]`
2. `EndpointConnectionManager::new()` takes the flag and passes it to each `EndpointActor`
3. `connect_endpoint()` checks the flag before calling `start_local_daemon()`
4. `preferences_window.rs` preserves the field on save (no UI toggle yet — edit JSON directly)

## Manual verification

```bash
# Set auto_start_daemon to false in preferences
echo '{"auto_start_daemon": false}' > ~/.config/rttx-devel/preferences.json

# Kill daemon, start GUI — it should NOT spawn the daemon
pkill -f rttx-server
RTTX_DEV_MODE=1 cargo run -p rttx

# Sidebar should show disconnected state, no rttx-server process spawned
ps aux | grep rttx-server
```

## Tests added

**Unit tests** (4):
- `auto_start_daemon_defaults_to_true` — default value
- `auto_start_daemon_roundtrips_false` — save/load with false
- `missing_auto_start_daemon_defaults_to_true` — backward compat
- `auto_start_daemon_flag_is_stored` — EndpointActor stores the flag

**Integration test** (1):
- `auto_start_daemon_backward_compat_and_roundtrip` — legacy JSON + roundtrip

**Updated existing tests**:
- `default_preferences_are_sensible` — asserts new field
- `preferences_roundtrip_all_fields` — includes new field

## Tests run

- `cargo fmt --check` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `cargo test -p rttx --lib preferences` ✅ (19 tests)
- `cargo test -p rttx --lib daemon_bridge` ✅ (11 tests)
- `cargo test -p rttx --test gtk_boundary_contracts` ✅
- `cargo test -p rttx --test preferences_integration` ✅

## Follow-ups

- UI toggle in preferences window (currently edit JSON directly)
- Could be exposed as a CLI flag too

Fixes #371