### PR TITLE
fix: skip resize on reconnect when terminal size matches daemon pane

### DIFF
--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -427,7 +427,7 @@ impl Window {
         pane.set_connected(true);
 
         let (cols, rows) = pane.terminal_size();
-        if cols > 0 && rows > 0 {
+        if cols > 0 && rows > 0 && (cols != restore.cols || rows != restore.rows) {
             self.send_managed_terminal_resize(&restore.layout_terminal_uuid, cols, rows);
         }
     }

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -20,6 +20,8 @@ pub struct WorkspacePaneRestore {
     pub title: String,
     pub cwd: String,
     pub scrollback: Vec<u8>,
+    pub cols: u16,
+    pub rows: u16,
 }
 
 /// Pure result of reconciling a workspace against a runtime snapshot.
@@ -452,6 +454,8 @@ impl WindowState {
                     title: pane_snapshot.title.clone(),
                     cwd: pane_snapshot.cwd.clone(),
                     scrollback: pane_snapshot.scrollback.clone(),
+                    cols: pane_snapshot.cols as u16,
+                    rows: pane_snapshot.rows as u16,
                 })
             })
             .collect::<Vec<_>>();
@@ -1083,6 +1087,8 @@ mod tests {
                 title: "Shell".into(),
                 cwd: "/srv/project".into(),
                 scrollback: b"restored output".to_vec(),
+                cols: 120,
+                rows: 40,
             }],
         );
         assert_eq!(state.sessions[0].runtime.runtime_id.as_deref(), Some(runtime_id.as_str()));
@@ -1495,5 +1501,28 @@ mod tests {
 
         // Second layout terminal should request a new pane.
         assert_eq!(opened.panes_to_create, vec!["right".to_string()]);
+    }
+
+    #[test]
+    fn snapshot_restore_carries_daemon_pane_dimensions() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let terminal_uuid = uuid::Uuid::new_v4().to_string();
+        let mut state =
+            window_state(vec![managed_session("ws-1", "Workspace", term(&terminal_uuid))]);
+
+        let mut snap = pane_snapshot(&terminal_uuid, "Shell", "/home", b"$ ");
+        snap.cols = 200;
+        snap.rows = 50;
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(&runtime_id, vec![snap]),
+        });
+
+        assert_eq!(transition.pane_snapshot_restores.len(), 1);
+        let restore = &transition.pane_snapshot_restores[0];
+        assert_eq!(restore.cols, 200);
+        assert_eq!(restore.rows, 50);
     }
 }

--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -454,3 +454,29 @@ fn graceful_restart_does_not_fossilize_stale_prompt_lines() {
         shutdown_server(&mut client, &mut server_child).await;
     });
 }
+
+#[tokio::test]
+async fn reattach_without_resize_does_not_duplicate_prompt() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, mut server_child) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&socket_path).await;
+    let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    // Detach and reattach without sending a resize.
+    let scrollback = reattach_snapshot_bytes(&mut client, &session_id, &pane_id).await;
+    let text = normalize_scrollback(&scrollback);
+
+    // The snapshot should end with exactly one prompt, not a duplicate.
+    assert!(
+        !text.contains("PROMPT> PROMPT> "),
+        "reattach snapshot should not contain duplicated prompts.\nscrollback:\n{text:?}"
+    );
+    assert!(
+        text.ends_with(PROMPT),
+        "reattach snapshot should end with a single prompt.\nscrollback:\n{text:?}"
+    );
+
+    shutdown_server(&mut client, &mut server_child).await;
+}


### PR DESCRIPTION
## What changed and why

`restore_managed_snapshot()` unconditionally sent a resize to the daemon after feeding the snapshot on reconnect. When the client terminal size matched the daemon pane size, this triggered SIGWINCH on the shell, causing it to redraw the prompt — duplicating the prompt already present in the snapshot.

The fix propagates the daemon pane dimensions (`cols`/`rows`) through `WorkspacePaneRestore` and skips the resize when sizes match.

## Changes

- Added `cols` and `rows` fields to `WorkspacePaneRestore`, populated from `PaneSnapshot`
- `restore_managed_snapshot()` now compares client terminal size with daemon pane size and only sends a resize when they differ
- No protocol changes — `PaneSnapshot` already carried `cols`/`rows`

## Manual verification

1. Start daemon: `RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground`
2. Start client: `RTTX_DEV_MODE=1 cargo run -p rttx`
3. Create a persistent workspace, type a command, observe single prompt
4. Kill and restart the client
5. Reconnect to the workspace — prompt should appear exactly once, no duplication

## Tests added

- **Unit test**: `snapshot_restore_carries_daemon_pane_dimensions` — verifies `WorkspacePaneRestore` propagates daemon pane dimensions from the snapshot
- **Integration test**: `reattach_without_resize_does_not_duplicate_prompt` — verifies that a detach/reattach cycle produces a snapshot ending with exactly one prompt

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass via Broadway)

Fixes #444