### PR TITLE
fix(server): broadcast TitleChanged when pane title updates via OSC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "prost",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.1',
+  version: '0.2.2',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -21,6 +21,8 @@ const DEFAULT_MAX_SCROLLBACK_LOG: u64 = 10 * 1024 * 1024;
 pub struct FeedResult {
     /// New CWD if it changed from the previous value.
     pub new_cwd: Option<String>,
+    /// New title if it changed from the previous value.
+    pub new_title: Option<String>,
 }
 
 /// Runtime state of a single pane.
@@ -72,9 +74,15 @@ impl Pane {
     pub fn feed_output(&mut self, data: &[u8]) -> FeedResult {
         self.screen.feed(data);
         self.pending_flush.extend_from_slice(data);
-        if let Some(title) = self.screen.title() {
-            self.title = Some(title.to_string());
-        }
+        let new_title = self.screen.title().and_then(|title| {
+            let title = title.to_string();
+            if self.title.as_deref() == Some(&title) {
+                None
+            } else {
+                self.title = Some(title.clone());
+                Some(title)
+            }
+        });
         let new_cwd = self.screen.cwd().and_then(|cwd| {
             let cwd = cwd.to_string();
             if self.cwd.as_deref() == Some(&cwd) {
@@ -84,7 +92,7 @@ impl Pane {
                 Some(cwd)
             }
         });
-        FeedResult { new_cwd }
+        FeedResult { new_cwd, new_title }
     }
 
     /// Flush pending scrollback bytes to the log file on disk.
@@ -375,5 +383,26 @@ mod tests {
         let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
         let result = pane.feed_output(b"hello world\r\n");
         assert!(result.new_cwd.is_none());
+        assert!(result.new_title.is_none());
+    }
+
+    #[test]
+    fn feed_output_returns_new_title_on_osc0() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let osc0 = b"\x1b]0;my-project\x07";
+        let result = pane.feed_output(osc0);
+        assert_eq!(result.new_title.as_deref(), Some("my-project"));
+        assert_eq!(pane.title.as_deref(), Some("my-project"));
+    }
+
+    #[test]
+    fn feed_output_returns_none_when_title_unchanged() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let osc0 = b"\x1b]0;my-project\x07";
+        let result = pane.feed_output(osc0);
+        assert!(result.new_title.is_some());
+
+        let result = pane.feed_output(osc0);
+        assert!(result.new_title.is_none());
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -812,21 +812,30 @@ fn spawn_pty_read_loop(
                         Ok(n) => {
                             let data = buf[..n].to_vec();
                             let mut s = server.lock().await;
-                            let new_cwd = if let Some(session) = s.sessions.get_mut(&session_id)
+                            let (new_cwd, new_title) = if let Some(session) = s.sessions.get_mut(&session_id)
                                 && let Some(pane) = session.panes.get_mut(&pane_id)
                             {
                                 let result = pane.feed_output(&data);
-                                result.new_cwd.and_then(|cwd| {
+                                let cwd = result.new_cwd.and_then(|cwd| {
                                     let rev = session.set_pane_cwd(pane_id, &cwd)?;
                                     Some((cwd, rev))
-                                })
+                                });
+                                let title = result.new_title.and_then(|title| {
+                                    let rev = session.set_pane_title(pane_id, title.clone())?;
+                                    Some((title, rev))
+                                });
+                                (cwd, title)
                             } else {
-                                None
+                                (None, None)
                             };
                             let msg = protocol::delta(session_id, pane_id, data);
                             s.broadcast_to_session(session_id, &msg);
                             if let Some((cwd, revision)) = new_cwd {
                                 let msg = protocol::cwd_changed(session_id, pane_id, cwd, revision);
+                                s.broadcast_to_session(session_id, &msg);
+                            }
+                            if let Some((title, revision)) = new_title {
+                                let msg = protocol::title_changed(session_id, pane_id, title, revision);
                                 s.broadcast_to_session(session_id, &msg);
                             }
                         }

--- a/services/rttx-server/tests/title_propagation.rs
+++ b/services/rttx-server/tests/title_propagation.rs
@@ -1,0 +1,82 @@
+//! Integration test: `TitleChanged` is broadcast when a pane's title changes via OSC.
+
+mod common;
+
+use common::{TestClient, send_input, start_test_server};
+use rttx_proto::proto;
+use std::time::Duration;
+
+/// Helper: create session, pane, attach, return IDs.
+async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+            name: "title-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    let create_pane = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            session_id: session_id.clone(),
+            cwd: None,
+            dark_background: None,
+        })),
+    };
+    client.send(&create_pane).await;
+    let pane_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+            session_id: session_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+
+    (session_id, pane_id)
+}
+
+#[tokio::test]
+async fn osc0_triggers_title_changed_broadcast() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&sock).await;
+    let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+
+    // Send a printf that emits an OSC 0 (set window title) escape sequence.
+    let title = "rttx-title-test-42";
+    let osc0_cmd = format!("printf '\\033]0;{title}\\007'\n");
+    send_input(&mut client, &session_id, &pane_id, osc0_cmd.as_bytes()).await;
+
+    // Collect messages — we should see a TitleChanged with our title among them.
+    let msgs = client.drain(Duration::from_secs(5)).await;
+    let title_msg = msgs.iter().find_map(|m| match &m.msg {
+        Some(proto::server_message::Msg::TitleChanged(t)) if t.title == title => Some(t),
+        _ => None,
+    });
+
+    assert!(
+        title_msg.is_some(),
+        "expected TitleChanged with title '{title}', titles seen: {:?}",
+        msgs.iter()
+            .filter_map(|m| match &m.msg {
+                Some(proto::server_message::Msg::TitleChanged(t)) => Some(&t.title),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## What changed

The server's PTY read loop broadcast `CwdChanged` when a pane's working directory changed (added in PR #394), but silently absorbed title changes from OSC 0/2 escape sequences. The pane's internal `title` field was updated by `feed_output()`, but `FeedResult` only contained `new_cwd` — there was no way for the PTY read loop to know the title changed and broadcast it to clients.

### Root cause

`Pane::feed_output()` unconditionally overwrote `self.title` from the screen's parsed OSC title without detecting whether it actually changed, and `FeedResult` had no `new_title` field. The PTY read loop in `server.rs` therefore never broadcast `TitleChanged`.

### Fix

1. Added `new_title: Option<String>` to `FeedResult`
2. Changed `feed_output()` to detect title changes (same dedup pattern as CWD)
3. Added `TitleChanged` broadcast in the PTY read loop alongside the existing `CwdChanged` broadcast

The client already handled `TitleChanged` messages correctly — no client changes needed.

## Manual verification

1. Open a managed workspace
2. Run `printf '\033]0;my-project\007'` in a pane
3. The sidebar subtitle should update to show "my-project"
4. `cd /tmp` — the shell prompt should update the title and the sidebar should reflect it

## Tests added

- **Unit**: `feed_output_returns_new_title_on_osc0` — verifies `FeedResult.new_title` is populated on OSC 0
- **Unit**: `feed_output_returns_none_when_title_unchanged` — verifies dedup (same title → `None`)
- **Integration**: `osc0_triggers_title_changed_broadcast` — end-to-end: sends OSC 0 via PTY input, verifies `TitleChanged` message is broadcast to the client

## Tests run

- `cargo test -p rttx-server --lib` — 81 passed (was 79, +2 new)
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 372 passed
- `cargo test -p rttx-server --test title_propagation` — 1 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass
- `cargo fmt --check` — clean
- Version consistency — 0.2.2 consistent
- Runtime behavior gate — passed

## Version bump

0.2.1 → 0.2.2 (UX-affecting change: titles now update live)

Fixes #399