### PR TITLE
fix: add drag-and-drop controllers to daemon-backed panes

### DIFF
--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -221,6 +221,29 @@ impl Window {
             win.send_managed_terminal_resize(&resize_terminal_uuid, cols, rows);
         });
 
+        let drag_source = gtk4::DragSource::new();
+        drag_source.set_actions(gtk4::gdk::DragAction::MOVE);
+        let drag_uuid = terminal_uuid.clone();
+        drag_source.connect_prepare(move |_, _, _| {
+            Some(gtk4::gdk::ContentProvider::for_value(&drag_uuid.to_value()))
+        });
+        pane_view.header().add_controller(drag_source);
+
+        let drop_target =
+            gtk4::DropTarget::new(glib::Type::STRING, gtk4::gdk::DragAction::MOVE);
+        let win = self.clone();
+        let target_uuid = terminal_uuid.clone();
+        drop_target.connect_drop(move |_, value, _, _| {
+            if let Ok(source_uuid) = value.get::<String>()
+                && source_uuid != target_uuid
+            {
+                win.swap_terminals(&source_uuid, &target_uuid);
+                return true;
+            }
+            false
+        });
+        pane_view.add_controller(drop_target);
+
         let win = self.clone();
         let focus_uuid = terminal_uuid.clone();
         let focus_controller = gtk4::EventControllerFocus::new();

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -229,8 +229,7 @@ impl Window {
         });
         pane_view.header().add_controller(drag_source);
 
-        let drop_target =
-            gtk4::DropTarget::new(glib::Type::STRING, gtk4::gdk::DragAction::MOVE);
+        let drop_target = gtk4::DropTarget::new(glib::Type::STRING, gtk4::gdk::DragAction::MOVE);
         let win = self.clone();
         let target_uuid = terminal_uuid.clone();
         drop_target.connect_drop(move |_, value, _, _| {

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3811,3 +3811,139 @@ fn popover_menu_after_close_does_not_crash() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+fn has_controller<T: IsA<glib::Object>>(widget: &impl IsA<gtk4::Widget>) -> bool {
+    let controllers = widget.observe_controllers();
+    for index in 0..controllers.n_items() {
+        if let Some(controller) = controllers.item(index)
+            && controller.downcast::<T>().is_ok()
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn managed_pane_has_drag_source_on_header() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.managed-drag-source-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let session_state = crate::test_helpers::managed_session(
+        "workspace-drag",
+        "Drag Workspace",
+        LayoutNode::new_terminal_with_uuid("drag-pane"),
+    );
+    window.imp().state.borrow_mut().sessions.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    let pane = window
+        .imp()
+        .persistent_terminals
+        .borrow()
+        .get("drag-pane")
+        .cloned()
+        .expect("managed pane should be present");
+
+    assert!(
+        has_controller::<gtk4::DragSource>(pane.header()),
+        "managed pane header should have a DragSource controller"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn managed_pane_has_drop_target() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.managed-drop-target-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let session_state = crate::test_helpers::managed_session(
+        "workspace-drop",
+        "Drop Workspace",
+        LayoutNode::new_terminal_with_uuid("drop-pane"),
+    );
+    window.imp().state.borrow_mut().sessions.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    let pane = window
+        .imp()
+        .persistent_terminals
+        .borrow()
+        .get("drop-pane")
+        .cloned()
+        .expect("managed pane should be present");
+
+    assert!(
+        has_controller::<gtk4::DropTarget>(&pane),
+        "managed pane should have a DropTarget controller"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn swap_terminals_works_for_managed_panes() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.managed-swap-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let layout = LayoutNode::Split {
+        orientation: crate::session::layout::SplitOrientation::Horizontal,
+        ratio: 0.5,
+        first: Box::new(LayoutNode::new_terminal_with_uuid("pane-a")),
+        second: Box::new(LayoutNode::new_terminal_with_uuid("pane-b")),
+    };
+    let session_state =
+        crate::test_helpers::managed_session("workspace-swap", "Swap Workspace", layout);
+    window.imp().state.borrow_mut().sessions.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    window.swap_terminals("pane-a", "pane-b");
+
+    let state = window.imp().state.borrow();
+    let session = state
+        .sessions
+        .iter()
+        .find(|s| s.uuid == "workspace-swap")
+        .expect("session should exist");
+    assert_eq!(
+        session.layout.terminal_uuids(),
+        vec!["pane-b", "pane-a"],
+        "swap should exchange pane positions in managed workspace"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3913,9 +3913,8 @@ fn swap_terminals_works_for_managed_panes() {
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.managed-swap-tests")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.managed-swap-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
@@ -3933,11 +3932,8 @@ fn swap_terminals_works_for_managed_panes() {
     window.swap_terminals("pane-a", "pane-b");
 
     let state = window.imp().state.borrow();
-    let session = state
-        .sessions
-        .iter()
-        .find(|s| s.uuid == "workspace-swap")
-        .expect("session should exist");
+    let session =
+        state.sessions.iter().find(|s| s.uuid == "workspace-swap").expect("session should exist");
     assert_eq!(
         session.layout.terminal_uuids(),
         vec!["pane-b", "pane-a"],


### PR DESCRIPTION
## What changed and why

`PersistentPaneView` (used for daemon-backed workspaces) was missing `DragSource` and `DropTarget` controllers. Pane rearrangement via header drag only worked for local (non-managed) `TerminalWidget` instances. Since the default workspace type is now managed/persistent, this effectively broke drag-and-drop for most users.

Added the same `DragSource` (on header) and `DropTarget` (on pane widget) setup to `connect_managed_pane` that `connect_terminal_signals` already provides for local terminals.

## Root cause

When `PersistentPaneView` was introduced for daemon-backed panes, the `connect_managed_pane` function set up input, resize, focus, split, close, zoom, and bell handlers — but never added drag-and-drop controllers. The local terminal path (`connect_terminal_signals`) had these controllers, but the managed path did not.

## Manual verification

1. Build and run with `RTTX_DEV_MODE=1 cargo run -p rttx`
2. Create a workspace with multiple panes (Ctrl+Shift+E or Ctrl+Shift+O)
3. Drag a pane header to rearrange — panes swap positions

## Tests added

- `managed_pane_has_drag_source_on_header` — verifies DragSource controller on header
- `managed_pane_has_drop_target` — verifies DropTarget controller on pane widget
- `swap_terminals_works_for_managed_panes` — verifies swap logic works for managed sessions

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 3 new GTK tests pass)

Fixes #448