### PR TITLE
feat: add Open Link and fix Copy Link in right-click context menu

### DIFF
--- a/clients/rttx/src/terminal/links.rs
+++ b/clients/rttx/src/terminal/links.rs
@@ -101,6 +101,14 @@ pub(crate) fn parse_file_uri(uri: &str) -> Option<String> {
     glib::filename_from_uri(uri).ok().map(|(path, _hostname)| path.display().to_string())
 }
 
+/// Return the human-readable text for a URI suitable for clipboard copy.
+///
+/// File URIs are converted back to filesystem paths; everything else is
+/// returned as-is.
+pub(crate) fn display_text_for_uri(uri: &str) -> String {
+    parse_file_uri(uri).unwrap_or_else(|| uri.to_string())
+}
+
 pub(crate) fn openable_uri_from_match_text(
     match_text: &str,
     current_directory: Option<&str>,
@@ -328,5 +336,26 @@ mod tests {
     fn gesture_denied_state_is_available() {
         // Compile-time check: EventSequenceState::Denied exists and is usable.
         assert_ne!(gtk4::EventSequenceState::Denied, gtk4::EventSequenceState::Claimed);
+    }
+
+    #[test]
+    fn display_text_for_file_uri_returns_path() {
+        assert_eq!(super::display_text_for_uri("file:///home/user/project"), "/home/user/project");
+    }
+
+    #[test]
+    fn display_text_for_http_uri_returns_uri() {
+        assert_eq!(
+            super::display_text_for_uri("https://example.com/docs"),
+            "https://example.com/docs"
+        );
+    }
+
+    #[test]
+    fn display_text_for_file_uri_decodes_percent() {
+        assert_eq!(
+            super::display_text_for_uri("file:///home/user/my%20project"),
+            "/home/user/my project"
+        );
     }
 }

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -633,6 +633,7 @@ mod pane_passive_tests {
 
 #[cfg(test)]
 mod search_tests {
+    use super::links;
     /// The PCRE2 literal escape pattern wraps user input safely so special
     /// regex characters are not interpreted.
     #[test]
@@ -671,5 +672,12 @@ mod search_tests {
         assert!(visible(false, true), "multi pane, not zoomed → visible");
         assert!(visible(true, false), "zoomed (was multi) → visible");
         assert!(visible(true, true), "zoomed + multi → visible");
+    }
+
+    /// Copy Link should show the filesystem path for file URIs, not the URI.
+    #[test]
+    fn display_text_for_file_uri_shows_path() {
+        assert_eq!(links::display_text_for_uri("file:///tmp/log.txt"), "/tmp/log.txt");
+        assert_eq!(links::display_text_for_uri("https://example.com"), "https://example.com");
     }
 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -44,6 +44,7 @@ mod imp {
         pub status_label: gtk4::Label,
         pub search_bar: gtk4::SearchBar,
         pub search_entry: gtk4::SearchEntry,
+        pub last_match_at_click: RefCell<Option<String>>,
     }
 
     impl Default for PersistentPaneView {
@@ -69,6 +70,7 @@ mod imp {
                 status_label: gtk4::Label::default(),
                 search_bar: gtk4::SearchBar::default(),
                 search_entry: gtk4::SearchEntry::default(),
+                last_match_at_click: RefCell::default(),
             }
         }
     }
@@ -144,6 +146,88 @@ mod imp {
             links::install_openable_link_controllers(&self.vte, move || {
                 link_target.upgrade().and_then(|pane| pane.current_directory())
             });
+
+            let copy_link_action = gtk4::gio::SimpleAction::new("copy-link", None);
+            copy_link_action.set_enabled(false);
+            let open_link_action = gtk4::gio::SimpleAction::new("open-link", None);
+            open_link_action.set_enabled(false);
+            let action_group = gtk4::gio::SimpleActionGroup::new();
+            action_group.add_action(&copy_link_action);
+            action_group.add_action(&open_link_action);
+            obj.insert_action_group("term", Some(&action_group));
+
+            let obj_weak = obj.downgrade();
+            copy_link_action.connect_activate(move |_, _| {
+                let Some(obj) = obj_weak.upgrade() else { return };
+                let matched = obj.imp().last_match_at_click.borrow().clone();
+                if let Some(uri) = matched
+                    && let Some(display) = gtk4::gdk::Display::default()
+                {
+                    display.clipboard().set_text(&links::display_text_for_uri(&uri));
+                }
+            });
+
+            let obj_weak = obj.downgrade();
+            open_link_action.connect_activate(move |_, _| {
+                let Some(obj) = obj_weak.upgrade() else { return };
+                let matched = obj.imp().last_match_at_click.borrow().clone();
+                if let Some(uri) = matched {
+                    links::launch_uri(&uri);
+                }
+            });
+
+            let menu = gtk4::gio::Menu::new();
+            let clipboard_section = gtk4::gio::Menu::new();
+            clipboard_section.append(Some("Copy"), Some("win.copy"));
+            clipboard_section.append(Some("Paste"), Some("win.paste"));
+            let link_section = gtk4::gio::Menu::new();
+            link_section.append(Some("Open Link"), Some("term.open-link"));
+            link_section.append(Some("Copy Link"), Some("term.copy-link"));
+            let pane_section = gtk4::gio::Menu::new();
+            pane_section.append(Some("Search"), Some("win.search"));
+            pane_section.append(Some("Split Horizontally"), Some("win.split-horizontal"));
+            pane_section.append(Some("Split Vertically"), Some("win.split-vertical"));
+            let session_section = gtk4::gio::Menu::new();
+            session_section.append(Some("New Session"), Some("win.new-session"));
+            session_section.append(Some("Toggle Input Sync"), Some("win.toggle-input-sync"));
+            session_section.append(Some("Preferences"), Some("win.preferences"));
+            let close_section = gtk4::gio::Menu::new();
+            close_section.append(Some("Close Pane"), Some("win.close-terminal"));
+            menu.append_section(None, &clipboard_section);
+            menu.append_section(None, &link_section);
+            menu.append_section(None, &pane_section);
+            menu.append_section(None, &session_section);
+            menu.append_section(None, &close_section);
+
+            let context_menu = gtk4::PopoverMenu::from_model(Some(&menu));
+            context_menu.set_has_arrow(false);
+            context_menu.set_parent(obj.upcast_ref::<gtk4::Widget>());
+
+            let right_click = gtk4::GestureClick::new();
+            right_click.set_button(3);
+            right_click.set_propagation_phase(gtk4::PropagationPhase::Capture);
+            let copy_link_ref = copy_link_action;
+            let open_link_ref = open_link_action;
+            let obj_weak = obj.downgrade();
+            right_click.connect_pressed(move |gesture, _, x, y| {
+                if let Some(obj) = obj_weak.upgrade() {
+                    let matched = links::openable_uri_at(
+                        &obj.imp().vte,
+                        x,
+                        y,
+                        obj.current_directory().as_deref(),
+                    );
+                    let has_link = matched.is_some();
+                    copy_link_ref.set_enabled(has_link);
+                    open_link_ref.set_enabled(has_link);
+                    obj.imp().last_match_at_click.replace(matched);
+                }
+                context_menu
+                    .set_pointing_to(Some(&gtk4::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
+                context_menu.popup();
+                gesture.set_state(gtk4::EventSequenceState::Claimed);
+            });
+            self.vte.add_controller(right_click);
 
             self.search_entry.set_hexpand(true);
             self.search_bar.set_child(Some(&self.search_entry));

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -183,18 +183,30 @@ mod imp {
 
             let copy_link_action = gtk4::gio::SimpleAction::new("copy-link", None);
             copy_link_action.set_enabled(false);
+            let open_link_action = gtk4::gio::SimpleAction::new("open-link", None);
+            open_link_action.set_enabled(false);
             let action_group = gtk4::gio::SimpleActionGroup::new();
             action_group.add_action(&copy_link_action);
+            action_group.add_action(&open_link_action);
             obj.insert_action_group("term", Some(&action_group));
 
             let obj_weak = obj.downgrade();
             copy_link_action.connect_activate(move |_, _| {
                 let Some(obj) = obj_weak.upgrade() else { return };
                 let matched = obj.imp().last_match_at_click.borrow().clone();
-                if let Some(text) = matched
+                if let Some(uri) = matched
                     && let Some(display) = gtk4::gdk::Display::default()
                 {
-                    display.clipboard().set_text(&text);
+                    display.clipboard().set_text(&links::display_text_for_uri(&uri));
+                }
+            });
+
+            let obj_weak = obj.downgrade();
+            open_link_action.connect_activate(move |_, _| {
+                let Some(obj) = obj_weak.upgrade() else { return };
+                let matched = obj.imp().last_match_at_click.borrow().clone();
+                if let Some(uri) = matched {
+                    links::launch_uri(&uri);
                 }
             });
 
@@ -202,7 +214,9 @@ mod imp {
             let clipboard_section = gtk4::gio::Menu::new();
             clipboard_section.append(Some("Copy"), Some("win.copy"));
             clipboard_section.append(Some("Paste"), Some("win.paste"));
-            clipboard_section.append(Some("Copy Link"), Some("term.copy-link"));
+            let link_section = gtk4::gio::Menu::new();
+            link_section.append(Some("Open Link"), Some("term.open-link"));
+            link_section.append(Some("Copy Link"), Some("term.copy-link"));
             let pane_section = gtk4::gio::Menu::new();
             pane_section.append(Some("Search"), Some("win.search"));
             pane_section.append(Some("Split Horizontally"), Some("win.split-horizontal"));
@@ -215,6 +229,7 @@ mod imp {
             let close_section = gtk4::gio::Menu::new();
             close_section.append(Some("Close Pane"), Some("win.close-terminal"));
             menu.append_section(None, &clipboard_section);
+            menu.append_section(None, &link_section);
             menu.append_section(None, &pane_section);
             menu.append_section(None, &session_section);
             menu.append_section(None, &close_section);
@@ -227,6 +242,7 @@ mod imp {
             right_click.set_button(3);
             right_click.set_propagation_phase(gtk4::PropagationPhase::Capture);
             let copy_link_ref = copy_link_action;
+            let open_link_ref = open_link_action;
             let obj_weak = obj.downgrade();
             right_click.connect_pressed(move |gesture, _, x, y| {
                 if let Some(obj) = obj_weak.upgrade() {
@@ -236,7 +252,9 @@ mod imp {
                         y,
                         obj.current_directory().as_deref(),
                     );
-                    copy_link_ref.set_enabled(matched.is_some());
+                    let has_link = matched.is_some();
+                    copy_link_ref.set_enabled(has_link);
+                    open_link_ref.set_enabled(has_link);
                     obj.imp().last_match_at_click.replace(matched);
                 }
                 context_menu

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1648,3 +1648,22 @@ fn persistent_pane_zoom_button_shows_restore_when_zoomed() {
     assert!(pane.zoom_button().is_visible());
     assert_eq!(pane.zoom_button().icon_name().unwrap(), "view-restore-symbolic");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn terminal_widget_has_open_and_copy_link_actions() {
+    require_display!();
+    let term = rttx::terminal::widget::TerminalWidget::new("t1", None);
+    // Actions exist but are disabled by default — activate returns Err.
+    assert!(term.activate_action("term.open-link", None).is_err());
+    assert!(term.activate_action("term.copy-link", None).is_err());
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn persistent_pane_has_open_and_copy_link_actions() {
+    require_display!();
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("p1", "s1");
+    assert!(pane.activate_action("term.open-link", None).is_err());
+    assert!(pane.activate_action("term.copy-link", None).is_err());
+}


### PR DESCRIPTION
## What changed and why

Right-clicking on a detected URL or file path in the terminal had no way to open or copy it. The `TerminalWidget` had a "Copy Link" action but it copied the raw `file://` URI instead of the filesystem path, and had no "Open Link". The `PersistentPaneView` had no right-click context menu at all.

### Changes

**`TerminalWidget`**:
- Added "Open Link" action that opens the URI with the system default handler
- Moved link actions to their own menu section (Open Link + Copy Link)
- Fixed "Copy Link" to use `display_text_for_uri()` — shows `/home/user/file` instead of `file:///home/user/file`

**`PersistentPaneView`**:
- Added full right-click context menu matching `TerminalWidget` (minus Bookmark Session)
- Includes: Copy, Paste, Open Link, Copy Link, Search, Split H/V, New Session, Toggle Input Sync, Preferences, Close Pane

**`links.rs`**:
- Added `display_text_for_uri()` — converts file URIs back to filesystem paths for human-readable clipboard content

### Manual verification

```bash
RTTX_DEV_MODE=1 cargo run -p rttx
# 1. Type: echo https://example.com
# 2. Right-click on the URL → see Open Link and Copy Link
# 3. Click Open Link → opens in browser
# 4. Click Copy Link → copies "https://example.com" to clipboard
# 5. Type: ls /tmp
# 6. Right-click on a path → Open Link opens file manager, Copy Link copies path
# 7. Right-click on non-link area → Open Link and Copy Link are greyed out
# 8. Repeat in a managed (persistent) workspace
```

### Tests added (6 new)

Unit tests in `links.rs`:
- `display_text_for_file_uri_returns_path`
- `display_text_for_http_uri_returns_uri`
- `display_text_for_file_uri_decodes_percent`

Pure-state test in `terminal/mod.rs`:
- `display_text_for_file_uri_shows_path`

Widget tests in `gtk_widget_tests.rs`:
- `terminal_widget_has_open_and_copy_link_actions`
- `persistent_pane_has_open_and_copy_link_actions`

### Tests run

- `cargo fmt --check` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all pass)
- `cargo test -p rttx --lib` ✅ (368 tests)
- Runtime behavior gate ✅

Fixes #382
Closes #60