### PR TITLE
feat: add layout rotation to toggle split orientations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ workspaces will fail to connect.
 | Jump to workspace 1-9 | Alt+1 through Alt+9 |
 | Zoom in / out / reset | Ctrl+Plus / Ctrl+Minus / Ctrl+0 |
 | Zoom pane (toggle) | Ctrl+Shift+Z |
+| Rotate layout | Ctrl+Shift+R |
 | Navigate panes | Alt+Arrow (configurable) |
 | Preferences | Ctrl+, |
 | Fullscreen | F11 |

--- a/clients/rttx/src/session/layout.rs
+++ b/clients/rttx/src/session/layout.rs
@@ -45,6 +45,16 @@ pub enum SplitOrientation {
     Vertical,
 }
 
+impl SplitOrientation {
+    #[must_use]
+    pub const fn toggled(self) -> Self {
+        match self {
+            Self::Horizontal => Self::Vertical,
+            Self::Vertical => Self::Horizontal,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Direction {
     Left,
@@ -374,6 +384,24 @@ impl LayoutNode {
                 first.set_terminal_custom_title(target_uuid, custom_title.clone())
                     || second.set_terminal_custom_title(target_uuid, custom_title)
             }
+        }
+    }
+
+    /// Return a new tree with every split orientation toggled.
+    ///
+    /// Horizontal splits become vertical and vice versa. Terminal nodes and
+    /// split ratios are preserved. Useful when switching between landscape
+    /// and portrait monitor orientations.
+    #[must_use]
+    pub fn rotated(&self) -> Self {
+        match self {
+            Self::Terminal { .. } => self.clone(),
+            Self::Split { orientation, ratio, first, second } => Self::Split {
+                orientation: orientation.toggled(),
+                ratio: *ratio,
+                first: Box::new(first.rotated()),
+                second: Box::new(second.rotated()),
+            },
         }
     }
 
@@ -739,6 +767,70 @@ mod tests {
             panic!("Expected Split");
         }
     }
+
+    // ── Rotation tests ───────────────────────────────────────────
+
+    #[test]
+    fn rotate_terminal_is_identity() {
+        let layout = term("t1");
+        assert_eq!(layout.rotated(), layout);
+    }
+
+    #[test]
+    fn rotate_single_horizontal_split_becomes_vertical() {
+        let layout = hsplit(term("t1"), term("t2"));
+        let rotated = layout.rotated();
+        assert_eq!(rotated, vsplit(term("t1"), term("t2")));
+    }
+
+    #[test]
+    fn rotate_single_vertical_split_becomes_horizontal() {
+        let layout = vsplit(term("t1"), term("t2"));
+        let rotated = layout.rotated();
+        assert_eq!(rotated, hsplit(term("t1"), term("t2")));
+    }
+
+    #[test]
+    fn rotate_preserves_ratios() {
+        let layout = split_ratio(SplitOrientation::Horizontal, 0.7, term("t1"), term("t2"));
+        let rotated = layout.rotated();
+        if let LayoutNode::Split { orientation, ratio, .. } = &rotated {
+            assert_eq!(*orientation, SplitOrientation::Vertical);
+            assert!((*ratio - 0.7).abs() < f64::EPSILON);
+        } else {
+            panic!("Expected Split");
+        }
+    }
+
+    #[test]
+    fn rotate_nested_toggles_all_orientations() {
+        let layout = hsplit(term("t1"), vsplit(term("t2"), term("t3")));
+        let rotated = layout.rotated();
+        assert_eq!(rotated, vsplit(term("t1"), hsplit(term("t2"), term("t3"))));
+    }
+
+    #[test]
+    fn rotate_preserves_terminal_uuids() {
+        let layout = hsplit(term("t1"), vsplit(term("t2"), term("t3")));
+        assert_eq!(layout.terminal_uuids(), layout.rotated().terminal_uuids());
+    }
+
+    #[test]
+    fn rotate_twice_is_identity() {
+        let layout = hsplit(
+            split_ratio(SplitOrientation::Vertical, 0.3, term("t1"), term("t2")),
+            term("t3"),
+        );
+        assert_eq!(layout.rotated().rotated(), layout);
+    }
+
+    #[test]
+    fn orientation_toggled() {
+        assert_eq!(SplitOrientation::Horizontal.toggled(), SplitOrientation::Vertical);
+        assert_eq!(SplitOrientation::Vertical.toggled(), SplitOrientation::Horizontal);
+    }
+
+    // ── End rotation tests ───────────────────────────────────────
 
     #[test]
     fn split_preserves_parent_ratio() {
@@ -1130,6 +1222,21 @@ pub mod proptests {
                     prop_assert_ne!(&adj, target, "Adjacent must differ from target");
                 }
             }
+        }
+
+        #[test]
+        fn rotate_twice_is_identity(layout in arb_layout()) {
+            prop_assert_eq!(layout.rotated().rotated(), layout);
+        }
+
+        #[test]
+        fn rotate_preserves_uuids(layout in arb_layout()) {
+            prop_assert_eq!(layout.terminal_uuids(), layout.rotated().terminal_uuids());
+        }
+
+        #[test]
+        fn rotate_preserves_count(layout in arb_layout()) {
+            prop_assert_eq!(layout.terminal_count(), layout.rotated().terminal_count());
         }
     }
 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -192,6 +192,7 @@ mod imp {
             pane_section.append(Some("Search"), Some("win.search"));
             pane_section.append(Some("Split Horizontally"), Some("win.split-horizontal"));
             pane_section.append(Some("Split Vertically"), Some("win.split-vertical"));
+            pane_section.append(Some("Rotate Layout"), Some("win.rotate-layout"));
             let session_section = gtk4::gio::Menu::new();
             session_section.append(Some("New Session"), Some("win.new-session"));
             session_section.append(Some("Toggle Input Sync"), Some("win.toggle-input-sync"));

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -221,6 +221,7 @@ mod imp {
             pane_section.append(Some("Search"), Some("win.search"));
             pane_section.append(Some("Split Horizontally"), Some("win.split-horizontal"));
             pane_section.append(Some("Split Vertically"), Some("win.split-vertical"));
+            pane_section.append(Some("Rotate Layout"), Some("win.rotate-layout"));
             let session_section = gtk4::gio::Menu::new();
             session_section.append(Some("New Session"), Some("win.new-session"));
             session_section.append(Some("Toggle Input Sync"), Some("win.toggle-input-sync"));

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -31,6 +31,7 @@ impl Window {
             ("zoom-out", &["<Ctrl>minus"], |w| w.zoom_focused(-1)),
             ("zoom-reset", &["<Ctrl>0"], |w| w.zoom_focused(0)),
             ("toggle-pane-zoom", &["<Ctrl><Shift>Z"], Self::toggle_pane_zoom),
+            ("rotate-layout", &["<Ctrl><Shift>R"], Self::rotate_layout),
             ("new-session", &["<Ctrl><Shift>T"], Self::add_session),
             ("new-ephemeral-workspace", &["<Ctrl><Shift><Alt>T"], Self::add_ephemeral_session),
             ("new-remote-workspace", &[], Self::show_new_remote_workspace_dialog),
@@ -253,6 +254,24 @@ impl Window {
                 }
                 session.zoomed_terminal_uuid = Some(focused);
             }
+            session.clone()
+        };
+        self.rebuild_session_content(&session_uuid, &session_state);
+        self.focus_session_terminal(&session_uuid);
+    }
+
+    fn rotate_layout(&self) {
+        let Some(session_uuid) =
+            self.imp().session_stack.visible_child_name().map(|n| n.to_string())
+        else {
+            return;
+        };
+        let session_state = {
+            let mut state = self.imp().state.borrow_mut();
+            let Some(session) = state.sessions.iter_mut().find(|s| s.uuid == session_uuid) else {
+                return;
+            };
+            session.layout = session.layout.rotated();
             session.clone()
         };
         self.rebuild_session_content(&session_uuid, &session_state);

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -1082,3 +1082,24 @@ fn preferences_bell_fields_roundtrip() {
     assert!(!loaded.audible_bell, "audible_bell=false must survive roundtrip");
     assert!(!loaded.visual_bell, "visual_bell=false must survive roundtrip");
 }
+
+/// Rotation must preserve all terminal UUIDs and produce a valid serializable tree.
+#[test]
+fn contract_rotate_preserves_structure_and_serializes() {
+    let layout = hsplit(
+        vsplit(term_full("a", "/a", "A"), term_full("b", "/b", "B")),
+        term_full("c", "/c", "C"),
+    );
+
+    let rotated = layout.rotated();
+
+    let uuids = rotated.terminal_uuids();
+    assert!(uuids.contains(&"a".to_string()));
+    assert!(uuids.contains(&"b".to_string()));
+    assert!(uuids.contains(&"c".to_string()));
+    assert_eq!(uuids.len(), 3);
+
+    let json = serde_json::to_string(&rotated).unwrap();
+    let restored: LayoutNode = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored, rotated);
+}

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -1146,3 +1146,29 @@ fn rename_sets_user_renamed_and_persists_name() {
     assert!(restored.user_renamed);
     assert!(restored.runtime.runtime_id.is_some());
 }
