### PR TITLE
fix(sidebar): use accent color for all connected workspace icons

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -405,8 +405,8 @@ pub struct ConnectionIcon {
 /// - Direct (no daemon): `utilities-terminal-symbolic`
 ///
 /// Color encodes connection state (changes dynamically):
-/// - `dim-label`: normal / connecting
-/// - `accent`: connected (remote) or recovered
+/// - `dim-label`: connecting
+/// - `accent`: connected or recovered
 /// - `warning`: disconnected
 /// - `error`: blocked
 #[must_use]
@@ -424,17 +424,16 @@ pub const fn connection_icon(
         "utilities-terminal-symbolic"
     };
     let (css_class, tooltip) = match status {
-        ConnectionStatus::Connected => match endpoint {
-            RuntimeEndpoint::Local => ("dim-label", "Local workspace"),
-            RuntimeEndpoint::Remote { .. } => ("accent", "Connected to remote host"),
-        },
-        ConnectionStatus::Recovered => ("accent", "Connection recovered"),
+        ConnectionStatus::Connected | ConnectionStatus::Recovered => {
+            let tooltip = match endpoint {
+                RuntimeEndpoint::Local => "Connected to local runtime",
+                RuntimeEndpoint::Remote { .. } => "Connected to remote host",
+            };
+            ("accent", tooltip)
+        }
         ConnectionStatus::Disconnected => ("warning", "Disconnected from runtime"),
         ConnectionStatus::Blocked(_) => ("error", "Connection blocked"),
-        _ => match endpoint {
-            RuntimeEndpoint::Local => ("dim-label", "Connecting to local runtime"),
-            RuntimeEndpoint::Remote { .. } => ("dim-label", "Connecting to remote host"),
-        },
+        _ => ("dim-label", "Connecting…"),
     };
     ConnectionIcon { icon_name, css_class, tooltip }
 }
@@ -759,7 +758,7 @@ mod tests {
     fn connection_icon_computer_for_local_connected() {
         let icon = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, true);
         assert_eq!(icon.icon_name, "computer-symbolic");
-        assert_eq!(icon.css_class, "dim-label");
+        assert_eq!(icon.css_class, "accent");
     }
 
     #[test]
