### PR TITLE
feat: unify workspace context menu on sidebar 3-dot button

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -352,6 +352,34 @@ pub fn present_workspace_actions(
     }
 }
 
+/// Which actions to show in the workspace context menu.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceMenuItems {
+    pub show_edit_connection: bool,
+    pub show_reconnect: bool,
+    pub show_detach: bool,
+}
+
+/// Input state for determining workspace menu items.
+#[derive(Debug, Clone)]
+pub struct WorkspaceMenuContext {
+    pub is_remote: bool,
+    pub is_managed: bool,
+    pub is_persistent: bool,
+    pub is_attached: bool,
+    pub is_disconnected: bool,
+}
+
+/// Determine which context menu items are relevant for a workspace.
+#[must_use]
+pub const fn workspace_menu_items(ctx: &WorkspaceMenuContext) -> WorkspaceMenuItems {
+    WorkspaceMenuItems {
+        show_edit_connection: ctx.is_remote,
+        show_reconnect: ctx.is_managed && ctx.is_disconnected,
+        show_detach: ctx.is_persistent && ctx.is_attached,
+    }
+}
+
 /// Render a connection state into pane header label and input availability.
 #[must_use]
 pub fn present_connection_status(status: &ConnectionStatus) -> ConnectionPresentation {
@@ -1064,5 +1092,74 @@ mod tests {
         let p = present_connection_status(&ConnectionStatus::Starting);
         assert_eq!(p.header_label, "Starting");
         assert!(!p.input_enabled);
+    }
+
+    #[test]
+    fn menu_items_local_persistent_connected() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: false,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: true,
+            is_disconnected: false,
+        });
+        assert!(!items.show_edit_connection);
+        assert!(!items.show_reconnect);
+        assert!(items.show_detach);
+    }
+
+    #[test]
+    fn menu_items_remote_persistent_disconnected() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: true,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: true,
+            is_disconnected: true,
+        });
+        assert!(items.show_edit_connection);
+        assert!(items.show_reconnect);
+        assert!(items.show_detach);
+    }
+
+    #[test]
+    fn menu_items_local_ephemeral_connected() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: false,
+            is_managed: true,
+            is_persistent: false,
+            is_attached: true,
+            is_disconnected: false,
+        });
+        assert!(!items.show_edit_connection);
+        assert!(!items.show_reconnect);
+        assert!(!items.show_detach);
+    }
+
+    #[test]
+    fn menu_items_managed_disconnected_not_attached() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: false,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: false,
+            is_disconnected: true,
+        });
+        assert!(items.show_reconnect);
+        assert!(!items.show_detach);
+    }
+
+    #[test]
+    fn menu_items_unmanaged_workspace() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: false,
+            is_managed: false,
+            is_persistent: false,
+            is_attached: false,
+            is_disconnected: false,
+        });
+        assert!(!items.show_edit_connection);
+        assert!(!items.show_reconnect);
+        assert!(!items.show_detach);
     }
 }

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -94,49 +94,100 @@ impl Window {
         about.present();
     }
 
