### PR TITLE
fix: propagate workspace rename from client to daemon

### DIFF
--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -558,6 +558,7 @@ pub fn extract_pane_id(msg: &proto::ServerMessage) -> Option<Uuid> {
         | Msg::AttachBlocked(_)
         | Msg::SessionDetached(_)
         | Msg::SessionTerminated(_)
+        | Msg::SessionRenamed(_)
         | Msg::Error(_) => return None,
     };
     bytes_to_uuid(bytes).ok()

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -36,6 +36,7 @@ pub enum ManagerOperation {
     RefreshInventory,
     SendInput,
     ResizePane,
+    RenameRuntime,
 }
 
 /// Event emitted back onto the GTK main loop from an endpoint actor.
@@ -134,6 +135,11 @@ enum EndpointCommand {
     Reconnect,
     ForgetWorkspace {
         workspace_id: String,
+    },
+    RenameRuntime {
+        workspace_id: String,
+        runtime_id: String,
+        name: String,
     },
 }
 
@@ -322,6 +328,21 @@ impl EndpointConnectionManager {
             .endpoint_handle(endpoint)
             .send(EndpointCommand::ForgetWorkspace { workspace_id: workspace_id.to_string() });
     }
+
+    /// Rename a runtime on the daemon.
+    pub fn rename_runtime(
+        &self,
+        workspace_id: &str,
+        endpoint: &RuntimeEndpoint,
+        runtime_id: &str,
+        name: &str,
+    ) {
+        let _ = self.endpoint_handle(endpoint).send(EndpointCommand::RenameRuntime {
+            workspace_id: workspace_id.to_string(),
+            runtime_id: runtime_id.to_string(),
+            name: name.to_string(),
+        });
+    }
 }
 
 #[derive(Debug)]
@@ -491,7 +512,8 @@ impl EndpointActor {
                     | proto::server_message::Msg::TitleChanged(_)
                     | proto::server_message::Msg::CwdChanged(_)
                     | proto::server_message::Msg::Bell(_)
-                    | proto::server_message::Msg::PaneResized(_),
+                    | proto::server_message::Msg::PaneResized(_)
+                    | proto::server_message::Msg::SessionRenamed(_),
                 ) => true,
                 Some(proto::server_message::Msg::SessionTerminated(_)) => !expect_terminated,
                 _ => false,
@@ -1020,6 +1042,26 @@ impl EndpointActor {
                 }
 
                 self.split_connection();
