### PR TITLE
fix: bypass stuck EndpointActor on explicit retry

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -143,6 +143,7 @@ enum EndpointCommand {
         runtime_id: String,
         name: String,
     },
+    Shutdown,
 }
 
 #[derive(Debug)]
@@ -205,6 +206,15 @@ impl EndpointConnectionManager {
         self.rt.spawn(actor.run());
         self.endpoints.borrow_mut().insert(key, EndpointHandle { cmd_tx: cmd_tx.clone() });
         cmd_tx
+    }
+
+    /// Shut down the existing actor for an endpoint so the next operation
+    /// creates a fresh one. Used by explicit user retry to bypass a stuck actor.
+    pub fn reset_endpoint(&self, endpoint: &RuntimeEndpoint) {
+        let key = endpoint.key();
+        if let Some(handle) = self.endpoints.borrow_mut().remove(&key) {
+            let _ = handle.cmd_tx.send(EndpointCommand::Shutdown);
+        }
     }
 
     /// Create or attach a managed workspace runtime asynchronously.
@@ -467,6 +477,9 @@ impl EndpointActor {
                 match event {
                     LoopEvent::Command(command) => {
                         let Some(command) = command else { break };
+                        if matches!(command, EndpointCommand::Shutdown) {
+                            break;
+                        }
                         self.handle_command(command).await;
                     }
                     LoopEvent::Message(message) => self.handle_runtime_message(message),
@@ -474,6 +487,9 @@ impl EndpointActor {
                 }
             } else {
                 let Some(command) = self.cmd_rx.recv().await else { break };
+                if matches!(command, EndpointCommand::Shutdown) {
+                    break;
+                }
                 self.handle_command(command).await;
             }
         }
@@ -1065,6 +1081,7 @@ impl EndpointActor {
             EndpointCommand::ForgetWorkspace { workspace_id } => {
                 self.tracked_workspaces.remove(&workspace_id);
             }
+            EndpointCommand::Shutdown => {}
         }
     }
 
@@ -2178,5 +2195,75 @@ mod tests {
             .expect("should receive reconnect command")
             .expect("channel should not close");
         assert!(matches!(cmd, EndpointCommand::Reconnect));
+    }
+
+    #[tokio::test]
+    async fn shutdown_command_stops_actor() {
+        let ((reader, writer), _server) = split_duplex_connection();
+        let actor = make_actor(reader, writer);
+
+        // Send Shutdown via the actor's own channel.
+        let tx = actor.self_tx.clone();
+        tx.send(EndpointCommand::Shutdown).unwrap();
+
+        // The actor should exit promptly.
+        tokio::time::timeout(Duration::from_secs(2), actor.run())
+            .await
+            .expect("actor should exit after Shutdown");
+    }
+
+    #[tokio::test]
+    async fn shutdown_command_stops_actor_without_connection() {
+        let (event_tx, _) = mpsc::unbounded_channel();
+        let (self_tx, cmd_rx) = mpsc::unbounded_channel();
+        let actor = EndpointActor::new(
+            RuntimeEndpoint::Local,
+            event_tx,
+            self_tx.clone(),
+            cmd_rx,
+            false,
+            10,
+        );
+
+        self_tx.send(EndpointCommand::Shutdown).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), actor.run())
+            .await
+            .expect("actor should exit after Shutdown even without connection");
+    }
+
+    #[test]
+    fn reset_endpoint_removes_handle_and_sends_shutdown() {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let manager = EndpointConnectionManager {
+            rt,
+            endpoints: RefCell::new(HashMap::new()),
+            event_tx,
+            auto_start_daemon: false,
+            reconnect_delay_secs: 10,
+        };
+
+        let endpoint = RuntimeEndpoint::Local;
+
+        // Create an actor by requesting its handle.
+        let tx = manager.endpoint_handle(&endpoint);
+        assert!(manager.endpoints.borrow().contains_key(&endpoint.key()));
+
+        // Reset should remove the handle.
+        manager.reset_endpoint(&endpoint);
+        assert!(!manager.endpoints.borrow().contains_key(&endpoint.key()));
+
+        // The old channel should have received Shutdown.
+        // (We can't easily recv from it since the actor owns cmd_rx,
+        // but we can verify the handle is gone and a new one is created.)
+        let tx2 = manager.endpoint_handle(&endpoint);
+        assert!(manager.endpoints.borrow().contains_key(&endpoint.key()));
+
+        // The new handle should be a different channel than the old one.
+        // Send on old channel — it should still work (actor hasn't consumed it yet)
+        // but the manager no longer references it.
+        assert!(tx.send(EndpointCommand::RefreshInventory).is_ok());
+        assert!(tx2.send(EndpointCommand::RefreshInventory).is_ok());
     }
 }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -267,6 +267,9 @@ impl Window {
             return;
         };
         self.set_workspace_connection_status(workspace_id, &ConnectionStatus::Connecting);
