### PR TITLE
fix(server): broadcast CwdChanged when pane CWD updates via OSC 7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "prost",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/clients/rttx/Cargo.toml
+++ b/clients/rttx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rttx"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 description = "A tiling terminal emulator for GNOME"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.0',
+  version: '0.2.1',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/Cargo.toml
+++ b/protocols/rttx-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rttx-proto"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 

--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rttx-server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -17,6 +17,12 @@ const DEFAULT_MAX_SCROLLBACK: usize = 10 * 1024 * 1024;
 /// Default on-disk scrollback log byte limit per pane (10 MB).
 const DEFAULT_MAX_SCROLLBACK_LOG: u64 = 10 * 1024 * 1024;
 
+/// What changed after feeding PTY output to a pane.
+pub struct FeedResult {
+    /// New CWD if it changed from the previous value.
+    pub new_cwd: Option<String>,
+}
+
 /// Runtime state of a single pane.
 pub struct Pane {
     /// Unique pane identifier.
@@ -63,15 +69,22 @@ impl Pane {
     }
 
     /// Feed PTY output into the screen state.
-    pub fn feed_output(&mut self, data: &[u8]) {
+    pub fn feed_output(&mut self, data: &[u8]) -> FeedResult {
         self.screen.feed(data);
         self.pending_flush.extend_from_slice(data);
         if let Some(title) = self.screen.title() {
             self.title = Some(title.to_string());
         }
-        if let Some(cwd) = self.screen.cwd() {
-            self.cwd = Some(cwd.to_string());
-        }
+        let new_cwd = self.screen.cwd().and_then(|cwd| {
+            let cwd = cwd.to_string();
+            if self.cwd.as_deref() == Some(&cwd) {
+                None
+            } else {
+                self.cwd = Some(cwd.clone());
+                Some(cwd)
+            }
+        });
+        FeedResult { new_cwd }
     }
 
     /// Flush pending scrollback bytes to the log file on disk.
@@ -330,5 +343,37 @@ mod tests {
         std::fs::write(&path, b"AAABBBCCC").unwrap();
         truncate_log_tail(&path, 3).unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"CCC");
+    }
+
+    #[test]
+    fn feed_output_returns_new_cwd_on_osc7() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        assert!(pane.cwd.is_none());
+
+        // OSC 7 with file URI.
+        let osc7 = b"\x1b]7;file://localhost/tmp/test\x07";
+        let result = pane.feed_output(osc7);
+        assert_eq!(result.new_cwd.as_deref(), Some("/tmp/test"));
+        assert_eq!(pane.cwd.as_deref(), Some("/tmp/test"));
+    }
+
+    #[test]
+    fn feed_output_returns_none_when_cwd_unchanged() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+
+        let osc7 = b"\x1b]7;file://localhost/tmp/test\x07";
+        let result = pane.feed_output(osc7);
+        assert!(result.new_cwd.is_some());
+
+        // Same CWD again — should not report a change.
+        let result = pane.feed_output(osc7);
+        assert!(result.new_cwd.is_none());
+    }
+
+    #[test]
+    fn feed_output_returns_none_for_plain_output() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let result = pane.feed_output(b"hello world\r\n");
+        assert!(result.new_cwd.is_none());
     }
 }

--- a/services/rttx-server/src/protocol.rs
+++ b/services/rttx-server/src/protocol.rs
@@ -256,6 +256,24 @@ pub fn title_changed(
     }
 }
 
+/// Build a `CwdChanged` message.
+#[must_use]
+pub fn cwd_changed(
+    session_id: Uuid,
+    pane_id: Uuid,
+    cwd: String,
+    revision: u64,
+) -> proto::ServerMessage {
+    proto::ServerMessage {
+        msg: Some(proto::server_message::Msg::CwdChanged(proto::CwdChanged {
+            session_id: uuid_to_bytes(session_id),
+            pane_id: uuid_to_bytes(pane_id),
+            cwd,
+            revision,
+        })),
+    }
+}
+
 /// Build an `AttachBlocked` response.
 #[must_use]
 pub fn attach_blocked(
@@ -408,5 +426,19 @@ mod tests {
                     .to_vec(),
             ]
         );
