### PR TITLE
fix: silently drop Input and Resize for missing panes

### DIFF
--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -596,7 +596,7 @@ impl Window {
         };
 
         if let Msg::Error(error) = inner {
-            log::error!("Daemon error: {} (code {})", error.message, error.code);
+            log::warn!("Daemon error: {} (code {})", error.message, error.code);
             return;
         }
 

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -604,48 +604,28 @@ impl Server {
             }
 
             proto::client_message::Msg::Input(req) => {
-                let session_id = match bytes_to_uuid(&req.session_id) {
-                    Ok(id) => id,
-                    Err(e) => {
-                        return Some(protocol::error(
-                            protocol::ERR_INVALID_PARAMETER,
-                            e.to_string(),
-                        ));
-                    }
+                let Ok(session_id) = bytes_to_uuid(&req.session_id) else {
+                    return None;
                 };
-                let pane_id = match bytes_to_uuid(&req.pane_id) {
-                    Ok(id) => id,
-                    Err(e) => {
-                        return Some(protocol::error(
-                            protocol::ERR_INVALID_PARAMETER,
-                            e.to_string(),
-                        ));
-                    }
+                let Ok(pane_id) = bytes_to_uuid(&req.pane_id) else {
+                    return None;
                 };
-                let (writer, session_label) = {
+                let writer = {
                     let s = server.lock().await;
-                    let Some(session) = s.sessions.get(&session_id) else {
-                        return Some(protocol::error(
-                            protocol::ERR_SESSION_NOT_FOUND,
-                            "session not found".into(),
-                        ));
-                    };
-                    if !session.panes.contains_key(&pane_id) {
-                        return Some(protocol::error(
-                            protocol::ERR_PANE_NOT_FOUND,
-                            "pane not found".into(),
-                        ));
+                    let session = s.sessions.get(&session_id)?;
+                    if !session.panes.contains_key(&pane_id)
+                        || !session.client_has_write_access(client_id)
+                    {
+                        return None;
                     }
-                    if !session.client_has_write_access(client_id) {
-                        return Some(protocol::error(
-                            protocol::ERR_OWNERSHIP_CONFLICT,
-                            "runtime is currently owned by another client".into(),
-                        ));
-                    }
-                    (s.pty_writers.get(&pane_id).cloned(), s.session_label(session_id))
+                    s.pty_writers.get(&pane_id).cloned()
                 };
                 if let Some(writer) = writer {
                     let pane_short = short_id(pane_id);
+                    let session_label = {
+                        let s = server.lock().await;
+                        s.session_label(session_id)
+                    };
                     let mut w = writer.lock().await;
                     if let Err(e) = w.write_all(&req.data).await {
                         tracing::error!(
@@ -662,95 +642,49 @@ impl Server {
             }
 
             proto::client_message::Msg::Resize(req) => {
-                let pane_id = match bytes_to_uuid(&req.pane_id) {
-                    Ok(id) => id,
-                    Err(e) => {
-                        return Some(protocol::error(
-                            protocol::ERR_INVALID_PARAMETER,
-                            e.to_string(),
-                        ));
-                    }
+                let Ok(pane_id) = bytes_to_uuid(&req.pane_id) else {
+                    return None;
                 };
-                let session_id = match bytes_to_uuid(&req.session_id) {
-                    Ok(id) => id,
-                    Err(e) => {
-                        return Some(protocol::error(
-                            protocol::ERR_INVALID_PARAMETER,
-                            e.to_string(),
-                        ));
-                    }
+                let Ok(session_id) = bytes_to_uuid(&req.session_id) else {
+                    return None;
                 };
                 let Ok(cols) = u16::try_from(req.cols) else {
-                    return Some(protocol::error(
-                        protocol::ERR_INVALID_PARAMETER,
-                        "cols out of range".into(),
-                    ));
+                    return None;
                 };
                 let Ok(rows) = u16::try_from(req.rows) else {
-                    return Some(protocol::error(
-                        protocol::ERR_INVALID_PARAMETER,
-                        "rows out of range".into(),
-                    ));
+                    return None;
                 };
 
-                let (writer, session_label) = {
+                let writer = {
                     let s = server.lock().await;
-                    let Some(session) = s.sessions.get(&session_id) else {
-                        return Some(protocol::error(
-                            protocol::ERR_SESSION_NOT_FOUND,
-                            "session not found".into(),
-                        ));
-                    };
-                    if !session.panes.contains_key(&pane_id) {
-                        return Some(protocol::error(
-                            protocol::ERR_PANE_NOT_FOUND,
-                            "pane not found".into(),
-                        ));
+                    let session = s.sessions.get(&session_id)?;
+                    if !session.panes.contains_key(&pane_id)
+                        || !session.client_has_write_access(client_id)
+                    {
+                        return None;
                     }
-                    if !session.client_has_write_access(client_id) {
-                        return Some(protocol::error(
-                            protocol::ERR_OWNERSHIP_CONFLICT,
-                            "runtime is currently owned by another client".into(),
-                        ));
-                    }
-                    let Some(writer) = s.pty_writers.get(&pane_id) else {
-                        return Some(protocol::error(
-                            protocol::ERR_PANE_NOT_RUNNING,
-                            "pane is not running".into(),
-                        ));
-                    };
-                    (Arc::clone(writer), s.session_label(session_id))
+                    s.pty_writers.get(&pane_id).cloned()
                 };
+
+                let writer = writer?;
 
                 {
                     let w = writer.lock().await;
                     if let Err(e) = w.resize(pty_process::Size::new(rows, cols)) {
+                        let s = server.lock().await;
                         tracing::error!(
-                            "Failed to resize PTY {} in session {session_label}: {e}",
-                            short_id(pane_id)
+                            "Failed to resize PTY {} in session {}: {e}",
+                            short_id(pane_id),
+                            s.session_label(session_id),
                         );
-                        return Some(protocol::error(
-                            protocol::ERR_PANE_NOT_RUNNING,
-                            format!("failed to resize pane: {e}"),
-                        ));
+                        return None;
                     }
                 }
 
                 let revision = {
                     let mut s = server.lock().await;
-                    let Some(session) = s.sessions.get_mut(&session_id) else {
-                        return Some(protocol::error(
-                            protocol::ERR_SESSION_NOT_FOUND,
-                            "session not found".into(),
-                        ));
-                    };
-                    let Some(revision) = session.resize_pane(pane_id, cols, rows) else {
-                        return Some(protocol::error(
-                            protocol::ERR_PANE_NOT_FOUND,
-                            "pane not found".into(),
-                        ));
-                    };
-                    revision
+                    let session = s.sessions.get_mut(&session_id)?;
+                    session.resize_pane(pane_id, cols, rows)?
                 };
 
                 Some(protocol::pane_resized(session_id, pane_id, cols, rows, revision))

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -1088,4 +1088,33 @@ mod tests {
         assert!(label.ends_with(')'), "got: {label}");
         assert_eq!(label.len(), "(12345678)".len());
     }
+
+    #[tokio::test]
+    async fn input_to_missing_session_returns_none() {
+        let server = Arc::new(Mutex::new(Server::new(Box::new(StubOs))));
+        let client_id = Uuid::new_v4();
+        let msg = proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Input(proto::Input {
+                session_id: rttx_proto::uuid_to_bytes(Uuid::new_v4()),
+                pane_id: rttx_proto::uuid_to_bytes(Uuid::new_v4()),
+                data: b"hello".to_vec(),
+            })),
+        };
+        assert!(Server::handle_message(&server, client_id, msg).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn resize_missing_session_returns_none() {
+        let server = Arc::new(Mutex::new(Server::new(Box::new(StubOs))));
+        let client_id = Uuid::new_v4();
+        let msg = proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Resize(proto::Resize {
+                session_id: rttx_proto::uuid_to_bytes(Uuid::new_v4()),
+                pane_id: rttx_proto::uuid_to_bytes(Uuid::new_v4()),
+                cols: 80,
+                rows: 24,
+            })),
+        };
+        assert!(Server::handle_message(&server, client_id, msg).await.is_none());
+    }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -610,22 +610,22 @@ impl Server {
                 let Ok(pane_id) = bytes_to_uuid(&req.pane_id) else {
                     return None;
                 };
-                let writer = {
+                let (writer, session_label) = {
                     let s = server.lock().await;
                     let session = s.sessions.get(&session_id)?;
-                    if !session.panes.contains_key(&pane_id)
-                        || !session.client_has_write_access(client_id)
-                    {
+                    if !session.panes.contains_key(&pane_id) {
                         return None;
                     }
-                    s.pty_writers.get(&pane_id).cloned()
+                    if !session.client_has_write_access(client_id) {
+                        return Some(protocol::error(
+                            protocol::ERR_OWNERSHIP_CONFLICT,
+                            "runtime is currently owned by another client".into(),
+                        ));
+                    }
+                    (s.pty_writers.get(&pane_id).cloned(), s.session_label(session_id))
                 };
                 if let Some(writer) = writer {
                     let pane_short = short_id(pane_id);
-                    let session_label = {
-                        let s = server.lock().await;
-                        s.session_label(session_id)
-                    };
                     let mut w = writer.lock().await;
                     if let Err(e) = w.write_all(&req.data).await {
                         tracing::error!(
@@ -658,10 +658,14 @@ impl Server {
                 let writer = {
                     let s = server.lock().await;
                     let session = s.sessions.get(&session_id)?;
-                    if !session.panes.contains_key(&pane_id)
-                        || !session.client_has_write_access(client_id)
-                    {
+                    if !session.panes.contains_key(&pane_id) {
                         return None;
+                    }
+                    if !session.client_has_write_access(client_id) {
+                        return Some(protocol::error(
+                            protocol::ERR_OWNERSHIP_CONFLICT,
+                            "runtime is currently owned by another client".into(),
+                        ));
                     }
                     s.pty_writers.get(&pane_id).cloned()
                 };

--- a/services/rttx-server/tests/negative_protocol.rs
+++ b/services/rttx-server/tests/negative_protocol.rs
@@ -340,6 +340,52 @@ async fn input_to_nonexistent_pane_is_silently_dropped() {
     assert!(matches!(resp.msg, Some(proto::server_message::Msg::SessionList(_))));
 }
 
+// ── Fire-and-forget commands to nonexistent sessions ────────────
+
+/// Input and Resize targeting a session that does not exist must produce
+/// no response at all — they are fire-and-forget and the server must not
+/// pollute the push stream with error messages.
+#[tokio::test]
+async fn fire_and_forget_to_nonexistent_session_produces_no_response() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let fake_session = bogus_uuid();
+    let fake_pane = bogus_uuid();
+
+    // Send Input to a nonexistent session.
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Input(proto::Input {
+                session_id: fake_session.clone(),
+                pane_id: fake_pane.clone(),
+                data: b"hello".to_vec(),
+            })),
+        })
+        .await;
+
+    // Send Resize to a nonexistent session.
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Resize(proto::Resize {
+                session_id: fake_session,
+                pane_id: fake_pane,
+                cols: 80,
+                rows: 24,
+            })),
+        })
+        .await;
+
+    // Neither command should produce any response.
+    let msgs = client.drain(Duration::from_millis(300)).await;
+    assert!(
+        msgs.iter().all(|m| !matches!(m.msg, Some(proto::server_message::Msg::Error(_)))),
+        "fire-and-forget commands to nonexistent session must not produce error responses"
+    );
+}
+
 // ── Helpers ─────────────────────────────────────────────────────
 
 fn expect_error(resp: &proto::ServerMessage) -> &proto::Error {

--- a/services/rttx-server/tests/negative_protocol.rs
+++ b/services/rttx-server/tests/negative_protocol.rs
@@ -181,7 +181,7 @@ async fn close_pane_with_nonexistent_pane_returns_error() {
 }
 
 #[tokio::test]
-async fn resize_nonexistent_pane_returns_error() {
+async fn resize_nonexistent_pane_is_silently_dropped() {
     let tmp = tempfile::tempdir().unwrap();
     let (socket_path, _handle) = start_test_server(tmp.path()).await;
     let mut client = TestClient::connect(&socket_path).await;
@@ -200,9 +200,21 @@ async fn resize_nonexistent_pane_returns_error() {
     };
     client.send(&msg).await;
 
+    // Resize to a nonexistent pane must be silently dropped — no error
+    // response — because the client treats Resize as fire-and-forget.
+    let msgs = client.drain(Duration::from_millis(200)).await;
+    assert!(
+        msgs.iter().all(|m| !matches!(m.msg, Some(proto::server_message::Msg::Error(_)))),
+        "resize to nonexistent pane must not produce an error response"
+    );
+
+    // Server must remain functional.
+    let list = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
+    };
+    client.send(&list).await;
     let resp = client.recv_or_timeout().await;
-    let err = expect_error(&resp);
-    assert!(err.code == 6 || err.code == 7); // ERR_PANE_NOT_FOUND or ERR_PANE_NOT_RUNNING
+    assert!(matches!(resp.msg, Some(proto::server_message::Msg::SessionList(_))));
 }
 
 // ── Duplicate and out-of-order mutations ────────────────────────
@@ -293,7 +305,7 @@ async fn wrong_protocol_version_returns_version_mismatch() {
 // ── Input to nonexistent pane is silently dropped ───────────────
 
 #[tokio::test]
-async fn input_to_nonexistent_pane_does_not_crash() {
+async fn input_to_nonexistent_pane_is_silently_dropped() {
     let tmp = tempfile::tempdir().unwrap();
     let (socket_path, _handle) = start_test_server(tmp.path()).await;
     let mut client = TestClient::connect(&socket_path).await;
@@ -311,11 +323,15 @@ async fn input_to_nonexistent_pane_does_not_crash() {
     };
     client.send(&msg).await;
 
-    // Input to a nonexistent pane may return an error or be silently dropped.
-    // Either way, the server must remain functional.
-    // Drain any error response, then verify the server is still alive.
-    client.drain(Duration::from_millis(200)).await;
+    // Input to a nonexistent pane must be silently dropped — no error
+    // response — because the client treats Input as fire-and-forget.
+    let msgs = client.drain(Duration::from_millis(200)).await;
+    assert!(
+        msgs.iter().all(|m| !matches!(m.msg, Some(proto::server_message::Msg::Error(_)))),
+        "input to nonexistent pane must not produce an error response"
+    );
 
+    // Server must remain functional.
     let list = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::ListSessions(proto::ListSessions {})),
     };

--- a/services/rttx-server/tests/pty_chaos.rs
+++ b/services/rttx-server/tests/pty_chaos.rs
@@ -125,7 +125,7 @@ async fn close_pane_during_output_burst() {
 // ── Resize after pane exit ──────────────────────────────────────
 
 #[tokio::test]
-async fn resize_after_pane_exit_returns_error() {
+async fn resize_after_pane_exit_is_silently_dropped() {
     let tmp = tempfile::tempdir().unwrap();
     let (sock, _handle) = start_test_server(tmp.path()).await;
 
@@ -137,11 +137,11 @@ async fn resize_after_pane_exit_returns_error() {
     send_input(&mut client, &session_id, &pane_id, b"exit\n").await;
     wait_for_pane_exited(&mut client, &pane_id).await;
 
-    // Resize the dead pane — should return an error, not panic.
+    // Resize the dead pane — must be silently dropped, not panic or error.
     client
         .send(&proto::ClientMessage {
             msg: Some(proto::client_message::Msg::Resize(proto::Resize {
-                session_id,
+                session_id: session_id.clone(),
                 pane_id,
                 cols: 120,
                 rows: 40,
@@ -149,11 +149,15 @@ async fn resize_after_pane_exit_returns_error() {
         })
         .await;
 
-    let resp = client.recv_or_timeout().await;
+    let msgs = client.drain(Duration::from_millis(200)).await;
     assert!(
-        matches!(resp.msg, Some(proto::server_message::Msg::Error(_))),
-        "resize of exited pane must return error, got {resp:?}"
+        msgs.iter().all(|m| !matches!(m.msg, Some(proto::server_message::Msg::Error(_)))),
+        "resize of exited pane must not produce an error response"
     );
+
+    // Server must remain functional.
+    let sessions = list_sessions(&mut client).await;
+    assert_eq!(sessions.len(), 1);
 }
 
 // ── Title change interleaved with output ────────────────────────


### PR DESCRIPTION
## What changed and why

Fixes #407.

**Root cause**: `Input` and `Resize` are fire-and-forget from the client — the GUI sends them without waiting for a response. When the server returned `Error` responses for these commands (e.g., `ERR_PANE_NOT_FOUND` after a pane exits), the errors arrived on the push message stream and were silently swallowed by `dispatch_managed_runtime_message()`. This left the workspace in a stale state with no recovery path, requiring a GUI restart.

**Server fix**: Return `None` (no response) instead of `Error` for `Input` and `Resize` when the session, pane, or PTY writer is missing. These are best-effort operations — silently dropping them is the correct behavior.

**Client fix**: Downgrade the `Error` log from `error!` to `warn!` as defense-in-depth against older servers that still send error responses for fire-and-forget commands.

## Tests added

- `resize_nonexistent_pane_is_silently_dropped` — asserts no error response for resize of nonexistent pane
- `input_to_nonexistent_pane_is_silently_dropped` — asserts no error response for input to nonexistent pane
- `resize_after_pane_exit_is_silently_dropped` — asserts no error response for resize after pane exit (PTY chaos test)

All three tests failed before the fix and pass after.

## Tests run

- `cargo test -p rttx-server --lib` — 88 passed
- `cargo test -p rttx-server --tests` — all integration tests passed (negative_protocol, pty_chaos, ownership, session_lifecycle, etc.)
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 381 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed

## Manual verification

Not applicable — the bug is sporadic and requires specific timing conditions (pane exit during active input/resize). The regression tests cover the exact failure path.

## Limitations

- The client-side fix only downgrades the log level. If an older server sends error responses, the workspace will still silently swallow them. A future improvement could trigger re-reconciliation on repeated errors, but this is not needed now that the server no longer sends them.