### PR TITLE
feat: make reconnect delay configurable, increase default to 10s

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -149,12 +149,14 @@ pub struct EndpointConnectionManager {
     endpoints: RefCell<HashMap<String, EndpointHandle>>,
     event_tx: mpsc::UnboundedSender<EndpointEvent>,
     auto_start_daemon: bool,
+    reconnect_delay_secs: u32,
 }
 
 impl EndpointConnectionManager {
     /// Create a new endpoint-scoped manager and its event receiver.
     pub fn new(
         auto_start_daemon: bool,
+        reconnect_delay_secs: u32,
     ) -> Result<(Self, mpsc::UnboundedReceiver<EndpointEvent>), DaemonError> {
         let rt = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
@@ -163,7 +165,13 @@ impl EndpointConnectionManager {
             .map_err(DaemonError::Io)?;
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         Ok((
-            Self { rt, endpoints: RefCell::new(HashMap::new()), event_tx, auto_start_daemon },
+            Self {
+                rt,
+                endpoints: RefCell::new(HashMap::new()),
+                event_tx,
+                auto_start_daemon,
+                reconnect_delay_secs,
+            },
             event_rx,
         ))
     }
@@ -184,6 +192,7 @@ impl EndpointConnectionManager {
             cmd_tx.clone(),
             cmd_rx,
             self.auto_start_daemon,
+            self.reconnect_delay_secs,
         );
         self.rt.spawn(actor.run());
         self.endpoints.borrow_mut().insert(key, EndpointHandle { cmd_tx: cmd_tx.clone() });
@@ -332,6 +341,7 @@ struct EndpointActor {
     /// Prevents spawning multiple daemon processes during reconnect loops.
     daemon_start_attempted: bool,
     auto_start_daemon: bool,
+    reconnect_delay_secs: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -389,6 +399,7 @@ impl EndpointActor {
         self_tx: mpsc::UnboundedSender<EndpointCommand>,
         cmd_rx: mpsc::UnboundedReceiver<EndpointCommand>,
         auto_start_daemon: bool,
+        reconnect_delay_secs: u32,
     ) -> Self {
         Self {
             endpoint,
@@ -405,6 +416,7 @@ impl EndpointActor {
             heartbeat_deadline: new_heartbeat_deadline(),
             daemon_start_attempted: false,
             auto_start_daemon,
+            reconnect_delay_secs,
         }
     }
 
@@ -1277,7 +1289,7 @@ impl EndpointActor {
     }
 
     fn next_reconnect_delay_secs(&self) -> u32 {
-        self.next_reconnect_attempt().min(5)
+        self.next_reconnect_attempt().min(self.reconnect_delay_secs)
     }
 
     fn schedule_reconnect(&mut self, delay_secs: u32) {
@@ -1403,6 +1415,7 @@ mod tests {
             heartbeat_deadline: new_heartbeat_deadline(),
             daemon_start_attempted: false,
             auto_start_daemon: true,
+            reconnect_delay_secs: 10,
         }
     }
 
@@ -1501,6 +1514,7 @@ mod tests {
             heartbeat_deadline: new_heartbeat_deadline(),
             daemon_start_attempted: false,
             auto_start_daemon: true,
+            reconnect_delay_secs: 10,
         };
         (actor, event_rx)
     }
@@ -1509,7 +1523,7 @@ mod tests {
     fn endpoint_actor_construction_does_not_require_tokio_runtime() {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
         let (self_tx, cmd_rx) = mpsc::unbounded_channel();
-        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true);
+        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true, 10);
         assert!(actor.reader.is_none());
         assert!(actor.writer.is_none());
     }
@@ -1705,7 +1719,7 @@ mod tests {
     fn daemon_start_attempted_flag_defaults_to_false() {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
         let (self_tx, cmd_rx) = mpsc::unbounded_channel();
-        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true);
+        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true, 10);
         assert!(
             !actor.daemon_start_attempted,
             "new actor must not have daemon_start_attempted set"
@@ -1716,7 +1730,40 @@ mod tests {
     fn auto_start_daemon_flag_is_stored() {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
         let (self_tx, cmd_rx) = mpsc::unbounded_channel();
-        let actor = EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, false);
+        let actor =
+            EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, false, 10);
         assert!(!actor.auto_start_daemon);
+    }
+
+    #[test]
+    fn reconnect_delay_caps_at_configured_value() {
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let mut actor =
+            EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true, 10);
+
+        // Ramp-up: delay = min(attempt, 10)
+        assert_eq!(actor.next_reconnect_delay_secs(), 1);
+        actor.reconnect_attempt = 5;
+        assert_eq!(actor.next_reconnect_delay_secs(), 6);
+        actor.reconnect_attempt = 9;
+        assert_eq!(actor.next_reconnect_delay_secs(), 10);
+        // Capped at configured max.
+        actor.reconnect_attempt = 100;
+        assert_eq!(actor.next_reconnect_delay_secs(), 10);
+    }
+
+    #[test]
+    fn reconnect_delay_respects_custom_cap() {
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let mut actor =
+            EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true, 3);
+
+        assert_eq!(actor.next_reconnect_delay_secs(), 1);
+        actor.reconnect_attempt = 2;
+        assert_eq!(actor.next_reconnect_delay_secs(), 3);
+        actor.reconnect_attempt = 50;
+        assert_eq!(actor.next_reconnect_delay_secs(), 3);
     }
 }

