### PR TITLE
chore: consolidate version to workspace Cargo.toml

### DIFF
--- a/.github/scripts/check-version-consistency.sh
+++ b/.github/scripts/check-version-consistency.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Verify that meson.build version matches the workspace Cargo.toml version.
+set -euo pipefail
+
+cargo_version=$(grep -A5 '^\[workspace\.package\]' Cargo.toml \
+    | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/')
+meson_version=$(grep "version:" meson.build | head -1 | sed "s/.*'\(.*\)'.*/\1/")
+
+if [[ "${cargo_version}" != "${meson_version}" ]]; then
+    echo >&2 "Version mismatch: Cargo.toml has ${cargo_version}, meson.build has ${meson_version}"
+    echo >&2 "Update meson.build to match the workspace version in Cargo.toml."
+    exit 1
+fi
+
+echo "Version consistent: ${cargo_version}"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Check version consistency
+        run: bash .github/scripts/check-version-consistency.sh
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ members = [
     "protocols/rttx-proto",
 ]
 resolver = "3"
+
+[workspace.package]
+version = "0.2.1"
+license = "GPL-3.0-or-later"

--- a/clients/rttx/Cargo.toml
+++ b/clients/rttx/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rttx"
-version = "0.2.1"
+version.workspace = true
 edition = "2024"
-license = "GPL-3.0-or-later"
+license.workspace = true
 description = "A tiling terminal emulator for GNOME"
 authors = ["Illya Yalovyy"]
 

--- a/protocols/rttx-proto/Cargo.toml
+++ b/protocols/rttx-proto/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rttx-proto"
-version = "0.2.1"
+version.workspace = true
 edition = "2024"
-license = "GPL-3.0-or-later"
+license.workspace = true
 
 [dependencies]
 prost = { version = "0.13", features = ["std", "prost-derive"] }

--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rttx-server"
-version = "0.2.1"
+version.workspace = true
 edition = "2024"
-license = "GPL-3.0-or-later"
+license.workspace = true
 
 [lints.rust]
 unsafe_code = "deny"


### PR DESCRIPTION
## What changed

Moved `version` and `license` to `[workspace.package]` in the root `Cargo.toml`. All three crates (`rttx`, `rttx-server`, `rttx-proto`) now inherit via `version.workspace = true`.

Added a CI check (`check-version-consistency.sh`) that verifies `meson.build` stays in sync with the workspace version.

### Before

Version bumps required editing 4 files:
- `clients/rttx/Cargo.toml`
- `services/rttx-server/Cargo.toml`
- `protocols/rttx-proto/Cargo.toml`
- `meson.build`

### After

Version bumps require editing 2 files:
- `Cargo.toml` (authoritative, all crates inherit)
- `meson.build` (mirror, CI catches drift)

`meson.build` can't read the version dynamically without bumping the meson requirement to 1.1+, so it stays as a CI-enforced mirror.

## Tests run

- `cargo build --workspace` (via individual packages) — pass
- `cargo test -p rttx-server --lib` — 79 passed
- `cargo test -p rttx --lib` — 372 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/check-version-consistency.sh` — consistent
- Verified mismatch detection works (sed 9.9.9 → caught)

Fixes #395