### PR TITLE
fix: add SSH timeout and BatchMode to prevent reconnect hang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "prost",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -132,6 +132,8 @@ impl DaemonConnection {
     /// kept alive for the connection to persist.
     pub async fn connect_ssh(host: &str) -> Result<(Self, SshHandle), DaemonError> {
         let mut child = tokio::process::Command::new("ssh")
+            .args(["-o", "BatchMode=yes"])
+            .args(["-o", "ConnectTimeout=10"])
             .arg(host)
             .arg("rttx-server")
             .arg("attach-stdio")
@@ -863,5 +865,14 @@ mod tests {
             })),
         };
         assert_eq!(extract_pane_id(&msg), None);
+    }
+
+    #[tokio::test]
+    async fn connect_ssh_to_bogus_host_fails_fast() {
+        let start = std::time::Instant::now();
+        let result = DaemonConnection::connect_ssh("rttx-nonexistent-host-test").await;
+        assert!(result.is_err(), "SSH to bogus host should fail");
+        // BatchMode=yes makes SSH fail immediately instead of hanging for auth.
+        assert!(start.elapsed().as_secs() < 15, "SSH should fail fast, not hang");
     }
 }

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -25,6 +25,8 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(20);
 #[cfg(not(test))]
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 
+const SSH_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Operation type for manager error reporting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManagerOperation {
@@ -1128,7 +1130,15 @@ impl EndpointActor {
                 self.daemon_start_attempted = false;
             }
             RuntimeEndpoint::Remote { host } => {
-                let (connection, ssh_handle) = DaemonConnection::connect_ssh(host).await?;
+                let (connection, ssh_handle) =
+                    tokio::time::timeout(SSH_CONNECT_TIMEOUT, DaemonConnection::connect_ssh(host))
+                        .await
+                        .map_err(|_| {
+                            DaemonError::Io(std::io::Error::new(
+                                std::io::ErrorKind::TimedOut,
+                                format!("SSH connection to {host} timed out"),
+                            ))
+                        })??;
                 self.connection = Some(connection);
                 self.ssh_handle = Some(ssh_handle);
             }
@@ -2102,5 +2112,17 @@ mod tests {
         assert!(saw_error, "ownership conflict should emit WorkspaceError");
 
         server.await.expect("fake server task should complete");
+    }
+
+    #[test]
+    fn ssh_connect_timeout_is_reasonable() {
+        assert!(
+            SSH_CONNECT_TIMEOUT >= Duration::from_secs(10),
+            "SSH timeout should be at least 10s to allow for slow networks"
+        );
+        assert!(
+            SSH_CONNECT_TIMEOUT <= Duration::from_secs(60),
+            "SSH timeout should not exceed 60s to avoid blocking the actor too long"
+        );
     }
 }

--- a/clients/rttx/tests/ssh_connection.rs
+++ b/clients/rttx/tests/ssh_connection.rs
@@ -1,0 +1,24 @@
+//! Integration tests for SSH connection behavior.
+//!
+//! Verifies that SSH connections fail fast instead of hanging when
+//! the remote host is unreachable or auth is not possible.
+
+use rttx::daemon::{DaemonConnection, DaemonError};
+
+#[tokio::test]
+async fn ssh_connection_to_unreachable_host_fails_within_timeout() {
+    let start = std::time::Instant::now();
+    let result = DaemonConnection::connect_ssh("rttx-nonexistent-host-test").await;
+
+    assert!(result.is_err(), "SSH to unreachable host should fail");
+    assert!(
+        start.elapsed().as_secs() < 15,
+        "SSH should fail fast with BatchMode=yes, took {}s",
+        start.elapsed().as_secs()
+    );
+
+    match result.unwrap_err() {
+        DaemonError::Io(_) | DaemonError::Disconnected => {}
+        other => panic!("expected Io or Disconnected error, got: {other:?}"),
+    }
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.2',
+  version: '0.2.3',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed

When the SSH connection to a remote daemon drops, the auto-reconnect spawns `ssh host rttx-server attach-stdio` with no timeout and no `BatchMode`. If SSH needs interactive auth or the host is unreachable, the `EndpointActor` blocks forever in `connect_ssh`, making all subsequent commands — including user-initiated "Retry Connection" — queue up and never execute.

### Root cause

`connect_ssh()` in `daemon.rs` spawned SSH with `stdin: piped()`, `stderr: null()`, and no SSH options. If SSH couldn't authenticate non-interactively, it would hang waiting for input. The `handshake().await` call would block indefinitely waiting for data on stdout.

### Fix

- Added `-o BatchMode=yes` so SSH fails immediately when non-interactive auth is not possible
- Added `-o ConnectTimeout=10` to cap the TCP connection time
- Wrapped the entire `connect_ssh` call in `tokio::time::timeout(30s)` as a safety net against any other hanging scenario
- The timeout error maps to `DaemonError::Io(TimedOut)` which classifies as `DaemonUnavailable` (transient), so the reconnect loop continues retrying

## Manual verification

1. Kill an SSH connection to a remote workspace: `pkill -f 'ssh cdt2 rttx-server'`
2. Observe the workspace goes red and starts reconnecting
3. The reconnect should either succeed quickly or fail fast and retry — never hang

## Tests added

- `connect_ssh_to_bogus_host_fails_fast` — verifies SSH to a non-existent host fails in under 15s (confirms BatchMode works)
- `ssh_connect_timeout_is_reasonable` — verifies the timeout constant is between 10s and 60s

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 374 passed (+2 new)
- `cargo test -p rttx-server --lib` — 81 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass
- `cargo fmt --check` — clean
- Version consistency — 0.2.3 consistent

## Follow-ups

- #402 — Non-transient errors kill reconnect loop silently
- #403 — "Retry connection" should bypass stuck actor
- #404 — Reconnect logging invisible in production

Fixes #401