-    pub(super) fn show_sidebar_context_menu(&self, session_uuid: &str) {
-        let is_remote = {
+    pub(super) fn show_workspace_popover_menu(&self, row: &SessionRow, session_uuid: &str) {
+        let items = {
             let state = self.imp().state.borrow();
-            state
-                .sessions
-                .iter()
-                .find(|s| s.uuid == session_uuid)
-                .is_some_and(|s| matches!(s.runtime.endpoint, RuntimeEndpoint::Remote { .. }))
+            let Some(session) = state.sessions.iter().find(|s| s.uuid == session_uuid) else {
+                return;
+            };
+            let disconnected =
+                self.imp().workspace_connection_status.borrow().get(session_uuid).is_some_and(
+                    |s| {
+                        matches!(
+                            s,
+                            ConnectionStatus::Disconnected
+                                | ConnectionStatus::Reconnecting { .. }
+                                | ConnectionStatus::Blocked(_)
+                        )
+                    },
+                );
+            crate::runtime::workspace_menu_items(&crate::runtime::WorkspaceMenuContext {
+                is_remote: matches!(session.runtime.endpoint, RuntimeEndpoint::Remote { .. }),
+                is_managed: session.uses_managed_runtime(),
+                is_persistent: session.mode.is_persistent(),
+                is_attached: session.runtime.runtime_id.is_some(),
+                is_disconnected: disconnected,
+            })
         };
-        if !is_remote {
-            return;
-        }
 
         let menu = gtk4::gio::Menu::new();
-        menu.append(Some("Edit Connection…"), Some("win.edit-connection"));
-        menu.append(Some("Retry Connection"), Some("win.retry-connection"));
+        menu.append(Some("Rename…"), Some("win.ctx-rename"));
+        if items.show_edit_connection {
+            menu.append(Some("Edit Connection…"), Some("win.ctx-edit-connection"));
+        }
+        if items.show_reconnect {
+            menu.append(Some("Reconnect"), Some("win.ctx-reconnect"));
+        }
+        if items.show_detach {
+            menu.append(Some("Detach"), Some("win.ctx-detach"));
+        }
+        menu.append(Some("Close"), Some("win.ctx-close"));
 
         let popover = gtk4::PopoverMenu::from_model(Some(&menu));
         popover.set_has_arrow(true);
+        let popover_parent = row.parent().unwrap_or_else(|| row.clone().upcast::<gtk4::Widget>());
+        popover.set_parent(&popover_parent);
 
-        let row = self
-            .sidebar_row_for_uuid(session_uuid)
-            .and_then(|r| r.parent())
-            .unwrap_or_else(|| self.imp().sidebar_list.clone().upcast());
-        popover.set_parent(&row);
-        popover.connect_closed(gtk4::prelude::WidgetExt::unparent);
-
-        let win = self.clone();
-        let uuid = session_uuid.to_string();
-        let edit_action = gtk4::gio::SimpleAction::new("edit-connection", None);
-        edit_action.connect_activate(move |_, _| {
-            win.show_edit_workspace_connection_dialog(&uuid);
+        let w = self.clone();
+        let u = session_uuid.to_string();
+        let r = row.clone();
+        let rename_action = gtk4::gio::SimpleAction::new("ctx-rename", None);
+        rename_action.connect_activate(move |_, _| {
+            w.show_rename_session_popover(&r, &u);
         });
+        self.add_action(&rename_action);
 
-        let win2 = self.clone();
-        let uuid2 = session_uuid.to_string();
-        let retry_action = gtk4::gio::SimpleAction::new("retry-connection", None);
-        retry_action.connect_activate(move |_, _| {
-            win2.retry_workspace_connection(&uuid2);
+        if items.show_edit_connection {
+            let w = self.clone();
+            let u = session_uuid.to_string();
+            let edit_action = gtk4::gio::SimpleAction::new("ctx-edit-connection", None);
+            edit_action.connect_activate(move |_, _| {
+                w.show_edit_workspace_connection_dialog(&u);
+            });
+            self.add_action(&edit_action);
+        }
+
+        if items.show_reconnect {
+            let w = self.clone();
+            let u = session_uuid.to_string();
+            let reconnect_action = gtk4::gio::SimpleAction::new("ctx-reconnect", None);
+            reconnect_action.connect_activate(move |_, _| {
+                w.retry_workspace_connection(&u);
+            });
+            self.add_action(&reconnect_action);
+        }
+
+        if items.show_detach {
+            let w = self.clone();
+            let u = session_uuid.to_string();
+            let detach_action = gtk4::gio::SimpleAction::new("ctx-detach", None);
+            detach_action.connect_activate(move |_, _| {
+                w.detach_session(&u);
+            });
+            self.add_action(&detach_action);
+        }
+
+        let w = self.clone();
+        let u = session_uuid.to_string();
+        let close_action = gtk4::gio::SimpleAction::new("ctx-close", None);
+        close_action.connect_activate(move |_, _| {
+            w.confirm_close_session(&u);
         });
+        self.add_action(&close_action);
 
-        self.add_action(&edit_action);
-        self.add_action(&retry_action);
+        popover.connect_closed(|popover| {
+            popover.unparent();
+        });
         popover.popup();
     }
 

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -490,15 +490,22 @@ impl Window {
         if session_state.uses_managed_runtime() {
             row.set_managed_actions_style();
             row.close_button().set_tooltip_text(Some("Workspace actions"));
+
+            let win = self.clone();
+            let session_uuid = session_state.uuid.clone();
+            let row_for_menu = row.clone();
+            row.close_button().connect_clicked(move |_| {
+                win.show_workspace_popover_menu(&row_for_menu, &session_uuid);
+            });
         } else {
             row.close_button().set_tooltip_text(Some("Close workspace"));
-        }
 
-        let win = self.clone();
-        let session_uuid = session_state.uuid.clone();
-        row.close_button().connect_clicked(move |_| {
-            win.confirm_close_session(&session_uuid);
-        });
+            let win = self.clone();
+            let session_uuid = session_state.uuid.clone();
+            row.close_button().connect_clicked(move |_| {
+                win.confirm_close_session(&session_uuid);
+            });
+        }
 
         let win = self.clone();
         let session_uuid = session_state.uuid.clone();
@@ -535,16 +542,6 @@ impl Window {
             false
         });
         row.add_controller(drop_target);
-
-        let win = self.clone();
-        let session_uuid_for_ctx = session_state.uuid.clone();
-        let ctx_gesture = gtk4::GestureClick::new();
-        ctx_gesture.set_button(3);
-        ctx_gesture.connect_released(move |gesture, _, _, _| {
-            gesture.set_state(gtk4::EventSequenceState::Claimed);
-            win.show_sidebar_context_menu(&session_uuid_for_ctx);
-        });
-        row.add_controller(ctx_gesture);
 
         let list_row = gtk4::ListBoxRow::new();
         list_row.set_child(Some(&row));
@@ -804,6 +801,72 @@ impl Window {
         self.renumber_session_rows();
     }
 
+    pub(super) fn detach_session(&self, session_uuid: &str) {
+        let imp = self.imp();
+
+        let (terminal_uuids, new_index, detach_info) = {
+            let mut state = imp.state.borrow_mut();
+            if state.sessions.len() <= 1 {
+                return;
+            }
+            let Some(pos) = state.sessions.iter().position(|s| s.uuid == session_uuid) else {
+                return;
+            };
+            let session = &state.sessions[pos];
+            let info = session
+                .runtime
+                .runtime_id
+                .as_ref()
+                .map(|runtime_id| (session.runtime.endpoint.clone(), runtime_id.clone()));
+            let uuids = session.layout.terminal_uuids();
+            let session = state.sessions.remove(pos);
+            drop(session);
+            let new_index = pos.min(state.sessions.len() - 1);
+            state.active_session_index = new_index;
+            (uuids, new_index, info)
+        };
+
+        {
+            let terminals = imp.terminals.borrow();
+            for uuid in &terminal_uuids {
+                if let Some(term) = terminals.get(uuid) {
+                    term.disconnect_child_exited();
+                }
+            }
+        }
+        {
+            let mut terminals = imp.terminals.borrow_mut();
+            for uuid in &terminal_uuids {
+                terminals.remove(uuid);
+            }
+        }
+        {
+            let mut panes = imp.persistent_terminals.borrow_mut();
+            for uuid in &terminal_uuids {
+                panes.remove(uuid);
+            }
+        }
+
+        if let Some((endpoint, runtime_id)) = detach_info
+            && let Some(manager) = imp.connection_manager.borrow().as_ref()
+        {
+            manager.detach_runtime(session_uuid, &endpoint, &runtime_id);
+            manager.forget_workspace(&endpoint, session_uuid);
+        }
+        imp.workspace_connection_status.borrow_mut().remove(session_uuid);
+        self.clear_workspace_reconnect_countdown(session_uuid);
+
+        if let Some(child) = imp.session_stack.child_by_name(session_uuid) {
+            imp.session_stack.remove(&child);
+        }
+        self.remove_sidebar_row(session_uuid);
+
+        if let Some(row) = imp.sidebar_list.row_at_index(new_index as i32) {
+            imp.sidebar_list.select_row(Some(&row));
+        }
+        self.renumber_session_rows();
+    }
+
     fn close_session(&self, session_uuid: &str) {
         let imp = self.imp();
 
@@ -869,29 +932,26 @@ impl Window {
         if let Some(child) = imp.session_stack.child_by_name(session_uuid) {
             imp.session_stack.remove(&child);
         }
-        if let Some(row) = imp.sidebar_list.row_at_index({
-            let mut idx = 0;
-            loop {
-                match imp.sidebar_list.row_at_index(idx) {
-                    Some(r) => {
-                        if let Some(sr) = r.child().and_then(|c| c.downcast::<SessionRow>().ok())
-                            && sr.uuid() == session_uuid
-                        {
-                            break idx;
-                        }
-                        idx += 1;
-                    }
-                    None => break -1,
-                }
-            }
-        }) {
-            imp.sidebar_list.remove(&row);
-        }
+        self.remove_sidebar_row(session_uuid);
 
         if let Some(row) = imp.sidebar_list.row_at_index(new_index as i32) {
             imp.sidebar_list.select_row(Some(&row));
         }
         self.renumber_session_rows();
+    }
+
+    fn remove_sidebar_row(&self, session_uuid: &str) {
+        let imp = self.imp();
+        let mut idx = 0;
+        while let Some(r) = imp.sidebar_list.row_at_index(idx) {
+            if let Some(sr) = r.child().and_then(|c| c.downcast::<SessionRow>().ok())
+                && sr.uuid() == session_uuid
+            {
+                imp.sidebar_list.remove(&r);
+                return;
+            }
+            idx += 1;
+        }
     }
 }
 

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -357,18 +357,4 @@ impl Window {
             self.refresh_sidebar_subtitle(&session_uuid);
         }
     }
-
-    pub(super) fn sidebar_row_for_uuid(&self, session_uuid: &str) -> Option<SessionRow> {
-        let imp = self.imp();
-        let mut idx = 0;
-        while let Some(row) = imp.sidebar_list.row_at_index(idx) {
-            if let Some(sr) = row.child().and_then(|c| c.downcast::<SessionRow>().ok())
-                && sr.uuid() == session_uuid
-            {
-                return Some(sr);
-            }
-            idx += 1;
-        }
-        None
-    }
 }

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -1008,3 +1008,36 @@ fn reconnect_status_carries_attempt_and_delay() {
         "expected Reconnecting with attempt=3, delay=10, got {status:?}"
     );
 }
+
+/// Contract: workspace_menu_items returns correct items for each workspace type.
+///
+/// The sidebar 3-dot popover menu uses this function to decide which actions
+/// to show. Rename and Close are always present (not gated by this function).
+#[test]
+fn workspace_menu_items_contract() {
+    use rttx::runtime::{WorkspaceMenuContext, workspace_menu_items};
+
+    // Remote + persistent + attached + disconnected → all optional items visible.
+    let all = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: true,
+        is_managed: true,
+        is_persistent: true,
+        is_attached: true,
+        is_disconnected: true,
+    });
+    assert!(all.show_edit_connection);
+    assert!(all.show_reconnect);
+    assert!(all.show_detach);
+
+    // Local + ephemeral + connected → no optional items.
+    let minimal = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: false,
+        is_managed: true,
+        is_persistent: false,
+        is_attached: true,
+        is_disconnected: false,
+    });
+    assert!(!minimal.show_edit_connection);
+    assert!(!minimal.show_reconnect);
+    assert!(!minimal.show_detach);
+}


