### PR TITLE
feat: add file logging with daily rotation for GUI and daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,12 +204,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "daemonize"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -229,19 +253,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "equivalent"
@@ -688,18 +699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,17 +736,6 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -913,6 +901,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +997,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,16 +1019,6 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
-]
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger",
- "log",
 ]
 
 [[package]]
@@ -1294,7 +1284,6 @@ dependencies = [
  "libadwaita",
  "log",
  "pretty_assertions",
- "pretty_env_logger",
  "proptest",
  "rstest",
  "rttx-proto",
@@ -1303,6 +1292,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing-appender",
+ "tracing-subscriber",
  "uuid",
  "vte4",
 ]
@@ -1344,6 +1335,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "vte",
@@ -1566,15 +1558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1584,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1722,6 +1736,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1993,15 +2019,6 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/Cargo.toml
+++ b/clients/rttx/Cargo.toml
@@ -46,7 +46,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 log = "0.4"
-pretty_env_logger = "0.5"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rttx-proto = { path = "../../protocols/rttx-proto" }
 bytes = "1"
 tokio = { version = "1", features = ["net", "io-util", "sync", "rt", "rt-multi-thread", "macros", "process", "time"] }

--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -74,14 +74,53 @@ pub(crate) const APP_CSS: &str = "\
         .accent-orange { color: @orange_5; }
     }";
 
