### PR TITLE
fix: keep workspace popover parented until action resolves

### DIFF
--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -95,6 +95,11 @@ impl Window {
     }
 
     pub(super) fn show_workspace_popover_menu(&self, row: &SessionRow, session_uuid: &str) {
+        // Unparent any previous popover so it doesn't leak.
+        if let Some(old) = self.imp().workspace_popover.borrow_mut().take() {
+            old.unparent();
+        }
+
         let items = {
             let state = self.imp().state.borrow();
             let Some(session) = state.sessions.iter().find(|s| s.uuid == session_uuid) else {
@@ -185,9 +190,7 @@ impl Window {
         });
         self.add_action(&close_action);
 
-        popover.connect_closed(|popover| {
-            popover.unparent();
-        });
+        self.imp().workspace_popover.replace(Some(popover.clone()));
         popover.popup();
     }
 

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -64,6 +64,7 @@ mod imp {
         pub workspace_connection_status: RefCell<HashMap<String, ConnectionStatus>>,
         pub workspace_reconnect_sources: RefCell<HashMap<String, glib::SourceId>>,
         pub focused_terminal_uuid: RefCell<Option<String>>,
+        pub workspace_popover: RefCell<Option<gtk4::PopoverMenu>>,
     }
 
     #[glib::object_subclass]


### PR DESCRIPTION
PopoverMenu actions (Close, Rename, Reconnect, Detach, Edit Connection) in the workspace ⋮ context menu silently failed because the popover was unparented in the `closed` signal handler before GTK could resolve the `win.*` action through the widget tree.

Store the popover in a `RefCell` and defer unparenting until the next popover is created.

Fixes #414