+    }
+
+    #[test]
+    fn cwd_changed_message_contains_correct_fields() {
+        let sid = Uuid::new_v4();
+        let pid = Uuid::new_v4();
+        let msg = cwd_changed(sid, pid, "/home/user".into(), 42);
+        let proto::server_message::Msg::CwdChanged(inner) = msg.msg.unwrap() else {
+            panic!("expected CwdChanged");
+        };
+        assert_eq!(inner.cwd, "/home/user");
+        assert_eq!(inner.revision, 42);
+        assert_eq!(inner.session_id, sid.as_bytes().to_vec());
+        assert_eq!(inner.pane_id, pid.as_bytes().to_vec());
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -812,13 +812,23 @@ fn spawn_pty_read_loop(
                         Ok(n) => {
                             let data = buf[..n].to_vec();
                             let mut s = server.lock().await;
-                            if let Some(session) = s.sessions.get_mut(&session_id)
+                            let new_cwd = if let Some(session) = s.sessions.get_mut(&session_id)
                                 && let Some(pane) = session.panes.get_mut(&pane_id)
                             {
-                                pane.feed_output(&data);
-                            }
+                                let result = pane.feed_output(&data);
+                                result.new_cwd.and_then(|cwd| {
+                                    let rev = session.set_pane_cwd(pane_id, &cwd)?;
+                                    Some((cwd, rev))
+                                })
+                            } else {
+                                None
+                            };
                             let msg = protocol::delta(session_id, pane_id, data);
                             s.broadcast_to_session(session_id, &msg);
+                            if let Some((cwd, revision)) = new_cwd {
+                                let msg = protocol::cwd_changed(session_id, pane_id, cwd, revision);
+                                s.broadcast_to_session(session_id, &msg);
+                            }
                         }
                         Err(e) => {
                             tracing::error!("PTY read error for pane {pane_id}: {e}");

--- a/services/rttx-server/src/session.rs
+++ b/services/rttx-server/src/session.rs
@@ -392,6 +392,13 @@ impl Session {
         Some(self.revision())
     }
 
+    /// Record a CWD change detected by `feed_output` and bump revision.
+    pub fn set_pane_cwd(&mut self, pane_id: Uuid, _cwd: &str) -> Option<u64> {
+        self.panes.get(&pane_id)?;
+        self.bump_revision();
+        Some(self.revision())
+    }
+
     /// Update a pane's exit status and return the resulting session revision.
     pub fn set_pane_exit_status(&mut self, pane_id: Uuid, status: Option<i32>) -> Option<u64> {
         let changed = {
@@ -596,8 +603,9 @@ mod tests {
         assert_eq!(session.set_pane_exit_status(pane_id, Some(7)), Some(5));
         assert_eq!(session.set_pane_exit_status(pane_id, Some(7)), Some(5));
         assert_eq!(session.set_pane_exit_status(pane_id, None), Some(6));
-        assert_eq!(session.rename("test".into()), 6);
-        assert_eq!(session.rename("renamed".into()), 7);
+        assert_eq!(session.set_pane_cwd(pane_id, "/tmp"), Some(7));
+        assert_eq!(session.rename("test".into()), 7);
+        assert_eq!(session.rename("renamed".into()), 8);
     }
 
     #[test]

--- a/services/rttx-server/tests/cwd_propagation.rs
+++ b/services/rttx-server/tests/cwd_propagation.rs
@@ -1,0 +1,75 @@
+//! Integration test: `CwdChanged` is broadcast when a pane's CWD changes.
+
+mod common;
+
+use common::{TestClient, send_input, start_test_server};
+use rttx_proto::proto;
+use std::time::Duration;
+
+/// Helper: create session, pane, attach, return IDs.
+async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+            name: "cwd-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    let create_pane = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            session_id: session_id.clone(),
+            cwd: None,
+            dark_background: None,
+        })),
+    };
+    client.send(&create_pane).await;
+    let pane_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+            session_id: session_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+
+    (session_id, pane_id)
+}
+
+#[tokio::test]
+async fn osc7_triggers_cwd_changed_broadcast() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&sock).await;
+    let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+
+    // Send a printf that emits an OSC 7 escape sequence.
+    let target = "/tmp";
+    let osc7_cmd = format!("printf '\\033]7;file://localhost{target}\\033\\\\'\n");
+    send_input(&mut client, &session_id, &pane_id, osc7_cmd.as_bytes()).await;
+
+    // Collect messages — we should see a CwdChanged among the Deltas.
+    let msgs = client.drain(Duration::from_secs(5)).await;
+    let cwd_msg = msgs.iter().find_map(|m| match &m.msg {
+        Some(proto::server_message::Msg::CwdChanged(c)) => Some(c),
+        _ => None,
+    });
+
+    assert!(cwd_msg.is_some(), "expected CwdChanged message, got: {msgs:?}");
+    let cwd = &cwd_msg.unwrap().cwd;
+    assert_eq!(cwd, target, "CwdChanged should contain the OSC 7 path");
+}


### PR DESCRIPTION
## What changed

The server never sent `CwdChanged` messages to clients. The proto message existed, the GUI client handled it (`window/runtime.rs:647-649`), but the server-side broadcast was completely missing. This meant the sidebar subtitle and any CWD-dependent display showed stale path information.

### Root cause

In the PTY read loop (`server.rs`), `pane.feed_output()` updated the internal `pane.cwd` from OSC 7 escape sequences, but no `CwdChanged` message was ever constructed or broadcast to connected clients. The only way clients received CWD was via the initial `Snapshot` on attach.

### Fix

- `pane.feed_output()` now returns `FeedResult { new_cwd }` — `Some(cwd)` when the CWD changed, `None` otherwise
- Added `protocol::cwd_changed()` builder (mirrors `title_changed()`)
- Added `session.set_pane_cwd()` to bump the session revision
- In the PTY read loop, after broadcasting `Delta`, if CWD changed, broadcast `CwdChanged`
- Version bumped to 0.2.1

## Manual verification

1. Open rttx with a daemon-managed workspace
2. `cd /tmp` in a pane
3. Sidebar subtitle should update to `/tmp`
4. `cd ~` — subtitle should update to `~`

## Tests added

- `feed_output_returns_new_cwd_on_osc7` — unit: verifies OSC 7 triggers CWD change detection
- `feed_output_returns_none_when_cwd_unchanged` — unit: same CWD doesn't report change
- `feed_output_returns_none_for_plain_output` — unit: plain text doesn't trigger CWD
- `cwd_changed_message_contains_correct_fields` — unit: protocol builder correctness
- `resize_title_and_exit_only_bump_revision_on_change` — updated: includes `set_pane_cwd` revision bump
- `osc7_triggers_cwd_changed_broadcast` — integration: end-to-end OSC 7 → `CwdChanged` broadcast

## Tests run

- `cargo test -p rttx-server --lib` — 79 passed
- `cargo test -p rttx-server --test cwd_propagation` — 1 passed
- `cargo test -p rttx --lib` — 372 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass
- `cargo fmt --check` — clean

Fixes #392