+
+#[test]
+fn rotate_layout_persists_through_serialization() {
+    let layout = hsplit(term("t1"), vsplit(term("t2"), term("t3")));
+    let original_uuids = layout.terminal_uuids();
+    let mut session = SessionState::new("test".into());
+    session.uuid = "s1".into();
+    session.layout = layout;
+
+    let mut state = WindowState {
+        active_session_index: 0,
+        sessions: vec![session],
+        ..WindowState::default()
+    };
+
+    state.sessions[0].layout = state.sessions[0].layout.rotated();
+
+    let json = serde_json::to_string(&state).unwrap();
+    let restored: WindowState = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(
+        restored.sessions[0].layout,
+        vsplit(term("t1"), hsplit(term("t2"), term("t3")))
+    );
+    assert_eq!(restored.sessions[0].layout.terminal_uuids(), original_uuids);
+}

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -1155,20 +1155,14 @@ fn rotate_layout_persists_through_serialization() {
     session.uuid = "s1".into();
     session.layout = layout;
 
-    let mut state = WindowState {
-        active_session_index: 0,
-        sessions: vec![session],
-        ..WindowState::default()
-    };
+    let mut state =
+        WindowState { active_session_index: 0, sessions: vec![session], ..WindowState::default() };
 
     state.sessions[0].layout = state.sessions[0].layout.rotated();
 
     let json = serde_json::to_string(&state).unwrap();
     let restored: WindowState = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(
-        restored.sessions[0].layout,
-        vsplit(term("t1"), hsplit(term("t2"), term("t3")))
-    );
+    assert_eq!(restored.sessions[0].layout, vsplit(term("t1"), hsplit(term("t2"), term("t3"))));
     assert_eq!(restored.sessions[0].layout.terminal_uuids(), original_uuids);
 }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.6',