+fn init_logging() {
+    use tracing_subscriber::EnvFilter;
+
+    let is_dev = config::is_development();
+    let default_level = if is_dev { "debug" } else { "rttx=info,warn" };
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    let log_dir = log_dir_path();
+    let _ = std::fs::create_dir_all(&log_dir);
+    let file_appender = tracing_appender::rolling::daily(&log_dir, "rttx.log");
+    cleanup_old_logs(&log_dir, "rttx.log", 3);
+
+    tracing_subscriber::fmt()
+        .with_writer(file_appender)
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .init();
+}
+
+fn cleanup_old_logs(dir: &std::path::Path, prefix: &str, keep_days: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    let mut log_files: Vec<_> = entries
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name().to_string_lossy().starts_with(prefix)
+                && e.file_type().is_ok_and(|t| t.is_file())
+        })
+        .collect();
+    log_files.sort_by_key(|e| std::cmp::Reverse(e.file_name()));
+    for old in log_files.into_iter().skip(keep_days + 1) {
+        let _ = std::fs::remove_file(old.path());
+    }
+}
+
+/// Return the log directory for the GUI.
+#[must_use]
+pub fn log_dir_path() -> std::path::PathBuf {
+    let cache_dir = glib::user_cache_dir();
+    let dir_name = if config::is_development() { "rttx-devel" } else { "rttx" };
+    cache_dir.join(dir_name)
+}
+
 /// Build and run the application.
 #[must_use]
 pub fn run() -> glib::ExitCode {
-    if config::is_development() && std::env::var_os("RUST_LOG").is_none() {
-        pretty_env_logger::formatted_builder().filter_level(log::LevelFilter::Debug).init();
-    } else {
-        pretty_env_logger::init();
-    }
+    init_logging();
 
     let app = adw::Application::builder()
         .application_id(config::app_id())

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.3',
+  version: '0.2.4',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -65,6 +65,7 @@ clap = { version = "4", features = ["derive"] }
 # Utilities
 uuid = { version = "1", features = ["v4", "serde"] }
 tracing = "0.1"
+tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "2"
 anyhow = "1"

--- a/services/rttx-server/src/lib.rs
+++ b/services/rttx-server/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod engine;
 pub mod ipc;
+pub mod logging;
 pub mod os;
 pub mod pane;
 pub mod protocol;

--- a/services/rttx-server/src/logging.rs
+++ b/services/rttx-server/src/logging.rs
@@ -1,0 +1,110 @@
+//! File logging with daily rotation and automatic cleanup.
+
+use std::path::Path;
+use tracing_subscriber::EnvFilter;
+
+/// Initialize file-based logging with daily rotation.
+///
+/// Logs are written to `log_dir/<prefix>.log.<date>`. Old log files beyond
+/// `keep_days` are removed on startup.
+pub fn init_file_logging(log_dir: &Path, prefix: &str, dev_mode: bool) {
+    let default_level = if dev_mode { "debug" } else { "info" };
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    let _ = std::fs::create_dir_all(log_dir);
+    let file_appender = tracing_appender::rolling::daily(log_dir, format!("{prefix}.log"));
+    cleanup_old_logs(log_dir, &format!("{prefix}.log"), 3);
+
+    tracing_subscriber::fmt()
+        .with_writer(file_appender)
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .init();
+}
+
+/// Remove rotated log files older than `keep_days`.
+pub fn cleanup_old_logs(dir: &Path, prefix: &str, keep_days: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    let mut log_files: Vec<_> = entries
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name().to_string_lossy().starts_with(prefix)
+                && e.file_type().is_ok_and(|t| t.is_file())
+        })
+        .collect();
+    log_files.sort_by_key(|e| std::cmp::Reverse(e.file_name()));
+    for old in log_files.into_iter().skip(keep_days + 1) {
+        let _ = std::fs::remove_file(old.path());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleanup_removes_oldest_files_beyond_keep_days() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        // Create 5 fake rotated log files.
+        for day in 1..=5 {
+            std::fs::write(dir.join(format!("rttx-server.log.2026-04-0{day}")), "log").unwrap();
+        }
+
+        cleanup_old_logs(dir, "rttx-server.log", 3);
+
+        let remaining: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+
+        // keep_days + 1 = 4 files (3 rotated + 1 current-ish).
+        assert_eq!(remaining.len(), 4, "should keep 4 files, got: {remaining:?}");
+        assert!(!remaining.contains(&"rttx-server.log.2026-04-01".to_string()));
+    }
+
+    #[test]
+    fn cleanup_is_noop_when_fewer_files_than_limit() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        std::fs::write(dir.join("rttx-server.log.2026-04-05"), "log").unwrap();
+
+        cleanup_old_logs(dir, "rttx-server.log", 3);
+
+        let count = std::fs::read_dir(dir).unwrap().count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn cleanup_ignores_unrelated_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        for day in 1..=5 {
+            std::fs::write(dir.join(format!("rttx-server.log.2026-04-0{day}")), "log").unwrap();
+        }
+        std::fs::write(dir.join("state.json"), "{}").unwrap();
+
+        cleanup_old_logs(dir, "rttx-server.log", 2);
+
+        let remaining: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+
+        assert!(remaining.contains(&"state.json".to_string()));
+        // 2 + 1 log files + state.json = 4
+        assert_eq!(remaining.len(), 4);
+    }
+
+    #[test]
+    fn cleanup_handles_missing_directory() {
+        cleanup_old_logs(Path::new("/nonexistent/path"), "rttx.log", 3);
+        // Should not panic.
+    }
+}

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -8,7 +8,6 @@ use rttx_server::os::unix::UnixOs;
 use rttx_server::server::Server;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 #[command(
@@ -35,6 +34,8 @@ enum Command {
     Status,
     /// Serve one client over stdin/stdout (for SSH)
     AttachStdio,
+    /// Show the path to the daemon log file
+    Logs,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -45,14 +46,15 @@ fn main() -> anyhow::Result<()> {
         Command::Stop => stop(),
         Command::Status => status(),
         Command::AttachStdio => attach_stdio(),
+        Command::Logs => {
+            logs();
+            Ok(())
+        }
     }
 }
 
