### PR TITLE
fix: forward mouse events to daemon for persistent panes

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -639,6 +639,29 @@ mod tests {
             Some(b"\x1bOP" as &[u8])
         );
     }
+
+    /// Managed backend must intercept all printable and control keys so VTE's
+    /// `commit` signal only fires for mouse events. Regression for #442.
+    #[test]
+    fn managed_backend_intercepts_all_typeable_keys() {
+        let keys_and_mods: &[(gtk4::gdk::Key, gtk4::gdk::ModifierType)] = &[
+            (gtk4::gdk::Key::a, gtk4::gdk::ModifierType::empty()),
+            (gtk4::gdk::Key::Return, gtk4::gdk::ModifierType::empty()),
+            (gtk4::gdk::Key::space, gtk4::gdk::ModifierType::empty()),
+            (gtk4::gdk::Key::Up, gtk4::gdk::ModifierType::empty()),
+            (gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK),
+            (gtk4::gdk::Key::x, gtk4::gdk::ModifierType::ALT_MASK),
+            (gtk4::gdk::Key::F5, gtk4::gdk::ModifierType::empty()),
+        ];
+        for (key, mods) in keys_and_mods {
+            let action =
+                terminal_key_action(TerminalInputBackend::Managed, *key, *mods, false, false);
+            assert!(
+                matches!(action, TerminalKeyAction::ForwardToPty(_)),
+                "managed backend must intercept {key:?}+{mods:?}, got {action:?}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -136,13 +136,16 @@ mod imp {
             self.header.append(&self.zoom_button);
             self.header.append(&self.close_button);
 
-            // VTE in feed mode — no PTY spawned.
+            // VTE in feed mode — no PTY spawned.  Input stays enabled so
+            // VTE generates mouse escape sequences via `commit` when the
+            // remote app enables mouse tracking.  Keyboard input is
+            // intercepted by the Capture-phase key controller installed in
+            // `connect_input`, so VTE never emits `commit` for keystrokes.
             self.vte.set_hexpand(true);
             self.vte.set_vexpand(true);
             self.vte.set_scroll_on_output(false);
             self.vte.set_scroll_on_keystroke(true);
             self.vte.set_scrollback_lines(10000);
-            self.vte.set_input_enabled(false);
             links::configure_openable_matches(&self.vte);
             let link_target = obj.downgrade();
             links::install_openable_link_controllers(&self.vte, move || {
@@ -622,11 +625,27 @@ impl PersistentPaneView {
         (vte.column_count() as u16, vte.row_count() as u16)
     }
 
-    /// Connect a callback for keyboard input.
+    /// Connect a callback for keyboard and mouse input.
     ///
     /// The callback receives the raw terminal bytes to send to the daemon.
+    /// Keyboard input is intercepted by a Capture-phase key controller and
+    /// encoded manually.  Mouse input is handled by VTE natively — when the
+    /// remote application enables mouse tracking, VTE emits escape sequences
+    /// through the `commit` signal which are forwarded here.
     pub fn connect_input<F: Fn(&[u8]) + 'static>(&self, f: F) {
         let forward_input = std::rc::Rc::new(f);
+
+        // Forward VTE-generated data (mouse escape sequences) to the daemon.
+        let commit_forward = std::rc::Rc::clone(&forward_input);
+        let commit_pane_weak = self.downgrade();
+        self.imp().vte.connect_commit(move |_, text, _| {
+            if let Some(pane) = commit_pane_weak.upgrade()
+                && pane.imp().accepts_input.get()
+            {
+                commit_forward(text.as_bytes());
+            }
+        });
+
         let pane_weak = self.downgrade();
         let key_controller = gtk4::EventControllerKey::new();
         key_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
@@ -1094,6 +1113,89 @@ mod tests {
         assert!(
             wait_until(1_000, || { forwarded.borrow().contains(&b"window action paste".to_vec()) }),
             "managed clipboard paste helper should deliver clipboard bytes to daemon input"
+        );
+
+        window.close();
+    }
+
+    /// VTE input must be enabled so mouse events generate escape sequences
+    /// via the `commit` signal. Regression for #442.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn vte_input_enabled_for_mouse_events() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("pane-1", "runtime-1");
+        assert!(
+            pane.vte().is_input_enabled(),
+            "VTE input must be enabled for mouse event propagation"
+        );
+    }
+
+    /// VTE `commit` data (mouse escape sequences) must be forwarded through
+    /// the input callback when the pane accepts input. Regression for #442.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn commit_signal_forwards_data_when_connected() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("pane-1", "runtime-1");
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 320);
+        window.set_child(Some(&pane));
+        window.present();
+        pump_events(50);
+
+        let connected = present_connection_status(&ConnectionStatus::Connected);
+        pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
+
+        let forwarded = Rc::new(RefCell::new(Vec::new()));
+        let forwarded_clone = Rc::clone(&forwarded);
+        pane.connect_input(move |bytes| {
+            forwarded_clone.borrow_mut().push(bytes.to_vec());
+        });
+
+        // Simulate VTE emitting a mouse escape sequence via commit.
+        let sgr_click = "\x1b[<0;5;10M";
+        pane.vte().emit_by_name::<()>("commit", &[&sgr_click, &(sgr_click.len() as u32)]);
+        pump_events(50);
+
+        assert!(
+            forwarded.borrow().contains(&sgr_click.as_bytes().to_vec()),
+            "VTE commit data must be forwarded to daemon input"
+        );
+
+        window.close();
+    }
+
+    /// VTE `commit` data must NOT be forwarded when the pane does not accept
+    /// input (disconnected, exited, etc.). Regression for #442.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn commit_signal_blocked_when_input_disabled() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("pane-1", "runtime-1");
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 320);
+        window.set_child(Some(&pane));
+        window.present();
+        pump_events(50);
+
+        let forwarded = Rc::new(RefCell::new(Vec::new()));
+        let forwarded_clone = Rc::clone(&forwarded);
+        pane.connect_input(move |bytes| {
+            forwarded_clone.borrow_mut().push(bytes.to_vec());
+        });
+
+        // Pane starts without accepting input (not connected).
+        let sgr_click = "\x1b[<0;5;10M";
+        pane.vte().emit_by_name::<()>("commit", &[&sgr_click, &(sgr_click.len() as u32)]);
+        pump_events(50);
+
+        assert!(
+            forwarded.borrow().is_empty(),
+            "VTE commit data must not be forwarded when pane does not accept input"
         );
 
         window.close();

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1692,3 +1692,44 @@ fn persistent_pane_has_open_and_copy_link_actions() {
     assert!(pane.activate_action("term.open-link", None).is_err());
     assert!(pane.activate_action("term.copy-link", None).is_err());
 }
+
+/// Persistent pane must forward VTE `commit` data (mouse escape sequences)
+/// to the daemon input callback. Regression for #442.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn persistent_pane_forwards_vte_commit_to_daemon_input() {
+    require_display!();
+
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("mouse-1", "runtime-1");
+    let window = gtk4::Window::new();
+    window.set_default_size(640, 320);
+    window.set_child(Some(&pane));
+    window.present();
+    pump_events(50);
+
+    let connected =
+        rttx::runtime::present_connection_status(&rttx::runtime::ConnectionStatus::Connected);
+    pane.set_connection_presentation(&rttx::runtime::ConnectionStatus::Connected, &connected);
+
+    let forwarded = Rc::new(RefCell::new(Vec::<Vec<u8>>::new()));
+    let forwarded_clone = Rc::clone(&forwarded);
+    pane.connect_input(move |bytes| {
+        forwarded_clone.borrow_mut().push(bytes.to_vec());
+    });
+
+    // Simulate VTE emitting an SGR mouse click sequence via commit.
+    let sgr_click = "\x1b[<0;10;5M";
+    pane.vte()
+        .emit_by_name::<()>("commit", &[&sgr_click, &(sgr_click.len() as u32)]);
+    pump_events(50);
+
+    assert!(
+        forwarded.borrow().contains(&sgr_click.as_bytes().to_vec()),
+        "persistent pane must forward VTE commit data to daemon input callback"
+    );
+
+    window.close();
+}

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1722,8 +1722,7 @@ fn persistent_pane_forwards_vte_commit_to_daemon_input() {
 
     // Simulate VTE emitting an SGR mouse click sequence via commit.
     let sgr_click = "\x1b[<0;10;5M";
-    pane.vte()
-        .emit_by_name::<()>("commit", &[&sgr_click, &(sgr_click.len() as u32)]);
+    pane.vte().emit_by_name::<()>("commit", &[&sgr_click, &(sgr_click.len() as u32)]);
     pump_events(50);
 
     assert!(


### PR DESCRIPTION
## What changed and why

`PersistentPaneView` (daemon-backed terminal panes) set `vte.set_input_enabled(false)` to prevent VTE from writing to a non-existent local PTY. This also disabled VTE's native mouse event handling, so mouse-aware applications (tmux, htop, vim, mc) running in daemon-backed panes never received mouse clicks, scroll, or drag events.

### Root cause

VTE with `input_enabled(false)` suppresses all input processing, including mouse escape sequence generation. While keyboard input was manually captured via an `EventControllerKey` and forwarded to the daemon, there was no equivalent mouse event handling.

### Fix

1. Remove `set_input_enabled(false)` — VTE defaults to input enabled
2. Connect to VTE's `commit` signal in `connect_input()` to forward mouse-generated escape sequences to the daemon
3. The existing Capture-phase key controller continues to intercept all keyboard events before VTE sees them, preventing duplicate keystroke data in the `commit` handler

When the remote application enables mouse tracking (via escape sequences like `\x1b[?1000h`), VTE processes the output through `feed()`, internally enables mouse mode, and then generates SGR mouse escape sequences via the `commit` signal when the user interacts with the mouse. These sequences are forwarded to the daemon as `Input` messages.

## Manual verification

1. Start a daemon-backed workspace (persistent or ephemeral)
2. Run `tmux` with `set -g mouse on`
3. Verify mouse clicks select tmux panes, scroll works, and window resizing via mouse drag works
4. Run `htop` and verify mouse clicks on process list work
5. Verify keyboard input still works correctly in daemon-backed panes

## Tests added

- `vte_input_enabled_for_mouse_events` — regression test verifying VTE input is enabled on persistent panes
- `commit_signal_forwards_data_when_connected` — verifies VTE commit data (mouse sequences) is forwarded through the input callback when connected
- `commit_signal_blocked_when_input_disabled` — verifies commit data is NOT forwarded when the pane doesn't accept input (disconnected, exited)

## Tests run

All tests pass locally:
- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (38 passed)
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass including new ones)

New GTK test results from quality test output:
- `vte_input_enabled_for_mouse_events` ... ok
- `commit_signal_forwards_data_when_connected` ... ok
- `commit_signal_blocked_when_input_disabled` ... ok

Existing persistent pane tests all pass (18 tests).

Fixes #442