### PR TITLE
chore: remove template-related UI and data paths

### DIFF
--- a/clients/rttx/src/session/recovery.rs
+++ b/clients/rttx/src/session/recovery.rs
@@ -8,14 +8,39 @@ use serde::{Deserialize, Serialize};
 
 use crate::shell_quote;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum PaneSource {
     EmptyShell,
     Bookmark { name: String },
     Command { title: String },
-    SessionTemplate { name: String },
     Manual,
+}
+
+impl<'de> Deserialize<'de> for PaneSource {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        /// Mirror of `PaneSource` that includes removed variants for backward
+        /// compatibility with persisted state.
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        #[allow(dead_code)] // fields in removed variants are intentionally discarded
+        enum Raw {
+            EmptyShell,
+            Bookmark { name: String },
+            Command { title: String },
+            SessionTemplate { name: String },
+            Manual,
+        }
+        match Raw::deserialize(deserializer)? {
+            Raw::EmptyShell => Ok(Self::EmptyShell),
+            Raw::Bookmark { name } => Ok(Self::Bookmark { name }),
+            Raw::Command { title } => Ok(Self::Command { title }),
+            Raw::SessionTemplate { .. } | Raw::Manual => Ok(Self::Manual),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -167,5 +192,18 @@ mod tests {
         let json = r#"{"source":{"bookmark":{"name":"Prod"}},"target":{"remote-tmux":{"ssh_target":"host","tmux_session":"web"}}}"#;
         let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
         assert_eq!(recovery.target, None);
+    }
+
+    #[test]
+    fn legacy_session_template_source_deserializes_as_manual() {
+        let json = r#"{"source":{"session-template":{"name":"Dev Setup"}}}"#;
+        let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
+        assert_eq!(recovery.source, PaneSource::Manual);
+    }
+
+    #[test]
+    fn session_template_variant_absent_from_enum() {
+        let json = serde_json::to_string(&PaneSource::Manual).unwrap();
+        assert!(!json.contains("session-template"));
     }
 }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -219,14 +219,6 @@ mod imp {
             ));
             self.command_empty.set_vexpand(true);
 
-            let templates_placeholder =
-                gtk4::Label::new(Some("Workspace templates will live here."));
-            templates_placeholder.set_wrap(true);
-            templates_placeholder.set_margin_start(18);
-            templates_placeholder.set_margin_end(18);
-            templates_placeholder.set_margin_top(18);
-            templates_placeholder.set_margin_bottom(18);
-
             let bookmarks_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
             bookmarks_page.append(&utility_header);
             bookmarks_page.append(&self.bookmark_search_entry);
@@ -242,7 +234,6 @@ mod imp {
             let utility_stack = gtk4::Stack::new();
             utility_stack.add_titled(&bookmarks_page, Some("bookmarks"), "Bookmarks");
             utility_stack.add_titled(&commands_page, Some("commands"), "Commands");
-            utility_stack.add_titled(&templates_placeholder, Some("templates"), "Templates");
 
             let utility_switcher = gtk4::StackSwitcher::builder().stack(&utility_stack).build();
             utility_switcher.set_margin_start(12);


### PR DESCRIPTION
## What changed and why

Removes all template-related code paths from the UI and data model, as specified by RFC-016 goal G6.

### Changes

- **`PaneSource::SessionTemplate` variant removed** from the enum. A custom `Deserialize` impl maps the legacy `session-template` variant to `Manual` so existing persisted state loads without error.
- **Templates placeholder tab removed** from the utility sidebar `StackSwitcher`. The sidebar now shows only Bookmarks and Commands.

### Manual verification

1. Build and run: `cargo build -p rttx --no-default-features --features vte-0_76 && RTTX_DEV_MODE=1 ./target/debug/rttx`
2. Open the tools sidebar (Ctrl+Shift+B) — only Bookmarks and Commands tabs should appear
3. Create a state file with a `session-template` source and verify it loads without error

### Tests added

- `legacy_session_template_source_deserializes_as_manual` — verifies backward-compatible deserialization of the removed variant
- `session_template_variant_absent_from_enum` — verifies the variant is no longer serialized

### Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76` — 39 passed, 0 failed
- `cargo test -p rttx-proto -p rttx-server` — all passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — 936 tests passed, 0 failed (158 GTK tests skipped due to pre-existing Broadway display limitation in this environment)

Fixes #433