-fn init_tracing(dev_mode: bool) {
-    let default_level = if dev_mode { "debug" } else { "info" };
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
-    tracing_subscriber::fmt().with_writer(std::io::stderr).with_env_filter(filter).init();
+fn init_tracing(dev_mode: bool, log_dir: &std::path::Path) {
+    rttx_server::logging::init_file_logging(log_dir, "rttx-server", dev_mode);
 }
 
 fn start(foreground: bool) -> anyhow::Result<()> {
@@ -88,7 +90,7 @@ fn start(foreground: bool) -> anyhow::Result<()> {
         }
     }
 
-    init_tracing(dev_mode);
+    init_tracing(dev_mode, &os.cache_dir());
 
     if dev_mode {
         tracing::info!("Starting rttx-server in DEVELOPMENT mode");
@@ -133,12 +135,18 @@ fn start(foreground: bool) -> anyhow::Result<()> {
 /// Intended to be invoked via SSH: `ssh host rttx-server attach-stdio`.
 /// Connects to the already-running local daemon and bridges the client's
 /// stdin/stdout to the daemon socket. The daemon keeps running after the
+fn logs() {
+    let os = UnixOs;
+    let log_dir = os.cache_dir();
+    println!("{}", log_dir.display());
+}
+
 /// SSH connection drops, so PTYs and runtimes survive GUI restarts.
 fn attach_stdio() -> anyhow::Result<()> {
     let dev_mode = rttx_server::os::unix::dev_mode_enabled();
-    init_tracing(dev_mode);
-
     let os = UnixOs;
+    init_tracing(dev_mode, &os.cache_dir());
+
     let socket_path = os.runtime_dir().join("rttx-server.sock");
 
     if !socket_path.exists() {

--- a/services/rttx-server/tests/logging_integration.rs
+++ b/services/rttx-server/tests/logging_integration.rs
@@ -1,0 +1,26 @@
+//! Integration tests for file logging infrastructure.
+
+use rttx_server::logging::cleanup_old_logs;
+use std::path::Path;
+
+#[test]
+fn cleanup_old_logs_keeps_correct_number_of_files() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    for day in 1..=7 {
+        std::fs::write(dir.join(format!("rttx-server.log.2026-04-{day:02}")), "data").unwrap();
+    }
+
+    cleanup_old_logs(dir, "rttx-server.log", 3);
+
+    let remaining: Vec<_> = std::fs::read_dir(dir).unwrap().filter_map(Result::ok).collect();
+
+    // 3 + 1 = 4 files kept (keep_days + 1 because the current day's file counts).
+    assert_eq!(remaining.len(), 4, "should keep 4 most recent log files");
+}
+
+#[test]
+fn cleanup_old_logs_does_not_panic_on_missing_dir() {
+    cleanup_old_logs(Path::new("/nonexistent/test/path"), "rttx-server.log", 3);
+}


### PR DESCRIPTION
## What changed

Both the GUI and daemon now write logs to files with daily rotation and automatic cleanup.

### Daemon
- Logs to `~/.cache/rttx-server/rttx-server.log.<date>`
- New `rttx-server logs` command prints the log directory path
- New `logging` module in `rttx-server` lib with `init_file_logging()` and `cleanup_old_logs()`

### GUI
- Logs to `~/.cache/rttx/rttx.log.<date>`
- Replaced `pretty_env_logger` with `tracing-subscriber` + `tracing-appender`
- Existing `log::info!()` calls continue to work via the tracing-log bridge

### Both
- Daily rotation via `tracing-appender`
- Automatic cleanup: keeps 3 days of logs
- Default level: `info` in production, `debug` in dev mode
- `RUST_LOG` override still works
- Dev mode uses separate log directories (`rttx-devel/`, `rttx-server-devel/`)

### Why
Production troubleshooting was nearly impossible — the GUI logged to stderr (journal) at ERROR-only level, and the daemon logged to /dev/null. When workspaces died sporadically (#407), the only evidence was 5 error lines with no context.

## Manual verification

```bash
# Daemon
cargo run -p rttx-server -- logs
# → prints ~/.cache/rttx-server/
ls ~/.cache/rttx-server/rttx-server.log*

# GUI (after running rttx)
ls ~/.cache/rttx/rttx.log*
```

## Tests added

4 unit tests in `services/rttx-server/src/logging.rs`:
- `cleanup_removes_oldest_files_beyond_keep_days`
- `cleanup_is_noop_when_fewer_files_than_limit`
- `cleanup_ignores_unrelated_files`
- `cleanup_handles_missing_directory`

## Tests run

- `cargo test -p rttx-server --lib` — 85 passed (+4 new)
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 376 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass

## Follow-ups

- #407 — fix workspace stuck in broken state after pane-not-found errors
- GUI command/shortcut to open log directory (deferred — `rttx-server logs` covers the immediate need)

Fixes #408