### PR TITLE
fix: retry connection falls back to new runtime on stale id

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -536,17 +536,10 @@ impl EndpointActor {
                     return;
                 }
 
-                let runtime_id = if let Some(runtime_id) = runtime_id {
-                    runtime_id
-                } else {
-                    let Ok(runtime_id) = self.create_runtime(&workspace_id, &name, policy).await
-                    else {
-                        return;
-                    };
-                    runtime_id
-                };
-
-                let Ok(snapshot) = self.attach_runtime(&workspace_id, &runtime_id).await else {
+                let Ok((runtime_id, snapshot)) = self
+                    .resolve_and_attach_runtime(&workspace_id, &name, policy, runtime_id.as_deref())
+                    .await
+                else {
                     return;
                 };
 
@@ -1166,6 +1159,52 @@ impl EndpointActor {
                 Err(())
             }
         }
+    }
+
+    /// Resolve a runtime id (reattach or create) and attach to it.
+    ///
+    /// When `existing_runtime_id` is provided, tries to reattach first.
+    /// If the runtime no longer exists (daemon restarted, ephemeral gone),
+    /// falls back to creating a fresh runtime so "Retry Connection" works.
+    /// Ownership conflicts and transport errors are reported immediately.
+    async fn resolve_and_attach_runtime(
+        &mut self,
+        workspace_id: &str,
+        name: &str,
+        policy: WorkspacePolicy,
+        existing_runtime_id: Option<&str>,
+    ) -> Result<(String, proto::Snapshot), ()> {
+        if let Some(runtime_id) = existing_runtime_id
+            && let Ok(runtime_uuid) = runtime_id.parse::<uuid::Uuid>()
+        {
+            match self.attach_runtime_via_active_channel(runtime_uuid).await {
+                Ok(snapshot) => return Ok((runtime_id.to_string(), snapshot)),
+                // Ownership conflict or transport failure — report, don't retry.
+                Err(
+                    ref error @ (DaemonError::AttachBlocked(_)
+                    | DaemonError::Io(_)
+                    | DaemonError::Disconnected),
+                ) => {
+                    self.handle_command_error(workspace_id, ManagerOperation::OpenWorkspace, error);
+                    return Err(());
+                }
+                // Runtime gone — fall through to create a new one.
+                Err(error) => {
+                    log::info!(
+                        "Reattach to {runtime_id} failed for {workspace_id}: \
+                         {error}, creating new runtime"
+                    );
+                }
+            }
+        }
+
+        let Ok(runtime_id) = self.create_runtime(workspace_id, name, policy).await else {
+            return Err(());
+        };
+        let Ok(snapshot) = self.attach_runtime(workspace_id, &runtime_id).await else {
+            return Err(());
+        };
+        Ok((runtime_id, snapshot))
     }
 
     async fn create_runtime_via_active_channel(
@@ -1835,5 +1874,191 @@ mod tests {
 
         assert_eq!(actor.reconnect_attempt, 0);
         assert!(event_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn resolve_and_attach_falls_back_to_new_runtime_on_stale_id() {
+        let ((reader, writer), mut server_stream) = split_duplex_connection();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let mut actor = EndpointActor {
+            endpoint: RuntimeEndpoint::Local,
+            event_tx,
+            self_tx,
+            cmd_rx,
+            connection: None,
+            reader: Some(reader),
+            writer: Some(writer),
+            ssh_handle: None,
+            tracked_workspaces: HashMap::new(),
+            reconnect_attempt: 0,
+            heartbeat: HeartbeatMonitor::default(),
+            heartbeat_deadline: new_heartbeat_deadline(),
+            daemon_start_attempted: false,
+            auto_start_daemon: true,
+            reconnect_delay_secs: 10,
+        };
+
+        let stale_runtime = Uuid::new_v4();
+        let new_runtime = Uuid::new_v4();
+        let pane_id = Uuid::new_v4();
+
+        let server = tokio::spawn(async move {
+            let mut read_buf = BytesMut::new();
+
+            // 1. Receive AttachSession for the stale runtime — reply "not found".
+            let msg = recv_client_message(&mut server_stream, &mut read_buf).await;
+            assert!(
+                matches!(msg.msg, Some(proto::client_message::Msg::AttachSession(_))),
+                "expected AttachSession, got {msg:?}"
+            );
+            send_server_message(
+                &mut server_stream,
+                &proto::ServerMessage {
+                    msg: Some(proto::server_message::Msg::Error(proto::Error {
+                        code: 4,
+                        message: "session not found".into(),
+                    })),
+                },
+            )
+            .await;
+
+            // 2. Receive CreateSession — reply with new runtime id.
+            let msg = recv_client_message(&mut server_stream, &mut read_buf).await;
+            assert!(
+                matches!(msg.msg, Some(proto::client_message::Msg::CreateSession(_))),
+                "expected CreateSession, got {msg:?}"
+            );
+            send_server_message(
+                &mut server_stream,
+                &proto::ServerMessage {
+                    msg: Some(proto::server_message::Msg::SessionCreated(proto::SessionCreated {
+                        session_id: rttx_proto::uuid_to_bytes(new_runtime),
+                        revision: 1,
+                    })),
+                },
+            )
+            .await;
+
+            // 3. Receive AttachSession for the new runtime — reply with snapshot.
+            let msg = recv_client_message(&mut server_stream, &mut read_buf).await;
+            assert!(
+                matches!(msg.msg, Some(proto::client_message::Msg::AttachSession(_))),
+                "expected AttachSession, got {msg:?}"
+            );
+            send_server_message(
+                &mut server_stream,
+                &proto::ServerMessage {
+                    msg: Some(proto::server_message::Msg::Snapshot(proto::Snapshot {
+                        session_id: rttx_proto::uuid_to_bytes(new_runtime),
+                        panes: vec![proto::PaneSnapshot {
+                            pane_id: rttx_proto::uuid_to_bytes(pane_id),
+                            title: "shell".into(),
+                            cwd: "/home".into(),
+                            cols: 80,
+                            rows: 24,
+                            scrollback: Vec::new(),
+                            exit_status: None,
+                        }],
+                        revision: 2,
+                        current_client_role: proto::RuntimeClientRole::Writer as i32,
+                    })),
+                },
+            )
+            .await;
+        });
+
+        let result = actor
+            .resolve_and_attach_runtime(
+                "ws-1",
+                "Test Workspace",
+                WorkspacePolicy::Ephemeral,
+                Some(&stale_runtime.to_string()),
+            )
+            .await;
+
+        let (runtime_id, snapshot) = result.expect("should fall back to new runtime");
+        assert_eq!(runtime_id, new_runtime.to_string());
+        assert_eq!(snapshot.panes.len(), 1);
+
+        // Verify no error events were emitted (the stale attach failure is
+        // handled internally, not surfaced as a workspace error).
+        let mut saw_error = false;
+        while let Ok(event) = event_rx.try_recv() {
+            if matches!(event, EndpointEvent::WorkspaceError { .. }) {
+                saw_error = true;
+            }
+        }
+        assert!(!saw_error, "stale-runtime fallback should not emit WorkspaceError");
+
+        server.await.expect("fake server task should complete");
+    }
+
+    #[tokio::test]
+    async fn resolve_and_attach_reports_ownership_conflict() {
+        let ((reader, writer), mut server_stream) = split_duplex_connection();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let mut actor = EndpointActor {
+            endpoint: RuntimeEndpoint::Local,
+            event_tx,
+            self_tx,
+            cmd_rx,
+            connection: None,
+            reader: Some(reader),
+            writer: Some(writer),
+            ssh_handle: None,
+            tracked_workspaces: HashMap::new(),
+            reconnect_attempt: 0,
+            heartbeat: HeartbeatMonitor::default(),
+            heartbeat_deadline: new_heartbeat_deadline(),
+            daemon_start_attempted: false,
+            auto_start_daemon: true,
+            reconnect_delay_secs: 10,
+        };
+
+        let runtime_id = Uuid::new_v4();
+
+        let server = tokio::spawn(async move {
+            let mut read_buf = BytesMut::new();
+
+            // Receive AttachSession — reply with AttachBlocked.
+            let msg = recv_client_message(&mut server_stream, &mut read_buf).await;
+            assert!(matches!(msg.msg, Some(proto::client_message::Msg::AttachSession(_))));
+            send_server_message(
+                &mut server_stream,
+                &proto::ServerMessage {
+                    msg: Some(proto::server_message::Msg::AttachBlocked(proto::AttachBlocked {
+                        session_id: rttx_proto::uuid_to_bytes(runtime_id),
+                        current_client_role: 0,
+                        attached_client_count: 1,
+                        read_only_client_count: 0,
+                    })),
+                },
+            )
+            .await;
+        });
+
+        let result = actor
+            .resolve_and_attach_runtime(
+                "ws-1",
+                "Test Workspace",
+                WorkspacePolicy::Persistent,
+                Some(&runtime_id.to_string()),
+            )
+            .await;
+
+        assert!(result.is_err(), "ownership conflict should not fall back");
+
+        // Should have emitted a WorkspaceError.
+        let mut saw_error = false;
+        while let Ok(event) = event_rx.try_recv() {
+            if matches!(event, EndpointEvent::WorkspaceError { .. }) {
+                saw_error = true;
+            }
+        }
+        assert!(saw_error, "ownership conflict should emit WorkspaceError");
+
+        server.await.expect("fake server task should complete");
     }
 }

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3451,3 +3451,74 @@ fn auto_rename_skipped_after_manual_rename() {
 
     window.close();
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn retry_workspace_connection_sets_connecting_and_rebuilds_on_open() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.retry-connection-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let runtime_id = uuid::Uuid::new_v4();
+    let pane_id = uuid::Uuid::new_v4();
+    let session_state = crate::test_helpers::managed_session_with_runtime(
+        "workspace-retry",
+        "Retry Workspace",
+        LayoutNode::new_terminal_with_uuid("retry-pane"),
+        RuntimeEndpoint::Local,
+        WorkspacePolicy::Persistent,
+        Some(&runtime_id.to_string()),
+    );
+    window.imp().state.borrow_mut().sessions.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    // Simulate disconnected state.
+    window.set_workspace_connection_status(&session_state.uuid, &ConnectionStatus::Disconnected);
+
+    // Call retry — should set status to Connecting.
+    window.retry_workspace_connection(&session_state.uuid);
+
+    assert_eq!(
+        window.imp().workspace_connection_status.borrow().get(&session_state.uuid),
+        Some(&ConnectionStatus::Connecting),
+        "retry should set status to Connecting"
+    );
+
+    // Simulate the daemon responding with WorkspaceOpened.
+    window.handle_endpoint_event(crate::daemon_bridge::EndpointEvent::WorkspaceOpened {
+        workspace_id: session_state.uuid.clone(),
+        runtime_id: runtime_id.to_string(),
+        snapshot: rttx_proto::proto::Snapshot {
+            session_id: rttx_proto::uuid_to_bytes(runtime_id),
+            panes: vec![rttx_proto::proto::PaneSnapshot {
+                pane_id: rttx_proto::uuid_to_bytes(pane_id),
+                title: "shell".into(),
+                cwd: "/home/user".into(),
+                cols: 80,
+                rows: 24,
+                scrollback: b"reconnected".to_vec(),
+                exit_status: None,
+            }],
+            revision: 5,
+            current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
+        },
+    });
+    pump_events(50);
+
+    // The session content should have been rebuilt.
+    let stack = &window.imp().session_stack;
+    assert!(
+        stack.child_by_name(&session_state.uuid).is_some(),
+        "session content should exist after WorkspaceOpened"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -1076,3 +1076,54 @@ fn zoom_preserves_layout_tree_integrity() {
     session.zoomed_terminal_uuid = None;
     assert_eq!(session.layout, layout);
 }
+
+// ── Retry connection with stale runtime ─────────────────────────
+
+#[test]
+fn workspace_opened_with_new_runtime_id_updates_session_state() {
+    use rttx::daemon_bridge::EndpointEvent;
+    use rttx::runtime::WorkspacePolicy;
+    use rttx::session::SessionState;
+
+    let stale_runtime = uuid::Uuid::new_v4().to_string();
+    let new_runtime = uuid::Uuid::new_v4();
+    let pane_id = uuid::Uuid::new_v4();
+
+    let mut session =
+        SessionState::new_managed_local("Retry Test".into(), WorkspacePolicy::Ephemeral, None);
+    session.runtime.runtime_id = Some(stale_runtime);
+
+    let mut state = WindowState { sessions: vec![session], ..Default::default() };
+
+    // Simulate the daemon responding with a different runtime id
+    // (the stale one was gone, so a new runtime was created).
+    let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+        workspace_id: state.sessions[0].uuid.clone(),
+        runtime_id: new_runtime.to_string(),
+        snapshot: rttx_proto::proto::Snapshot {
+            session_id: rttx_proto::uuid_to_bytes(new_runtime),
+            panes: vec![rttx_proto::proto::PaneSnapshot {
+                pane_id: rttx_proto::uuid_to_bytes(pane_id),
+                title: "shell".into(),
+                cwd: "/home".into(),
+                cols: 80,
+                rows: 24,
+                scrollback: Vec::new(),
+                exit_status: None,
+            }],
+            revision: 1,
+            current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
+        },
+    });
+
+    // The session should have the new runtime id.
+    assert_eq!(
+        state.sessions[0].runtime.runtime_id.as_deref(),
+        Some(new_runtime.to_string().as_str()),
+        "runtime_id should be updated to the new runtime"
+    );
+
+    // The workspace should be rebuilt.
+    assert_eq!(transition.rebuilt_workspaces.len(), 1);
+    assert_eq!(transition.rebuilt_workspaces[0].workspace_id, state.sessions[0].uuid);
+}


### PR DESCRIPTION
## What changed

When a workspace had a saved `runtime_id` that no longer exists on the daemon
(daemon restarted, ephemeral runtime gone), the **Retry Connection** context
menu action would attempt to reattach, fail with a server error, and emit a
`Blocked` status — effectively doing nothing visible to the user.

### Root cause

`OpenWorkspace` in the endpoint actor used the saved `runtime_id` directly.
If the runtime no longer existed, `attach_runtime` failed and the handler
returned after emitting an error. No fallback to creating a fresh runtime.

### Fix

Add `resolve_and_attach_runtime()` that:
1. Tries to reattach to the saved runtime first
2. On ownership conflict (`AttachBlocked`) or transport failure — reports
   immediately without fallback
3. On other server errors (session not found, version mismatch) — falls back
   to creating a fresh runtime and attaching to it

The auto-reconnect (`Reconnect` command) is unchanged — it still uses the
direct `attach_runtime` without fallback, which is correct for background
reconnection.

## Manual verification

1. Start rttx with a daemon-backed workspace
2. Stop the daemon (`rttx-server stop`)
3. Restart the daemon (`rttx-server start`)
4. Click the 3-dot menu → Reconnect on the disconnected workspace
5. Workspace should reconnect with a fresh runtime

## Tests added

- `resolve_and_attach_falls_back_to_new_runtime_on_stale_id` — daemon bridge
  unit test: stale runtime → server error → create new → attach succeeds
- `resolve_and_attach_reports_ownership_conflict` — daemon bridge unit test:
  `AttachBlocked` → error reported, no fallback
- `retry_workspace_connection_sets_connecting_and_rebuilds_on_open` — GTK
  widget test: retry sets Connecting, WorkspaceOpened rebuilds session
- `workspace_opened_with_new_runtime_id_updates_session_state` — integration
  test: WorkspaceOpened with new runtime_id updates session state

## Tests run

- `cargo test -p rttx --lib` — 370 passed
- `cargo test -p rttx-server --lib` — 74 passed
- `cargo test -p rttx --test session_lifecycle` — 37 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass
- Runtime behavior gate — pass

Fixes #384