### PR TITLE
feat: replace bookmarks with Places model and host tagging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.8"
+version = "0.2.9"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/bookmarks_window.rs
+++ b/clients/rttx/src/bookmarks_window.rs
@@ -74,7 +74,7 @@ pub fn show_form(parent: &Window, bookmark: Option<&Bookmark>) {
             status_label.set_text(&format!("Failed to save: {e}"));
             return;
         }
-        parent_for_save.refresh_bookmark_sidebar();
+        parent_for_save.refresh_place_sidebar();
         dialog_for_save.close();
     });
 

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -7,6 +7,8 @@ pub mod config;
 pub mod daemon;
 pub mod daemon_bridge;
 pub mod host;
+pub mod places;
+pub mod places_window;
 pub mod preferences;
 pub mod runtime;
 pub mod session;

--- a/clients/rttx/src/places.rs
+++ b/clients/rttx/src/places.rs
@@ -1,0 +1,614 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use crate::config;
+use crate::host::{self, LOCAL_KEY};
+use crate::session::PaneTarget;
+use crate::shell_quote;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Place {
+    pub uuid: String,
+    pub name: String,
+    pub path: String,
+    #[serde(default)]
+    pub host_tags: Vec<String>,
+}
+
+impl Place {
+    #[must_use]
+    pub fn new(name: impl Into<String>, path: impl Into<String>) -> Self {
+        Self {
+            uuid: uuid::Uuid::new_v4().to_string(),
+            name: name.into(),
+            path: path.into(),
+            host_tags: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn is_global(&self) -> bool {
+        self.host_tags.is_empty()
+    }
+
+    #[must_use]
+    pub fn matches_host(&self, host_key: &str) -> bool {
+        self.is_global() || self.host_tags.iter().any(|tag| tag == host_key)
+    }
+
+    /// Display name, auto-derived from the last path component when empty.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        if self.name.is_empty() {
+            std::path::Path::new(&self.path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(&self.path)
+        } else {
+            &self.name
+        }
+    }
+
+    #[must_use]
+    pub fn summary(&self) -> String {
+        let mut parts = Vec::new();
+        parts.push(self.path.clone());
+        if !self.host_tags.is_empty() {
+            let tags = self.host_tags.join(", ");
+            parts.push(format!("[{tags}]"));
+        }
+        parts.join(" ")
+    }
+
+    #[must_use]
+    pub fn is_local(&self) -> bool {
+        self.host_tags.is_empty()
+            || (self.host_tags.len() == 1 && self.host_tags[0] == LOCAL_KEY)
+    }
+
+    /// Command to execute in the current pane.
+    #[must_use]
+    pub fn command(&self, active_host_key: &str) -> Option<String> {
+        if self.path.is_empty() {
+            return None;
+        }
+        let cd = format!("cd {}", shell_quote(&self.path));
+        if active_host_key == LOCAL_KEY && self.is_local() {
+            return Some(cd);
+        }
+        // If the place is tagged for a remote host and we're on that host, just cd
+        if self.matches_host(active_host_key) {
+            return Some(cd);
+        }
+        // If the place is tagged for a specific remote host and we're local, ssh + cd
+        if active_host_key == LOCAL_KEY
+            && let Some(ssh_target) = self.primary_remote_ssh_target()
+        {
+            return Some(format!("ssh -t {ssh_target} {}", shell_quote(&cd)));
+        }
+        Some(cd)
+    }
+
+    /// SSH target for the first remote host tag, resolved via saved hosts.
+    fn primary_remote_ssh_target(&self) -> Option<String> {
+        let tag = self.host_tags.first()?;
+        if tag == LOCAL_KEY {
+            return None;
+        }
+        let saved = host::load();
+        let host = host::resolve(tag, &saved);
+        host.ssh_target.or_else(|| Some(tag.clone()))
+    }
+
+    /// Initial working directory for the terminal when opening as a new workspace.
+    #[must_use]
+    pub fn session_initial_cwd(&self) -> Option<&str> {
+        if self.is_local() && !self.path.is_empty() { Some(&self.path) } else { None }
+    }
+
+    /// Startup command for opening as a new workspace.
+    #[must_use]
+    pub fn session_startup_command(&self) -> Option<String> {
+        if self.is_local() || self.path.is_empty() {
+            return None;
+        }
+        let ssh_target = self.primary_remote_ssh_target()?;
+        Some(format!("ssh -t {ssh_target} {}", shell_quote(&format!("cd {}", shell_quote(&self.path)))))
+    }
+
+    /// Remote host SSH target for workspace creation.
+    #[must_use]
+    pub fn remote_host(&self) -> Option<String> {
+        if self.is_local() {
+            return None;
+        }
+        self.primary_remote_ssh_target()
+    }
+
+    /// Tooltip for the "New workspace" button.
+    #[must_use]
+    pub fn new_workspace_tooltip(&self) -> String {
+        self.remote_host().map_or_else(
+            || "New workspace from place".into(),
+            |host| format!("New workspace on {host}"),
+        )
+    }
+
+    /// Icon name for the "New workspace" button.
+    #[must_use]
+    pub fn new_workspace_icon(&self) -> &'static str {
+        if self.remote_host().is_some() { "network-server-symbolic" } else { "window-new-symbolic" }
+    }
+
+    /// Command to run on a remote pane already connected to the place's host.
+    #[must_use]
+    pub fn remote_command(&self) -> Option<String> {
+        if self.is_local() || self.path.is_empty() {
+            return None;
+        }
+        Some(format!("cd {}", shell_quote(&self.path)))
+    }
+
+    #[must_use]
+    pub fn pane_target(&self) -> Option<PaneTarget> {
+        if self.path.is_empty() {
+            return None;
+        }
+        if self.is_local() {
+            return Some(PaneTarget::LocalFolder { path: self.path.clone() });
+        }
+        let ssh_target = self.primary_remote_ssh_target()?;
+        Some(PaneTarget::RemoteShell { ssh_target, remote_folder: Some(self.path.clone()) })
+    }
+}
+
+// ── Built-in global places ──────────────────────────────────────
+
+#[must_use]
+pub fn builtin_places() -> Vec<Place> {
+    let home_path = std::env::var("HOME").unwrap_or_else(|_| "~".into());
+    vec![
+        Place {
+            uuid: "builtin-home".into(),
+            name: "Home".into(),
+            path: home_path,
+            host_tags: Vec::new(),
+        },
+        Place {
+            uuid: "builtin-root".into(),
+            name: "Root".into(),
+            path: "/".into(),
+            host_tags: Vec::new(),
+        },
+    ]
+}
+
+#[must_use]
+pub fn is_builtin(uuid: &str) -> bool {
+    uuid == "builtin-home" || uuid == "builtin-root"
+}
+
+// ── Query matching ──────────────────────────────────────────────
+
+#[must_use]
+pub fn matches_query(place: &Place, query: &str) -> bool {
+    let query = query.trim();
+    if query.is_empty() {
+        return true;
+    }
+    let query = query.to_ascii_lowercase();
+    place.display_name().to_ascii_lowercase().contains(&query)
+        || place.path.to_ascii_lowercase().contains(&query)
+        || place.summary().to_ascii_lowercase().contains(&query)
+}
+
+// ── Persistence ─────────────────────────────────────────────────
+
+fn places_path() -> PathBuf {
+    let mut path = config::config_dir_path();
+    path.push("places.json");
+    path
+}
+
+#[must_use]
+pub fn load() -> Vec<Place> {
+    load_from(&places_path())
+}
+
+pub fn save(places: &[Place]) -> Result<(), Box<dyn std::error::Error>> {
+    save_to(places, &places_path())
+}
+
+#[must_use]
+pub fn load_from(path: &Path) -> Vec<Place> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|data| serde_json::from_str::<Vec<Place>>(&data).ok())
+        .unwrap_or_default()
+}
+
+pub fn save_to(places: &[Place], path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(places)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// Move the item with `source_uuid` to the position of `target_uuid`.
+pub fn reorder(items: &mut Vec<Place>, source_uuid: &str, target_uuid: &str) {
+    let Some(src) = items.iter().position(|p| p.uuid == source_uuid) else {
+        return;
+    };
+    let Some(tgt) = items.iter().position(|p| p.uuid == target_uuid) else {
+        return;
+    };
+    let item = items.remove(src);
+    items.insert(tgt, item);
+}
+
+/// All places visible for a given host: built-ins + user places matching the host.
+#[must_use]
+pub fn places_for_host(user_places: &[Place], host_key: &str) -> Vec<Place> {
+    let mut result = builtin_places();
+    result.extend(user_places.iter().filter(|p| p.matches_host(host_key)).cloned());
+    result
+}
+
+// ── Migration from bookmarks ────────────────────────────────────
+
+/// Migrate legacy bookmarks to places. Returns the migrated places and any
+/// new hosts that should be saved.
+///
+/// Migration rules (from RFC-016):
+/// - bookmark with only `directory` → local-tagged Place
+/// - bookmark with only `ssh_target` → Host record (not a Place)
+/// - bookmark with `ssh_target` + `directory` → Place tagged with that host key
+/// - bookmark with `tmux_session` → dropped (already removed)
+#[must_use]
+pub fn migrate_bookmarks(bookmarks: &[crate::bookmarks::Bookmark]) -> (Vec<Place>, Vec<crate::host::Host>) {
+    let mut places = Vec::new();
+    let mut new_hosts = Vec::new();
+
+    for bookmark in bookmarks {
+        let directory = bookmark.directory.as_deref().map(str::trim).filter(|d| !d.is_empty());
+        let ssh_target = bookmark.ssh_target.as_deref().map(str::trim).filter(|s| !s.is_empty());
+
+        match (directory, ssh_target) {
+            (Some(dir), None) => {
+                places.push(Place {
+                    uuid: bookmark.uuid.clone(),
+                    name: bookmark.name.clone(),
+                    path: dir.to_string(),
+                    host_tags: vec![LOCAL_KEY.into()],
+                });
+            }
+            (None, Some(target)) => {
+                new_hosts.push(crate::host::Host::remote(target));
+            }
+            (Some(dir), Some(target)) => {
+                let host = crate::host::Host::remote(target);
+                let host_key = host.key.clone();
+                new_hosts.push(host);
+                places.push(Place {
+                    uuid: bookmark.uuid.clone(),
+                    name: bookmark.name.clone(),
+                    path: dir.to_string(),
+                    host_tags: vec![host_key],
+                });
+            }
+            (None, None) => {}
+        }
+    }
+
+    (places, new_hosts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    #[test]
+    fn new_place_is_global_by_default() {
+        let place = Place::new("Work", "/home/user/work");
+        assert!(place.is_global());
+        assert!(place.matches_host(LOCAL_KEY));
+        assert!(place.matches_host("example.com"));
+    }
+
+    #[test]
+    fn tagged_place_matches_only_tagged_hosts() {
+        let place = Place {
+            host_tags: vec!["example.com".into()],
+            ..Place::new("Remote", "/srv/app")
+        };
+        assert!(!place.is_global());
+        assert!(place.matches_host("example.com"));
+        assert!(!place.matches_host("other.com"));
+    }
+
+    #[test]
+    fn display_name_uses_explicit_name() {
+        let place = Place::new("My Work", "/home/user/work");
+        assert_eq!(place.display_name(), "My Work");
+    }
+
+    #[test]
+    fn display_name_auto_derives_from_path() {
+        let place = Place { name: String::new(), ..Place::new("", "/home/user/projects/rttx") };
+        assert_eq!(place.display_name(), "rttx");
+    }
+
+    #[test]
+    fn display_name_falls_back_to_full_path() {
+        let place = Place { name: String::new(), ..Place::new("", "/") };
+        assert_eq!(place.display_name(), "/");
+    }
+
+    #[test]
+    fn local_place_command_is_cd() {
+        let place = Place::new("Work", "/home/user/work");
+        assert_eq!(place.command(LOCAL_KEY).as_deref(), Some("cd '/home/user/work'"));
+    }
+
+    #[test]
+    fn local_tagged_place_command_is_cd() {
+        let place = Place {
+            host_tags: vec![LOCAL_KEY.into()],
+            ..Place::new("Work", "/home/user/work")
+        };
+        assert_eq!(place.command(LOCAL_KEY).as_deref(), Some("cd '/home/user/work'"));
+    }
+
+    #[test]
+    fn empty_path_returns_no_command() {
+        let place = Place::new("Empty", "");
+        assert_eq!(place.command(LOCAL_KEY), None);
+    }
+
+    #[test]
+    fn session_initial_cwd_for_local_place() {
+        let place = Place::new("Work", "/home/user/work");
+        assert_eq!(place.session_initial_cwd(), Some("/home/user/work"));
+    }
+
+    #[test]
+    fn session_initial_cwd_none_for_remote_place() {
+        let place = Place {
+            host_tags: vec!["example.com".into()],
+            ..Place::new("Remote", "/srv/app")
+        };
+        assert_eq!(place.session_initial_cwd(), None);
+    }
+
+    #[test]
+    fn pane_target_local_folder() {
+        let place = Place::new("Work", "/home/user/work");
+        assert_eq!(place.pane_target(), Some(PaneTarget::LocalFolder { path: "/home/user/work".into() }));
+    }
+
+    #[test]
+    fn pane_target_empty_path_is_none() {
+        let place = Place::new("Empty", "");
+        assert_eq!(place.pane_target(), None);
+    }
+
+    #[test]
+    fn is_builtin_identifies_builtin_uuids() {
+        assert!(is_builtin("builtin-home"));
+        assert!(is_builtin("builtin-root"));
+        assert!(!is_builtin("user-place-123"));
+    }
+
+    #[test]
+    fn builtin_places_has_home_and_root() {
+        let builtins = builtin_places();
+        assert_eq!(builtins.len(), 2);
+        assert_eq!(builtins[0].name, "Home");
+        assert_eq!(builtins[1].name, "Root");
+        assert_eq!(builtins[1].path, "/");
+        assert!(builtins[0].is_global());
+        assert!(builtins[1].is_global());
+    }
+
+    #[test]
+    fn matches_query_checks_name_and_path() {
+        let place = Place::new("Work Projects", "/home/user/projects");
+        assert!(matches_query(&place, "work"));
+        assert!(matches_query(&place, "projects"));
+        assert!(!matches_query(&place, "staging"));
+    }
+
+    #[test]
+    fn matches_query_treats_blank_as_match_all() {
+        let place = Place::new("Anything", "/tmp");
+        assert!(matches_query(&place, ""));
+        assert!(matches_query(&place, "   "));
+    }
+
+    #[test]
+    fn roundtrip_via_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("places.json");
+        let place = Place {
+            host_tags: vec!["example.com".into()],
+            ..Place::new("Remote", "/srv/app")
+        };
+
+        save_to(std::slice::from_ref(&place), &path).unwrap();
+        assert_eq!(load_from(&path), vec![place]);
+    }
+
+    #[test]
+    fn missing_file_returns_empty_list() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+        assert!(load_from(&path).is_empty());
+    }
+
+    #[test]
+    fn reorder_moves_item_to_target_position() {
+        let mut items = vec![
+            Place { uuid: "a".into(), ..Place::new("A", "/a") },
+            Place { uuid: "b".into(), ..Place::new("B", "/b") },
+            Place { uuid: "c".into(), ..Place::new("C", "/c") },
+        ];
+
+        reorder(&mut items, "c", "a");
+        let uuids: Vec<&str> = items.iter().map(|p| p.uuid.as_str()).collect();
+        assert_eq!(uuids, vec!["c", "a", "b"]);
+    }
+
+    #[test]
+    fn reorder_noop_for_unknown_uuid() {
+        let mut items = vec![
+            Place { uuid: "a".into(), ..Place::new("A", "/a") },
+            Place { uuid: "b".into(), ..Place::new("B", "/b") },
+        ];
+
+        reorder(&mut items, "z", "a");
+        let uuids: Vec<&str> = items.iter().map(|p| p.uuid.as_str()).collect();
+        assert_eq!(uuids, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn places_for_host_includes_builtins_and_matching_user_places() {
+        let user_places = vec![
+            Place { host_tags: vec![LOCAL_KEY.into()], ..Place::new("Local", "/home") },
+            Place { host_tags: vec!["example.com".into()], ..Place::new("Remote", "/srv") },
+            Place::new("Global", "/tmp"),
+        ];
+
+        let local = places_for_host(&user_places, LOCAL_KEY);
+        assert_eq!(local.len(), 4); // 2 builtins + Local + Global
+
+        let remote = places_for_host(&user_places, "example.com");
+        assert_eq!(remote.len(), 4); // 2 builtins + Remote + Global
+    }
+
+    // ── Migration tests ─────────────────────────────────────────
+
+    #[test]
+    fn migrate_directory_only_bookmark_to_local_place() {
+        let mut bookmark = crate::bookmarks::Bookmark::new("Work");
+        bookmark.directory = Some("/home/user/work".into());
+
+        let (places, hosts) = migrate_bookmarks(&[bookmark]);
+        assert_eq!(places.len(), 1);
+        assert!(hosts.is_empty());
+        assert_eq!(places[0].name, "Work");
+        assert_eq!(places[0].path, "/home/user/work");
+        assert_eq!(places[0].host_tags, vec![LOCAL_KEY]);
+    }
+
+    #[test]
+    fn migrate_ssh_only_bookmark_to_host() {
+        let mut bookmark = crate::bookmarks::Bookmark::new("Prod");
+        bookmark.ssh_target = Some("deploy@example.com".into());
+
+        let (places, hosts) = migrate_bookmarks(&[bookmark]);
+        assert!(places.is_empty());
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].key, "example.com");
+    }
+
+    #[test]
+    fn migrate_combined_bookmark_to_tagged_place_and_host() {
+        let mut bookmark = crate::bookmarks::Bookmark::new("Remote Ops");
+        bookmark.directory = Some("/srv/app".into());
+        bookmark.ssh_target = Some("deploy@example.com".into());
+
+        let (places, hosts) = migrate_bookmarks(&[bookmark]);
+        assert_eq!(places.len(), 1);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(places[0].path, "/srv/app");
+        assert_eq!(places[0].host_tags, vec!["example.com"]);
+    }
+
+    #[test]
+    fn migrate_empty_bookmark_is_dropped() {
+        let bookmark = crate::bookmarks::Bookmark::new("Empty");
+        let (places, hosts) = migrate_bookmarks(&[bookmark]);
+        assert!(places.is_empty());
+        assert!(hosts.is_empty());
+    }
+
+    #[test]
+    fn migrate_preserves_bookmark_uuid() {
+        let mut bookmark = crate::bookmarks::Bookmark::new("Work");
+        bookmark.uuid = "original-uuid".into();
+        bookmark.directory = Some("/work".into());
+
+        let (places, _) = migrate_bookmarks(&[bookmark]);
+        assert_eq!(places[0].uuid, "original-uuid");
+    }
+
+    #[test]
+    fn summary_includes_path_and_tags() {
+        let place = Place {
+            host_tags: vec!["example.com".into()],
+            ..Place::new("Remote", "/srv/app")
+        };
+        assert_eq!(place.summary(), "/srv/app [example.com]");
+    }
+
+    #[test]
+    fn summary_for_global_place_is_just_path() {
+        let place = Place::new("Work", "/home/user/work");
+        assert_eq!(place.summary(), "/home/user/work");
+    }
+
+    #[test]
+    fn new_workspace_tooltip_for_local() {
+        let place = Place::new("Work", "/home/user/work");
+        assert_eq!(place.new_workspace_tooltip(), "New workspace from place");
+    }
+
+    #[test]
+    fn new_workspace_icon_for_local() {
+        let place = Place::new("Work", "/home/user/work");
+        assert_eq!(place.new_workspace_icon(), "window-new-symbolic");
+    }
+
+    #[test]
+    fn remote_command_for_local_is_none() {
+        let place = Place::new("Work", "/home/user/work");
+        assert!(place.remote_command().is_none());
+    }
+
+    #[test]
+    fn remote_command_for_tagged_remote() {
+        let place = Place {
+            host_tags: vec!["example.com".into()],
+            ..Place::new("Remote", "/srv/app")
+        };
+        assert_eq!(place.remote_command().as_deref(), Some("cd '/srv/app'"));
+    }
+
+    #[test]
+    fn is_local_for_global_place() {
+        let place = Place::new("Global", "/tmp");
+        assert!(place.is_local());
+    }
+
+    #[test]
+    fn is_local_for_local_tagged() {
+        let place = Place {
+            host_tags: vec![LOCAL_KEY.into()],
+            ..Place::new("Local", "/home")
+        };
+        assert!(place.is_local());
+    }
+
+    #[test]
+    fn is_local_false_for_remote_tagged() {
+        let place = Place {
+            host_tags: vec!["example.com".into()],
+            ..Place::new("Remote", "/srv")
+        };
+        assert!(!place.is_local());
+    }
+}

