### PR TITLE
fix(terminal): mark daemon panes exited after eof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -370,6 +370,24 @@ mod tests {
     }
 
     #[test]
+    fn ctrl_d_encodes_eof_byte() {
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK),
+            Some(vec![0x04])
+        );
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::d,
+                gtk4::gdk::ModifierType::CONTROL_MASK,
+                false,
+                true,
+            ),
+            TerminalKeyAction::ForwardToPty(vec![0x04])
+        );
+    }
+
+    #[test]
     fn managed_ctrl_v_prefers_clipboard_paste_over_shell_syn() {
         let modifiers = gtk4::gdk::ModifierType::CONTROL_MASK
             | gtk4::gdk::ModifierType::LOCK_MASK

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -32,6 +32,7 @@ mod imp {
         pub visual_bell: Cell<bool>,
         pub connected: Cell<bool>,
         pub accepts_input: Cell<bool>,
+        pub exited: Cell<bool>,
         pub input_key_controller: RefCell<Option<gtk4::EventControllerKey>>,
         pub vte: vte4::Terminal,
         pub terminal_scroller: gtk4::ScrolledWindow,
@@ -58,6 +59,7 @@ mod imp {
                 visual_bell: Cell::default(),
                 connected: Cell::default(),
                 accepts_input: Cell::default(),
+                exited: Cell::default(),
                 input_key_controller: RefCell::default(),
                 vte: vte4::Terminal::new(),
                 terminal_scroller: gtk4::ScrolledWindow::new(),
@@ -479,12 +481,32 @@ impl PersistentPaneView {
         status: &ConnectionStatus,
         presentation: &ConnectionPresentation,
     ) {
+        self.imp().exited.set(false);
         self.imp()
             .connected
             .set(matches!(status, ConnectionStatus::Connected | ConnectionStatus::Recovered));
         self.imp().status_label.set_label(&presentation.header_label);
         self.imp().status_label.set_tooltip_text(Some(&status.label()));
         self.imp().accepts_input.set(presentation.input_enabled);
+    }
+
+    /// Mark the remote process as exited and make the pane visibly non-interactive.
+    pub fn mark_exited(&self, status: i32) {
+        self.imp().connected.set(false);
+        self.imp().accepts_input.set(false);
+        let label = if status == 0 { "Exited".into() } else { format!("Exited {status}") };
+        self.imp().status_label.set_label(&label);
+        self.imp()
+            .status_label
+            .set_tooltip_text(Some(&format!("Process exited with status {status}")));
+        if !self.imp().exited.replace(true) {
+            let message = if status == 0 {
+                "\r\n[Process exited]\r\n".into()
+            } else {
+                format!("\r\n[Process exited with status {status}]\r\n")
+            };
+            self.imp().vte.feed(message.as_bytes());
+        }
     }
 
     /// Mark this pane as active (focused).
@@ -701,6 +723,11 @@ impl PersistentPaneView {
     }
 
     #[cfg(test)]
+    pub(crate) fn exited_for_test(&self) -> bool {
+        self.imp().exited.get()
+    }
+
+    #[cfg(test)]
     pub(crate) fn emit_input_key_for_test(
         &self,
         key: gtk4::gdk::Key,
@@ -779,6 +806,30 @@ mod tests {
 
         let recovered = present_connection_status(&ConnectionStatus::Recovered);
         pane.set_connection_presentation(&ConnectionStatus::Recovered, &recovered);
+        assert_eq!(pane.status_label_text_for_test(), "Connected");
+    }
+
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn mark_exited_disables_input_and_reports_status() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("pane-1", "runtime-1");
+        let connected = present_connection_status(&ConnectionStatus::Connected);
+        pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
+        assert!(pane.input_enabled_for_test());
+
+        pane.mark_exited(0);
+
+        assert!(pane.exited_for_test());
+        assert!(!pane.input_enabled_for_test());
+        assert_eq!(pane.status_label_text_for_test(), "Exited");
+
+        let connected = present_connection_status(&ConnectionStatus::Connected);
+        pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
+
+        assert!(!pane.exited_for_test());
+        assert!(pane.input_enabled_for_test());
         assert_eq!(pane.status_label_text_for_test(), "Connected");
     }
 
@@ -923,6 +974,16 @@ mod tests {
                 false,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x16])
+        );
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::d,
+                gtk4::gdk::ModifierType::CONTROL_MASK,
+                false,
+                true,
+            ),
+            TerminalKeyAction::ForwardToPty(vec![0x04])
         );
         assert_eq!(
             terminal_key_action(

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -660,6 +660,7 @@ impl Window {
                 self.refresh_sidebar_subtitle_if_active(&layout_terminal_uuid);
             }
             Msg::PaneExited(exited) => {
+                pane.mark_exited(exited.status);
                 let visible_session = self.imp().session_stack.visible_child_name();
                 let state = self.imp().state.borrow();
                 let in_background = terminal_is_in_background_session(

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3645,3 +3645,57 @@ fn cwd_changed_updates_layout_node() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn managed_pane_exit_marks_visible_pane_exited() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.managed-pane-exit-test").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    let layout_uuid = "managed-pane-exit";
+    let runtime_pane_id = uuid::Uuid::new_v4();
+    let mut session_state = crate::test_helpers::managed_session_with_runtime(
+        "ws-exit",
+        "Exit Test",
+        LayoutNode::new_terminal_with_uuid(layout_uuid),
+        RuntimeEndpoint::Local,
+        WorkspacePolicy::Persistent,
+        Some("runtime-exit"),
+    );
+    session_state
+        .runtime
+        .pane_bindings
+        .insert(layout_uuid.to_string(), runtime_pane_id.to_string());
+
+    window.imp().state.borrow_mut().sessions.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    let msg = rttx_proto::proto::ServerMessage {
+        msg: Some(rttx_proto::proto::server_message::Msg::PaneExited(
+            rttx_proto::proto::PaneExited {
+                session_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
+                pane_id: rttx_proto::uuid_to_bytes(runtime_pane_id),
+                status: 0,
+                revision: 2,
+            },
+        )),
+    };
+    window.dispatch_managed_runtime_message(&RuntimeEndpoint::Local, &msg);
+
+    let pane = window.imp().persistent_terminals.borrow().get(layout_uuid).cloned().unwrap();
+    assert!(pane.exited_for_test());
+    assert!(!pane.input_enabled_for_test());
+    assert_eq!(pane.status_label_text_for_test(), "Exited");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/ui/common.py
+++ b/clients/rttx/tests/ui/common.py
@@ -201,11 +201,12 @@ def terminal_caret_offset(node: Atspi.Accessible) -> int:
 class TestEnvironment:
     """Isolated weston/XDG environment shared by one UI test."""
 
-    def __init__(self) -> None:
+    def __init__(self, extra_env: dict[str, str] | None = None) -> None:
         self.root_dir = tempfile.mkdtemp(prefix="rttx-ui-test-")
         self.runtime_dir = os.path.join(self.root_dir, "run")
         self.config_home = os.path.join(self.root_dir, "config")
         self.cache_home = os.path.join(self.root_dir, "cache")
+        self.extra_env = extra_env or {}
         os.makedirs(self.runtime_dir, mode=0o700, exist_ok=True)
         os.makedirs(self.config_home, exist_ok=True)
         os.makedirs(self.cache_home, exist_ok=True)
@@ -242,6 +243,7 @@ class TestEnvironment:
         env["PATH"] = os.path.join(TARGET_DIR, "debug") + os.pathsep + env["PATH"]
         env.pop("GTK_A11Y", None)
         env.pop("DISPLAY", None)
+        env.update(self.extra_env)
         if disable_shell_spawn:
             env["RTTX_DISABLE_SHELL_SPAWN"] = "1"
         else:
@@ -378,8 +380,12 @@ class AppFixture:
     rttx instance.
     """
 
-    def __init__(self, disable_shell_spawn: bool = True) -> None:
-        self.environment = TestEnvironment()
+    def __init__(
+        self,
+        disable_shell_spawn: bool = True,
+        extra_env: dict[str, str] | None = None,
+    ) -> None:
+        self.environment = TestEnvironment(extra_env=extra_env)
         self.disable_shell_spawn = disable_shell_spawn
         self._app: subprocess.Popen | None = None
         self.atspi_app: Atspi.Accessible | None = None

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -117,5 +117,41 @@ class TestManagedBlackBox(unittest.TestCase):
         )
 
 
+class TestManagedPaneExitBlackBox(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.fixture = AppFixture(
+            disable_shell_spawn=True, extra_env={"SHELL": "/bin/true"}
+        )
+        self.fixture.start_daemon()
+        self.fixture.start()
+
+    def tearDown(self) -> None:
+        self.fixture.stop()
+
+    def test_managed_pane_exit_is_visible_when_shell_exits(self) -> None:
+        """A daemon PaneExited event must leave a clear, non-hanging pane."""
+        button = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "New persistent workspace"
+        )
+        self.assertIsNotNone(button, "persistent workspace button not visible")
+        click(button)
+
+        close_pane = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0
+        )
+        self.assertIsNotNone(close_pane, "managed workspace controls never appeared")
+
+        exited = self.fixture.wait_for_showing_name(
+            Atspi.Role.LABEL, "Exited", timeout=20.0
+        )
+        self.assertIsNotNone(exited, "managed pane never reported the exited process")
+        self.assertEqual(
+            len(self.fixture.wait_for_terminal_count(1, timeout=5.0)),
+            1,
+            "managed exited pane should remain visible for the user",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.4',
+  version: '0.2.5',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/tests/pty_io.rs
+++ b/services/rttx-server/tests/pty_io.rs
@@ -287,3 +287,33 @@ async fn pane_exit_produces_pane_exited_message() {
     assert_eq!(exitpane_id, expectedpane_id);
     assert_eq!(exited.status, 7);
 }
+
+#[tokio::test]
+async fn ctrl_d_at_shell_prompt_produces_pane_exited_message() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+    client.drain(Duration::from_millis(500)).await;
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Input(proto::Input {
+                session_id: session_id.clone(),
+                pane_id: pane_id.clone(),
+                data: vec![0x04],
+            })),
+        })
+        .await;
+
+    let msgs = client.drain(Duration::from_secs(3)).await;
+    let exited = msgs.iter().find_map(|m| match &m.msg {
+        Some(proto::server_message::Msg::PaneExited(pe)) => Some(pe.clone()),
+        _ => None,
+    });
+
+    let exited = exited.expect("Ctrl+D at shell prompt must produce PaneExited");
+    assert_eq!(exited.pane_id, pane_id);
+    assert_eq!(exited.status, 0);
+}


### PR DESCRIPTION
## What changed

- Mark daemon-backed terminal panes as exited when the client receives `PaneExited`.
- Disable input and update the pane status to `Exited` / `Exited <status>` instead of leaving the pane looking connected.
- Feed a short process-exited marker into the VTE once per exit event.
- Add regression coverage for Ctrl+D EOF handling, daemon `PaneExited`, visible client state, and AT-SPI visible exit presentation.
- Bump workspace patch version to `0.2.5` across Cargo and Meson because this changes visible UX.

## Why

Ctrl+D was already encoded and forwarded correctly, and the daemon already emitted `PaneExited`. The visible client only used `PaneExited` for background notifications, so visible daemon-backed panes appeared to hang after the shell exited.

## Tests added

- `terminal::tests::ctrl_d_encodes_eof_byte` covers Ctrl+D key encoding and managed terminal forwarding.
- `terminal::persistent_widget::tests::managed_input_action_keeps_shell_control_sequences_when_no_shortcut_applies` now also asserts Ctrl+D forwards `0x04`.
- `services/rttx-server/tests/pty_io.rs::ctrl_d_at_shell_prompt_produces_pane_exited_message` covers daemon EOF-to-`PaneExited` behavior.
- `terminal::persistent_widget::tests::mark_exited_disables_input_and_reports_status` covers pane exit presentation state.
- `window::tests::managed_pane_exit_marks_visible_pane_exited` covers client dispatch of `PaneExited` into the visible pane.
- `test_managed_blackbox.TestManagedPaneExitBlackBox.test_managed_pane_exit_is_visible_when_shell_exits` covers visible AT-SPI behavior for daemon-backed process exit.

## Tests run

- `cargo build --workspace`
- `cargo test --workspace`
- `bash .github/scripts/run-clippy.sh`
- `bash .github/scripts/run-quality-tests.sh` (first run hit a non-reproducible `title_propagation` failure; targeted rerun passed, full rerun passed)
- `cargo build -p rttx && ./run_ui_tests.sh`
- `cargo fmt --check`
- `bash .github/scripts/check-version-consistency.sh`
- `python3 .github/scripts/check_runtime_behavior_policy.py --base origin/mainline --head HEAD`
- Targeted Ctrl+D/exit tests:
  - `cargo test --manifest-path clients/rttx/Cargo.toml terminal::tests::ctrl_d_encodes_eof_byte --lib -- --exact`
  - `cargo test --manifest-path clients/rttx/Cargo.toml terminal::persistent_widget::tests::managed_input_action_keeps_shell_control_sequences_when_no_shortcut_applies --lib -- --exact`
  - `cargo test --manifest-path services/rttx-server/Cargo.toml --test pty_io ctrl_d_at_shell_prompt_produces_pane_exited_message -- --nocapture`
  - `cargo test --manifest-path clients/rttx/Cargo.toml terminal::persistent_widget::tests::mark_exited_disables_input_and_reports_status --lib -- --ignored --exact --nocapture`
  - `cargo test --manifest-path clients/rttx/Cargo.toml window::tests::managed_pane_exit_marks_visible_pane_exited --lib -- --ignored --exact --nocapture`
  - `./run_ui_tests.sh managed_pane_exit`

## Manual verification

- Verified through the headless AT-SPI UI harness that a daemon-backed pane whose shell exits shows `Exited` and remains visible.
- Literal Ctrl+D AT-SPI key injection was investigated, but the current headless harness does not reliably deliver keyboard text to VTE; Ctrl+D itself is therefore covered at the key-encoding and daemon protocol layers, while the UI test covers the resulting `PaneExited` behavior.

## Remaining limitations

- No protocol change.
- No RFC required; this is a scoped bug fix to existing terminal exit handling.

Fixes #411