+            }
+            EndpointCommand::RenameRuntime { workspace_id, runtime_id, name } => {
+                let Some(runtime_uuid) = parse_uuid(
+                    &workspace_id,
+                    ManagerOperation::RenameRuntime,
+                    &runtime_id,
+                    &self.event_tx,
+                ) else {
+                    return;
+                };
+                if self.ensure_connected(&workspace_id).await.is_err() {
+                    return;
+                }
+                let msg = proto::ClientMessage {
+                    msg: Some(proto::client_message::Msg::RenameSession(proto::RenameSession {
+                        session_id: rttx_proto::uuid_to_bytes(runtime_uuid),
+                        name,
+                    })),
+                };
+                let _ = self.send_message(&msg).await;
             }
             EndpointCommand::ForgetWorkspace { workspace_id } => {
                 self.tracked_workspaces.remove(&workspace_id);

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -259,7 +259,7 @@ impl Window {
     }
 
     pub(super) fn rename_session(&self, session_uuid: &str, new_name: &str) {
-        {
+        let runtime_info = {
             let mut state = self.imp().state.borrow_mut();
             let Some(session) =
                 state.sessions.iter_mut().find(|session| session.uuid == session_uuid)
@@ -268,6 +268,16 @@ impl Window {
             };
             session.name = new_name.to_string();
             session.user_renamed = true;
+            session
+                .runtime
+                .managed
+                .then(|| (session.runtime.endpoint.clone(), session.runtime.runtime_id.clone()))
+        };
+
+        if let Some((endpoint, Some(runtime_id))) = runtime_info
+            && let Some(manager) = self.imp().connection_manager.borrow().as_ref()
+        {
+            manager.rename_runtime(session_uuid, &endpoint, &runtime_id, new_name);
         }
 
         let mut idx = 0;

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -673,6 +673,7 @@ impl Window {
             | Msg::AttachBlocked(_)
             | Msg::SessionDetached(_)
             | Msg::SessionTerminated(_)
+            | Msg::SessionRenamed(_)
             | Msg::Pong(_)
             | Msg::Error(_) => {}
         }

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -7,7 +7,6 @@
 use pretty_assertions::assert_eq;
 use rttx::runtime::WorkspaceRuntime;
 use rttx::session::*;
-
 // ── Helpers (can't use test_helpers from lib, so inline) ─────────
 
 fn term(id: &str) -> LayoutNode {
@@ -1126,4 +1125,24 @@ fn workspace_opened_with_new_runtime_id_updates_session_state() {
     // The workspace should be rebuilt.
     assert_eq!(transition.rebuilt_workspaces.len(), 1);
     assert_eq!(transition.rebuilt_workspaces[0].workspace_id, state.sessions[0].uuid);
+}
+
+#[test]
+fn rename_sets_user_renamed_and_persists_name() {
+    let mut session = SessionState::new_managed_local(
+        "Original".into(),
+        rttx::runtime::WorkspacePolicy::Ephemeral,
+        None,
+    );
+    session.runtime.runtime_id = Some(uuid::Uuid::new_v4().to_string());
+    assert!(!session.user_renamed);
+
+    session.name = "Renamed".into();
+    session.user_renamed = true;
+
+    let json = serde_json::to_string(&session).unwrap();
+    let restored: SessionState = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored.name, "Renamed");
+    assert!(restored.user_renamed);
+    assert!(restored.runtime.runtime_id.is_some());
 }

--- a/protocols/rttx-proto/proto/rttx.proto
+++ b/protocols/rttx-proto/proto/rttx.proto
@@ -72,6 +72,11 @@ message SetPaneTitle {
     string title = 3;
 }
 
+message RenameSession {
+    bytes session_id = 1;
+    string name = 2;
+}
+
 message Shutdown {}
 
 message Ping {
@@ -219,6 +224,12 @@ message AttachBlocked {
     uint32 read_only_client_count = 4;
 }
 
+message SessionRenamed {
+    bytes session_id = 1;
+    string name = 2;
+    uint64 revision = 3;
+}
+
 message Error {
     uint32 code = 1;
     string message = 2;
@@ -245,6 +256,7 @@ message ClientMessage {
         Shutdown shutdown = 11;
         TerminateSession terminate_session = 12;
         Ping ping = 13;
+        RenameSession rename_session = 14;
     }
 }
 
@@ -267,5 +279,6 @@ message ServerMessage {
         SessionTerminated session_terminated = 15;
         AttachBlocked attach_blocked = 16;
         Pong pong = 17;
+        SessionRenamed session_renamed = 18;
     }
 }

--- a/services/rttx-server/src/protocol.rs
+++ b/services/rttx-server/src/protocol.rs
@@ -284,6 +284,18 @@ pub const fn error(code: u32, message: String) -> proto::ServerMessage {
     }
 }
 
+/// Build a `SessionRenamed` response.
+#[must_use]
+pub fn session_renamed(session_id: Uuid, name: String, revision: u64) -> proto::ServerMessage {
+    proto::ServerMessage {
+        msg: Some(proto::server_message::Msg::SessionRenamed(proto::SessionRenamed {
+            session_id: uuid_to_bytes(session_id),
+            name,
+            revision,
+        })),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -761,6 +761,33 @@ impl Server {
                 Some(protocol::title_changed(session_id, pane_id, req.title, revision))
             }
 
+            proto::client_message::Msg::RenameSession(req) => {
+                let session_id = match bytes_to_uuid(&req.session_id) {
+                    Ok(id) => id,
+                    Err(e) => {
+                        return Some(protocol::error(
+                            protocol::ERR_INVALID_PARAMETER,
+                            e.to_string(),
+                        ));
+                    }
+                };
+                let mut s = server.lock().await;
+                let Some(session) = s.sessions.get_mut(&session_id) else {
+                    return Some(protocol::error(
+                        protocol::ERR_SESSION_NOT_FOUND,
+                        "session not found".into(),
+                    ));
+                };
+                if !session.client_has_write_access(client_id) {
+                    return Some(protocol::error(
+                        protocol::ERR_OWNERSHIP_CONFLICT,
+                        "runtime is currently owned by another client".into(),
+                    ));
+                }
+                let revision = session.rename(req.name.clone());
+                Some(protocol::session_renamed(session_id, req.name, revision))
+            }
+
             proto::client_message::Msg::Shutdown(_) => None,
         }
     }

--- a/services/rttx-server/src/session.rs
+++ b/services/rttx-server/src/session.rs
@@ -354,6 +354,15 @@ impl Session {
         DetachOutcome::Detached { revision: self.revision() }
     }
 
+    /// Rename this session and return the resulting revision.
+    pub fn rename(&mut self, name: String) -> u64 {
+        if self.name != name {
+            self.name = name;
+            self.bump_revision();
+        }
+        self.revision()
+    }
+
     /// Update a pane's size and return the resulting session revision.
     pub fn resize_pane(&mut self, pane_id: Uuid, cols: u16, rows: u16) -> Option<u64> {
         let changed = {
@@ -587,6 +596,20 @@ mod tests {
         assert_eq!(session.set_pane_exit_status(pane_id, Some(7)), Some(5));
         assert_eq!(session.set_pane_exit_status(pane_id, Some(7)), Some(5));
         assert_eq!(session.set_pane_exit_status(pane_id, None), Some(6));
+        assert_eq!(session.rename("test".into()), 6);
+        assert_eq!(session.rename("renamed".into()), 7);
+    }
+
+    #[test]
+    fn rename_updates_name_and_persists() {
+        let mut session = Session::new("original".into());
+        assert_eq!(session.name, "original");
+
+        session.rename("updated".into());
+        assert_eq!(session.name, "updated");
+
+        let persisted = session.to_persisted();
+        assert_eq!(persisted.name, "updated");
     }
 
     #[test]

--- a/services/rttx-server/tests/session_lifecycle.rs
+++ b/services/rttx-server/tests/session_lifecycle.rs
@@ -163,3 +163,92 @@ async fn create_and_close_pane() {
     let resp = client.recv().await;
     assert!(matches!(resp.msg, Some(proto::server_message::Msg::PaneClosed(_))));
 }
+
+#[tokio::test]
+async fn rename_session_updates_name_and_inventory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let session_id =
+        common::create_session(&mut client, "original", proto::RuntimePolicy::Persistent).await;
+    common::attach_rw(&mut client, &session_id).await;
+
+    // Rename the session.
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::RenameSession(proto::RenameSession {
+                session_id: session_id.clone(),
+                name: "renamed".into(),
+            })),
+        })
+        .await;
+
+    // Expect SessionRenamed response.
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionRenamed(renamed)) => {
+                assert_eq!(renamed.session_id, session_id);
+                assert_eq!(renamed.name, "renamed");
+                break;
+            }
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected SessionRenamed, got {other:?}"),
+        }
+    }
+
+    // Verify inventory reflects the new name.
+    let sessions = common::list_sessions(&mut client).await;
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].name, "renamed");
+}
+
+#[tokio::test]
+async fn rename_session_persists_across_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let session_id =
+        common::create_session(&mut client, "before", proto::RuntimePolicy::Persistent).await;
+    common::attach_rw(&mut client, &session_id).await;
+
+    // Rename.
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::RenameSession(proto::RenameSession {
+                session_id: session_id.clone(),
+                name: "after".into(),
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionRenamed(_)) => break,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected SessionRenamed, got {other:?}"),
+        }
+    }
+
+    // Wait for state to be persisted with the new name.
+    common::wait_for_state_containing(&tmp.path().join("cache"), "after", Duration::from_secs(5))
+        .await;
+
+    // Shutdown and restart.
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Shutdown(proto::Shutdown {})),
+        })
+        .await;
+    let _ = handle.await;
+
+    let (socket_path2, _handle2) = start_test_server(tmp.path()).await;
+    let mut client2 = TestClient::connect(&socket_path2).await;
+    client2.handshake().await;
+
+    let sessions = common::list_sessions(&mut client2).await;
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].name, "after");
+}


