### PR TITLE
feat: add reconnect cycle logging for diagnostics

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -996,6 +996,11 @@ impl EndpointActor {
                 if workspaces.is_empty() {
                     return;
                 }
+                log::debug!(
+                    "Reconnect attempt to {} for {} workspace(s)",
+                    self.endpoint.key(),
+                    workspaces.len()
+                );
                 let primary = workspaces[0].clone();
                 if let Err(problem) = self.ensure_connected(&primary).await {
                     if problem.is_transient() {
@@ -1005,6 +1010,11 @@ impl EndpointActor {
                     return;
                 }
 
+                log::info!(
+                    "Reconnected to {}, reattaching {} workspace(s)",
+                    self.endpoint.key(),
+                    self.tracked_workspaces.len()
+                );
                 for (workspace_id, runtime_id) in self.tracked_workspaces.clone() {
                     if let Ok(snapshot) = self.attach_runtime(&workspace_id, &runtime_id).await {
                         let _ = self.event_tx.send(EndpointEvent::WorkspaceOpened {
@@ -1043,6 +1053,11 @@ impl EndpointActor {
             }
             Err(error) => {
                 let problem = classify_connection_problem(&error);
+                log::debug!(
+                    "Connection to {} failed: {error} ({})",
+                    self.endpoint.key(),
+                    if problem.is_transient() { "transient" } else { "permanent" }
+                );
                 if problem.is_transient() {
                     let attempt = self.next_reconnect_attempt();
                     let delay_secs = self.next_reconnect_delay_secs();
@@ -1070,11 +1085,11 @@ impl EndpointActor {
             RuntimeEndpoint::Local => {
                 let socket_path = default_socket_path();
                 if !socket_path.exists() && !self.daemon_start_attempted && self.auto_start_daemon {
+                    log::info!("Auto-starting local daemon");
                     self.daemon_start_attempted = true;
                     Self::start_local_daemon(&socket_path).await?;
                 }
                 self.connection = Some(DaemonConnection::connect(&socket_path).await?);
-                // Connection succeeded — allow future start attempts if daemon dies again.
                 self.daemon_start_attempted = false;
             }
             RuntimeEndpoint::Remote { host } => {
@@ -1264,6 +1279,11 @@ impl EndpointActor {
     }
 
     fn handle_disconnect(&mut self) {
+        log::warn!(
+            "Connection lost to {} ({} tracked workspace(s))",
+            self.endpoint.key(),
+            self.tracked_workspaces.len()
+        );
         self.connection = None;
         self.reader = None;
         self.writer = None;
@@ -1294,6 +1314,12 @@ impl EndpointActor {
 
     fn schedule_reconnect(&mut self, delay_secs: u32) {
         self.reconnect_attempt = self.reconnect_attempt.saturating_add(1);
+        log::info!(
+            "Scheduling reconnect to {} (attempt {}, delay {}s)",
+            self.endpoint.key(),
+            self.reconnect_attempt,
+            delay_secs
+        );
         let self_tx = self.self_tx.clone();
         let delay = Duration::from_secs(u64::from(delay_secs));
         tokio::spawn(async move {
@@ -1765,5 +1791,49 @@ mod tests {
         assert_eq!(actor.next_reconnect_delay_secs(), 3);
         actor.reconnect_attempt = 50;
         assert_eq!(actor.next_reconnect_delay_secs(), 3);
+    }
+
+    #[tokio::test]
+    async fn handle_disconnect_schedules_reconnect_for_tracked_workspaces() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let mut actor =
+            EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true, 10);
+        actor.tracked_workspaces.insert("ws-1".into(), "rt-1".into());
+
+        actor.handle_disconnect();
+
+        assert_eq!(actor.reconnect_attempt, 1);
+        assert!(actor.connection.is_none());
+        // Should have emitted Disconnected + Reconnecting for the tracked workspace.
+        let ev1 = event_rx.try_recv().unwrap();
+        assert!(matches!(
+            ev1,
+            EndpointEvent::WorkspaceConnectionChanged {
+                status: ConnectionStatus::Disconnected,
+                ..
+            }
+        ));
+        let ev2 = event_rx.try_recv().unwrap();
+        assert!(matches!(
+            ev2,
+            EndpointEvent::WorkspaceConnectionChanged {
+                status: ConnectionStatus::Reconnecting { attempt: 1, retry_in_secs: 1 },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn handle_disconnect_without_tracked_workspaces_does_not_schedule() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let mut actor =
+            EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, true, 10);
+
+        actor.handle_disconnect();
+
+        assert_eq!(actor.reconnect_attempt, 0);
+        assert!(event_rx.try_recv().is_err());
     }
 }

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -990,3 +990,21 @@ fn reconnect_delay_secs_backward_compat_and_roundtrip() {
     save_to(&prefs, &custom).unwrap();
     assert_eq!(load_from(&custom).reconnect_delay_secs, 30);
 }
+
+/// Contract: reconnect status carries attempt and delay for diagnostic logging.
+///
+/// The reconnect cycle logs attempt number and delay from the ConnectionStatus.
+/// This test verifies the status machine produces the expected values.
+#[test]
+fn reconnect_status_carries_attempt_and_delay() {
+    use rttx::runtime::{ConnectionEvent, ConnectionStatus, advance_connection_status};
+
+    let status = advance_connection_status(
+        &ConnectionStatus::Connecting,
+        ConnectionEvent::RetryScheduled { attempt: 3, retry_in_secs: 10 },
+    );
+    assert!(
+        matches!(status, ConnectionStatus::Reconnecting { attempt: 3, retry_in_secs: 10 }),
+        "expected Reconnecting with attempt=3, delay=10, got {status:?}"
+    );
+}


### PR DESCRIPTION
## What changed and why

The reconnect cycle in `daemon_bridge.rs` had almost no logging — only heartbeat-related messages. When investigating reconnect storms or daemon-spawning issues (like the OOM from #361), there was no way to trace what the GUI was doing without adding ad-hoc prints.

Added 6 log statements at key points in the reconnect cycle:

| Point | Level | What it logs |
|---|---|---|
| `handle_disconnect` | warn | Connection loss with tracked workspace count |
| `schedule_reconnect` | info | Attempt number and delay in seconds |
| Reconnect command (start) | debug | Attempt with workspace count |
| Reconnect command (success) | info | Successful reconnection, reattaching count |
| `ensure_connected` failure | debug | Error message with transient/permanent classification |
| `connect_endpoint` auto-start | info | Daemon auto-start triggered |

## Log levels rationale

- `warn`: connection loss — always visible, actionable
- `info`: reconnect scheduling and success — visible in default dev mode
- `debug`: attempt details and failure classification — visible with `RUST_LOG=rttx=debug`

## Manual verification

```bash
RTTX_DEV_MODE=1 RUST_LOG=rttx=debug cargo run -p rttx
# Kill daemon while connected, observe log output:
# WARN  Connection lost to local (1 tracked workspace(s))
# INFO  Scheduling reconnect to local (attempt 1, delay 1s)
# DEBUG Reconnect attempt to local for 1 workspace(s)
# DEBUG Connection to local failed: ... (transient)
# INFO  Scheduling reconnect to local (attempt 2, delay 2s)
# ...
# INFO  Reconnected to local, reattaching 1 workspace(s)
```

## Tests added

- `handle_disconnect_schedules_reconnect_for_tracked_workspaces` — verifies disconnect with tracked workspaces emits Disconnected + Reconnecting events and increments attempt counter
- `handle_disconnect_without_tracked_workspaces_does_not_schedule` — verifies disconnect without tracked workspaces skips reconnect scheduling

## Tests run

- `cargo fmt --check` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `cargo test -p rttx --lib daemon_bridge` ✅ (15 tests)
- `cargo test -p rttx --lib` ✅ (358 tests)

Fixes #373