+  version: '0.2.7',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Implements layout rotation (Ctrl+Shift+R) that toggles every split orientation in the current workspace's layout tree. Horizontal splits become vertical and vice versa, while terminal nodes and split ratios are preserved.

This is useful when switching between landscape and portrait monitor orientations — a layout optimized for a wide screen can be instantly adapted for a tall screen.

Fixes #446

## Changes

- `SplitOrientation::toggled()` — const method for H↔V conversion
- `LayoutNode::rotated()` — recursively toggles all split orientations, preserving ratios and terminal UUIDs
- `rotate-layout` window action with `Ctrl+Shift+R` keyboard shortcut
- "Rotate Layout" context menu entry in both terminal widget variants (direct and persistent)
- Version bump to 0.2.7

## Manual verification

1. Open rttx, create a workspace with multiple splits (mix of horizontal and vertical)
2. Press Ctrl+Shift+R — all horizontal splits become vertical and vice versa
3. Press Ctrl+Shift+R again — layout returns to original
4. Right-click a pane → "Rotate Layout" does the same
5. Close and reopen rttx — rotated layout persists correctly

## Tests added

Unit tests (8):
- `rotate_terminal_is_identity`
- `rotate_single_horizontal_split_becomes_vertical`
- `rotate_single_vertical_split_becomes_horizontal`
- `rotate_preserves_ratios`
- `rotate_nested_toggles_all_orientations`
- `rotate_preserves_terminal_uuids`
- `rotate_twice_is_identity`
- `orientation_toggled`

Property-based tests (3):
- `rotate_twice_is_identity`
- `rotate_preserves_uuids`
- `rotate_preserves_count`

GTK boundary contract test (1):
- `contract_rotate_preserves_structure_and_serializes`

Integration test (1):
- `rotate_layout_persists_through_serialization`

## Tests run

- `cargo build --workspace` ✅ (with `--no-default-features --features vte-0_76` for client)
- `cargo test --workspace` ✅ (all 501+ tests pass, 0 failures)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all rotation tests appear and pass)