### PR TITLE
docs(rfc): reframe workspace management v2

### DIFF
--- a/designs/RFC-016-workspace-management-v2.md
+++ b/designs/RFC-016-workspace-management-v2.md
@@ -11,56 +11,65 @@
 
 ## Summary
 
-Rework workspace creation, split-pane creation, bookmarks, and the right sidebar to reduce
-friction and eliminate confusion. Replace the single "+" button with explicit creation
-controls, replace bookmarks with Hosts and Places, scope commands and places to the active
-host, and remove tmux and template support.
+Rework workspace creation, session attachment, split-pane creation, and the right sidebar to
+make the product action-oriented and consistent.
 
-The one-tab-one-endpoint architecture is preserved.
+The UI should lead with what the user wants to do:
+- create a new daemon-backed workspace
+- connect to an existing daemon-backed workspace
+- fall back to a direct connection when needed
+
+The one-workspace-one-endpoint architecture is preserved. A workspace remains a tab, and a
+tab never mixes endpoints or runtime policies.
 
 ---
 
 ## Goals
 
-- **G1** — Common new-tab and split-pane actions are explicit and low-friction
-- **G2** — The right sidebar shows only content relevant to the active workspace's host
-- **G3** — Saved paths display compactly in dropdowns without losing distinguishability
-- **G4** — Connecting to a remote host with existing runtimes offers a clear attach-or-create
-  choice
-- **G5** — Remove dead-weight features (tmux bookmarks, templates) that add confusion
+- **G1** — The primary actions are explicit: `New`, `Connect to Existing`, `New Direct`
+- **G2** — Local and remote hosts follow the same creation and attachment model
+- **G3** — Discovering existing sessions on a host is explicit and not hidden behind side
+  effects
+- **G4** — The right sidebar is host-aware by default, but still lets users inspect and manage
+  global and orphaned content
+- **G5** — Direct mode remains available as a backup path without dominating the main UX
+- **G6** — Tmux and template features are removed from this model
 
 ## Non-Goals
 
-- **NG1** — Mixed-endpoint tabs (one tab with panes on different hosts)
-- **NG2** — Bookmark/command management UI (deferred)
-- **NG3** — Automatic host discovery (SSH config parsing, mDNS)
+- **NG1** — Mixed-endpoint tabs
+- **NG2** — Full command/place management UI
+- **NG3** — Session takeover from another client
+- **NG4** — Automatic host discovery (SSH config parsing, mDNS)
 
 ---
 
 ## Background & Motivation
 
-The current workspace and pane creation flow has four problems:
+The current experience is moving in the right direction, but it still feels implementation-led
+instead of user-led.
 
-1. **The "+" button always creates local-persistent.** Ephemeral and remote are buried in the
-   hamburger menu. Most users never discover them.
+### Problems in the current experience
 
-2. **Split panes always clone the parent.** There is no explicit choice between "clone what I
-   have" and "start a fresh pane in this workspace."
+1. **Creation is framed around backend types instead of user intent.**
+   `Direct`, `Persistent`, and `Remote` are transport/runtime concepts. Users usually think in
+   terms of "start something new" or "connect to what is already running."
 
-3. **Bookmarks conflate four concepts** (folder, SSH host, tmux session, combined) into one
-   entity. Users must understand the interaction matrix to create a useful bookmark.
+2. **Discoverability of existing sessions is inconsistent.**
+   A user should be able to explicitly ask "what sessions exist on this host?" without first
+   triggering a create-or-attach side effect.
 
-4. **Commands and bookmarks are global.** The same list appears whether you're on localhost or
-   a remote dev box. Commands that make sense locally (`cargo build`) are useless on a remote
-   host running a different project.
+3. **Direct mode has too much visual weight.**
+   It still needs to exist as a fallback path when daemon-backed flows are unavailable or
+   broken, but it should not lead the product.
 
-### What we're removing
+4. **Bookmarks are still too rigid.**
+   A place or command may be useful on multiple hosts, or globally. A single-host binding is
+   too narrow.
 
-| Feature | Reason |
-|---------|--------|
-| tmux bookmark type | Users can run tmux directly. Special handling adds complexity without proportional value. |
-| Templates | Low usage, unclear UX. Will revisit when the new model stabilizes. |
-| Combined bookmarks (SSH + folder + tmux) | Replaced by the Host + Place model which is more intuitive. |
+5. **The sidebar cannot gracefully represent orphaned host associations.**
+   If a host is removed but items still reference it, those items should remain visible and
+   manageable.
 
 ---
 
