### PR TITLE
fix: always schedule reconnect regardless of error type

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -1020,10 +1020,7 @@ impl EndpointActor {
                 );
                 let primary = workspaces[0].clone();
                 if let Err(problem) = self.ensure_connected(&primary).await {
-                    if problem.is_transient() {
-                        let delay_secs = self.next_reconnect_delay_secs();
-                        self.schedule_reconnect(delay_secs);
-                    }
+                    self.schedule_reconnect_for_problem(&problem);
                     return;
                 }
 
@@ -1417,6 +1414,18 @@ impl EndpointActor {
             tokio::time::sleep(delay).await;
             let _ = self_tx.send(EndpointCommand::Reconnect);
         });
+    }
+
+    /// Schedule a reconnect based on the error type. Non-transient errors
+    /// use the maximum delay but still retry — the underlying problem may
+    /// resolve (e.g., daemon restarts with correct version).
+    fn schedule_reconnect_for_problem(&mut self, problem: &ConnectionProblem) {
+        let delay_secs = if problem.is_transient() {
+            self.next_reconnect_delay_secs()
+        } else {
+            self.reconnect_delay_secs
+        };
+        self.schedule_reconnect(delay_secs);
     }
 
     fn emit_status(&self, workspace_id: &str, status: ConnectionStatus) {
@@ -2124,5 +2133,50 @@ mod tests {
             SSH_CONNECT_TIMEOUT <= Duration::from_secs(60),
             "SSH timeout should not exceed 60s to avoid blocking the actor too long"
         );
+    }
+
+    /// Verify that a non-transient connection error during reconnect still
+    /// schedules another attempt instead of silently killing the loop.
+    #[tokio::test]
+    async fn schedule_reconnect_for_non_transient_uses_max_delay() {
+        let (event_tx, _) = mpsc::unbounded_channel();
+        let (self_tx, mut self_rx) = mpsc::unbounded_channel();
+        let (_, cmd_rx) = mpsc::unbounded_channel();
+        let mut actor =
+            EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, false, 10);
+
+        let non_transient = ConnectionProblem::VersionMismatch;
+        assert!(!non_transient.is_transient());
+
+        actor.schedule_reconnect_for_problem(&non_transient);
+
+        // Non-transient should use max delay (reconnect_delay_secs = 10).
+        assert_eq!(actor.reconnect_attempt, 1);
+
+        let cmd = tokio::time::timeout(Duration::from_secs(15), self_rx.recv())
+            .await
+            .expect("should receive reconnect command")
+            .expect("channel should not close");
+        assert!(matches!(cmd, EndpointCommand::Reconnect));
+    }
+
+    #[tokio::test]
+    async fn schedule_reconnect_for_transient_uses_progressive_delay() {
+        let (event_tx, _) = mpsc::unbounded_channel();
+        let (self_tx, mut self_rx) = mpsc::unbounded_channel();
+        let (_, cmd_rx) = mpsc::unbounded_channel();
+        let mut actor =
+            EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, false, 10);
+
+        actor.schedule_reconnect_for_problem(&ConnectionProblem::DaemonUnavailable);
+
+        // Transient at attempt 1 should use delay = min(1, 10) = 1s.
+        assert_eq!(actor.reconnect_attempt, 1);
+
+        let cmd = tokio::time::timeout(Duration::from_secs(5), self_rx.recv())
+            .await
+            .expect("should receive reconnect command")
+            .expect("channel should not close");
+        assert!(matches!(cmd, EndpointCommand::Reconnect));
     }
 }

--- a/clients/rttx/tests/reconnect_scheduling.rs
+++ b/clients/rttx/tests/reconnect_scheduling.rs
@@ -1,0 +1,30 @@
+//! Integration tests for reconnect scheduling behavior.
+//!
+//! Verifies that the reconnect loop handles both transient and
+//! non-transient errors without silently dying.
+
+use rttx::runtime::ConnectionProblem;
+
+#[test]
+fn non_transient_errors_are_not_classified_as_transient() {
+    let cases = [
+        ConnectionProblem::VersionMismatch,
+        ConnectionProblem::OwnershipConflict,
+        ConnectionProblem::Protocol("test".into()),
+        ConnectionProblem::UserActionRequired("test".into()),
+    ];
+    for problem in &cases {
+        assert!(
+            !problem.is_transient(),
+            "{problem:?} should not be transient — reconnect must still retry with max delay"
+        );
+    }
+}
+
+#[test]
+fn transient_errors_are_classified_correctly() {
+    assert!(
+        ConnectionProblem::DaemonUnavailable.is_transient(),
+        "DaemonUnavailable should be transient for progressive backoff"
+    );
+}


### PR DESCRIPTION
## What changed

The `Reconnect` handler in `daemon_bridge.rs` only scheduled a retry when `ensure_connected` failed with a transient error (`DaemonUnavailable`). Non-transient errors (version mismatch, protocol error, ownership conflict, etc.) silently killed the reconnect loop — no further automatic reconnection was attempted, and no clear indication was given to the user.

### Root cause

```rust
// Before: non-transient errors fall through without scheduling
if let Err(problem) = self.ensure_connected(&primary).await {
    if problem.is_transient() {
        self.schedule_reconnect(delay_secs);
    }
    return;  // ← loop dies here for non-transient
}
```

### Fix

Extracted `schedule_reconnect_for_problem()` that always schedules a retry:
- Transient errors: progressive backoff (1s, 2s, ..., up to max)
- Non-transient errors: max delay immediately (the problem may resolve — daemon restarts with correct version, user re-authenticates, etc.)

```rust
// After: always schedule, use max delay for non-transient
if let Err(problem) = self.ensure_connected(&primary).await {
    self.schedule_reconnect_for_problem(&problem);
    return;
}
```

## Manual verification

1. Connect to a remote workspace
2. Kill the SSH connection: `pkill -f 'ssh host rttx-server'`
3. Observe the workspace reconnects automatically
4. The reconnect loop should never stop — even if the error is non-transient

## Tests added

- `schedule_reconnect_for_non_transient_uses_max_delay` — unit: non-transient errors schedule reconnect with max delay
- `schedule_reconnect_for_transient_uses_progressive_delay` — unit: transient errors use progressive backoff
- `non_transient_errors_are_not_classified_as_transient` — integration: all non-transient error types are correctly classified
- `transient_errors_are_classified_correctly` — integration: DaemonUnavailable is transient

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 376 passed (+2 new)
- `cargo test -p rttx-server --lib` — 81 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass
- Runtime behavior policy — passed

## Follow-ups

- #403 — "Retry connection" should bypass stuck actor
- #404 — Reconnect logging invisible in production

Fixes #402