### PR TITLE
fix: cap snapshot bytes and scroll to bottom on reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -444,6 +444,7 @@ impl PersistentPaneView {
 
     /// Feed a snapshot's scrollback bytes into VTE to restore state on attach.
     /// Bell characters are stripped to prevent historical bells from ringing.
+    /// Scrolls to the bottom so the viewport shows the most recent output.
     pub fn feed_snapshot(&self, scrollback: &[u8]) {
         if scrollback.is_empty() {
             return;
@@ -453,6 +454,10 @@ impl PersistentPaneView {
             self.imp().vte.feed(&filtered);
         } else {
             self.imp().vte.feed(scrollback);
+        }
+        let adj = self.imp().vte.vadjustment();
+        if let Some(adj) = adj {
+            adj.set_value(adj.upper() - adj.page_size());
         }
     }
 

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1221,6 +1221,31 @@ fn persistent_pane_view_feed_snapshot_restores_cursor_after_multiline_formatted_
     window.close();
 }
 
+/// After feeding a large snapshot, the viewport must be scrolled to the
+/// bottom so the user sees the most recent output. Regression test for #440.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn persistent_pane_view_feed_snapshot_scrolls_to_bottom() {
+    require_display!();
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("pane-1", "session-1");
+    let window = present_widget(&pane);
+    pump_events(50);
+
+    // Feed enough lines to exceed the visible area.
+    let mut data = Vec::new();
+    for i in 0..200 {
+        data.extend_from_slice(format!("line {i}\r\n").as_bytes());
+    }
+    pane.feed_snapshot(&data);
+    pump_events(50);
+
+    let adj = pane.vte().vadjustment().expect("VTE should have a vadjustment");
+    let at_bottom = (adj.value() + adj.page_size() - adj.upper()).abs() < 1.0;
+    assert!(at_bottom, "viewport should be scrolled to the bottom after snapshot feed");
+    window.close();
+}
+
 #[test]
 #[ignore = "requires isolated GTK harness"]
 fn persistent_pane_resize_callback_tracks_allocated_terminal_size() {

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.5',
+  version: '0.2.6',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -17,6 +17,14 @@ const DEFAULT_MAX_SCROLLBACK: usize = 10 * 1024 * 1024;
 /// Default on-disk scrollback log byte limit per pane (10 MB).
 const DEFAULT_MAX_SCROLLBACK_LOG: u64 = 10 * 1024 * 1024;
 
+/// Maximum bytes sent in a snapshot to a reconnecting client (256 KB).
+///
+/// The full in-memory buffer can be up to 10 MB, but replaying all of it
+/// into VTE on the client is slow and the leading bytes may start
+/// mid-escape-sequence after the scrollback cap truncation. This smaller
+/// cap keeps reconnect fast and avoids formatting corruption.
+pub const MAX_SNAPSHOT_BYTES: usize = 256 * 1024;
+
 /// What changed after feeding PTY output to a pane.
 pub struct FeedResult {
     /// New CWD if it changed from the previous value.

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -66,6 +66,25 @@ impl PaneScreen {
         &self.performer.raw_bytes
     }
 
+    /// Return a tail slice of raw bytes suitable for client snapshot replay.
+    ///
+    /// Caps the returned data to `max_bytes` and finds a clean newline
+    /// boundary so the snapshot never starts mid-escape-sequence.
+    #[must_use]
+    pub fn snapshot_bytes(&self, max_bytes: usize) -> &[u8] {
+        let raw = &self.performer.raw_bytes;
+        if raw.len() <= max_bytes {
+            return raw;
+        }
+        let start = raw.len() - max_bytes;
+        // Find the first newline at or after `start` to avoid splitting
+        // mid-escape-sequence.
+        raw[start..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map_or(&raw[start..], |offset| &raw[start + offset + 1..])
+    }
+
     /// Return the terminal title if set via OSC.
     #[must_use]
     pub fn title(&self) -> Option<&str> {
@@ -276,6 +295,62 @@ mod tests {
         screen.feed(b"\r\n\r\n\r\n"); // row 3
         screen.feed(b"\x1b[2A"); // up 2 → row 1
         assert_eq!(screen.cursor_position().0, 1);
+    }
+
+    #[test]
+    fn snapshot_bytes_returns_all_when_under_cap() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"line 1\nline 2\n");
+        assert_eq!(screen.snapshot_bytes(1024), b"line 1\nline 2\n");
+    }
+
+    #[test]
+    fn snapshot_bytes_caps_at_newline_boundary() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"aaaa\nbbbb\ncccc\n");
+        // Cap to 10 bytes — start=5 ("bbbb\ncccc\n"), finds newline at
+        // offset 4, returns from "cccc\n".
+        let snap = screen.snapshot_bytes(10);
+        assert_eq!(snap, b"cccc\n");
+    }
+
+    #[test]
+    fn snapshot_bytes_avoids_mid_escape_sequence_split() {
+        let mut screen = PaneScreen::new(1024);
+        // ESC[31m (red) followed by text and newline, then more content
+        screen.feed(b"old line\n\x1b[31mred text\nmore\n");
+        // Cap to 15: start=15, raw[15..] = "red text\nmore\n"
+        // finds newline at offset 8, returns "more\n"
+        // Cap to 22: start=8, raw[8..] = "\n\x1b[31mred text\nmore\n"
+        // finds newline at offset 0, returns "\x1b[31mred text\nmore\n"
+        let snap = screen.snapshot_bytes(22);
+        assert_eq!(snap, b"\x1b[31mred text\nmore\n");
+    }
+
+    #[test]
+    fn snapshot_bytes_falls_back_to_raw_tail_when_no_newline() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"no newlines at all in this data");
+        let snap = screen.snapshot_bytes(10);
+        assert_eq!(snap, b" this data");
+    }
+
+    #[test]
+    fn snapshot_bytes_large_buffer_stays_within_cap() {
+        let mut screen = PaneScreen::new(1024 * 1024);
+        // Simulate a long session with many lines of colored output.
+        for i in 0..10_000 {
+            screen.feed(format!("\x1b[32mline {i}: some output text\x1b[0m\n").as_bytes());
+        }
+        let cap = 4096;
+        let snap = screen.snapshot_bytes(cap);
+        assert!(snap.len() <= cap);
+        // Should start at a line boundary, not mid-escape-sequence.
+        assert!(
+            snap[0] == b'\x1b' || snap[0].is_ascii_graphic() || snap[0].is_ascii_whitespace(),
+            "snapshot starts with unexpected byte: 0x{:02x}",
+            snap[0]
+        );
     }
 
     #[test]

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -389,7 +389,10 @@ impl Server {
                         cwd: pane.effective_cwd().unwrap_or_default(),
                         cols: u32::from(pane.cols),
                         rows: u32::from(pane.rows),
-                        scrollback: pane.screen.raw_bytes().to_vec(),
+                        scrollback: pane
+                            .screen
+                            .snapshot_bytes(crate::pane::MAX_SNAPSHOT_BYTES)
+                            .to_vec(),
                         exit_status: pane.exit_status,
                     })
                     .collect();