### PR DESCRIPTION
## What changed and why

The sidebar workspace row had two separate interaction paths:
- A right-click context menu (only for remote workspaces, showing Edit Connection + Retry)
- A 3-dot suffix button that only triggered close confirmation

This was inconsistent and made workspace management actions hard to discover.

### Changes

Replaced both with a single PopoverMenu on the 3-dot button for managed workspaces. Menu items are shown based on workspace state:

| Item | Condition |
|---|---|
| Rename… | Always |
| Edit Connection… | Remote workspaces only |
| Reconnect | Managed + disconnected/reconnecting/blocked |
| Detach | Persistent + attached (keeps runtime running) |
| Close | Always |

Non-managed workspaces keep the direct close button (no menu needed — they have no daemon actions).

### Implementation details

- `workspace_menu_items()` pure function with `WorkspaceMenuContext` struct determines which items to show — fully unit-testable
- `detach_session()` removes workspace from GUI but calls `detach_runtime` instead of `terminate_runtime`, and does NOT add to `dismissed_runtime_ids` so the runtime can be recovered
- Extracted `remove_sidebar_row()` helper used by both close and detach
- Removed unused `sidebar_row_for_uuid()`
- Removed right-click gesture from sidebar rows

## Manual verification

```bash
RTTX_DEV_MODE=1 cargo run -p rttx
# 1. Create a managed workspace → 3-dot button shows popover with Rename/Close
# 2. Create a remote workspace → popover also shows Edit Connection
# 3. Kill daemon → popover shows Reconnect
# 4. Persistent workspace → popover shows Detach
# 5. Right-click on sidebar row → no context menu (removed)
```

## Tests added

Unit tests (5):
- `menu_items_local_persistent_connected` — detach visible, no edit/reconnect
- `menu_items_remote_persistent_disconnected` — all items visible
- `menu_items_local_ephemeral_connected` — no optional items
- `menu_items_managed_disconnected_not_attached` — reconnect but no detach
- `menu_items_unmanaged_workspace` — no optional items

Integration test (1):
- `workspace_menu_items_contract` — verifies the pure function contract

## Tests run

- `cargo fmt --check` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all pass)
- `cargo test -p rttx --lib` ✅ (363 tests)
- Runtime behavior gate: N/A (no runtime-affecting files)

Fixes #378