@@ -68,348 +77,297 @@ The current workspace and pane creation flow has four problems:
 
 | Audience     | Impact |
 |--------------|--------|
-| End users    | Faster workspace creation, less confusion, host-aware sidebar |
-| Contributors | Simpler bookmark model, fewer code paths |
+| End users    | Clearer new-vs-attach flows, more consistent host model, better sidebar scoping |
+| Contributors | Simpler top-level UX model, less attach/create ambiguity |
 | Packagers    | No impact |
 
 ---
 
 ## Design
 
-### 1. Tab creation bar
+### 1. Top bar actions
 
-The header bar replaces the single "+" button with a row of creation controls:
+Replace the current creation affordance with three primary actions:
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│ [Direct ▾]  [Persistent ▾]  [Remote ▾]          [Tools] [≡]    │
-└──────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+│ [New ▾]  [Connect to Existing ▾]  [New Direct]   [Tools] [≡]     │
+└────────────────────────────────────────────────────────────────────┘
 ```
 
-Each is a split button: clicking the button creates with defaults, clicking the dropdown
-arrow shows saved places (for Direct/Persistent) or saved hosts (for Remote).
+These controls are action-oriented, not runtime-oriented.
 
-#### Direct button
+#### New
 
-- **Click**: New direct tab in `$HOME`
-- **Dropdown**: List of saved local places. Selecting one creates a direct tab in that
-  directory.
+Creates a new daemon-backed workspace.
 
-#### Persistent button
+- The menu contains the local host plus saved remote hosts
+- Selecting a host opens the **New Workspace** dialog for that host
+- The dialog is the same for local and remote
 
-- **Click**: New local-persistent tab in `$HOME`
-- **Dropdown**: List of saved local places. Selecting one creates a persistent tab in that
-  directory.
+#### Connect to Existing
 
-#### Remote button
+Attaches to an already-running daemon-backed workspace.
 
-- **Click**: Opens the host list dropdown immediately (no default — you must pick a host)
-- **Dropdown**: List of saved hosts. Selecting one initiates connection.
+- The menu contains the local host plus saved remote hosts
+- Selecting a host opens the **Connect to Existing** dialog for that host
+- The dialog is the same for local and remote
 
-When a host is selected, the remote attach flow begins (see §4).
+#### New Direct
+
+Creates a new direct workspace immediately.
+
+This remains available as a fallback path when the daemon model is unavailable or when the
+user intentionally wants a direct session. It is intentionally a secondary action, not the
+main workflow.
 
 #### Keyboard shortcuts
 
 | Action | Shortcut |
 |--------|----------|
-| New direct tab | Ctrl+Shift+T (unchanged) |
-| New persistent tab | Ctrl+Shift+P |
-| New remote tab | Ctrl+Shift+R |
+| New workspace | Ctrl+Shift+T |
+| Connect to existing | Ctrl+Shift+A |
+| New direct | Ctrl+Shift+D |
 
-### 2. Hosts and Places
+### 2. Host model
 
-Bookmarks are replaced by two separate concepts.
-
-#### Hosts
-
-A saved SSH connection target.
+Local and remote should participate in the same selection model.
 
 ```rust
 struct Host {
-    uuid: String,
-    name: String,           // display name, e.g. "dev-box"
-    ssh_target: String,     // user@host or host, passed to ssh
-    endpoint_key: String,   // canonical identity derived from ssh_target
+    key: String,         // canonical endpoint key, e.g. "local" or normalized SSH target
+    name: String,        // display name
+    kind: HostKind,      // Local or Remote
+    ssh_target: Option<String>,
 }
 ```
 
-`endpoint_key` is the canonical remote identity used throughout the UI and persistence. It is
-derived from a normalized SSH target and is what remote workspaces, places, and commands match
-against. A Host record is saved metadata layered on top of endpoint identity, not the identity
-itself.
+#### Host identity
 
-Hosts appear in the Remote dropdown and in the right sidebar when managing connections.
+`key` is the canonical identity used throughout the UI and persistence.
 
-#### Places
+- Local uses a reserved built-in key: `local`
+- Remote hosts use a normalized endpoint key derived from the SSH target
+- Matching for sessions, commands, and places is always done by host key
 
-A saved directory shortcut, scoped to a host.
+Saved host records are metadata layered on top of endpoint identity. If a workspace is opened
+for a host that does not currently exist in the saved host list, the workspace still has a
+stable host key and the UI still works.
+
+### 3. New Workspace dialog
+
+When the user chooses a host from **New**, the GUI opens a host-specific dialog instead of
+creating immediately.
+
+```
+┌──────────────────────────────────────────────┐
+│ New Workspace: dev-box                       │
+│ Search: [______________________________]     │
+│                                              │
+│ Suggested                                    │
+│  • Home                                      │
+│  • Root                                      │
+│                                              │
+│ Saved Places                                 │
+│  • ~/pro/rttx                                │
+│  • ~/src/redis                               │
+│  • /srv/app                                  │
+└──────────────────────────────────────────────┘
+```
+
+#### Behavior
+
+- The dialog includes search
+- The list is scoped to the selected host, plus global places
+- `Home` and `Root` are always present as built-in global entries
+- Choosing an entry creates a new daemon-backed workspace on that host at that place
+- The dialog may later support "empty/new shell" explicitly, but the initial design assumes
+  that choosing `Home` or `Root` covers the common path
+
+This flow makes "new local" and "new remote" the same user experience.
+
+### 4. Connect to Existing dialog
+
+When the user chooses a host from **Connect to Existing**, the GUI opens a session picker for
+that host.
+
+```
+┌──────────────────────────────────────────────┐
+│ Connect to Existing: dev-box                 │
+│ Search: [______________________________]     │
+│                                              │
+│ Available                                    │
+│  • ~/pro/rttx           2 panes              │
+│  • ~/src/redis          1 pane               │
+│                                              │
+│ Busy                                         │
+│  • /srv/app             Connected elsewhere  │
+└──────────────────────────────────────────────┘
+```
+
+#### Behavior
+
+- The dialog shows all daemon-backed sessions discoverable on the selected host
+- Sessions connected by another client are visible but disabled
+- Sessions already attached by the same client are visible but disabled
+- Busy and already-open sessions must be visually distinct
+- This RFC does not add takeover. That remains future work
+
+The key product rule is explicitness: the user is consciously in a "connect to existing"
+flow, not discovering existing sessions as a side effect of a create action.
+
+### 5. Direct mode
+
+Direct mode remains supported, but it is intentionally separated from the primary daemon-backed
+flows.
+
+#### Product position
+
+- Direct is a backup path
+- Direct is not the default
+- Direct should not shape the main mental model
+
+This keeps the feature available without letting it stand in the way of the primary experience.
+
+### 6. Places and commands
+
+Bookmarks are replaced with **Places**. Commands remain commands.
+
+Both are tag-based rather than single-host-bound.
 
 ```rust
 struct Place {
     uuid: String,
-    path: String,           // absolute path, e.g. "/home/user/projects/rttx"
-    host_key: Option<String>,   // None = local, Some(endpoint_key) = specific remote host
-    global: bool,               // true = show for every host
+    path: String,
+    host_tags: Vec<String>,   // empty = global
 }