+        if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
+            manager.reset_endpoint(&session_state.runtime.endpoint);
+        }
         self.connect_managed_workspace(&session_state);
     }
 

--- a/clients/rttx/tests/retry_connection.rs
+++ b/clients/rttx/tests/retry_connection.rs
@@ -1,0 +1,23 @@
+//! Integration tests for retry-connection behavior.
+//!
+//! Verifies that explicit user retry bypasses a stuck endpoint actor
+//! by shutting it down and creating a fresh one.
+
+use rttx::daemon_bridge::EndpointConnectionManager;
+use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+
+#[test]
+fn reset_endpoint_creates_fresh_actor_on_next_access() {
+    let (manager, _event_rx) = EndpointConnectionManager::new(false, 10).unwrap();
+    let endpoint = RuntimeEndpoint::Local;
+
+    // First access creates an actor.
+    manager.open_workspace("ws-1", &endpoint, "Test", WorkspacePolicy::default(), None, None);
+
+    // Reset kills the old actor.
+    manager.reset_endpoint(&endpoint);
+
+    // Next access should create a fresh actor (not reuse the old one).
+    // If the old actor were reused, it would be shut down and unable to process.
+    manager.open_workspace("ws-1", &endpoint, "Test", WorkspacePolicy::default(), None, None);
+}


### PR DESCRIPTION
## What changed

When the user clicks "Retry connection" from the workspace context menu, the GUI now shuts down the existing endpoint actor and creates a fresh one, instead of sending a command to a potentially stuck actor.

### Root cause

`retry_workspace_connection()` called `connect_managed_workspace()` which sent `OpenWorkspace` to the existing `EndpointActor` via its command channel. If the actor was stuck (e.g., blocked in a hanging SSH connection per #401), the command sat in the channel queue and was never processed. The user saw no response.

### Fix

- Add `Shutdown` variant to `EndpointCommand`
- Add `reset_endpoint()` to `EndpointConnectionManager`: sends `Shutdown` to the old actor and removes it from the endpoint map
- Call `reset_endpoint()` in `retry_workspace_connection()` before `connect_managed_workspace()`
- The actor's run loop checks for `Shutdown` and breaks immediately

### Manual verification

1. Connect to a workspace
2. Kill the daemon (`rttx-server stop`)
3. Click "Retry connection" — should attempt a fresh connection instead of hanging

## Tests added

3 unit tests in `daemon_bridge.rs`:
- `shutdown_command_stops_actor` — actor with connection exits on Shutdown
- `shutdown_command_stops_actor_without_connection` — actor without connection exits on Shutdown
- `reset_endpoint_removes_handle_and_sends_shutdown` — manager removes handle and new access creates fresh actor

1 integration test in `tests/retry_connection.rs`:
- `reset_endpoint_creates_fresh_actor_on_next_access`

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 379 passed (+3 new)
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass
- Runtime behavior policy — passed (both pure-state and integration evidence)

Fixes #403