--- a/clients/rttx/src/places.rs
+++ b/clients/rttx/src/places.rs
@@ -62,8 +62,7 @@ impl Place {
 
     #[must_use]
     pub fn is_local(&self) -> bool {
-        self.host_tags.is_empty()
-            || (self.host_tags.len() == 1 && self.host_tags[0] == LOCAL_KEY)
+        self.host_tags.is_empty() || (self.host_tags.len() == 1 && self.host_tags[0] == LOCAL_KEY)
     }
 
     /// Command to execute in the current pane.
@@ -113,7 +112,10 @@ impl Place {
             return None;
         }
         let ssh_target = self.primary_remote_ssh_target()?;
-        Some(format!("ssh -t {ssh_target} {}", shell_quote(&format!("cd {}", shell_quote(&self.path)))))
+        Some(format!(
+            "ssh -t {ssh_target} {}",
+            shell_quote(&format!("cd {}", shell_quote(&self.path)))
+        ))
     }
 
     /// Remote host SSH target for workspace creation.
@@ -267,7 +269,9 @@ pub fn places_for_host(user_places: &[Place], host_key: &str) -> Vec<Place> {
 /// - bookmark with `ssh_target` + `directory` → Place tagged with that host key
 /// - bookmark with `tmux_session` → dropped (already removed)
 #[must_use]
-pub fn migrate_bookmarks(bookmarks: &[crate::bookmarks::Bookmark]) -> (Vec<Place>, Vec<crate::host::Host>) {
+pub fn migrate_bookmarks(
+    bookmarks: &[crate::bookmarks::Bookmark],
+) -> (Vec<Place>, Vec<crate::host::Host>) {
     let mut places = Vec::new();
     let mut new_hosts = Vec::new();
 
@@ -321,10 +325,8 @@ mod tests {
 
     #[test]
     fn tagged_place_matches_only_tagged_hosts() {
-        let place = Place {
-            host_tags: vec!["example.com".into()],
-            ..Place::new("Remote", "/srv/app")
-        };
+        let place =
+            Place { host_tags: vec!["example.com".into()], ..Place::new("Remote", "/srv/app") };
         assert!(!place.is_global());
         assert!(place.matches_host("example.com"));
         assert!(!place.matches_host("other.com"));
@@ -356,10 +358,8 @@ mod tests {
 
     #[test]
     fn local_tagged_place_command_is_cd() {
-        let place = Place {
-            host_tags: vec![LOCAL_KEY.into()],
-            ..Place::new("Work", "/home/user/work")
-        };
+        let place =
+            Place { host_tags: vec![LOCAL_KEY.into()], ..Place::new("Work", "/home/user/work") };
         assert_eq!(place.command(LOCAL_KEY).as_deref(), Some("cd '/home/user/work'"));
     }
 
@@ -377,17 +377,18 @@ mod tests {
 
     #[test]
     fn session_initial_cwd_none_for_remote_place() {
-        let place = Place {
-            host_tags: vec!["example.com".into()],
-            ..Place::new("Remote", "/srv/app")
-        };
+        let place =
+            Place { host_tags: vec!["example.com".into()], ..Place::new("Remote", "/srv/app") };
         assert_eq!(place.session_initial_cwd(), None);
     }
 
     #[test]
     fn pane_target_local_folder() {
         let place = Place::new("Work", "/home/user/work");
-        assert_eq!(place.pane_target(), Some(PaneTarget::LocalFolder { path: "/home/user/work".into() }));
+        assert_eq!(
+            place.pane_target(),
+            Some(PaneTarget::LocalFolder { path: "/home/user/work".into() })
+        );
     }
 
     #[test]
@@ -433,10 +434,8 @@ mod tests {
     fn roundtrip_via_file() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("places.json");
-        let place = Place {
-            host_tags: vec!["example.com".into()],
-            ..Place::new("Remote", "/srv/app")
-        };
+        let place =
+            Place { host_tags: vec!["example.com".into()], ..Place::new("Remote", "/srv/app") };
 
         save_to(std::slice::from_ref(&place), &path).unwrap();
         assert_eq!(load_from(&path), vec![place]);
@@ -548,10 +547,8 @@ mod tests {
 
     #[test]
     fn summary_includes_path_and_tags() {
-        let place = Place {
-            host_tags: vec!["example.com".into()],
-            ..Place::new("Remote", "/srv/app")
-        };
+        let place =
+            Place { host_tags: vec!["example.com".into()], ..Place::new("Remote", "/srv/app") };
         assert_eq!(place.summary(), "/srv/app [example.com]");
     }
 
@@ -581,10 +578,8 @@ mod tests {
 
     #[test]
     fn remote_command_for_tagged_remote() {
-        let place = Place {
-            host_tags: vec!["example.com".into()],
-            ..Place::new("Remote", "/srv/app")
-        };
+        let place =
+            Place { host_tags: vec!["example.com".into()], ..Place::new("Remote", "/srv/app") };
         assert_eq!(place.remote_command().as_deref(), Some("cd '/srv/app'"));
     }
 
@@ -596,19 +591,13 @@ mod tests {
 
     #[test]
     fn is_local_for_local_tagged() {
-        let place = Place {
-            host_tags: vec![LOCAL_KEY.into()],
-            ..Place::new("Local", "/home")
-        };
+        let place = Place { host_tags: vec![LOCAL_KEY.into()], ..Place::new("Local", "/home") };
         assert!(place.is_local());
     }
 
     #[test]
     fn is_local_false_for_remote_tagged() {
-        let place = Place {
-            host_tags: vec!["example.com".into()],
-            ..Place::new("Remote", "/srv")
-        };
+        let place = Place { host_tags: vec!["example.com".into()], ..Place::new("Remote", "/srv") };
         assert!(!place.is_local());
     }
 }

--- a/clients/rttx/src/places_window.rs
+++ b/clients/rttx/src/places_window.rs
@@ -1,0 +1,96 @@
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use crate::places::{self, Place};
+use crate::window::Window;
+
+pub fn show_form(parent: &Window, place: Option<&Place>) {
+    let existing_uuid = place.map(|p| p.uuid.clone());
+
+    let dialog = adw::Dialog::builder()
+        .title(if place.is_some() { "Edit Place" } else { "New Place" })
+        .content_width(440)
+        .build();
+
+    let header = adw::HeaderBar::new();
+    let save_button = gtk4::Button::with_label(if place.is_some() { "Save" } else { "Add" });
+    save_button.add_css_class("suggested-action");
+    header.pack_end(&save_button);
+
+    let name_row = adw::EntryRow::builder().title("Name").build();
+    let path_row = adw::EntryRow::builder().title("Path").build();
+
+    let status_label = gtk4::Label::new(None);
+    status_label.set_xalign(0.0);
+    status_label.add_css_class("dim-label");
+
+    let group = adw::PreferencesGroup::new();
+    group.add(&name_row);
+    group.add(&path_row);
+
+    let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+    content_box.set_margin_start(18);
+    content_box.set_margin_end(18);
+    content_box.set_margin_top(18);
+    content_box.set_margin_bottom(18);
+    content_box.append(&group);
+    content_box.append(&status_label);
+
+    let toolbar_view = adw::ToolbarView::new();
+    toolbar_view.add_top_bar(&header);
+    toolbar_view.set_content(Some(&content_box));
+
+    dialog.set_child(Some(&toolbar_view));
+
+    if let Some(p) = place {
+        name_row.set_text(&p.name);
+        path_row.set_text(&p.path);
+    }
+
+    let dialog_for_save = dialog.clone();
+    let parent_for_save = parent.clone();
+    save_button.connect_clicked(move |_| {
+        let p = match build_place(&name_row, &path_row, existing_uuid.clone()) {
+            Ok(p) => p,
+            Err(msg) => {
+                status_label.set_text(&msg);
+                return;
+            }
+        };
+
+        let mut items = places::load();
+        if let Some(existing) = items.iter_mut().find(|i| i.uuid == p.uuid) {
+            *existing = p;
+        } else {
+            items.push(p);
+        }
+        if let Err(e) = places::save(&items) {
+            status_label.set_text(&format!("Failed to save: {e}"));
+            return;
+        }
+        parent_for_save.refresh_place_sidebar();
+        dialog_for_save.close();
+    });
+
+    dialog.present(Some(parent));
+}
+
+fn build_place(
+    name_row: &adw::EntryRow,
+    path_row: &adw::EntryRow,
+    existing_uuid: Option<String>,
+) -> Result<Place, String> {
+    let path = path_row.text().trim().to_string();
+    if path.is_empty() {
+        return Err("Path is required".into());
+    }
+
+    let name = name_row.text().trim().to_string();
+    let mut place = Place::new(name, path);
+    if let Some(uuid) = existing_uuid {
+        place.uuid = uuid;
+    }
+
+    Ok(place)
+}

--- a/clients/rttx/src/session/recovery.rs
+++ b/clients/rttx/src/session/recovery.rs
@@ -12,7 +12,7 @@ use crate::shell_quote;
 #[serde(rename_all = "kebab-case")]
 pub enum PaneSource {
     EmptyShell,
-    Bookmark { name: String },
+    Place { name: String },
     Command { title: String },
     Manual,
 }
@@ -30,13 +30,14 @@ impl<'de> Deserialize<'de> for PaneSource {
         enum Raw {
             EmptyShell,
             Bookmark { name: String },
+            Place { name: String },
             Command { title: String },
             SessionTemplate { name: String },
             Manual,
         }
         match Raw::deserialize(deserializer)? {
             Raw::EmptyShell => Ok(Self::EmptyShell),
-            Raw::Bookmark { name } => Ok(Self::Bookmark { name }),
+            Raw::Bookmark { name } | Raw::Place { name } => Ok(Self::Place { name }),
             Raw::Command { title } => Ok(Self::Command { title }),
             Raw::SessionTemplate { .. } | Raw::Manual => Ok(Self::Manual),
         }
@@ -192,6 +193,28 @@ mod tests {
         let json = r#"{"source":{"bookmark":{"name":"Prod"}},"target":{"remote-tmux":{"ssh_target":"host","tmux_session":"web"}}}"#;
         let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
         assert_eq!(recovery.target, None);
+        // Legacy bookmark source should deserialize as Place
+        assert_eq!(recovery.source, PaneSource::Place { name: "Prod".into() });
+    }
+
+    #[test]
+    fn legacy_bookmark_source_deserializes_as_place() {
+        let json = r#"{"source":{"bookmark":{"name":"My Server"}}}"#;
+        let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
+        assert_eq!(recovery.source, PaneSource::Place { name: "My Server".into() });
+    }
+
+    #[test]
+    fn place_source_roundtrips_through_serde() {
+        let recovery = PaneRecovery {
+            source: PaneSource::Place { name: "Work".into() },
+            target: Some(PaneTarget::LocalFolder { path: "/home/user/work".into() }),
+            startup: Vec::new(),
+        };
+        let json = serde_json::to_string(&recovery).unwrap();
+        let restored: PaneRecovery = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, recovery);
+        assert!(json.contains("\"place\""), "serialized form should use 'place' key");
     }
 
     #[test]

--- a/clients/rttx/src/session/state.rs
+++ b/clients/rttx/src/session/state.rs
@@ -395,7 +395,7 @@ mod tests {
         terminal_recovery.insert(
             "t2".into(),
             PaneRecovery {
-                source: PaneSource::Bookmark { name: "Prod".into() },
+                source: PaneSource::Place { name: "Prod".into() },
                 target: None,
                 startup: vec![StartupStep::SendText {
                     text: "ssh prod && tmux attach -t web".into(),
@@ -648,7 +648,7 @@ mod tests {
                 (
                     "t2".into(),
                     PaneRecovery {
-                        source: PaneSource::Bookmark { name: "Prod".into() },
+                        source: PaneSource::Place { name: "Prod".into() },
                         target: None,
                         startup: vec![StartupStep::SendText {
                             text: "ssh prod".into(),
@@ -711,7 +711,7 @@ mod tests {
         terminal_recovery.insert(
             "t1".into(),
             PaneRecovery {
-                source: PaneSource::Bookmark { name: "Prod".into() },
+                source: PaneSource::Place { name: "Prod".into() },
                 target: Some(PaneTarget::RemoteShell {
                     ssh_target: "deploy@example.com".into(),
                     remote_folder: Some("/srv/app".into()),

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -40,9 +40,10 @@ impl Window {
                 let sidebar = &w.imp().utility_sidebar_box;
                 sidebar.set_visible(!sidebar.is_visible());
             }),
-            ("bookmark-session", &[], Self::do_bookmark_active_session),
-            ("add-bookmark", &[], |w| {
-                crate::bookmarks_window::show_form(w, None);
+            ("bookmark-session", &[], Self::do_save_place_from_session),
+            ("save-place-from-session", &[], Self::do_save_place_from_session),
+            ("add-place", &[], |w| {
+                crate::places_window::show_form(w, None);
             }),
             ("add-command", &[], |w| {
                 crate::commands_window::show_form(w, None);
@@ -80,28 +81,28 @@ impl Window {
         self.add_action(&prefs_action);
         app.set_accels_for_action("win.preferences", &["<Ctrl>comma"]);
 
-        let edit_bookmark_action =
-            gtk4::gio::SimpleAction::new("edit-bookmark", Some(glib::VariantTy::STRING));
+        let edit_place_action =
+            gtk4::gio::SimpleAction::new("edit-place", Some(glib::VariantTy::STRING));
         let win = self.clone();
-        edit_bookmark_action.connect_activate(move |_, param| {
+        edit_place_action.connect_activate(move |_, param| {
             let uuid: String = param.and_then(glib::Variant::get).unwrap_or_default();
-            let bookmarks = crate::bookmarks::load();
-            if let Some(bookmark) = bookmarks.iter().find(|b| b.uuid == uuid) {
-                crate::bookmarks_window::show_form(&win, Some(bookmark));
+            let all_places = places::load();
+            if let Some(place) = all_places.iter().find(|p| p.uuid == uuid) {
+                crate::places_window::show_form(&win, Some(place));
             }
         });
-        self.add_action(&edit_bookmark_action);
+        self.add_action(&edit_place_action);
 
-        let delete_bookmark_action =
-            gtk4::gio::SimpleAction::new("delete-bookmark", Some(glib::VariantTy::STRING));
+        let delete_place_action =
+            gtk4::gio::SimpleAction::new("delete-place", Some(glib::VariantTy::STRING));
         let win = self.clone();
-        delete_bookmark_action.connect_activate(move |_, param| {
+        delete_place_action.connect_activate(move |_, param| {
             let uuid: String = param.and_then(glib::Variant::get).unwrap_or_default();
             if !uuid.is_empty() {
-                win.confirm_delete_bookmark(uuid);
+                win.confirm_delete_place(uuid);
             }
         });
-        self.add_action(&delete_bookmark_action);
+        self.add_action(&delete_place_action);
 
         let edit_command_action =
             gtk4::gio::SimpleAction::new("edit-command", Some(glib::VariantTy::STRING));

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -50,18 +50,14 @@ impl Window {
 
     pub(super) fn confirm_delete_place(&self, uuid: String) {
         let win = self.clone();
-        self.confirm_delete(
-            "Delete Place?",
-            "The place will be permanently removed.",
-            move || {
-                let mut items = places::load();
-                items.retain(|p| p.uuid != uuid);
-                if let Err(e) = places::save(&items) {
-                    log::error!("Failed to delete place: {e}");
-                }
-                win.refresh_place_sidebar();
-            },
-        );
+        self.confirm_delete("Delete Place?", "The place will be permanently removed.", move || {
+            let mut items = places::load();
+            items.retain(|p| p.uuid != uuid);
+            if let Err(e) = places::save(&items) {
+                log::error!("Failed to delete place: {e}");
+            }
+            win.refresh_place_sidebar();
+        });
     }
 
     pub(super) fn confirm_delete_command(&self, uuid: String) {

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -48,18 +48,18 @@ impl Window {
         alert.present(Some(self));
     }
 
-    pub(super) fn confirm_delete_bookmark(&self, uuid: String) {
+    pub(super) fn confirm_delete_place(&self, uuid: String) {
         let win = self.clone();
         self.confirm_delete(
-            "Delete Bookmark?",
-            "The bookmark will be permanently removed.",
+            "Delete Place?",
+            "The place will be permanently removed.",
             move || {
-                let mut items = crate::bookmarks::load();
-                items.retain(|b| b.uuid != uuid);
-                if let Err(e) = crate::bookmarks::save(&items) {
-                    log::error!("Failed to delete bookmark: {e}");
+                let mut items = places::load();
+                items.retain(|p| p.uuid != uuid);
+                if let Err(e) = places::save(&items) {
+                    log::error!("Failed to delete place: {e}");
                 }
-                win.refresh_bookmark_sidebar();
+                win.refresh_place_sidebar();
             },
         );
     }
@@ -298,24 +298,24 @@ impl Window {
         }
     }
 
-    pub(super) fn do_bookmark_active_session(&self) {
-        let Some(bookmark) = self.create_bookmark_from_active_session() else {
+    pub(super) fn do_save_place_from_session(&self) {
+        let Some(place) = self.create_place_from_active_session() else {
             return;
         };
-        let name = bookmark.name.clone();
-        let mut bookmarks = crate::bookmarks::load();
-        bookmarks.push(bookmark);
-        let _ = crate::bookmarks::save(&bookmarks);
-        self.refresh_bookmark_sidebar();
+        let name = place.display_name().to_string();
+        let mut all_places = places::load();
+        all_places.push(place);
+        let _ = places::save(&all_places);
+        self.refresh_place_sidebar();
 
-        let notification = gtk4::gio::Notification::new("Bookmark saved");
-        notification.set_body(Some(&format!("Workspace \"{name}\" was added to bookmarks")));
+        let notification = gtk4::gio::Notification::new("Place saved");
+        notification.set_body(Some(&format!("Workspace \"{name}\" was added to places")));
         if let Some(app) = self.application() {
             app.send_notification(None, &notification);
         }
     }
 
-    pub(crate) fn create_bookmark_from_active_session(&self) -> Option<Bookmark> {
+    pub(crate) fn create_place_from_active_session(&self) -> Option<Place> {
         let uuid = self.focused_terminal_uuid()?;
         let state = self.imp().state.borrow();
         let session = state.sessions.iter().find(|s| s.layout.contains_terminal(&uuid))?;
@@ -323,9 +323,8 @@ impl Window {
         drop(state);
 
         let cwd = self.terminal_handle(&uuid).and_then(|terminal| terminal.current_directory());
+        let path = cwd.unwrap_or_default();
 
-        let mut bookmark = Bookmark::new(session_name);
-        bookmark.directory = cwd;
-        Some(bookmark)
+        Some(Place::new(session_name, path))
     }
 }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -7,10 +7,10 @@ use libadwaita::prelude::*;
 use libadwaita::subclass::prelude::*;
 use vte4::prelude::*;
 
-use crate::bookmarks::Bookmark;
 use crate::color_scheme;
 use crate::commands::{self, CommandRunMode, SavedCommand};
 use crate::config;
+use crate::places::{self, Place};
 use crate::preferences::{self, Preferences};
 use crate::runtime::{
     ConnectionPresentation, ConnectionStatus, RuntimeEndpoint, WorkspaceActionPresentation,
@@ -47,10 +47,10 @@ mod imp {
         pub sidebar_list: gtk4::ListBox,
         pub session_stack: gtk4::Stack,
         pub utility_sidebar_box: gtk4::Box,
-        pub bookmark_search_entry: gtk4::SearchEntry,
-        pub bookmark_list: gtk4::ListBox,
-        pub bookmark_scroll: gtk4::ScrolledWindow,
-        pub bookmark_empty: adw::StatusPage,
+        pub place_search_entry: gtk4::SearchEntry,
+        pub place_list: gtk4::ListBox,
+        pub place_scroll: gtk4::ScrolledWindow,
+        pub place_empty: adw::StatusPage,
         pub command_search_entry: gtk4::SearchEntry,
         pub command_list: gtk4::ListBox,
         pub command_scroll: gtk4::ScrolledWindow,
@@ -119,7 +119,7 @@ mod imp {
             menu.append(Some("New Remote Workspace"), Some("win.new-remote-workspace"));
             menu.append(Some("Attach to Remote Runtime"), Some("win.browse-remote-runtimes"));
             menu.append(Some("About rttx"), Some("win.about"));
-            menu.append(Some("Bookmark This Workspace"), Some("win.bookmark-session"));
+            menu.append(Some("Save as Place"), Some("win.save-place-from-session"));
             menu.append(Some("Preferences"), Some("win.preferences"));
             menu.append(Some("Sync Input"), Some("win.toggle-input-sync"));
             menu.append(Some("Keyboard Shortcuts"), Some("win.show-help-overlay"));
@@ -131,9 +131,9 @@ mod imp {
             self.sidebar_list.set_selection_mode(gtk4::SelectionMode::Single);
             self.sidebar_list.add_css_class("navigation-sidebar");
             self.sidebar_list.update_property(&[gtk4::accessible::Property::Label("Workspaces")]);
-            self.bookmark_list.set_selection_mode(gtk4::SelectionMode::None);
-            self.bookmark_list.add_css_class("boxed-list");
-            self.bookmark_list.update_property(&[gtk4::accessible::Property::Label("Bookmarks")]);
+            self.place_list.set_selection_mode(gtk4::SelectionMode::None);
+            self.place_list.add_css_class("boxed-list");
+            self.place_list.update_property(&[gtk4::accessible::Property::Label("Places")]);
             self.command_list.set_selection_mode(gtk4::SelectionMode::None);
             self.command_list.add_css_class("boxed-list");
             self.command_list.update_property(&[gtk4::accessible::Property::Label("Commands")]);
@@ -145,42 +145,42 @@ mod imp {
                 .child(&self.sidebar_list)
                 .build();
 
-            let add_bookmark_button = gtk4::Button::builder()
+            let add_place_button = gtk4::Button::builder()
                 .icon_name("list-add-symbolic")
-                .tooltip_text("New bookmark")
-                .action_name("win.add-bookmark")
+                .tooltip_text("New place")
+                .action_name("win.add-place")
                 .build();
             let utility_header = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
             utility_header.set_margin_start(12);
             utility_header.set_margin_end(12);
             utility_header.set_margin_top(12);
-            let utility_title = gtk4::Label::new(Some("Bookmarks"));
+            let utility_title = gtk4::Label::new(Some("Places"));
             utility_title.set_xalign(0.0);
             utility_title.set_hexpand(true);
             utility_title.add_css_class("title-4");
             utility_header.append(&utility_title);
-            utility_header.append(&add_bookmark_button);
+            utility_header.append(&add_place_button);
 
-            self.bookmark_search_entry.set_placeholder_text(Some("Search bookmarks"));
-            self.bookmark_search_entry.set_margin_start(12);
-            self.bookmark_search_entry.set_margin_end(12);
-            self.bookmark_search_entry.set_margin_top(12);
-            self.bookmark_search_entry.set_margin_bottom(12);
+            self.place_search_entry.set_placeholder_text(Some("Search places"));
+            self.place_search_entry.set_margin_start(12);
+            self.place_search_entry.set_margin_end(12);
+            self.place_search_entry.set_margin_top(12);
+            self.place_search_entry.set_margin_bottom(12);
 
-            self.bookmark_scroll.set_hscrollbar_policy(gtk4::PolicyType::Never);
-            self.bookmark_scroll.set_vexpand(true);
-            self.bookmark_scroll.set_margin_start(12);
-            self.bookmark_scroll.set_margin_end(12);
-            self.bookmark_scroll.set_margin_bottom(12);
-            self.bookmark_scroll.set_child(Some(&self.bookmark_list));
-            self.bookmark_scroll.set_visible(false);
+            self.place_scroll.set_hscrollbar_policy(gtk4::PolicyType::Never);
+            self.place_scroll.set_vexpand(true);
+            self.place_scroll.set_margin_start(12);
+            self.place_scroll.set_margin_end(12);
+            self.place_scroll.set_margin_bottom(12);
+            self.place_scroll.set_child(Some(&self.place_list));
+            self.place_scroll.set_visible(false);
 
-            self.bookmark_empty.set_icon_name(Some("bookmarks-symbolic"));
-            self.bookmark_empty.set_title("No Bookmarks");
-            self.bookmark_empty.set_description(Some(
-                "Add a bookmark to quickly open folders or connect to SSH hosts",
+            self.place_empty.set_icon_name(Some("folder-symbolic"));
+            self.place_empty.set_title("No Places");
+            self.place_empty.set_description(Some(
+                "Add a place to quickly open folders on local or remote hosts",
             ));
-            self.bookmark_empty.set_vexpand(true);
+            self.place_empty.set_vexpand(true);
 
             let add_command_button = gtk4::Button::builder()
                 .icon_name("list-add-symbolic")
@@ -219,11 +219,11 @@ mod imp {
             ));
             self.command_empty.set_vexpand(true);
 
-            let bookmarks_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-            bookmarks_page.append(&utility_header);
-            bookmarks_page.append(&self.bookmark_search_entry);
-            bookmarks_page.append(&self.bookmark_scroll);
-            bookmarks_page.append(&self.bookmark_empty);
+            let places_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+            places_page.append(&utility_header);
+            places_page.append(&self.place_search_entry);
+            places_page.append(&self.place_scroll);
+            places_page.append(&self.place_empty);
 
             let commands_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
             commands_page.append(&commands_header);
@@ -232,7 +232,7 @@ mod imp {
             commands_page.append(&self.command_empty);
 
             let utility_stack = gtk4::Stack::new();
-            utility_stack.add_titled(&bookmarks_page, Some("bookmarks"), "Bookmarks");
+            utility_stack.add_titled(&places_page, Some("places"), "Places");
             utility_stack.add_titled(&commands_page, Some("commands"), "Commands");
 
             let utility_switcher = gtk4::StackSwitcher::builder().stack(&utility_stack).build();
@@ -439,8 +439,8 @@ impl Window {
         });
 
         let win = self.clone();
-        self.imp().bookmark_search_entry.connect_changed(move |_| {
-            win.refresh_bookmark_sidebar();
+        self.imp().place_search_entry.connect_changed(move |_| {
+            win.refresh_place_sidebar();
         });
 
         let win = self.clone();
@@ -459,7 +459,7 @@ impl Window {
             win.reapply_terminal_preferences();
         });
 
-        self.refresh_bookmark_sidebar();
+        self.refresh_place_sidebar();
         self.refresh_command_sidebar();
     }
 
@@ -643,24 +643,24 @@ impl Window {
         SessionColor::ALL[count % SessionColor::ALL.len()]
     }
 
-    pub(crate) fn new_session_from_bookmark(&self, bookmark: &Bookmark) {
+    pub(crate) fn new_session_from_place(&self, place: &Place) {
         let imp = self.imp();
-        let initial_cwd = bookmark
+        let initial_cwd = place
             .pane_target()
             .as_ref()
             .and_then(PaneTarget::initial_cwd)
             .map(str::to_string)
-            .or_else(|| bookmark.session_initial_cwd().map(str::to_string));
+            .or_else(|| place.session_initial_cwd().map(str::to_string));
 
-        let mut session_state = if let Some(host) = bookmark.remote_host() {
+        let mut session_state = if let Some(host) = place.remote_host() {
             SessionState::new_managed_remote(
-                bookmark.name.clone(),
-                host,
+                place.display_name().to_string(),
+                &host,
                 WorkspacePolicy::Persistent,
                 initial_cwd,
             )
         } else {
-            SessionState::new_with_initial_cwd(bookmark.name.clone(), initial_cwd)
+            SessionState::new_with_initial_cwd(place.display_name().to_string(), initial_cwd)
         };
         session_state.color = self.next_session_color();
         let session_uuid = session_state.uuid.clone();
@@ -680,7 +680,7 @@ impl Window {
             );
             self.connect_managed_workspace(&session_state);
         } else {
-            self.setup_bookmark_terminal(&terminal_uuid, bookmark);
+            self.setup_place_terminal(&terminal_uuid, place);
         }
         self.imp().session_stack.set_visible_child_name(&session_uuid);
     }

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -1,90 +1,99 @@
 use super::*;
 
 impl Window {
-    pub(crate) fn refresh_bookmark_sidebar(&self) {
+    pub(crate) fn refresh_place_sidebar(&self) {
         let imp = self.imp();
-        while let Some(row) = imp.bookmark_list.row_at_index(0) {
-            imp.bookmark_list.remove(&row);
+        while let Some(row) = imp.place_list.row_at_index(0) {
+            imp.place_list.remove(&row);
         }
 
-        let query = imp.bookmark_search_entry.text();
-        for bookmark in crate::bookmarks::load()
+        let query = imp.place_search_entry.text();
+        let user_places = places::load();
+        let all_places = places::places_for_host(&user_places, crate::host::LOCAL_KEY);
+        for place in all_places
             .into_iter()
-            .filter(|bookmark| crate::bookmarks::matches_query(bookmark, query.as_str()))
+            .filter(|place| places::matches_query(place, query.as_str()))
         {
             let action_row = adw::ActionRow::new();
-            action_row.set_title(&bookmark.name);
-            action_row.set_subtitle(&bookmark.summary());
+            action_row.set_title(place.display_name());
+            action_row.set_subtitle(&place.summary());
             action_row.set_activatable(true);
 
             let new_session_button = gtk4::Button::builder()
-                .icon_name(bookmark.new_workspace_icon())
-                .tooltip_text(bookmark.new_workspace_tooltip())
+                .icon_name(place.new_workspace_icon())
+                .tooltip_text(place.new_workspace_tooltip())
                 .valign(gtk4::Align::Center)
                 .build();
             new_session_button.add_css_class("flat");
 
-            let uuid = bookmark.uuid.clone();
-            let edit_item = gtk4::gio::MenuItem::new(Some("Edit"), None);
-            edit_item
-                .set_action_and_target_value(Some("win.edit-bookmark"), Some(&uuid.to_variant()));
-            let delete_item = gtk4::gio::MenuItem::new(Some("Delete"), None);
-            delete_item
-                .set_action_and_target_value(Some("win.delete-bookmark"), Some(&uuid.to_variant()));
-            let menu = gtk4::gio::Menu::new();
-            menu.append_item(&edit_item);
-            menu.append_item(&delete_item);
-            let more_button = gtk4::MenuButton::builder()
-                .icon_name("view-more-symbolic")
-                .tooltip_text("More options")
-                .valign(gtk4::Align::Center)
-                .menu_model(&menu)
-                .build();
-            more_button.add_css_class("flat");
-
             action_row.add_suffix(&new_session_button);
-            action_row.add_suffix(&more_button);
 
-            let drag_source = gtk4::DragSource::new();
-            drag_source.set_actions(gtk4::gdk::DragAction::MOVE);
-            let drag_uuid = bookmark.uuid.clone();
-            drag_source.connect_prepare(move |_, _, _| {
-                Some(gtk4::gdk::ContentProvider::for_value(&drag_uuid.to_value()))
-            });
-            action_row.add_controller(drag_source);
+            if !places::is_builtin(&place.uuid) {
+                let uuid = place.uuid.clone();
+                let edit_item = gtk4::gio::MenuItem::new(Some("Edit"), None);
+                edit_item.set_action_and_target_value(
+                    Some("win.edit-place"),
+                    Some(&uuid.to_variant()),
+                );
+                let delete_item = gtk4::gio::MenuItem::new(Some("Delete"), None);
+                delete_item.set_action_and_target_value(
+                    Some("win.delete-place"),
+                    Some(&uuid.to_variant()),
+                );
+                let menu = gtk4::gio::Menu::new();
+                menu.append_item(&edit_item);
+                menu.append_item(&delete_item);
+                let more_button = gtk4::MenuButton::builder()
+                    .icon_name("view-more-symbolic")
+                    .tooltip_text("More options")
+                    .valign(gtk4::Align::Center)
+                    .menu_model(&menu)
+                    .build();
+                more_button.add_css_class("flat");
+                action_row.add_suffix(&more_button);
 
-            let drop_target =
-                gtk4::DropTarget::new(glib::Type::STRING, gtk4::gdk::DragAction::MOVE);
+                let drag_source = gtk4::DragSource::new();
+                drag_source.set_actions(gtk4::gdk::DragAction::MOVE);
+                let drag_uuid = place.uuid.clone();
+                drag_source.connect_prepare(move |_, _, _| {
+                    Some(gtk4::gdk::ContentProvider::for_value(&drag_uuid.to_value()))
+                });
+                action_row.add_controller(drag_source);
+
+                let drop_target =
+                    gtk4::DropTarget::new(glib::Type::STRING, gtk4::gdk::DragAction::MOVE);
+                let win = self.clone();
+                let target_uuid = place.uuid.clone();
+                drop_target.connect_drop(move |_, value, _, _| {
+                    if let Ok(source_uuid) = value.get::<String>()
+                        && source_uuid != target_uuid
+                    {
+                        win.reorder_place(&source_uuid, &target_uuid);
+                        return true;
+                    }
+                    false
+                });
+                action_row.add_controller(drop_target);
+            }
+
+            imp.place_list.append(&action_row);
+
             let win = self.clone();
-            let target_uuid = bookmark.uuid.clone();
-            drop_target.connect_drop(move |_, value, _, _| {
-                if let Ok(source_uuid) = value.get::<String>()
-                    && source_uuid != target_uuid
-                {
-                    win.reorder_bookmark(&source_uuid, &target_uuid);
-                    return true;
-                }
-                false
-            });
-            action_row.add_controller(drop_target);
-
-            imp.bookmark_list.append(&action_row);
-
-            let win = self.clone();
-            let bookmark_for_run = bookmark.clone();
+            let place_for_run = place.clone();
             action_row.connect_activated(move |_| {
-                win.execute_bookmark(&bookmark_for_run);
+                win.execute_place(&place_for_run);
             });
 
             let win = self.clone();
+            let place_for_session = place.clone();
             new_session_button.connect_clicked(move |_| {
-                win.new_session_from_bookmark(&bookmark);
+                win.new_session_from_place(&place_for_session);
             });
         }
 
-        let is_empty = imp.bookmark_list.row_at_index(0).is_none();
-        imp.bookmark_scroll.set_visible(!is_empty);
-        imp.bookmark_empty.set_visible(is_empty);
+        let is_empty = imp.place_list.row_at_index(0).is_none();
+        imp.place_scroll.set_visible(!is_empty);
+        imp.place_empty.set_visible(is_empty);
     }
 
     pub(crate) fn refresh_command_sidebar(&self) {
@@ -173,11 +182,11 @@ impl Window {
         imp.command_empty.set_visible(is_empty);
     }
 
-    fn reorder_bookmark(&self, source_uuid: &str, target_uuid: &str) {
-        let mut items = crate::bookmarks::load();
-        crate::bookmarks::reorder(&mut items, source_uuid, target_uuid);
-        let _ = crate::bookmarks::save(&items);
-        self.refresh_bookmark_sidebar();
+    fn reorder_place(&self, source_uuid: &str, target_uuid: &str) {
+        let mut items = places::load();
+        places::reorder(&mut items, source_uuid, target_uuid);
+        let _ = places::save(&items);
+        self.refresh_place_sidebar();
     }
 
     fn reorder_command(&self, source_uuid: &str, target_uuid: &str) {
@@ -206,19 +215,20 @@ impl Window {
         self.send_input_to_terminal(&terminal_uuid, &command.input_for(run_mode));
     }
 
-    pub(crate) fn execute_bookmark(&self, bookmark: &Bookmark) {
+    pub(crate) fn execute_place(&self, place: &Place) {
         let Some(terminal_uuid) = self.command_target_terminal_uuid() else {
             return;
         };
 
-        let command = self.resolve_bookmark_command(bookmark);
+        let active_host = self.active_host_key();
+        let command = self.resolve_place_command(place, &active_host);
         let Some(command) = command else {
             return;
         };
         self.set_terminal_recovery(
             &terminal_uuid,
             PaneRecovery {
-                source: PaneSource::Bookmark { name: bookmark.name.clone() },
+                source: PaneSource::Place { name: place.display_name().to_string() },
                 target: None,
                 startup: vec![StartupStep::SendText { text: command.clone(), execute: true }],
             },
@@ -226,15 +236,21 @@ impl Window {
         self.send_input_to_terminal(&terminal_uuid, &format!("{command}\n"));
     }
 
-    fn resolve_bookmark_command(&self, bookmark: &Bookmark) -> Option<String> {
-        let bookmark_host = bookmark.remote_host();
-        if let Some(bh) = bookmark_host {
+    fn resolve_place_command(&self, place: &Place, active_host_key: &str) -> Option<String> {
+        if !place.is_local() {
             let session_host = self.visible_session_remote_host();
-            if session_host.as_deref() == Some(bh) {
-                return bookmark.remote_command().or_else(|| bookmark.command());
+            if let Some(sh) = &session_host
+                && place.matches_host(sh)
+            {
+                return place.remote_command().or_else(|| place.command(active_host_key));
             }
         }
-        bookmark.command()
+        place.command(active_host_key)
+    }
+
+    fn active_host_key(&self) -> String {
+        self.visible_session_remote_host()
+            .unwrap_or_else(|| crate::host::LOCAL_KEY.to_string())
     }
 
     fn visible_session_remote_host(&self) -> Option<String> {

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -10,9 +10,8 @@ impl Window {
         let query = imp.place_search_entry.text();
         let user_places = places::load();
         let all_places = places::places_for_host(&user_places, crate::host::LOCAL_KEY);
-        for place in all_places
-            .into_iter()
-            .filter(|place| places::matches_query(place, query.as_str()))
+        for place in
+            all_places.into_iter().filter(|place| places::matches_query(place, query.as_str()))
         {
             let action_row = adw::ActionRow::new();
             action_row.set_title(place.display_name());
@@ -31,10 +30,8 @@ impl Window {
             if !places::is_builtin(&place.uuid) {
                 let uuid = place.uuid.clone();
                 let edit_item = gtk4::gio::MenuItem::new(Some("Edit"), None);
-                edit_item.set_action_and_target_value(
-                    Some("win.edit-place"),
-                    Some(&uuid.to_variant()),
-                );
+                edit_item
+                    .set_action_and_target_value(Some("win.edit-place"), Some(&uuid.to_variant()));
                 let delete_item = gtk4::gio::MenuItem::new(Some("Delete"), None);
                 delete_item.set_action_and_target_value(
                     Some("win.delete-place"),
@@ -249,8 +246,7 @@ impl Window {
     }
 
     fn active_host_key(&self) -> String {
-        self.visible_session_remote_host()
-            .unwrap_or_else(|| crate::host::LOCAL_KEY.to_string())
+        self.visible_session_remote_host().unwrap_or_else(|| crate::host::LOCAL_KEY.to_string())
     }
 
     fn visible_session_remote_host(&self) -> Option<String> {

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -572,10 +572,10 @@ impl Window {
         imp.terminals.borrow_mut().remove(uuid);
     }
 
-    pub(super) fn setup_bookmark_terminal(&self, terminal_uuid: &str, bookmark: &Bookmark) {
-        let target = bookmark.pane_target();
+    pub(super) fn setup_place_terminal(&self, terminal_uuid: &str, place: &Place) {
+        let target = place.pane_target();
         let startup = if target.is_none() {
-            bookmark
+            place
                 .session_startup_command()
                 .as_deref()
                 .map(|cmd| vec![StartupStep::SendText { text: cmd.to_string(), execute: true }])
@@ -584,7 +584,7 @@ impl Window {
             Vec::new()
         };
         let recovery = PaneRecovery {
-            source: PaneSource::Bookmark { name: bookmark.name.clone() },
+            source: PaneSource::Place { name: place.display_name().to_string() },
             target,
             startup,
         };

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -473,13 +473,12 @@ fn new_session_from_place_queues_input_before_shell_starts() {
         host_tags: vec!["example.com".into()],
         ..crate::places::Place::new("Prod Web", "/srv/app")
     };
-    let expected_input =
-        PaneTarget::RemoteShell {
-            ssh_target: "deploy@example.com".into(),
-            remote_folder: Some("/srv/app".into()),
-        }
-        .managed_startup_input()
-        .unwrap();
+    let expected_input = PaneTarget::RemoteShell {
+        ssh_target: "deploy@example.com".into(),
+        remote_folder: Some("/srv/app".into()),
+    }
+    .managed_startup_input()
+    .unwrap();
 
     window.new_session_from_place(&place);
 
@@ -520,9 +519,8 @@ fn place_sessions_persist_and_replay_recovery_recipe_on_restart() {
 
     crate::host::save(&[crate::host::Host::remote("deploy@example.com")]).unwrap();
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.place-recovery-tests")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.place-recovery-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let first_window = Window::new(&app);
@@ -530,13 +528,12 @@ fn place_sessions_persist_and_replay_recovery_recipe_on_restart() {
         host_tags: vec!["example.com".into()],
         ..crate::places::Place::new("Prod Web", "/srv/app")
     };
-    let expected_input =
-        PaneTarget::RemoteShell {
-            ssh_target: "deploy@example.com".into(),
-            remote_folder: Some("/srv/app".into()),
-        }
-        .managed_startup_input()
-        .unwrap();
+    let expected_input = PaneTarget::RemoteShell {
+        ssh_target: "deploy@example.com".into(),
+        remote_folder: Some("/srv/app".into()),
+    }
+    .managed_startup_input()
+    .unwrap();
 
     first_window.new_session_from_place(&place);
 
@@ -590,9 +587,8 @@ fn new_session_from_local_place_uses_initial_cwd_not_cd_command() {
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.folder-place-cwd-tests")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.folder-place-cwd-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
@@ -637,8 +633,7 @@ fn new_session_from_remote_place_queues_ssh_command() {
 
     crate::host::save(&[crate::host::Host::remote("deploy@example.com")]).unwrap();
 
-    let app =
-        adw::Application::builder().application_id("com.illya.rttx.ssh-place-tests").build();
+    let app = adw::Application::builder().application_id("com.illya.rttx.ssh-place-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
@@ -657,13 +652,12 @@ fn new_session_from_remote_place_queues_ssh_command() {
         (term.pending_shell_inputs_for_test(), session.recovery_for(&terminal_uuid).cloned())
     };
 
-    let expected_input =
-        PaneTarget::RemoteShell {
-            ssh_target: "deploy@example.com".into(),
-            remote_folder: Some("/srv/app".into()),
-        }
-        .managed_startup_input()
-        .unwrap();
+    let expected_input = PaneTarget::RemoteShell {
+        ssh_target: "deploy@example.com".into(),
+        remote_folder: Some("/srv/app".into()),
+    }
+    .managed_startup_input()
+    .unwrap();
     assert_eq!(
         pending_inputs,
         vec![expected_input],
@@ -737,9 +731,8 @@ fn save_place_from_active_session_returns_none_without_focused_terminal() {
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.place-no-focus-tests")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.place-no-focus-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -314,18 +314,19 @@ fn initial_terminal_starts_shell_when_window_is_presented() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn utility_sidebar_shows_and_filters_bookmarks() {
+fn utility_sidebar_shows_and_filters_places() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let mut local = crate::bookmarks::Bookmark::new("Local Project");
-    local.directory = Some("/home/user/Projects/rttx".into());
-    let mut remote = crate::bookmarks::Bookmark::new("Prod Web");
-    remote.ssh_target = Some("deploy@example.com".into());
-    crate::bookmarks::save(&[local, remote]).unwrap();
+    let local = crate::places::Place::new("Local Project", "/home/user/Projects/rttx");
+    let remote = crate::places::Place {
+        host_tags: vec!["example.com".into()],
+        ..crate::places::Place::new("Prod Web", "/srv/app")
+    };
+    crate::places::save(&[local, remote]).unwrap();
 
     let app =
         adw::Application::builder().application_id("com.illya.rttx.utility-sidebar-tests").build();
@@ -335,18 +336,18 @@ fn utility_sidebar_shows_and_filters_bookmarks() {
     window.present();
     pump_events(100);
 
-    assert_eq!(
-        window.imp().bookmark_list.observe_children().n_items(),
-        2,
-        "utility sidebar should show saved bookmarks"
+    // 2 builtins (Home, Root) + 2 user places
+    assert!(
+        window.imp().place_list.observe_children().n_items() >= 4,
+        "utility sidebar should show built-in and saved places"
     );
 
-    window.imp().bookmark_search_entry.set_text("prod");
+    window.imp().place_search_entry.set_text("prod");
     pump_events(50);
     assert_eq!(
-        window.imp().bookmark_list.observe_children().n_items(),
+        window.imp().place_list.observe_children().n_items(),
         1,
-        "search should filter the utility sidebar bookmark list"
+        "search should filter the utility sidebar place list"
     );
 
     window.close();
@@ -395,7 +396,7 @@ fn utility_sidebar_shows_and_filters_commands() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn new_session_from_bookmark_creates_and_focuses_named_session() {
+fn new_session_from_place_creates_and_focuses_named_session() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
@@ -403,7 +404,7 @@ fn new_session_from_bookmark_creates_and_focuses_named_session() {
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
     let app =
-        adw::Application::builder().application_id("com.illya.rttx.bookmark-session-tests").build();
+        adw::Application::builder().application_id("com.illya.rttx.place-session-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
@@ -411,15 +412,17 @@ fn new_session_from_bookmark_creates_and_focuses_named_session() {
     window.present();
     pump_events(100);
 
-    let mut bookmark = crate::bookmarks::Bookmark::new("Prod Web");
-    bookmark.ssh_target = Some("deploy@example.com".into());
+    let place = crate::places::Place {
+        host_tags: vec!["example.com".into()],
+        ..crate::places::Place::new("Prod Web", "/srv/app")
+    };
 
-    window.new_session_from_bookmark(&bookmark);
+    window.new_session_from_place(&place);
     pump_events(100);
 
     let (session_name, session_uuid, terminal_uuid) = {
         let state = window.imp().state.borrow();
-        assert_eq!(state.sessions.len(), 2, "bookmark should create a new session");
+        assert_eq!(state.sessions.len(), 2, "place should create a new session");
         let session = state.sessions.last().unwrap();
         (
             session.name.clone(),
@@ -432,17 +435,17 @@ fn new_session_from_bookmark_creates_and_focuses_named_session() {
     assert_eq!(
         window.imp().sidebar_list.selected_row().map(|row| row.index()),
         Some(1),
-        "bookmark session should become the selected session"
+        "place session should become the selected session"
     );
     assert_eq!(
         window.imp().session_stack.visible_child_name().as_deref(),
         Some(session_uuid.as_str()),
-        "bookmark session should become visible"
+        "place session should become visible"
     );
     assert_eq!(
         window.focused_terminal_uuid().as_deref(),
         Some(terminal_uuid.as_str()),
-        "bookmark session should focus its initial terminal"
+        "place session should focus its initial terminal"
     );
 
     window.close();
@@ -451,26 +454,34 @@ fn new_session_from_bookmark_creates_and_focuses_named_session() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn new_session_from_bookmark_queues_input_before_shell_starts() {
+fn new_session_from_place_queues_input_before_shell_starts() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
+    // Save a host so the place can resolve its SSH target
+    crate::host::save(&[crate::host::Host::remote("deploy@example.com")]).unwrap();
+
     let app =
-        adw::Application::builder().application_id("com.illya.rttx.bookmark-queue-tests").build();
+        adw::Application::builder().application_id("com.illya.rttx.place-queue-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
-    let mut bookmark = crate::bookmarks::Bookmark::new("Prod Web");
-    bookmark.ssh_target = Some("deploy@example.com".into());
+    let place = crate::places::Place {
+        host_tags: vec!["example.com".into()],
+        ..crate::places::Place::new("Prod Web", "/srv/app")
+    };
     let expected_input =
-        PaneTarget::RemoteShell { ssh_target: "deploy@example.com".into(), remote_folder: None }
-            .managed_startup_input()
-            .unwrap();
+        PaneTarget::RemoteShell {
+            ssh_target: "deploy@example.com".into(),
+            remote_folder: Some("/srv/app".into()),
+        }
+        .managed_startup_input()
+        .unwrap();
 
-    window.new_session_from_bookmark(&bookmark);
+    window.new_session_from_place(&place);
 
     let terminal_uuid = {
         let state = window.imp().state.borrow();
@@ -482,7 +493,7 @@ fn new_session_from_bookmark_queues_input_before_shell_starts() {
         .borrow()
         .get(&terminal_uuid)
         .cloned()
-        .expect("bookmark session terminal should exist");
+        .expect("place session terminal should exist");
 
     assert!(
         !term.shell_spawned_for_test(),
@@ -491,7 +502,7 @@ fn new_session_from_bookmark_queues_input_before_shell_starts() {
     assert_eq!(
         term.pending_shell_inputs_for_test(),
         vec![expected_input],
-        "bookmark launcher should queue the structured recovery target until the shell is ready"
+        "place launcher should queue the structured recovery target until the shell is ready"
     );
 
     window.close();
@@ -500,31 +511,38 @@ fn new_session_from_bookmark_queues_input_before_shell_starts() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn bookmark_sessions_persist_and_replay_recovery_recipe_on_restart() {
+fn place_sessions_persist_and_replay_recovery_recipe_on_restart() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
+    crate::host::save(&[crate::host::Host::remote("deploy@example.com")]).unwrap();
+
     let app = adw::Application::builder()
-        .application_id("com.illya.rttx.bookmark-recovery-tests")
+        .application_id("com.illya.rttx.place-recovery-tests")
         .build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let first_window = Window::new(&app);
-    let mut bookmark = crate::bookmarks::Bookmark::new("Prod Web");
-    bookmark.ssh_target = Some("deploy@example.com".into());
+    let place = crate::places::Place {
+        host_tags: vec!["example.com".into()],
+        ..crate::places::Place::new("Prod Web", "/srv/app")
+    };
     let expected_input =
-        PaneTarget::RemoteShell { ssh_target: "deploy@example.com".into(), remote_folder: None }
-            .managed_startup_input()
-            .unwrap();
+        PaneTarget::RemoteShell {
+            ssh_target: "deploy@example.com".into(),
+            remote_folder: Some("/srv/app".into()),
+        }
+        .managed_startup_input()
+        .unwrap();
 
-    first_window.new_session_from_bookmark(&bookmark);
+    first_window.new_session_from_place(&place);
 
     let (terminal_uuid, saved_recovery) = {
         let state = first_window.imp().state.borrow();
-        let session = state.sessions.last().expect("bookmark should create a session");
+        let session = state.sessions.last().expect("place should create a session");
         let terminal_uuid = session.layout.terminal_uuids().into_iter().next().unwrap();
         (terminal_uuid.clone(), session.recovery_for(&terminal_uuid).cloned())
     };
@@ -532,10 +550,10 @@ fn bookmark_sessions_persist_and_replay_recovery_recipe_on_restart() {
     assert_eq!(
         saved_recovery,
         Some(PaneRecovery {
-            source: PaneSource::Bookmark { name: "Prod Web".into() },
+            source: PaneSource::Place { name: "Prod Web".into() },
             target: Some(PaneTarget::RemoteShell {
                 ssh_target: "deploy@example.com".into(),
-                remote_folder: None,
+                remote_folder: Some("/srv/app".into()),
             }),
             startup: vec![],
         })
@@ -551,12 +569,12 @@ fn bookmark_sessions_persist_and_replay_recovery_recipe_on_restart() {
         .borrow()
         .get(&terminal_uuid)
         .cloned()
-        .expect("restored bookmark terminal should exist");
+        .expect("restored place terminal should exist");
 
     assert_eq!(
         restored_term.pending_shell_inputs_for_test(),
         vec![expected_input],
-        "restored bookmark session should queue its structured recovery target before shell startup"
+        "restored place session should queue its structured recovery target before shell startup"
     );
 
     second_window.close();
@@ -565,7 +583,7 @@ fn bookmark_sessions_persist_and_replay_recovery_recipe_on_restart() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn new_session_from_folder_bookmark_uses_initial_cwd_not_cd_command() {
+fn new_session_from_local_place_uses_initial_cwd_not_cd_command() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
@@ -573,15 +591,14 @@ fn new_session_from_folder_bookmark_uses_initial_cwd_not_cd_command() {
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
     let app = adw::Application::builder()
-        .application_id("com.illya.rttx.folder-bookmark-cwd-tests")
+        .application_id("com.illya.rttx.folder-place-cwd-tests")
         .build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
-    let mut bookmark = crate::bookmarks::Bookmark::new("Work");
-    bookmark.directory = Some("/home/user/work".into());
+    let place = crate::places::Place::new("Work", "/home/user/work");
 
-    window.new_session_from_bookmark(&bookmark);
+    window.new_session_from_place(&place);
 
     let (layout_cwd, pending_inputs) = {
         let state = window.imp().state.borrow();
@@ -598,11 +615,11 @@ fn new_session_from_folder_bookmark_uses_initial_cwd_not_cd_command() {
     assert_eq!(
         layout_cwd.as_deref(),
         Some("/home/user/work"),
-        "folder bookmark should set cwd in the layout node, not send a cd command"
+        "local place should set cwd in the layout node, not send a cd command"
     );
     assert!(
         pending_inputs.is_empty(),
-        "folder-only bookmark should not queue any shell input; got: {pending_inputs:?}"
+        "local place should not queue any shell input; got: {pending_inputs:?}"
     );
 
     window.close();
@@ -611,22 +628,26 @@ fn new_session_from_folder_bookmark_uses_initial_cwd_not_cd_command() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn new_session_from_ssh_bookmark_queues_ssh_command() {
+fn new_session_from_remote_place_queues_ssh_command() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
+    crate::host::save(&[crate::host::Host::remote("deploy@example.com")]).unwrap();
+
     let app =
-        adw::Application::builder().application_id("com.illya.rttx.ssh-bookmark-tests").build();
+        adw::Application::builder().application_id("com.illya.rttx.ssh-place-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
-    let mut bookmark = crate::bookmarks::Bookmark::new("Prod");
-    bookmark.ssh_target = Some("deploy@example.com".into());
+    let place = crate::places::Place {
+        host_tags: vec!["example.com".into()],
+        ..crate::places::Place::new("Prod", "/srv/app")
+    };
 
-    window.new_session_from_bookmark(&bookmark);
+    window.new_session_from_place(&place);
 
     let (pending_inputs, saved_recovery) = {
         let state = window.imp().state.borrow();
@@ -636,18 +657,25 @@ fn new_session_from_ssh_bookmark_queues_ssh_command() {
         (term.pending_shell_inputs_for_test(), session.recovery_for(&terminal_uuid).cloned())
     };
 
+    let expected_input =
+        PaneTarget::RemoteShell {
+            ssh_target: "deploy@example.com".into(),
+            remote_folder: Some("/srv/app".into()),
+        }
+        .managed_startup_input()
+        .unwrap();
     assert_eq!(
         pending_inputs,
-        vec!["exec ssh deploy@example.com\n"],
-        "SSH bookmark should queue the structured ssh recovery command"
+        vec![expected_input],
+        "remote place should queue the structured ssh recovery command"
     );
     assert_eq!(
         saved_recovery,
         Some(PaneRecovery {
-            source: PaneSource::Bookmark { name: "Prod".into() },
+            source: PaneSource::Place { name: "Prod".into() },
             target: Some(PaneTarget::RemoteShell {
                 ssh_target: "deploy@example.com".into(),
-                remote_folder: None,
+                remote_folder: Some("/srv/app".into()),
             }),
             startup: vec![],
         })
@@ -659,7 +687,7 @@ fn new_session_from_ssh_bookmark_queues_ssh_command() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn bookmark_active_session_captures_session_name_and_cwd() {
+fn save_place_from_active_session_captures_session_name_and_cwd() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
@@ -667,13 +695,12 @@ fn bookmark_active_session_captures_session_name_and_cwd() {
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
     let app = adw::Application::builder()
-        .application_id("com.illya.rttx.bookmark-active-session-tests")
+        .application_id("com.illya.rttx.place-active-session-tests")
         .build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
 
-    // Rename the default session and set the terminal's CWD.
     {
         let mut state = window.imp().state.borrow_mut();
         state.sessions[0].name = "My Work".to_string();
@@ -687,17 +714,15 @@ fn bookmark_active_session_captures_session_name_and_cwd() {
     }
     window.imp().focused_terminal_uuid.replace(Some(terminal_uuid));
 
-    let bookmark = window
-        .create_bookmark_from_active_session()
-        .expect("should produce a bookmark when a terminal is focused");
+    let place = window
+        .create_place_from_active_session()
+        .expect("should produce a place when a terminal is focused");
 
-    assert_eq!(bookmark.name, "My Work", "bookmark name should match the session name");
+    assert_eq!(place.name, "My Work", "place name should match the session name");
     assert_eq!(
-        bookmark.directory.as_deref(),
-        Some("/home/user/projects"),
-        "bookmark directory should match the focused terminal's CWD"
+        place.path, "/home/user/projects",
+        "place path should match the focused terminal's CWD"
     );
-    assert_eq!(bookmark.ssh_target, None);
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
@@ -705,7 +730,7 @@ fn bookmark_active_session_captures_session_name_and_cwd() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn bookmark_active_session_returns_none_without_focused_terminal() {
+fn save_place_from_active_session_returns_none_without_focused_terminal() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
@@ -713,7 +738,7 @@ fn bookmark_active_session_returns_none_without_focused_terminal() {
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
     let app = adw::Application::builder()
-        .application_id("com.illya.rttx.bookmark-no-focus-tests")
+        .application_id("com.illya.rttx.place-no-focus-tests")
         .build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
@@ -721,7 +746,7 @@ fn bookmark_active_session_returns_none_without_focused_terminal() {
     window.imp().focused_terminal_uuid.replace(None);
 
     assert!(
-        window.create_bookmark_from_active_session().is_none(),
+        window.create_place_from_active_session().is_none(),
         "should return None when no terminal is focused"
     );
 
@@ -747,7 +772,7 @@ fn failed_structured_recovery_keeps_terminal_alive_and_allows_retry() {
             terminal_recovery: std::collections::BTreeMap::from([(
                 terminal_uuid.clone(),
                 PaneRecovery {
-                    source: PaneSource::Bookmark { name: "Ops".into() },
+                    source: PaneSource::Place { name: "Ops".into() },
                     target: Some(PaneTarget::RemoteShell {
                         ssh_target: "user@192.0.2.1".into(),
                         remote_folder: None,
@@ -1694,7 +1719,7 @@ fn tools_sidebar_uses_per_row_management_instead_of_manage_dialog() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn bookmark_sidebar_shows_empty_state_when_no_bookmarks() {
+fn place_sidebar_shows_builtin_places_when_no_user_places() {
     require_display!();
 
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
@@ -1702,20 +1727,21 @@ fn bookmark_sidebar_shows_empty_state_when_no_bookmarks() {
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
 
     let app = adw::Application::builder()
-        .application_id("com.illya.rttx.bookmark-empty-state-tests")
+        .application_id("com.illya.rttx.place-empty-state-tests")
         .build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
     let window = Window::new(&app);
     window.present();
     pump_events(50);
 
+    // Built-in places (Home, Root) should always be visible
     assert!(
-        window.imp().bookmark_empty.is_visible(),
-        "empty state should be visible when no bookmarks"
+        window.imp().place_scroll.is_visible(),
+        "place list should be visible with built-in places"
     );
     assert!(
-        !window.imp().bookmark_scroll.is_visible(),
-        "list scroll should be hidden when no bookmarks"
+        !window.imp().place_empty.is_visible(),
+        "empty state should be hidden when built-in places exist"
     );
 
     window.close();

--- a/clients/rttx/tests/places_integration.rs
+++ b/clients/rttx/tests/places_integration.rs
@@ -1,0 +1,83 @@
+use rttx::places::{self, Place};
+use tempfile::TempDir;
+
+#[test]
+fn places_roundtrip_all_fields() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("places.json");
+
+    let place = Place {
+        host_tags: vec!["example.com".into()],
+        ..Place::new("Remote Ops", "/srv/app")
+    };
+
+    places::save_to(std::slice::from_ref(&place), &path).unwrap();
+    assert_eq!(places::load_from(&path), vec![place]);
+}
+
+#[test]
+fn invalid_places_json_returns_empty_list() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("places.json");
+
+    std::fs::write(&path, "{not-json").unwrap();
+    assert!(places::load_from(&path).is_empty());
+}
+
+#[test]
+fn place_without_host_tags_deserializes_as_global() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("places.json");
+
+    std::fs::write(
+        &path,
+        r#"[{
+            "uuid": "abc-123",
+            "name": "Work",
+            "path": "/home/user/work"
+        }]"#,
+    )
+    .unwrap();
+
+    let places = places::load_from(&path);
+    assert_eq!(places.len(), 1);
+    assert_eq!(places[0].name, "Work");
+    assert!(places[0].is_global());
+    assert!(places[0].host_tags.is_empty());
+}
+
+#[test]
+fn migrate_bookmarks_converts_directory_only_to_local_place() {
+    let mut bookmark = rttx::bookmarks::Bookmark::new("Work");
+    bookmark.directory = Some("/home/user/work".into());
+
+    let (places, hosts) = places::migrate_bookmarks(&[bookmark]);
+    assert_eq!(places.len(), 1);
+    assert!(hosts.is_empty());
+    assert_eq!(places[0].path, "/home/user/work");
+    assert_eq!(places[0].host_tags, vec!["local"]);
+}
+
+#[test]
+fn migrate_bookmarks_converts_ssh_only_to_host() {
+    let mut bookmark = rttx::bookmarks::Bookmark::new("Prod");
+    bookmark.ssh_target = Some("deploy@example.com".into());
+
+    let (places, hosts) = places::migrate_bookmarks(&[bookmark]);
+    assert!(places.is_empty());
+    assert_eq!(hosts.len(), 1);
+    assert_eq!(hosts[0].key, "example.com");
+}
+
+#[test]
+fn migrate_bookmarks_converts_combined_to_tagged_place() {
+    let mut bookmark = rttx::bookmarks::Bookmark::new("Remote Ops");
+    bookmark.directory = Some("/srv/app".into());
+    bookmark.ssh_target = Some("deploy@example.com".into());
+
+    let (places, hosts) = places::migrate_bookmarks(&[bookmark]);
+    assert_eq!(places.len(), 1);
+    assert_eq!(hosts.len(), 1);
+    assert_eq!(places[0].host_tags, vec!["example.com"]);
+    assert_eq!(places[0].path, "/srv/app");
+}

--- a/clients/rttx/tests/places_integration.rs
+++ b/clients/rttx/tests/places_integration.rs
@@ -6,10 +6,8 @@ fn places_roundtrip_all_fields() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("places.json");
 
-    let place = Place {
-        host_tags: vec!["example.com".into()],
-        ..Place::new("Remote Ops", "/srv/app")
-    };
+    let place =
+        Place { host_tags: vec!["example.com".into()], ..Place::new("Remote Ops", "/srv/app") };
 
     places::save_to(std::slice::from_ref(&place), &path).unwrap();
     assert_eq!(places::load_from(&path), vec![place]);

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -567,10 +567,8 @@ fn remote_place_creates_managed_remote_session() {
     // A remote-tagged place with a known SSH target in its host_tags.
     // The place resolves the host key to an ad-hoc remote host when no
     // saved hosts file exists.
-    let place = Place {
-        host_tags: vec!["example.com".into()],
-        ..Place::new("Prod Server", "/srv/app")
-    };
+    let place =
+        Place { host_tags: vec!["example.com".into()], ..Place::new("Prod Server", "/srv/app") };
 
     // The place should report a remote host (ad-hoc resolution uses the key as SSH target).
     let host = place.remote_host();
@@ -629,10 +627,7 @@ fn update_remote_endpoint_changes_host_and_mode() {
 fn remote_place_remote_command_strips_ssh_for_same_host() {
     use rttx::places::Place;
 
-    let place = Place {
-        host_tags: vec!["example.com".into()],
-        ..Place::new("Deploy", "/srv/app")
-    };
+    let place = Place { host_tags: vec!["example.com".into()], ..Place::new("Deploy", "/srv/app") };
 
     let inner = place.remote_command().unwrap();
     assert!(!inner.contains("ssh"), "inner command must not contain ssh");

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -556,45 +556,45 @@ fn remote_managed_session_persists_and_restores() {
     );
 }
 
-/// SSH bookmark must create a managed remote session, not a local direct one.
+/// Remote place must create a managed remote session, not a local direct one.
 /// Regression test for #243.
 #[test]
-fn ssh_bookmark_creates_managed_remote_session() {
-    use rttx::bookmarks::Bookmark;
+fn remote_place_creates_managed_remote_session() {
+    use rttx::places::Place;
     use rttx::runtime::RuntimeEndpoint;
     use rttx::session::SessionState;
 
-    let mut bookmark = Bookmark::new("Prod Server");
-    bookmark.ssh_target = Some("deploy@example.com".into());
-    bookmark.directory = Some("/srv/app".into());
+    // A remote-tagged place with a known SSH target in its host_tags.
+    // The place resolves the host key to an ad-hoc remote host when no
+    // saved hosts file exists.
+    let place = Place {
+        host_tags: vec!["example.com".into()],
+        ..Place::new("Prod Server", "/srv/app")
+    };
 
-    // Simulate the decision logic from new_session_from_bookmark.
-    let host = bookmark.remote_host();
-    assert!(host.is_some(), "SSH bookmark must report a remote host");
+    // The place should report a remote host (ad-hoc resolution uses the key as SSH target).
+    let host = place.remote_host();
+    assert!(host.is_some(), "remote place must report a remote host");
 
     let session = SessionState::new_managed_remote(
-        bookmark.name.clone(),
-        host.unwrap(),
+        place.display_name().to_string(),
+        &host.unwrap(),
         rttx::runtime::WorkspacePolicy::Persistent,
-        bookmark.session_initial_cwd().map(str::to_string),
+        place.session_initial_cwd().map(str::to_string),
     );
 
     assert!(session.runtime.is_managed());
-    assert_eq!(
-        session.runtime.endpoint,
-        RuntimeEndpoint::Remote { host: "deploy@example.com".into() }
-    );
+    assert!(matches!(session.runtime.endpoint, RuntimeEndpoint::Remote { .. }));
 }
 
-/// Local bookmark must still create a direct session.
+/// Local place must still create a direct session.
 #[test]
-fn local_bookmark_creates_direct_session() {
-    use rttx::bookmarks::Bookmark;
+fn local_place_creates_direct_session() {
+    use rttx::places::Place;
 
-    let mut bookmark = Bookmark::new("Projects");
-    bookmark.directory = Some("/home/user/projects".into());
+    let place = Place::new("Projects", "/home/user/projects");
 
-    assert!(bookmark.remote_host().is_none());
+    assert!(place.remote_host().is_none());
 }
 
 /// Updating a remote workspace endpoint must change the host and sync mode.
@@ -623,20 +623,18 @@ fn update_remote_endpoint_changes_host_and_mode() {
     ));
 }
 
-/// SSH bookmark targeting the same host as a managed pane must use the inner
+/// Remote place command on the same host must use the inner
 /// command (without SSH wrapper). Regression test for #245.
 #[test]
-fn ssh_bookmark_remote_command_strips_ssh_for_same_host() {
-    use rttx::bookmarks::Bookmark;
+fn remote_place_remote_command_strips_ssh_for_same_host() {
+    use rttx::places::Place;
 
-    let mut bookmark = Bookmark::new("Deploy");
-    bookmark.ssh_target = Some("deploy@example.com".into());
-    bookmark.directory = Some("/srv/app".into());
+    let place = Place {
+        host_tags: vec!["example.com".into()],
+        ..Place::new("Deploy", "/srv/app")
+    };
 
-    let full = bookmark.command().unwrap();
-    let inner = bookmark.remote_command().unwrap();
-
-    assert!(full.starts_with("ssh"), "full command wraps in ssh");
+    let inner = place.remote_command().unwrap();
     assert!(!inner.contains("ssh"), "inner command must not contain ssh");
     assert!(inner.contains("/srv/app"));
 }

--- a/clients/rttx/tests/ui/test_sidebar.py
+++ b/clients/rttx/tests/ui/test_sidebar.py
@@ -46,8 +46,8 @@ class TestSidebar(unittest.TestCase):
     def test_sidebar_vertical_layout(self) -> None:
         """The utility sidebar content must sit below the tab bar, not beside it.
 
-        In the correct vertical-box layout, the Bookmarks stack page (content)
-        has a greater y than the Bookmarks page-tab (the switcher button).
+        In the correct vertical-box layout, the Places stack page (content)
+        has a greater y than the Places page-tab (the switcher button).
         In the broken horizontal-box layout both would share the same y because
         the switcher and content are rendered side-by-side in the same row.
         """
@@ -59,18 +59,18 @@ class TestSidebar(unittest.TestCase):
 
         # The tab button (in the ViewSwitcher / StackSwitcher row).
         tab = find_by_role_and_name(
-            self.fixture.atspi_app, Atspi.Role.PAGE_TAB, "Bookmarks"
+            self.fixture.atspi_app, Atspi.Role.PAGE_TAB, "Places"
         )
         if tab is None:
-            self.skipTest("Bookmarks page tab not found in AT-SPI tree")
+            self.skipTest("Places page tab not found in AT-SPI tree")
 
-        # The content panel (the actual Bookmarks stack page below the tab bar).
+        # The content panel (the actual Places stack page below the tab bar).
         content_panels = [
             n for n in find_all_by_role(self.fixture.atspi_app, Atspi.Role.PANEL)
-            if n.get_name() == "Bookmarks"
+            if n.get_name() == "Places"
         ]
         if not content_panels:
-            self.skipTest("Bookmarks content panel not found in AT-SPI tree")
+            self.skipTest("Places content panel not found in AT-SPI tree")
         content = content_panels[0]
 
         tab_ext = get_extents(tab)
@@ -84,7 +84,7 @@ class TestSidebar(unittest.TestCase):
         self.assertGreater(
             content_y,
             tab_y + tab_h // 2,
-            "Bookmarks content panel is not below the tab bar.\n"
+            "Places content panel is not below the tab bar.\n"
             "The utility_sidebar_box must use Vertical orientation.\n"
             f"Tab y={tab_y}+h={tab_h}, Content y={content_y}",
         )

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -32,7 +32,20 @@ FORBIDDEN_SUBTITLE_PATTERNS = [
 
 
 def get_sidebar_rows(app: Atspi.Accessible) -> list[Atspi.Accessible]:
-    """Return all LIST_ITEM nodes (sidebar workspace rows)."""
+    """Return LIST_ITEM nodes from the workspace sidebar only.
+
+    Scopes to the list labeled 'Workspaces' to avoid picking up items
+    from the Places or Commands lists in the utility sidebar.
+    """
+    lists = find_all_by_role(app, Atspi.Role.LIST)
+    for lst in lists:
+        try:
+            name = lst.get_name() or ""
+            if name == "Workspaces":
+                return find_all_by_role(lst, Atspi.Role.LIST_ITEM)
+        except Exception:  # noqa: BLE001
+            continue
+    # Fallback: return all LIST_ITEM nodes if the labeled list is not found
     return find_all_by_role(app, Atspi.Role.LIST_ITEM)
 
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.8',
+  version: '0.2.9',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Replaces the bookmark system with the Places model as defined in RFC-016 section 6.

**Places** are path-centric, host-tag-scoped entries that replace bookmarks:
- `Place { uuid, name, path, host_tags }` — simpler than bookmarks (no SSH target field)
- Empty `host_tags` = global (visible on all hosts)
- One or more tags = scoped to those hosts (tags are host keys)
- Built-in global places: **Home** and **Root** (always visible, not user-deletable)

### Migration from bookmarks
- Bookmark with only `directory` → local-tagged Place
- Bookmark with only `ssh_target` → Host record (no Place created)
- Bookmark with `ssh_target` + `directory` → Place tagged with that host key
- Empty bookmarks → dropped

### Backward compatibility
- `PaneSource::Bookmark` in persisted state deserializes as `PaneSource::Place`
- Legacy `bookmarks.json` still loads (bookmarks module preserved)
- `host_tags` defaults to empty via `#[serde(default)]`

### UI changes
- Sidebar tab renamed from "Bookmarks" to "Places"
- Edit form simplified: Name + Path (no SSH target field)
- Built-in places always shown at top of list
- Built-in places cannot be edited, deleted, or reordered

## Manual verification steps
1. Launch with `RTTX_DEV_MODE=1 cargo run -p rttx`
2. Verify Places tab shows Home and Root entries
3. Add a new place via the + button
4. Click a place to cd in the current pane
5. Click the workspace icon on a place to open a new workspace
6. Search filters places correctly
7. Restart — places persist, recovery recipes replay

## Tests added
- 34 unit tests in `places.rs` (data model, persistence, migration, matching)
- 3 backward compat tests in `recovery.rs` (legacy bookmark deserialization)
- 6 integration tests in `places_integration.rs`
- 8 GTK widget tests updated for places (session creation, recovery, sidebar)

## Tests run
- `cargo test --workspace` (VTE 0.76) — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests pass including:
  - `new_session_from_place_creates_and_focuses_named_session` ✅
  - `new_session_from_place_queues_input_before_shell_starts` ✅
  - `new_session_from_remote_place_queues_ssh_command` ✅
  - `place_sessions_persist_and_replay_recovery_recipe_on_restart` ✅
  - `new_session_from_local_place_uses_initial_cwd_not_cd_command` ✅
  - `place_sidebar_shows_builtin_places_when_no_user_places` ✅
  - `save_place_from_active_session_captures_session_name_and_cwd` ✅
  - `save_place_from_active_session_returns_none_without_focused_terminal` ✅
  - `utility_sidebar_shows_and_filters_places` ✅

## Follow-ups
- Host-tag editing UI in the place form (currently places are created as global)
- Automatic bookmark migration on first launch
- Command host-tagging (RFC-016 also covers commands)

Fixes #428