-```
 
-Places appear in the Direct/Persistent dropdowns (local places) and in the right sidebar
-(host-scoped places for the active workspace).
-
-#### Global places
-
-A place with `host_key: None` and `global: true` appears in the sidebar for every host. Use
-case: paths like `/tmp` or `/var/log` that exist on every machine.
-
-#### Migration
-
-Existing bookmarks are migrated automatically:
-- Bookmark with only `directory` → local Place
-- Bookmark with only `ssh_target` → Host
-- Bookmark with `ssh_target` + `directory` → Host + Place scoped to that host's `endpoint_key`
-- Bookmark with `tmux_session` → dropped
-
-### 3. Path contraction for dropdowns
-
-Places are displayed in dropdowns with limited width. Full paths like
-`/home/user/projects/rttx/clients/rttx/src` are too long. We need a contraction algorithm
-that is both compact and unambiguous.
-
-#### Algorithm: disambiguating fish-style contraction
-
-Given a set of paths to display together, contract each path so that:
-1. The leaf component (last segment) is always shown in full
-2. Parent components are shortened to the minimum prefix that distinguishes them from
-   siblings at the same level in the set
-3. Home directory is replaced with `~`
-4. The result fits within a maximum character width (default: 40)
-
-**Step 1 — Tilde collapse**: Replace `$HOME` prefix with `~`.
-
-**Step 2 — Build a trie** of all path components across all paths in the set.
-
-**Step 3 — For each path**, walk the trie. At each level, find the shortest prefix of the
-component that is unique among its siblings in the trie. If the component has no siblings,
-use 1 character.
-
-**Step 4 — Width constraint**: If the contracted path still exceeds the max width, shorten
-from the left (closest to root), reducing components to 1 character each until it fits.
-The leaf is never shortened.
-
-#### Examples
-
-Given these three local places:
-```
-/home/user/projects/rttx
-/home/user/projects/redis
-/home/user/pictures/vacation
-```
-
-After tilde collapse:
-```
-~/projects/rttx
-~/projects/redis
-~/pictures/vacation
-```
-
-Trie at level 2 (under `~`): `projects` and `pictures` are siblings.
-- `projects` → `pro` (minimum to distinguish from `pictures`)
-- `pictures` → `pic`
-
-Trie at level 3 (under `projects`): `rttx` and `redis` are siblings, but both are leaves
-so they stay full.
-
-Result:
-```
-~/pro/rttx
-~/pro/redis
-~/pic/vacation
-```
-
-If we add `/home/user/projects/rttx/clients/rttx/src`:
-```
-~/pro/rttx
-~/pro/redis
-~/pic/vacation
-~/pro/rttx/c/r/src
-```
-
-The inner `clients` has no siblings at that level → 1 char. Same for the inner `rttx`.
-
-#### Edge cases
-
-- **Single path**: No siblings anywhere → every parent gets 1 char.
-  `/home/user/projects/rttx` → `~/p/rttx`
-- **Root paths**: `/var/log` → `/v/log` (no tilde collapse)
-- **Identical prefixes**: `/opt/app-v1/src` and `/opt/app-v2/src` →
-  `app-v1` and `app-v2` need 6 chars each to disambiguate → `/o/app-v1/src` and
-  `/o/app-v2/src`
-
-### 4. Remote attach flow
-
-When the user selects a host from the Remote dropdown, the GUI connects to the remote
-daemon. The daemon may already have running runtimes (persistent workspaces from a previous
-session).
-
-#### Case A: No existing runtimes
-
-The daemon has no running runtimes. The GUI creates a new persistent workspace on the
-remote host and opens it as a new tab.
-
-**User journey**: Remote ▾ → "dev-box" → new tab appears, shell prompt on dev-box.
-**Clicks**: 2 (dropdown + host selection).
-
-#### Case B: Existing runtimes
-
-The daemon reports one or more running runtimes via `ListSessions`. The GUI must let the
-user choose: attach to an existing runtime, or create a new one.
-
-**UX: Inline popover on the Remote dropdown**
-
-When the host has existing runtimes, instead of immediately creating a tab, a popover
-appears below the host entry:
-
-```
-┌─────────────────────────────────┐
-│  dev-box                        │
-│  ───────────────────────────    │
-│  ● Attach: ~/pro/rttx    (2p)  │
-│  ● Attach: ~/src/redis   (1p)  │
-│  ───────────────────────────    │
-│  + New workspace                │
-└─────────────────────────────────┘
-```
-
-Each existing runtime shows:
-- Its contracted CWD (from the first pane's last known working directory)
-- Pane count in parentheses (`2p` = 2 panes)
-
-Selecting "Attach" opens that runtime as a new tab. Selecting "New workspace" creates a
-fresh persistent workspace.
-
-**User journey (attach)**: Remote ▾ → "dev-box" → popover → "Attach: ~/pro/rttx" → tab.
-**Clicks**: 3.
-
-**User journey (new)**: Remote ▾ → "dev-box" → popover → "New workspace" → tab.
-**Clicks**: 3.
-
-#### Case C: Single existing runtime
-
-When there is exactly one runtime, the popover still appears (no auto-attach). The user
-might want a new workspace, not the existing one. Auto-attaching would be surprising.
-
-#### Remote + Place
-
-A user can also create a remote workspace at a specific directory. This is a 2-click
-operation from the right sidebar:
-
-1. Switch to a tab connected to the target host (or create one via Remote dropdown)
-2. Click a place in the right sidebar → the active pane `cd`s to that directory
-
-This is not a single-action "remote + place" creation from the header bar. The header bar
-Remote button connects to a host; the sidebar navigates within it. This separation keeps
-the header bar simple and avoids a two-level dropdown (host → place) which would be
-clunky.
-
-### 5. Host-scoped right sidebar
-
-The right sidebar auto-switches content based on the active workspace's endpoint. This RFC
-keeps the existing one-workspace-one-endpoint architecture, so the sidebar is scoped by the
-active workspace, not by individual panes or per-project context inside a workspace.
-
-#### Structure
-
-```
-┌─────────────────────┐
-│  [Places] [Commands] │
-│  ─────────────────── │
-│  🔍 filter           │
-│                      │
-│  ~/pro/rttx          │
-│  ~/pro/redis         │
-│  ~/pic/vacation      │
-│                      │
-│  ── Global ────────  │
-│  /tmp                │
-│  /var/log            │
-└─────────────────────┘
-```
-
-#### Switching logic
-
-When the user switches tabs:
-1. Determine the active workspace's endpoint: `Local` or `Remote { host }`
-2. Convert the endpoint into a scope key: `None` for local, `Some(endpoint_key)` for remote
-3. Filter places to show only those matching the scope key (plus global places)
-4. Filter commands to show only those matching the scope key (plus global commands)
-
-For local workspaces, show places/commands where `host_key` is `None`.
-For remote workspaces, show places/commands where `host_key` matches the workspace's
-`endpoint_key`.
-
-Global entries (marked `global: true`) appear in a separate section at the bottom,
-regardless of the active host.
-
-If a remote workspace is connected to an endpoint that does not yet have a saved Host record,
-the sidebar still scopes by `endpoint_key`. The Host object is optional metadata; matching and
-filtering do not depend on it existing.
-
-#### Commands
-
-Commands gain a `host_key` field, same as places:
-
-```rust
 struct SavedCommand {
     uuid: String,
     title: String,
     body: String,
     default_run_mode: CommandRunMode,
-    host_key: Option<String>,   // None = local, Some(endpoint_key) = specific remote host
-    global: bool,               // true = show for all hosts
+    host_tags: Vec<String>,   // empty = global
 }
 ```
 
-Existing commands are migrated as local (`host_key: None`).
+#### Tagging rules
 
-### 6. Split pane behavior
+- `host_tags.is_empty()` means the item is global
+- One or more tags means the item is scoped to those hosts
+- A place or command may be tagged for any number of hosts
+- Host tags are host keys, not display names
 
-When splitting a pane (Ctrl+Shift+E / Ctrl+Shift+O), the GUI opens a split chooser anchored to
-the split action. The chooser uses the same explicit-creation pattern as new-tab creation, but
-it is constrained to the active workspace's runtime. A workspace remains bound to one endpoint
-and one runtime policy, so the chooser never offers cross-endpoint or cross-runtime actions.
+#### Built-in global places
+
+The global place set includes these entries by default:
+- `Home`
+- `Root`
+
+Additional global places and commands are user-managed content.
+
+#### Migration
+
+Existing bookmarks are migrated as follows:
+- bookmark with only `directory` → local-tagged Place
+- bookmark with only `ssh_target` → Host
+- bookmark with `ssh_target` + `directory` → Place tagged with that host key
+- bookmark with `tmux_session` → dropped
+
+Existing commands migrate into the new tag model:
+- local-only commands become tagged with `local`
+- commands that were intended to be global may later be retagged by the user
+
+### 7. Host-aware right sidebar
+
+The right sidebar becomes host-aware, but not host-blind.
+
+```
+┌──────────────────────────────────────────────┐
+│ Search: [______________________________]     │
+│ Host: [dev-box ▾]                            │
+│                                              │
+│ [Places] [Commands]                          │
+│                                              │
+│ Host-specific                                │
+│  • ~/pro/rttx                                │
+│  • ~/src/redis                               │
+│                                              │
+│ Global                                       │
+│  • Home                                      │
+│  • Root                                      │
+│  • /tmp                                      │
+└──────────────────────────────────────────────┘
+```
+
+#### Default behavior
+
+- When the user switches workspaces, the sidebar host selector automatically follows the
+  active workspace host
+- Places and commands shown in the host-specific section are those tagged with the selected
+  host key
+- Items with no tags appear in the global section
+
+#### Manual override
+
+The user may manually change the host selector in the sidebar to inspect content for a
+different host without switching tabs.
+
+#### Selector population
+
+The sidebar host selector must not be derived only from the current saved host list.
+
+It is populated from:
+- host keys currently assigned to places or commands
+- plus the active workspace host, when needed for context
+
+This guarantees that orphaned content remains visible and manageable.
+
+#### Orphaned tags
+
+If a host record is deleted but items still reference that host key:
+
+- the tag remains intact
+- the selector still shows it
+- the UI renders it as missing/orphaned
+- cleanup is explicit, not automatic
+
+Automatic cleanup on host deletion is worse UX because it silently removes information users
+may still need to inspect or retag later.
+
+### 8. Split pane behavior
+
+Split-pane creation should use the same explicit model as top-level creation, but it remains
+constrained to the current workspace.
 
 ```
 ┌──────────────────────────────┐
 │ Clone parent                │
 │ New shell                   │