--- a/clients/rttx/src/preferences.rs
+++ b/clients/rttx/src/preferences.rs
@@ -79,6 +79,8 @@ pub struct Preferences {
     pub pane_navigation_keys: PaneNavigationKeys,
     #[serde(default = "default_true")]
     pub auto_start_daemon: bool,
+    #[serde(default = "default_reconnect_delay_secs")]
+    pub reconnect_delay_secs: u32,
 }
 
 fn default_font() -> String {
@@ -102,6 +104,9 @@ const fn default_scrollback() -> i64 {
 const fn default_true() -> bool {
     true
 }
+const fn default_reconnect_delay_secs() -> u32 {
+    10
+}
 impl Default for Preferences {
     fn default() -> Self {
         Self {
@@ -120,6 +125,7 @@ impl Default for Preferences {
             default_session_folder: default_session_folder(),
             pane_navigation_keys: PaneNavigationKeys::default(),
             auto_start_daemon: true,
+            reconnect_delay_secs: default_reconnect_delay_secs(),
         }
     }
 }
@@ -173,6 +179,8 @@ struct PreferencesDisk {
     pane_navigation_keys: PaneNavigationKeys,
     #[serde(default = "default_true")]
     auto_start_daemon: bool,
+    #[serde(default = "default_reconnect_delay_secs")]
+    reconnect_delay_secs: u32,
 }
 
 impl From<PreferencesDisk> for Preferences {
@@ -205,6 +213,7 @@ impl From<PreferencesDisk> for Preferences {
             default_session_folder: raw.default_session_folder,
             pane_navigation_keys: raw.pane_navigation_keys,
             auto_start_daemon: raw.auto_start_daemon,
+            reconnect_delay_secs: raw.reconnect_delay_secs,
         }
     }
 }
@@ -274,6 +283,7 @@ mod tests {
         assert!(!prefs.scroll_on_output);
         assert!(!prefs.smart_clipboard);
         assert!(prefs.auto_start_daemon);
+        assert_eq!(prefs.reconnect_delay_secs, 10);
     }
 
     #[test]
@@ -465,5 +475,27 @@ mod tests {
         std::fs::write(&path, "{}").unwrap();
         let loaded = load_from(&path);
         assert!(loaded.auto_start_daemon);
+    }
+
+    #[test]
+    fn reconnect_delay_secs_defaults_to_10() {
+        assert_eq!(Preferences::default().reconnect_delay_secs, 10);
+    }
+
+    #[test]
+    fn reconnect_delay_secs_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("prefs.json");
+        let prefs = Preferences { reconnect_delay_secs: 30, ..Default::default() };
+        save_to(&prefs, &path).unwrap();
+        assert_eq!(load_from(&path).reconnect_delay_secs, 30);
+    }
+
+    #[test]
+    fn missing_reconnect_delay_secs_defaults_to_10() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("prefs.json");
+        std::fs::write(&path, "{}").unwrap();
+        assert_eq!(load_from(&path).reconnect_delay_secs, 10);
     }
 }

--- a/clients/rttx/src/preferences_window.rs
+++ b/clients/rttx/src/preferences_window.rs
@@ -199,6 +199,7 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
                 _ => PaneNavigationKeys::AltArrow,
             },
             auto_start_daemon: prefs.auto_start_daemon,
