### PR TITLE
chore: remove tmux-related data model and UI paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/bookmarks.rs
+++ b/clients/rttx/src/bookmarks.rs
@@ -13,8 +13,6 @@ pub struct Bookmark {
     pub directory: Option<String>,
     #[serde(default)]
     pub ssh_target: Option<String>,
-    #[serde(default)]
-    pub tmux_session: Option<String>,
 }
 
 impl Bookmark {
@@ -25,7 +23,6 @@ impl Bookmark {
             name: name.into(),
             directory: None,
             ssh_target: None,
-            tmux_session: None,
         }
     }
 
@@ -33,8 +30,7 @@ impl Bookmark {
     pub fn command(&self) -> Option<String> {
         let directory = non_empty(self.directory.as_deref());
         let ssh_target = non_empty(self.ssh_target.as_deref());
-        let tmux_session = non_empty(self.tmux_session.as_deref());
-        let local_command = local_command(directory, tmux_session);
+        let local_command = directory.map(|d| format!("cd {}", shell_quote(d)));
 
         match (ssh_target, local_command) {
             (Some(target), Some(command)) => {
@@ -54,9 +50,6 @@ impl Bookmark {
         }
         if let Some(target) = non_empty(self.ssh_target.as_deref()) {
             parts.push(format!("ssh {target}"));
-        }
-        if let Some(session) = non_empty(self.tmux_session.as_deref()) {
-            parts.push(format!("tmux {session}"));
         }
 
         if parts.is_empty() { "Empty bookmark".into() } else { parts.join(" | ") }
@@ -78,21 +71,17 @@ impl Bookmark {
     /// None for local directory-only bookmarks — `session_initial_cwd` handles the directory.
     #[must_use]
     pub fn session_startup_command(&self) -> Option<String> {
-        let directory = non_empty(self.directory.as_deref());
         let ssh_target = non_empty(self.ssh_target.as_deref());
-        let tmux_session = non_empty(self.tmux_session.as_deref());
 
-        match (ssh_target, tmux_session) {
-            (Some(target), _) => {
-                let remote_cmd = local_command(directory, tmux_session);
-                Some(remote_cmd.map_or_else(
-                    || format!("ssh {target}"),
-                    |cmd| format!("ssh -t {target} {}", shell_quote(&cmd)),
-                ))
-            }
-            (None, Some(session)) => Some(tmux_command(session)),
-            (None, None) => None,
-        }
+        ssh_target.map(|target| {
+            let directory = non_empty(self.directory.as_deref());
+            directory.map_or_else(
+                || format!("ssh {target}"),
+                |dir| {
+                    format!("ssh -t {target} {}", shell_quote(&format!("cd {}", shell_quote(dir))))
+                },
+            )
+        })
     }
 
     /// SSH host for remote workspace creation, if this bookmark targets a remote host.
@@ -117,34 +106,28 @@ impl Bookmark {
     }
 
     /// Command to run on a remote pane that is already connected to the bookmark's host.
-    /// Returns the inner command (cd, tmux, etc.) without the SSH wrapper.
+    /// Returns the inner command (cd, etc.) without the SSH wrapper.
     /// None if the bookmark has no SSH target or no inner command beyond just connecting.
     #[must_use]
     pub fn remote_command(&self) -> Option<String> {
         non_empty(self.ssh_target.as_deref())?;
-        local_command(non_empty(self.directory.as_deref()), non_empty(self.tmux_session.as_deref()))
+        non_empty(self.directory.as_deref()).map(|d| format!("cd {}", shell_quote(d)))
     }
 
     #[must_use]
     pub fn pane_target(&self) -> Option<PaneTarget> {
         let directory = non_empty(self.directory.as_deref()).map(str::to_string);
         let ssh_target = non_empty(self.ssh_target.as_deref()).map(str::to_string);
-        let tmux_session = non_empty(self.tmux_session.as_deref()).map(str::to_string);
 
-        match (directory, ssh_target, tmux_session) {
-            (Some(path), None, None) => Some(PaneTarget::LocalFolder { path }),
-            (None, None, Some(session)) => Some(PaneTarget::LocalTmux { session }),
-            (Some(_path), None, Some(session)) => Some(PaneTarget::LocalTmux { session }),
-            (None, Some(ssh_target), None) => {
+        match (directory, ssh_target) {
+            (Some(path), None) => Some(PaneTarget::LocalFolder { path }),
+            (None, Some(ssh_target)) => {
                 Some(PaneTarget::RemoteShell { ssh_target, remote_folder: None })
             }
-            (Some(path), Some(ssh_target), None) => {
+            (Some(path), Some(ssh_target)) => {
                 Some(PaneTarget::RemoteShell { ssh_target, remote_folder: Some(path) })
             }
-            (None | Some(_), Some(ssh_target), Some(tmux_session)) => {
-                Some(PaneTarget::RemoteTmux { ssh_target, tmux_session })
-            }
-            (None, None, None) => None,
+            (None, None) => None,
         }
     }
 }
@@ -167,22 +150,6 @@ pub fn matches_query(bookmark: &Bookmark, query: &str) -> bool {
 
 fn non_empty(value: Option<&str>) -> Option<&str> {
     value.map(str::trim).filter(|value| !value.is_empty())
-}
-
-fn local_command(directory: Option<&str>, tmux_session: Option<&str>) -> Option<String> {
-    match (directory, tmux_session) {
-        (Some(directory), Some(session)) => {
-            Some(format!("cd {} && ({})", shell_quote(directory), tmux_command(session)))
-        }
-        (Some(directory), None) => Some(format!("cd {}", shell_quote(directory))),
-        (None, Some(session)) => Some(tmux_command(session)),
-        (None, None) => None,
-    }
-}
-
-fn tmux_command(session: &str) -> String {
-    let session = shell_quote(session);
-    format!("tmux attach-session -t {session} || tmux new-session -s {session}")
 }
 
 fn bookmarks_path() -> PathBuf {
@@ -252,44 +219,14 @@ mod tests {
     }
 
     #[test]
-    fn tmux_bookmark_builds_attach_or_create_command() {
-        let mut bookmark = Bookmark::new("Ops");
-        bookmark.tmux_session = Some("ops".into());
-
-        assert_eq!(
-            bookmark.command().as_deref(),
-            Some("tmux attach-session -t 'ops' || tmux new-session -s 'ops'")
-        );
-    }
-
-    #[test]
-    fn combined_bookmark_builds_remote_cd_then_tmux_command() {
+    fn combined_bookmark_builds_remote_cd_command() {
         let mut bookmark = Bookmark::new("Remote Ops");
         bookmark.directory = Some("/srv/app".into());
         bookmark.ssh_target = Some("deploy@example.com".into());
-        bookmark.tmux_session = Some("deploy".into());
 
         assert_eq!(
             bookmark.command().as_deref(),
-            Some(
-                "ssh -t deploy@example.com 'cd '\"'\"'/srv/app'\"'\"' && (tmux attach-session -t '\"'\"'deploy'\"'\"' || tmux new-session -s '\"'\"'deploy'\"'\"')'"
-            )
-        );
-    }
-
-    #[test]
-    fn pane_target_prefers_remote_tmux_for_ssh_tmux_bookmarks() {
-        let mut bookmark = Bookmark::new("Remote Ops");
-        bookmark.directory = Some("/srv/app".into());
-        bookmark.ssh_target = Some("deploy@example.com".into());
-        bookmark.tmux_session = Some("deploy".into());
-
-        assert_eq!(
-            bookmark.pane_target(),
-            Some(PaneTarget::RemoteTmux {
-                ssh_target: "deploy@example.com".into(),
-                tmux_session: "deploy".into(),
-            })
+            Some("ssh -t deploy@example.com 'cd '\"'\"'/srv/app'\"'\"''")
         );
     }
 
@@ -320,12 +257,10 @@ mod tests {
         let mut bookmark = Bookmark::new("Prod Web");
         bookmark.directory = Some("/srv/app".into());
         bookmark.ssh_target = Some("deploy@example.com".into());
-        bookmark.tmux_session = Some("web".into());
 
         assert!(matches_query(&bookmark, "prod"));
         assert!(matches_query(&bookmark, "srv/app"));
         assert!(matches_query(&bookmark, "deploy@example.com"));
-        assert!(matches_query(&bookmark, "tmux attach-session"));
         assert!(!matches_query(&bookmark, "staging"));
     }
 
@@ -343,7 +278,6 @@ mod tests {
         let mut bookmark = Bookmark::new("Work");
         bookmark.directory = Some("/work".into());
         bookmark.ssh_target = Some("dev@example.com".into());
-        bookmark.tmux_session = Some("main".into());
 
         save_to(&[bookmark.clone()], &path).unwrap();
         assert_eq!(load_from(&path), vec![bookmark]);
@@ -383,31 +317,15 @@ mod tests {
     }
 
     #[test]
-    fn local_dir_and_tmux_session_initial_cwd_is_dir_and_startup_command_is_tmux_only() {
-        let mut bookmark = Bookmark::new("Local Dev");
-        bookmark.directory = Some("/home/user/work".into());
-        bookmark.tmux_session = Some("dev".into());
-
-        assert_eq!(bookmark.session_initial_cwd(), Some("/home/user/work"));
-        assert_eq!(
-            bookmark.session_startup_command().as_deref(),
-            Some("tmux attach-session -t 'dev' || tmux new-session -s 'dev'")
-        );
-    }
-
-    #[test]
-    fn ssh_with_dir_and_tmux_session_startup_command_includes_full_chain() {
+    fn ssh_with_dir_session_startup_command_includes_cd() {
         let mut bookmark = Bookmark::new("Remote Dev");
         bookmark.ssh_target = Some("deploy@example.com".into());
         bookmark.directory = Some("/srv/app".into());
-        bookmark.tmux_session = Some("web".into());
 
         assert_eq!(bookmark.session_initial_cwd(), None);
         assert_eq!(
             bookmark.session_startup_command().as_deref(),
-            Some(
-                "ssh -t deploy@example.com 'cd '\"'\"'/srv/app'\"'\"' && (tmux attach-session -t '\"'\"'web'\"'\"' || tmux new-session -s '\"'\"'web'\"'\"')'"
-            )
+            Some("ssh -t deploy@example.com 'cd '\"'\"'/srv/app'\"'\"''")
         );
     }
 
@@ -508,7 +426,6 @@ mod tests {
         let mut b = Bookmark::new("Deploy");
         b.ssh_target = Some("deploy@example.com".into());
         b.directory = Some("/srv/app".into());
-        b.tmux_session = Some("web".into());
 
         let full = b.command().unwrap();
         assert!(full.starts_with("ssh"), "full command should start with ssh: {full}");
@@ -516,7 +433,6 @@ mod tests {
         let inner = b.remote_command().unwrap();
         assert!(!inner.contains("ssh"), "remote_command must not contain ssh: {inner}");
         assert!(inner.contains("/srv/app"), "remote_command must contain directory");
-        assert!(inner.contains("tmux"), "remote_command must contain tmux");
     }
 
     #[test]
@@ -531,5 +447,20 @@ mod tests {
         let mut b = Bookmark::new("Local");
         b.directory = Some("/home/user".into());
         assert!(b.remote_command().is_none());
+    }
+
+    #[test]
+    fn legacy_bookmark_with_tmux_session_field_loads_without_error() {
+        let json = r#"[{
+            "uuid": "abc",
+            "name": "Old",
+            "directory": "/work",
+            "ssh_target": "host",
+            "tmux_session": "dev"
+        }]"#;
+        let bookmarks: Vec<Bookmark> = serde_json::from_str(json).unwrap();
+        assert_eq!(bookmarks.len(), 1);
+        assert_eq!(bookmarks[0].name, "Old");
+        assert_eq!(bookmarks[0].directory.as_deref(), Some("/work"));
     }
 }

--- a/clients/rttx/src/bookmarks_window.rs
+++ b/clients/rttx/src/bookmarks_window.rs
@@ -21,7 +21,6 @@ pub fn show_form(parent: &Window, bookmark: Option<&Bookmark>) {
     let name_row = adw::EntryRow::builder().title("Name").build();
     let directory_row = adw::EntryRow::builder().title("Directory").build();
     let ssh_target_row = adw::EntryRow::builder().title("SSH target / args").build();
-    let tmux_session_row = adw::EntryRow::builder().title("Tmux session").build();
 
     let status_label = gtk4::Label::new(None);
     status_label.set_xalign(0.0);
@@ -31,7 +30,6 @@ pub fn show_form(parent: &Window, bookmark: Option<&Bookmark>) {
     group.add(&name_row);
     group.add(&directory_row);
     group.add(&ssh_target_row);
-    group.add(&tmux_session_row);
 
     let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
     content_box.set_margin_start(18);
@@ -51,25 +49,20 @@ pub fn show_form(parent: &Window, bookmark: Option<&Bookmark>) {
         name_row.set_text(&b.name);
         directory_row.set_text(b.directory.as_deref().unwrap_or_default());
         ssh_target_row.set_text(b.ssh_target.as_deref().unwrap_or_default());
-        tmux_session_row.set_text(b.tmux_session.as_deref().unwrap_or_default());
     }
 
     let dialog_for_save = dialog.clone();
     let parent_for_save = parent.clone();
     save_button.connect_clicked(move |_| {
-        let b = match build_bookmark(
-            &name_row,
-            &directory_row,
-            &ssh_target_row,
-            &tmux_session_row,
-            existing_uuid.clone(),
-        ) {
-            Ok(b) => b,
-            Err(msg) => {
-                status_label.set_text(&msg);
-                return;
-            }
-        };
+        let b =
+            match build_bookmark(&name_row, &directory_row, &ssh_target_row, existing_uuid.clone())
+            {
+                Ok(b) => b,
+                Err(msg) => {
+                    status_label.set_text(&msg);
+                    return;
+                }
+            };
 
         let mut items = bookmarks::load();
         if let Some(existing) = items.iter_mut().find(|i| i.uuid == b.uuid) {
@@ -92,7 +85,6 @@ fn build_bookmark(
     name_row: &adw::EntryRow,
     directory_row: &adw::EntryRow,
     ssh_target_row: &adw::EntryRow,
-    tmux_session_row: &adw::EntryRow,
     existing_uuid: Option<String>,
 ) -> Result<Bookmark, String> {
     let name = name_row.text().trim().to_string();
@@ -106,10 +98,9 @@ fn build_bookmark(
     }
     bookmark.directory = entry_value(directory_row);
     bookmark.ssh_target = entry_value(ssh_target_row);
-    bookmark.tmux_session = entry_value(tmux_session_row);
 
     if !bookmark.is_actionable() {
-        return Err("Add a directory, SSH target, tmux session, or a combination of them".into());
+        return Err("Add a directory, SSH target, or both".into());
     }
 
     Ok(bookmark)

--- a/clients/rttx/src/session/recovery.rs
+++ b/clients/rttx/src/session/recovery.rs
@@ -28,18 +28,29 @@ pub enum StartupStep {
 #[serde(rename_all = "kebab-case")]
 pub enum PaneTarget {
     LocalFolder { path: String },
-    LocalTmux { session: String },
     RemoteShell { ssh_target: String, remote_folder: Option<String> },
-    RemoteTmux { ssh_target: String, tmux_session: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PaneRecovery {
     pub source: PaneSource,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_pane_target")]
     pub target: Option<PaneTarget>,
     #[serde(default)]
     pub startup: Vec<StartupStep>,
+}
+
+/// Deserializes `Option<PaneTarget>`, mapping removed variants (local-tmux,
+/// remote-tmux) to `None` so old persisted state loads without error.
+fn deserialize_pane_target<'de, D>(deserializer: D) -> Result<Option<PaneTarget>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<serde_json::Value> = Option::deserialize(deserializer)?;
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    Ok(serde_json::from_value::<PaneTarget>(value).ok())
 }
 
 impl PaneRecovery {
@@ -54,7 +65,7 @@ impl PaneTarget {
     pub const fn initial_cwd(&self) -> Option<&str> {
         match self {
             Self::LocalFolder { path } => Some(path.as_str()),
-            _ => None,
+            Self::RemoteShell { .. } => None,
         }
     }
 
@@ -62,15 +73,10 @@ impl PaneTarget {
     pub fn managed_startup_input(&self) -> Option<String> {
         match self {
             Self::LocalFolder { .. } => None,
-            Self::LocalTmux { session } => Some(format!("exec {}\n", tmux_attach_command(session))),
             Self::RemoteShell { ssh_target, remote_folder } => {
                 let remote_command = remote_folder.as_deref().map(remote_shell_command);
                 Some(format!("exec {}\n", ssh_exec_command(ssh_target, remote_command.as_deref())))
             }
-            Self::RemoteTmux { ssh_target, tmux_session } => Some(format!(
-                "exec {}\n",
-                ssh_exec_command(ssh_target, Some(&tmux_attach_command(tmux_session)))
-            )),
         }
     }
 
@@ -85,16 +91,8 @@ impl PaneTarget {
             Self::LocalFolder { path } => {
                 format!("Failed to open local folder {path} (exit status {status})")
             }
-            Self::LocalTmux { session } => {
-                format!("Failed to attach local tmux session {session} (exit status {status})")
-            }
             Self::RemoteShell { ssh_target, .. } => {
                 format!("Failed to connect to {ssh_target} (exit status {status})")
-            }
-            Self::RemoteTmux { ssh_target, tmux_session } => {
-                format!(
-                    "Failed to attach tmux session {tmux_session} on {ssh_target} (exit status {status})"
-                )
             }
         }
     }
@@ -117,10 +115,6 @@ impl StartupStep {
 
 fn remote_shell_command(path: &str) -> String {
     format!("cd {} && exec ${{SHELL:-/bin/bash}} -l", shell_quote(path))
-}
-
-fn tmux_attach_command(session: &str) -> String {
-    format!("tmux attach-session -t {}", shell_quote(session))
 }
 
 fn ssh_exec_command(ssh_target: &str, remote_command: Option<&str>) -> String {
@@ -147,23 +141,6 @@ mod tests {
     }
 
     #[test]
-    fn pane_target_managed_startup_input_uses_attach_only_tmux() {
-        assert_eq!(
-            PaneTarget::LocalTmux { session: "dev".into() }.managed_startup_input().as_deref(),
-            Some("exec tmux attach-session -t 'dev'\n")
-        );
-        assert_eq!(
-            PaneTarget::RemoteTmux {
-                ssh_target: "deploy@example.com".into(),
-                tmux_session: "web".into(),
-            }
-            .managed_startup_input()
-            .as_deref(),
-            Some("exec ssh -t deploy@example.com 'tmux attach-session -t '\"'\"'web'\"'\"''\n")
-        );
-    }
-
-    #[test]
     fn pane_target_remote_shell_with_folder_builds_replayable_command() {
         assert_eq!(
             PaneTarget::RemoteShell {
@@ -176,5 +153,19 @@ mod tests {
                 "exec ssh -t deploy@example.com 'cd '\"'\"'/srv/app'\"'\"' && exec ${SHELL:-/bin/bash} -l'\n"
             )
         );
+    }
+
+    #[test]
+    fn legacy_local_tmux_target_deserializes_as_none() {
+        let json = r#"{"source":"empty-shell","target":{"local-tmux":{"session":"dev"}}}"#;
+        let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
+        assert_eq!(recovery.target, None);
+    }
+
+    #[test]
+    fn legacy_remote_tmux_target_deserializes_as_none() {
+        let json = r#"{"source":{"bookmark":{"name":"Prod"}},"target":{"remote-tmux":{"ssh_target":"host","tmux_session":"web"}}}"#;
+        let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
+        assert_eq!(recovery.target, None);
     }
 }

--- a/clients/rttx/src/session/state.rs
+++ b/clients/rttx/src/session/state.rs
@@ -712,9 +712,9 @@ mod tests {
             "t1".into(),
             PaneRecovery {
                 source: PaneSource::Bookmark { name: "Prod".into() },
-                target: Some(PaneTarget::RemoteTmux {
+                target: Some(PaneTarget::RemoteShell {
                     ssh_target: "deploy@example.com".into(),
-                    tmux_session: "web".into(),
+                    remote_folder: Some("/srv/app".into()),
                 }),
                 startup: Vec::new(),
             },

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -178,7 +178,7 @@ mod imp {
             self.bookmark_empty.set_icon_name(Some("bookmarks-symbolic"));
             self.bookmark_empty.set_title("No Bookmarks");
             self.bookmark_empty.set_description(Some(
-                "Add a bookmark to quickly open folders, connect to SSH hosts, or attach to tmux sessions",
+                "Add a bookmark to quickly open folders or connect to SSH hosts",
             ));
             self.bookmark_empty.set_vexpand(true);
 

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -413,7 +413,6 @@ fn new_session_from_bookmark_creates_and_focuses_named_session() {
 
     let mut bookmark = crate::bookmarks::Bookmark::new("Prod Web");
     bookmark.ssh_target = Some("deploy@example.com".into());
-    bookmark.tmux_session = Some("web".into());
 
     window.new_session_from_bookmark(&bookmark);
     pump_events(100);
@@ -466,13 +465,10 @@ fn new_session_from_bookmark_queues_input_before_shell_starts() {
     let window = Window::new(&app);
     let mut bookmark = crate::bookmarks::Bookmark::new("Prod Web");
     bookmark.ssh_target = Some("deploy@example.com".into());
-    bookmark.tmux_session = Some("web".into());
-    let expected_input = PaneTarget::RemoteTmux {
-        ssh_target: "deploy@example.com".into(),
-        tmux_session: "web".into(),
-    }
-    .managed_startup_input()
-    .unwrap();
+    let expected_input =
+        PaneTarget::RemoteShell { ssh_target: "deploy@example.com".into(), remote_folder: None }
+            .managed_startup_input()
+            .unwrap();
 
     window.new_session_from_bookmark(&bookmark);
 
@@ -519,13 +515,10 @@ fn bookmark_sessions_persist_and_replay_recovery_recipe_on_restart() {
     let first_window = Window::new(&app);
     let mut bookmark = crate::bookmarks::Bookmark::new("Prod Web");
     bookmark.ssh_target = Some("deploy@example.com".into());
-    bookmark.tmux_session = Some("web".into());
-    let expected_input = PaneTarget::RemoteTmux {
-        ssh_target: "deploy@example.com".into(),
-        tmux_session: "web".into(),
-    }
-    .managed_startup_input()
-    .unwrap();
+    let expected_input =
+        PaneTarget::RemoteShell { ssh_target: "deploy@example.com".into(), remote_folder: None }
+            .managed_startup_input()
+            .unwrap();
 
     first_window.new_session_from_bookmark(&bookmark);
 
@@ -540,9 +533,9 @@ fn bookmark_sessions_persist_and_replay_recovery_recipe_on_restart() {
         saved_recovery,
         Some(PaneRecovery {
             source: PaneSource::Bookmark { name: "Prod Web".into() },
-            target: Some(PaneTarget::RemoteTmux {
+            target: Some(PaneTarget::RemoteShell {
                 ssh_target: "deploy@example.com".into(),
-                tmux_session: "web".into(),
+                remote_folder: None,
             }),
             startup: vec![],
         })
@@ -666,58 +659,6 @@ fn new_session_from_ssh_bookmark_queues_ssh_command() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn new_session_from_local_dir_and_tmux_bookmark_uses_initial_cwd_and_queues_tmux() {
-    require_display!();
-
-    let tmp = tempfile::TempDir::new().unwrap();
-    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
-    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
-
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.local-tmux-bookmark-tests")
-        .build();
-    app.register(gtk4::gio::Cancellable::NONE).unwrap();
-
-    let window = Window::new(&app);
-    let mut bookmark = crate::bookmarks::Bookmark::new("Local Dev");
-    bookmark.directory = Some("/home/user/work".into());
-    bookmark.tmux_session = Some("dev".into());
-
-    window.new_session_from_bookmark(&bookmark);
-
-    let (layout_cwd, pending_inputs, saved_recovery) = {
-        let state = window.imp().state.borrow();
-        let session = state.sessions.last().unwrap();
-        let terminal_uuid = session.layout.terminal_uuids().into_iter().next().unwrap();
-        let layout_cwd = match &session.layout {
-            LayoutNode::Terminal { cwd, .. } => cwd.clone(),
-            _ => None,
-        };
-        let term = window.imp().terminals.borrow().get(&terminal_uuid).cloned().unwrap();
-        (
-            layout_cwd,
-            term.pending_shell_inputs_for_test(),
-            session.recovery_for(&terminal_uuid).cloned(),
-        )
-    };
-
-    assert_eq!(layout_cwd.as_deref(), Some("/home/user/work"));
-    assert_eq!(pending_inputs, vec!["exec tmux attach-session -t 'dev'\n"]);
-    assert_eq!(
-        saved_recovery,
-        Some(PaneRecovery {
-            source: PaneSource::Bookmark { name: "Local Dev".into() },
-            target: Some(PaneTarget::LocalTmux { session: "dev".into() }),
-            startup: vec![],
-        })
-    );
-
-    window.close();
-    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
-}
-
-#[test]
-#[ignore = "requires isolated GTK harness"]
 fn bookmark_active_session_captures_session_name_and_cwd() {
     require_display!();
 
@@ -757,7 +698,6 @@ fn bookmark_active_session_captures_session_name_and_cwd() {
         "bookmark directory should match the focused terminal's CWD"
     );
     assert_eq!(bookmark.ssh_target, None);
-    assert_eq!(bookmark.tmux_session, None);
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
@@ -808,8 +748,9 @@ fn failed_structured_recovery_keeps_terminal_alive_and_allows_retry() {
                 terminal_uuid.clone(),
                 PaneRecovery {
                     source: PaneSource::Bookmark { name: "Ops".into() },
-                    target: Some(PaneTarget::LocalTmux {
-                        session: "rttx-definitely-missing-session".into(),
+                    target: Some(PaneTarget::RemoteShell {
+                        ssh_target: "user@192.0.2.1".into(),
+                        remote_folder: None,
                     }),
                     startup: vec![],
                 },
@@ -843,9 +784,9 @@ fn failed_structured_recovery_keeps_terminal_alive_and_allows_retry() {
         .expect("recoverable terminal should exist");
 
     let failed = wait_until(3000, || term.recovery_message_visible_for_test());
-    assert!(failed, "missing local tmux session should leave the pane alive and show retry UI");
+    assert!(failed, "unreachable SSH host should leave the pane alive and show retry UI");
     assert!(
-        term.recovery_message_for_test().contains("Failed to attach local tmux session"),
+        term.recovery_message_for_test().contains("Failed to connect to"),
         "failure message should stay inside the pane"
     );
     assert!(

--- a/clients/rttx/tests/bookmarks_integration.rs
+++ b/clients/rttx/tests/bookmarks_integration.rs
@@ -9,7 +9,6 @@ fn bookmarks_roundtrip_all_fields() {
     let mut bookmark = Bookmark::new("Remote Ops");
     bookmark.directory = Some("/srv/app".into());
     bookmark.ssh_target = Some("deploy@example.com".into());
-    bookmark.tmux_session = Some("deploy".into());
 
     bookmarks::save_to(&[bookmark.clone()], &path).unwrap();
     assert_eq!(bookmarks::load_from(&path), vec![bookmark]);
@@ -22,4 +21,28 @@ fn invalid_bookmark_json_returns_empty_list() {
 
     std::fs::write(&path, "{not-json").unwrap();
     assert!(bookmarks::load_from(&path).is_empty());
+}
+
+#[test]
+fn legacy_bookmark_with_tmux_session_field_loads_gracefully() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("bookmarks.json");
+
+    std::fs::write(
+        &path,
+        r#"[{
+            "uuid": "abc-123",
+            "name": "Old Tmux Bookmark",
+            "directory": "/work",
+            "ssh_target": "host",
+            "tmux_session": "dev"
+        }]"#,
+    )
+    .unwrap();
+
+    let bookmarks = bookmarks::load_from(&path);
+    assert_eq!(bookmarks.len(), 1);
+    assert_eq!(bookmarks[0].name, "Old Tmux Bookmark");
+    assert_eq!(bookmarks[0].directory.as_deref(), Some("/work"));
+    assert_eq!(bookmarks[0].ssh_target.as_deref(), Some("host"));
 }

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -632,7 +632,6 @@ fn ssh_bookmark_remote_command_strips_ssh_for_same_host() {
     let mut bookmark = Bookmark::new("Deploy");
     bookmark.ssh_target = Some("deploy@example.com".into());
     bookmark.directory = Some("/srv/app".into());
-    bookmark.tmux_session = Some("web".into());
 
     let full = bookmark.command().unwrap();
     let inner = bookmark.remote_command().unwrap();
@@ -640,7 +639,6 @@ fn ssh_bookmark_remote_command_strips_ssh_for_same_host() {
     assert!(full.starts_with("ssh"), "full command wraps in ssh");
     assert!(!inner.contains("ssh"), "inner command must not contain ssh");
     assert!(inner.contains("/srv/app"));
-    assert!(inner.contains("tmux"));
 }
 
 /// Splitting a pane in a remote managed session must preserve the remote

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.7',
+  version: '0.2.8',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Removes all tmux-related code paths from the data model and UI per RFC-016 goal G6. Tmux support is dropped — keeping dead code adds maintenance burden and confuses the mental model.

### Changes

- **Bookmark struct**: Removed `tmux_session` field. Old `bookmarks.json` files with this field load gracefully (serde ignores unknown fields).
- **PaneTarget enum**: Removed `LocalTmux` and `RemoteTmux` variants. Added a custom deserializer that maps these removed variants to `None` so old persisted session state loads without error.
- **Bookmark form UI**: Removed the "Tmux session" entry row from the bookmark dialog.
- **Helper functions**: Removed `tmux_command`, `tmux_attach_command`, and related logic from `bookmarks.rs` and `recovery.rs`.
- **UI text**: Updated bookmark empty state description to remove tmux mention.
- **Version**: Bumped to 0.2.8.

### How to manually verify

1. Build and run: `RTTX_DEV_MODE=1 cargo run -p rttx --no-default-features --features vte-0_76`
2. Open the bookmark dialog — no tmux session field should appear
3. Create a bookmark with directory and/or SSH target — should work normally
4. Place an old `bookmarks.json` with `tmux_session` fields in the config dir — should load without error, tmux field silently ignored
5. Place an old `sessions.json` with `local-tmux` or `remote-tmux` pane targets — should load without error, those targets become `None`

### Tests added

**Backward compatibility tests:**
- `legacy_bookmark_with_tmux_session_field_loads_without_error` (unit)
- `legacy_bookmark_with_tmux_session_field_loads_gracefully` (integration)
- `legacy_local_tmux_target_deserializes_as_none` (unit)
- `legacy_remote_tmux_target_deserializes_as_none` (unit)

**Updated existing tests:**
- Bookmark GTK tests updated to use SSH-only bookmarks instead of SSH+tmux
- Recovery failure test updated to use `RemoteShell` with unreachable host instead of `LocalTmux`
- Removed tmux-specific test (`new_session_from_local_dir_and_tmux_bookmark_uses_initial_cwd_and_queues_tmux`)

### Tests run

All local checks pass:
- `cargo build --workspace` (with VTE 0.76 features) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` — 393 passed, 0 failed ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass via Broadway)

GTK tests confirmed passing:
- `bookmark_active_session_captures_session_name_and_cwd` ✅
- `bookmark_active_session_returns_none_without_focused_terminal` ✅
- `bookmark_sessions_persist_and_replay_recovery_recipe_on_restart` ✅
- `failed_structured_recovery_keeps_terminal_alive_and_allows_retry` ✅
- `new_session_from_bookmark_creates_and_focuses_named_session` ✅
- `new_session_from_bookmark_queues_input_before_shell_starts` ✅

### Remaining limitations

None. One pre-existing flaky test in the server suite (`ctrl_d_at_shell_prompt_produces_pane_exited_message`) occasionally fails when run in the full suite but passes in isolation — unrelated to this change.

Fixes #432