+│ Open place: Home            │
 │ Open place: ~/pro/rttx      │
-│ Open place: ~/pro/redis     │
 └──────────────────────────────┘
 ```
 
 #### Split chooser rules
 
-- **Clone parent**: Same endpoint, same working directory, same launch context
-- **New shell**: New pane in the current workspace using that workspace's default launch mode
-- **Open place**: New pane in the current workspace, starting at a place scoped to the current
-  host
+- **Clone parent**: same launch context and working directory as the source pane
+- **New shell**: new pane in the current workspace using the workspace's default launch mode
+- **Open place**: new pane in the current workspace at a host-compatible place
 
-For a local workspace, the place list is local places plus global places.
-For a remote workspace, the place list is places matching that remote workspace's
-`endpoint_key` plus global places.
+Because a workspace is still a single tab bound to one endpoint/runtime policy, split never
+offers cross-host or cross-runtime actions.
 
-This keeps split explicit without violating the one-workspace-one-endpoint architecture.
-
-### 7. Terminology changes
+### 9. Terminology
 
 | Old term | New term | Reason |
 |----------|----------|--------|
-| Bookmark | *(removed)* | Replaced by Host and Place |
-| Bookmark (folder) | Place | Clearer: it's a directory shortcut |
-| Bookmark (SSH) | Host | Clearer: it's a connection target |
-| Bookmark (tmux) | *(removed)* | Feature removed |
-| Bookmark (combined) | *(removed)* | Replaced by Host + Place scoping |
-| Template | *(removed)* | Feature removed, revisit later |
+| Bookmark | Place | A saved navigation target |
+| Bookmark (SSH) | Host | A connection target |
+| Template | *(removed)* | Not part of the primary model |
+| tmux bookmark | *(removed)* | Dropped |
+| Persistent workspace | Workspace | Default daemon-backed workspace path |
+| Direct workspace | Direct | Secondary fallback path |
 
 ---
 
@@ -417,40 +375,42 @@ This keeps split explicit without violating the one-workspace-one-endpoint archi
 
 | Goal | How addressed |
 |------|---------------|
-| G1 — Explicit, low-friction creation | Split buttons for new tabs, chooser for splits, no hidden workspace types |
-| G2 — Host-scoped sidebar | Auto-switch on tab change, filter by endpoint key |
-| G3 — Compact paths | Disambiguating fish-style contraction with max-width constraint |
-| G4 — Remote attach UX | Popover showing existing runtimes + "New workspace" option |
-| G5 — Remove dead weight | tmux bookmarks and templates removed |
+| G1 — Explicit primary actions | Top bar uses `New`, `Connect to Existing`, `New Direct` |
+| G2 — Same local/remote model | Both flows begin with host selection |
+| G3 — Explicit session discovery | Existing sessions are reachable only through a dedicated attach flow |
+| G4 — Host-aware but manageable sidebar | Default host-following selector, global section, orphan visibility |
+| G5 — Direct as backup | Direct remains available but secondary |
+| G6 — Remove dead weight | Tmux and templates are dropped |
 
 ---
 
 ## Development Plan
 
-- [ ] **Data model: Host and Place** — new structs, storage, migration from bookmarks
-- [ ] **Path contraction** — implement the disambiguating contraction algorithm
-- [ ] **Tab creation bar** — replace "+" with Direct/Persistent/Remote split buttons
-- [ ] **Remote attach popover** — inventory query + attach/create choice
-- [ ] **Host-scoped sidebar** — auto-switch places and commands on tab change
-- [ ] **Command host scoping** — add `host_key` to `SavedCommand`, migrate existing
-- [ ] **Split chooser** — replace implicit clone-only split with explicit in-workspace chooser
-- [ ] **Remove tmux support** — drop `tmux_session` from data model and UI
-- [ ] **Remove templates** — drop template UI and related code
-- [ ] **Keyboard shortcuts** — Ctrl+Shift+P (persistent), Ctrl+Shift+R (remote)
+- [ ] Replace the top bar entrypoints with `New`, `Connect to Existing`, and `New Direct`
+- [ ] Introduce canonical host keys for local and remote endpoints
+- [ ] Add the **New Workspace** dialog with search and host-scoped place selection
+- [ ] Add the **Connect to Existing** dialog with clear available/busy state
+- [ ] Replace bookmark storage with Places + host-tagging
+- [ ] Update commands to use host tags instead of single-host binding
+- [ ] Add built-in global places: `Home` and `Root`
+- [ ] Rework the right sidebar around search + host selector + tagged content
+- [ ] Preserve and surface orphaned tags instead of cleaning them automatically
+- [ ] Replace clone-only split with an explicit in-workspace split chooser
+- [ ] Remove tmux-related data model and UI paths
+- [ ] Remove template-related UI and data paths
 
 ---
 
 ## Open Questions
 
-- **Q1** — Should the path contraction algorithm run on every dropdown open (recomputing
-  the trie from the current place set), or precompute and cache? The place set is small
-  (typically <50 entries), so recomputing is likely fine.
-- **Q2** — When a remote host is unreachable, should the Remote dropdown show it grayed out
-  with a tooltip, or show it normally and fail on click? Grayed out requires background
-  connectivity checks which add complexity.
-- **Q3** — Should places support user-defined short names (aliases) in addition to the
-  auto-contracted path? This would let users name a place "rttx" instead of "~/pro/rttx".
-  Deferred for now — the contraction algorithm should be sufficient.
+- **Q1** — In the **New Workspace** dialog, do we want an explicit "Empty shell" row in addition
+  to `Home` and `Root`, or are those sufficient?
+- **Q2** — Should the host menus in the top bar show recent hosts first, or always keep a fixed
+  local-then-remote ordering?
+- **Q3** — Do we want aliases for places in v2, or is path-only presentation sufficient for the
+  first implementation?
+- **Q4** — Should host deletion offer an explicit cleanup dialog for affected tags immediately,
+  or should cleanup remain a later management action?
 
 ---
 
@@ -459,5 +419,3 @@ This keeps split explicit without violating the one-workspace-one-endpoint archi
 - [RFC-002: Adwaita Modernization & SessionRow Redesign](./RFC-002-adwaita-modernization.md)
 - [RFC-013: Persistent Host Sessions](./RFC-013-persistent-host-sessions.md)
 - [RFC-015: Workspace Sidebar Row Content Specification](./RFC-015-workspace-sidebar-rows.md)
-- [fish shell `prompt_pwd`](https://fishshell.com/docs/current/cmds/prompt_pwd.html) — prior art for path shortening
-- [spwd](https://github.com/ayosec/spwd) — prior art for max-width path contraction


### PR DESCRIPTION
## Summary
- reframe RFC 16 around explicit user intents: `New`, `Connect to Existing`, and `New Direct`
- treat local and remote as the same host-selection model for daemon-backed flows
- replace single-host bindings with host-tagged places and commands
- make orphaned tags visible and manageable rather than silently cleaning them up
- keep direct mode as a secondary fallback path rather than a primary top-level concept

## Why
The previous RFC 16 draft was a step forward, but it still exposed runtime/backend concepts too directly and made session discovery feel inconsistent. This revision makes the workflow action-first and host-aware:
- creating a new workspace is explicit
- connecting to an existing session is explicit
- local and remote follow the same mental model
- sidebar filtering remains useful even when host records are deleted

## Verification
- repo commit hooks ran successfully during commit
- RFC-only change; no runtime or behavioral tests required