+            reconnect_delay_secs: prefs.reconnect_delay_secs,
         };
         if let Err(e) = preferences::save(&new_prefs) {
             log::error!("Failed to save preferences: {e}");

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -157,8 +157,10 @@ impl Window {
             return true;
         }
 
+        let prefs = crate::preferences::load();
         match crate::daemon_bridge::EndpointConnectionManager::new(
-            crate::preferences::load().auto_start_daemon,
+            prefs.auto_start_daemon,
+            prefs.reconnect_delay_secs,
         ) {
             Ok((manager, rx)) => {
                 self.start_endpoint_event_poller(rx);

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -968,3 +968,25 @@ fn auto_start_daemon_backward_compat_and_roundtrip() {
     save_to(&prefs, &explicit).unwrap();
     assert!(!load_from(&explicit).auto_start_daemon);
 }
+
+/// Contract: reconnect_delay_secs defaults to 10 and survives roundtrip.
+///
+/// Existing preferences files without this field must load with 10s default
+/// (backward compat). Custom values must persist.
+#[test]
+fn reconnect_delay_secs_backward_compat_and_roundtrip() {
+    use rttx::preferences::{Preferences, load_from, save_to};
+
+    let dir = tempfile::tempdir().unwrap();
+
+    // Backward compat: missing field defaults to 10.
+    let legacy = dir.path().join("legacy.json");
+    std::fs::write(&legacy, r#"{"font": "Hack 10"}"#).unwrap();
+    assert_eq!(load_from(&legacy).reconnect_delay_secs, 10);
+
+    // Roundtrip with custom value.
+    let custom = dir.path().join("custom.json");
+    let prefs = Preferences { reconnect_delay_secs: 30, ..Default::default() };
+    save_to(&prefs, &custom).unwrap();
+    assert_eq!(load_from(&custom).reconnect_delay_secs, 30);
+}

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -32,6 +32,7 @@ fn preferences_roundtrip_all_fields() {
         default_session_folder: DefaultSessionFolder::Custom("/home/user/dev".into()),
         pane_navigation_keys: PaneNavigationKeys::AltArrow,
         auto_start_daemon: true,
+        reconnect_delay_secs: 10,
     };
 
     preferences::save_to(&prefs, &path).unwrap();


### PR DESCRIPTION
## What changed and why

The reconnect delay was hardcoded to ramp from 1s to a max of 5s. This is aggressive when the daemon is genuinely down — with many disconnected workspaces, the reconnect timer fires every 5 seconds.

Added `reconnect_delay_secs` to GUI preferences (default: 10). The delay still ramps from 1s per attempt but now caps at the configured value instead of the hardcoded 5.

## How it works

1. `reconnect_delay_secs` field added to `Preferences` and `PreferencesDisk` with `#[serde(default = "default_reconnect_delay_secs")]`
2. `EndpointConnectionManager::new()` takes the value and passes it to each `EndpointActor`
3. `next_reconnect_delay_secs()` uses `self.reconnect_delay_secs` as the cap instead of hardcoded 5
4. `preferences_window.rs` preserves the field on save (no UI control yet — edit JSON directly)

## Manual verification

```bash
# Set custom delay
echo '{"reconnect_delay_secs": 30}' > ~/.config/rttx-devel/preferences.json

# Kill daemon, start GUI — reconnect attempts should cap at 30s
pkill -f rttx-server
RTTX_DEV_MODE=1 RUST_LOG=rttx=debug cargo run -p rttx
# Watch logs for reconnect delay values
```

## Tests added

**Unit tests** (5):
- `reconnect_delay_secs_defaults_to_10` — default value
- `reconnect_delay_secs_roundtrips` — save/load with custom value
- `missing_reconnect_delay_secs_defaults_to_10` — backward compat
- `reconnect_delay_caps_at_configured_value` — ramp-up and cap at 10
- `reconnect_delay_respects_custom_cap` — ramp-up and cap at 3

**Integration test** (1):
- `reconnect_delay_secs_backward_compat_and_roundtrip` — legacy JSON + roundtrip

## Tests run

- `cargo fmt --check` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `cargo test -p rttx --lib` ✅ (356 tests)
- `cargo test -p rttx --test gtk_boundary_contracts` ✅
- `cargo test -p rttx --test preferences_integration` ✅

Fixes #372