### PR DESCRIPTION
## What changed

When a workspace was renamed in the GUI sidebar, the new name was stored only in the client-side `SessionState`. The daemon's runtime kept the original name, causing:

1. Name inconsistency between GUI and daemon
2. Wrong name on recovery/reconnect if GUI state is lost
3. Stale names in daemon inventory

### Root cause

`rename_session()` in `window/dialogs.rs` updated `session.name` and `session.user_renamed` but never sent a message to the daemon.

### Fix

- Add `RenameSession` client→server protocol message and `SessionRenamed` server→client response
- Add `Session::rename()` on the server (bumps revision only on actual change)
- Handle `RenameSession` in the server message dispatcher with write-access check
- Add `RenameRuntime` endpoint command on the client
- Wire `rename_session()` to call `rename_runtime()` when the session has a runtime_id

## Manual verification

1. Start rttx with a daemon-backed workspace
2. Rename the workspace via sidebar
3. Run `rttx-server status` or restart the daemon — the new name persists

## Tests added

- `rename_updates_name_and_persists` — server unit test: rename changes name, bumps revision, persists
- `resize_title_and_exit_only_bump_revision_on_change` — extended with rename no-op assertion
- `rename_session_updates_name_and_inventory` — server integration: rename via protocol, verify inventory
- `rename_session_persists_across_restart` — server integration: rename persists across daemon restart
- `rename_sets_user_renamed_and_persists_name` — client integration: rename serialization roundtrip

## Tests run

- `cargo test -p rttx --lib` — 370 passed
- `cargo test -p rttx-server --lib` — 75 passed (was 74)
- `cargo test -p rttx --test session_lifecycle` — 38 passed (was 37)
- `cargo test -p rttx-server --test session_lifecycle` — 5 passed (was 3)
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass
- Runtime behavior gate — pass (no runtime-affecting changes detected)

Fixes #386