### PR DESCRIPTION
## What changed and why

Reconnecting to a daemon with long scrollback history (e.g. a kiro-cli session) caused three UX problems:

1. **Formatting corruption** — the raw byte buffer truncation in `PaneScreen::feed()` via `drain(..excess)` can cut mid-escape-sequence. When replayed into VTE on the client, the partial leading escape sequence corrupts rendering.
2. **Slow loading** — the entire raw buffer (up to 10 MB) was sent over the wire and fed into VTE in one shot.
3. **Wrong viewport position** — after feeding the snapshot, VTE did not scroll to the bottom, so the user saw an arbitrary position instead of the most recent output.

### Changes

- **`PaneScreen::snapshot_bytes(max_bytes)`** — new method that returns a tail slice of raw bytes capped to `max_bytes`, truncated at a clean newline boundary so the snapshot never starts mid-escape-sequence
- **`MAX_SNAPSHOT_BYTES`** (256 KB) — snapshot wire cap, much smaller than the 10 MB in-memory buffer
- **Server snapshot building** — uses `snapshot_bytes()` instead of `raw_bytes()` when building pane snapshots for `AttachSession` responses
- **Client `feed_snapshot()`** — scrolls VTE to the bottom after feeding the snapshot data

### Version bump

0.2.5 → 0.2.6 (4 source files changed)

## Manual verification

1. Start rttx-server and create a workspace
2. Run a command that produces a lot of output (e.g. `seq 100000` or a long kiro-cli session)
3. Close the GUI window
4. Reopen — the snapshot loads quickly, formatting is clean, and the viewport shows the most recent output

## Tests added

### Unit tests (screen.rs)
- `snapshot_bytes_returns_all_when_under_cap` — small buffer returned as-is
- `snapshot_bytes_caps_at_newline_boundary` — truncation finds clean newline boundary
- `snapshot_bytes_avoids_mid_escape_sequence_split` — escape sequences not split
- `snapshot_bytes_falls_back_to_raw_tail_when_no_newline` — fallback when no newline exists
- `snapshot_bytes_large_buffer_stays_within_cap` — 10K lines of colored output stays within cap

### GTK widget test
- `persistent_pane_view_feed_snapshot_scrolls_to_bottom` — viewport at bottom after large snapshot feed

## Tests run

- `cargo test -p rttx-proto` ✅
- `cargo test -p rttx-server` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass including new one)

Fixes #440