@@ -780,7 +779,7 @@ mod tests {
     #[test]
     fn connection_icon_color_for_local_managed() {
         let ep = RuntimeEndpoint::Local;
-        assert_eq!(connection_icon(&ep, &ConnectionStatus::Connected, true).css_class, "dim-label");
+        assert_eq!(connection_icon(&ep, &ConnectionStatus::Connected, true).css_class, "accent");
         assert_eq!(connection_icon(&ep, &ConnectionStatus::Recovered, true).css_class, "accent");
         assert_eq!(
             connection_icon(&ep, &ConnectionStatus::Disconnected, true).css_class,
@@ -850,7 +849,22 @@ mod tests {
         let ep = RuntimeEndpoint::Local;
         let icon = connection_icon(&ep, &ConnectionStatus::Connected, false);
         assert_eq!(icon.icon_name, "utilities-terminal-symbolic");
-        assert_eq!(icon.css_class, "dim-label");
+        assert_eq!(icon.css_class, "accent");
+    }
+
+    #[test]
+    fn connected_color_consistent_across_all_workspace_types() {
+        let local_managed =
+            connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, true);
+        let remote_managed = connection_icon(
+            &RuntimeEndpoint::Remote { host: "h".into() },
+            &ConnectionStatus::Connected,
+            true,
+        );
+        let direct = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, false);
+        assert_eq!(local_managed.css_class, "accent");
+        assert_eq!(remote_managed.css_class, "accent");
+        assert_eq!(direct.css_class, "accent");
     }
 
     #[test]
@@ -865,13 +879,13 @@ mod tests {
         assert_eq!(disconnected.tooltip, "Disconnected from runtime");
 
         let connecting_local = connection_icon(&local, &ConnectionStatus::Connecting, true);
-        assert_eq!(connecting_local.tooltip, "Connecting to local runtime");
+        assert_eq!(connecting_local.tooltip, "Connecting…");
 
         let connecting_remote = connection_icon(&remote, &ConnectionStatus::Connecting, true);
-        assert_eq!(connecting_remote.tooltip, "Connecting to remote host");
+        assert_eq!(connecting_remote.tooltip, "Connecting…");
 
         let local_connected = connection_icon(&local, &ConnectionStatus::Connected, true);
-        assert_eq!(local_connected.tooltip, "Local workspace");
+        assert_eq!(local_connected.tooltip, "Connected to local runtime");
     }
 
     #[test]

--- a/clients/rttx/src/sidebar.rs
+++ b/clients/rttx/src/sidebar.rs
@@ -316,14 +316,13 @@ mod tests {
 
         let local = crate::runtime::ConnectionIcon {
             icon_name: "computer-symbolic",
-            css_class: "dim-label",
-            tooltip: "Local workspace",
+            css_class: "accent",
+            tooltip: "Connected to local runtime",
         };
         row.set_connection_icon(&local);
         assert!(row.imp().connection_icon.is_visible());
         assert_eq!(row.imp().connection_icon.icon_name().unwrap(), "computer-symbolic");
-        assert!(!row.imp().connection_icon.has_css_class("accent"));
-        assert!(row.imp().connection_icon.has_css_class("dim-label"));
+        assert!(row.imp().connection_icon.has_css_class("accent"));
     }
 
     #[test]

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -1041,3 +1041,25 @@ fn workspace_menu_items_contract() {
     assert!(!minimal.show_reconnect);
     assert!(!minimal.show_detach);
 }
+
+/// Regression: connected icon color must be consistent across all endpoint types.
+///
+/// Previously, local connected workspaces used "dim-label" (gray) while remote
+/// connected workspaces used "accent" (colored), making local workspaces look
+/// disconnected.
+#[test]
+fn connected_icon_color_consistent_across_endpoints() {
+    use rttx::runtime::{ConnectionStatus, RuntimeEndpoint, connection_icon};
+
+    let local = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, true);
+    let remote = connection_icon(
+        &RuntimeEndpoint::Remote { host: "h".into() },
+        &ConnectionStatus::Connected,
+        true,
+    );
+    let direct = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, false);
+
+    assert_eq!(local.css_class, remote.css_class, "local and remote connected must match");
+    assert_eq!(local.css_class, direct.css_class, "local and direct connected must match");
+    assert_eq!(local.css_class, "accent", "connected workspaces must use accent color");
+}


### PR DESCRIPTION
## What changed

Connected local daemon workspaces showed a gray (`dim-label`) sidebar icon while remote connected workspaces showed an accent-colored icon. This made local workspaces look disconnected even when they were fully connected.

### Root cause

`connection_icon()` in `runtime.rs` mapped `Connected + Local` to `"dim-label"` (gray) but `Connected + Remote` to `"accent"` (colored). The color coding was inconsistent across endpoint types.

### Fix

Unify `Connected` and `Recovered` states into a single match arm that always returns `"accent"` regardless of endpoint type. Tooltips remain endpoint-specific (`Connected to local runtime` vs `Connected to remote host`). The `Connecting` state uses a generic `Connecting…` tooltip since the endpoint distinction isn't useful while still connecting.

Color mapping after fix:
| State | CSS class | Visual |
|---|---|---|
| Connected / Recovered | `accent` | Colored (all endpoints) |
| Connecting / Starting / Reconnecting | `dim-label` | Gray |
| Disconnected | `warning` | Yellow |
| Blocked | `error` | Red |

## Manual verification

1. Start rttx with a local daemon workspace
2. Sidebar icon should show accent color (not gray) when connected
3. Stop daemon → icon turns yellow (warning)
4. Restart daemon → icon returns to accent color

## Tests added

- `connected_color_consistent_across_all_workspace_types` — verifies all three workspace types (local managed, remote managed, direct) use `accent` when connected

## Tests updated

- `connection_icon_computer_for_local_connected` — now asserts `accent` instead of `dim-label`
- `connection_icon_color_for_local_managed` — Connected now asserts `accent`
- `connection_icon_direct_uses_terminal_icon` — now asserts `accent`
- `connection_icon_tooltips_describe_state` — updated tooltip expectations
- Sidebar `set_connection_icon` test — local connected now uses `accent`

## Tests run

- `cargo test -p rttx --lib` — 371 passed (was 370)
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass
- `cargo fmt --check` — clean

Fixes #388