### PR TITLE
feat: command host tags and shared form dialog builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.8"
+version = "0.2.9"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/bookmarks_window.rs
+++ b/clients/rttx/src/bookmarks_window.rs
@@ -3,47 +3,25 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 
 use crate::bookmarks::{self, Bookmark};
+use crate::form_dialog::{self, FormDialog};
 use crate::window::Window;
 
 pub fn show_form(parent: &Window, bookmark: Option<&Bookmark>) {
     let existing_uuid = bookmark.map(|b| b.uuid.clone());
 
-    let dialog = adw::Dialog::builder()
-        .title(if bookmark.is_some() { "Edit Bookmark" } else { "New Bookmark" })
-        .content_width(440)
-        .build();
-
-    let header = adw::HeaderBar::new();
-    let save_button = gtk4::Button::with_label(if bookmark.is_some() { "Save" } else { "Add" });
-    save_button.add_css_class("suggested-action");
-    header.pack_end(&save_button);
+    let form = FormDialog::new("Bookmark", bookmark.is_some(), 440);
 
     let name_row = adw::EntryRow::builder().title("Name").build();
     let directory_row = adw::EntryRow::builder().title("Directory").build();
     let ssh_target_row = adw::EntryRow::builder().title("SSH target / args").build();
-
-    let status_label = gtk4::Label::new(None);
-    status_label.set_xalign(0.0);
-    status_label.add_css_class("dim-label");
 
     let group = adw::PreferencesGroup::new();
     group.add(&name_row);
     group.add(&directory_row);
     group.add(&ssh_target_row);
 
-    let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
-    content_box.set_margin_start(18);
-    content_box.set_margin_end(18);
-    content_box.set_margin_top(18);
-    content_box.set_margin_bottom(18);
-    content_box.append(&group);
-    content_box.append(&status_label);
-
-    let toolbar_view = adw::ToolbarView::new();
-    toolbar_view.add_top_bar(&header);
-    toolbar_view.set_content(Some(&content_box));
-
-    dialog.set_child(Some(&toolbar_view));
+    form.content_box.append(&group);
+    form.finish_layout();
 
     if let Some(b) = bookmark {
         name_row.set_text(&b.name);
@@ -51,9 +29,10 @@ pub fn show_form(parent: &Window, bookmark: Option<&Bookmark>) {
         ssh_target_row.set_text(b.ssh_target.as_deref().unwrap_or_default());
     }
 
-    let dialog_for_save = dialog.clone();
+    let dialog = form.dialog.clone();
+    let status_label = form.status_label.clone();
     let parent_for_save = parent.clone();
-    save_button.connect_clicked(move |_| {
+    form.save_button.connect_clicked(move |_| {
         let b =
             match build_bookmark(&name_row, &directory_row, &ssh_target_row, existing_uuid.clone())
             {
@@ -75,10 +54,10 @@ pub fn show_form(parent: &Window, bookmark: Option<&Bookmark>) {
             return;
         }
         parent_for_save.refresh_bookmark_sidebar();
-        dialog_for_save.close();
+        dialog.close();
     });
 
-    dialog.present(Some(parent));
+    form.present(parent);
 }
 
 fn build_bookmark(
@@ -96,18 +75,12 @@ fn build_bookmark(
     if let Some(uuid) = existing_uuid {
         bookmark.uuid = uuid;
     }
-    bookmark.directory = entry_value(directory_row);
-    bookmark.ssh_target = entry_value(ssh_target_row);
+    bookmark.directory = form_dialog::entry_value(directory_row);
+    bookmark.ssh_target = form_dialog::entry_value(ssh_target_row);
 
     if !bookmark.is_actionable() {
         return Err("Add a directory, SSH target, or both".into());
     }
 
     Ok(bookmark)
-}
-
-fn entry_value(row: &adw::EntryRow) -> Option<String> {
-    let text = row.text();
-    let trimmed = text.trim();
-    if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
 }

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -281,10 +281,7 @@ mod tests {
 
     #[test]
     fn migrate_legacy_tags_untagged_commands_with_local() {
-        let mut commands = vec![
-            SavedCommand::new("A", "echo a"),
-            SavedCommand::new("B", "echo b"),
-        ];
+        let mut commands = vec![SavedCommand::new("A", "echo a"), SavedCommand::new("B", "echo b")];
         migrate_legacy(&mut commands);
         assert_eq!(commands[0].host_tags, vec!["local"]);
         assert_eq!(commands[1].host_tags, vec!["local"]);

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -17,6 +17,9 @@ pub struct SavedCommand {
     pub body: String,
     #[serde(default = "default_run_mode")]
     pub default_run_mode: CommandRunMode,
+    /// Host keys this command is scoped to. Empty means global (visible everywhere).
+    #[serde(default)]
+    pub host_tags: Vec<String>,
 }
 
 const fn default_run_mode() -> CommandRunMode {
@@ -31,6 +34,7 @@ impl SavedCommand {
             title: title.into(),
             body: body.into(),
             default_run_mode: CommandRunMode::Run,
+            host_tags: Vec::new(),
         }
     }
 
@@ -58,6 +62,25 @@ pub fn matches_query(command: &SavedCommand, query: &str) -> bool {
     let query = query.to_ascii_lowercase();
     command.title.to_ascii_lowercase().contains(&query)
         || command.body.to_ascii_lowercase().contains(&query)
+        || command.host_tags.iter().any(|tag| tag.to_ascii_lowercase().contains(&query))
+}
+
+/// Returns `true` if the command should be visible for the given host key.
+///
+/// Global commands (empty `host_tags`) are visible everywhere.
+/// Tagged commands are visible only when `host_key` matches one of their tags.
+#[must_use]
+pub fn is_visible_on(command: &SavedCommand, host_key: &str) -> bool {
+    command.host_tags.is_empty() || command.host_tags.iter().any(|tag| tag == host_key)
+}
+
+/// Migrate legacy commands that lack host tags by tagging them with `"local"`.
+pub fn migrate_legacy(commands: &mut [SavedCommand]) {
+    for command in commands.iter_mut() {
+        if command.host_tags.is_empty() {
+            command.host_tags.push(crate::host::LOCAL_KEY.into());
+        }
+    }
 }
 
 fn commands_path() -> PathBuf {
@@ -191,5 +214,88 @@ mod tests {
         let loaded = load_from(&path);
         let uuids: Vec<&str> = loaded.iter().map(|c| c.uuid.as_str()).collect();
         assert_eq!(uuids, vec!["a", "c", "b"]);
+    }
+
+    // ── Host tags ───────────────────────────────────────────────
+
+    #[test]
+    fn new_command_has_empty_host_tags() {
+        let command = SavedCommand::new("Test", "echo test");
+        assert!(command.host_tags.is_empty());
+    }
+
+    #[test]
+    fn host_tags_roundtrip_via_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("commands.json");
+        let mut command = SavedCommand::new("Deploy", "cargo build");
+        command.host_tags = vec!["local".into(), "example.com".into()];
+
+        save_to(&[command.clone()], &path).unwrap();
+        assert_eq!(load_from(&path), vec![command]);
+    }
+
+    #[test]
+    fn legacy_json_without_host_tags_deserializes_with_empty_vec() {
+        let json = r#"[{
+            "uuid": "abc",
+            "title": "Old",
+            "body": "echo old",
+            "default_run_mode": "run"
+        }]"#;
+        let commands: Vec<SavedCommand> = serde_json::from_str(json).unwrap();
+        assert_eq!(commands[0].host_tags, Vec::<String>::new());
+    }
+
+    #[test]
+    fn matches_query_searches_host_tags() {
+        let mut command = SavedCommand::new("Deploy", "cargo build");
+        command.host_tags = vec!["example.com".into()];
+        assert!(matches_query(&command, "example"));
+        assert!(!matches_query(&command, "staging"));
+    }
+
+    #[test]
+    fn is_visible_on_global_command_visible_everywhere() {
+        let command = SavedCommand::new("Global", "echo hi");
+        assert!(is_visible_on(&command, "local"));
+        assert!(is_visible_on(&command, "example.com"));
+    }
+
+    #[test]
+    fn is_visible_on_tagged_command_visible_only_on_matching_host() {
+        let mut command = SavedCommand::new("Local only", "echo hi");
+        command.host_tags = vec!["local".into()];
+        assert!(is_visible_on(&command, "local"));
+        assert!(!is_visible_on(&command, "example.com"));
+    }
+
+    #[test]
+    fn is_visible_on_multi_tagged_command() {
+        let mut command = SavedCommand::new("Multi", "echo hi");
+        command.host_tags = vec!["local".into(), "example.com".into()];
+        assert!(is_visible_on(&command, "local"));
+        assert!(is_visible_on(&command, "example.com"));
+        assert!(!is_visible_on(&command, "other.com"));
+    }
+
+    #[test]
+    fn migrate_legacy_tags_untagged_commands_with_local() {
+        let mut commands = vec![
+            SavedCommand::new("A", "echo a"),
+            SavedCommand::new("B", "echo b"),
+        ];
+        migrate_legacy(&mut commands);
+        assert_eq!(commands[0].host_tags, vec!["local"]);
+        assert_eq!(commands[1].host_tags, vec!["local"]);
+    }
+
+    #[test]
+    fn migrate_legacy_preserves_existing_tags() {
+        let mut command = SavedCommand::new("Tagged", "echo tagged");
+        command.host_tags = vec!["example.com".into()];
+        let mut commands = vec![command];
+        migrate_legacy(&mut commands);
+        assert_eq!(commands[0].host_tags, vec!["example.com"]);
     }
 }

--- a/clients/rttx/src/commands_window.rs
+++ b/clients/rttx/src/commands_window.rs
@@ -3,20 +3,14 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 
 use crate::commands::{self, CommandRunMode, SavedCommand};
+use crate::form_dialog::FormDialog;
+use crate::host;
 use crate::window::Window;
 
 pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
     let existing_uuid = command.map(|c| c.uuid.clone());
 
-    let dialog = adw::Dialog::builder()
-        .title(if command.is_some() { "Edit Command" } else { "New Command" })
-        .content_width(480)
-        .build();
-
-    let header = adw::HeaderBar::new();
-    let save_button = gtk4::Button::with_label(if command.is_some() { "Save" } else { "Add" });
-    save_button.add_css_class("suggested-action");
-    header.pack_end(&save_button);
+    let form = FormDialog::new("Command", command.is_some(), 480);
 
     let title_row = adw::EntryRow::builder().title("Title").build();
 
@@ -32,42 +26,39 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
     run_mode_row.add_suffix(&run_mode);
     run_mode_row.set_activatable_widget(Some(&run_mode));
 
-    let status_label = gtk4::Label::new(None);
-    status_label.set_xalign(0.0);
-    status_label.add_css_class("dim-label");
+    let host_tags_row =
+        adw::EntryRow::builder().title("Host tags (comma-separated, empty = global)").build();
 
     let title_group = adw::PreferencesGroup::new();
     title_group.add(&title_row);
 
     let behavior_group = adw::PreferencesGroup::new();
     behavior_group.add(&run_mode_row);
+    behavior_group.add(&host_tags_row);
 
-    let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
-    content_box.set_margin_start(18);
-    content_box.set_margin_end(18);
-    content_box.set_margin_top(18);
-    content_box.set_margin_bottom(18);
-    content_box.append(&title_group);
-    content_box.append(&body_scroll);
-    content_box.append(&behavior_group);
-    content_box.append(&status_label);
-
-    let toolbar_view = adw::ToolbarView::new();
-    toolbar_view.add_top_bar(&header);
-    toolbar_view.set_content(Some(&content_box));
-
-    dialog.set_child(Some(&toolbar_view));
+    form.content_box.append(&title_group);
+    form.content_box.append(&body_scroll);
+    form.content_box.append(&behavior_group);
+    form.finish_layout();
 
     if let Some(c) = command {
         title_row.set_text(&c.title);
         body_buffer.set_text(&c.body);
         run_mode.set_selected(run_mode_index(c.default_run_mode));
+        host_tags_row.set_text(&c.host_tags.join(", "));
     }
 
-    let dialog_for_save = dialog.clone();
+    let dialog = form.dialog.clone();
+    let status_label = form.status_label.clone();
     let parent_for_save = parent.clone();
-    save_button.connect_clicked(move |_| {
-        let cmd = match build_command(&title_row, &body_buffer, &run_mode, existing_uuid.clone()) {
+    form.save_button.connect_clicked(move |_| {
+        let cmd = match build_command(
+            &title_row,
+            &body_buffer,
+            &run_mode,
+            &host_tags_row,
+            existing_uuid.clone(),
+        ) {
             Ok(c) => c,
             Err(msg) => {
                 status_label.set_text(&msg);
@@ -86,16 +77,17 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
             return;
         }
         parent_for_save.refresh_command_sidebar();
-        dialog_for_save.close();
+        dialog.close();
     });
 
-    dialog.present(Some(parent));
+    form.present(parent);
 }
 
 fn build_command(
     title_row: &adw::EntryRow,
     body_buffer: &gtk4::TextBuffer,
     run_mode: &gtk4::DropDown,
+    host_tags_row: &adw::EntryRow,
     existing_uuid: Option<String>,
 ) -> Result<SavedCommand, String> {
     let title = title_row.text().trim().to_string();
@@ -114,7 +106,20 @@ fn build_command(
         command.uuid = uuid;
     }
     command.default_run_mode = run_mode_from_index(run_mode.selected());
+    command.host_tags = parse_host_tags(&host_tags_row.text());
     Ok(command)
+}
+
+/// Parse a comma-separated host tags string into a deduplicated list of host keys.
+pub(crate) fn parse_host_tags(input: &str) -> Vec<String> {
+    let mut tags: Vec<String> = input
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(host::normalize_ssh_key)
+        .collect();
+    tags.dedup();
+    tags
 }
 
 const fn run_mode_from_index(index: u32) -> CommandRunMode {
@@ -128,5 +133,36 @@ const fn run_mode_index(run_mode: CommandRunMode) -> u32 {
     match run_mode {
         CommandRunMode::Run => 0,
         CommandRunMode::Insert => 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_host_tags_splits_on_comma() {
+        assert_eq!(parse_host_tags("local, example.com"), vec!["local", "example.com"]);
+    }
+
+    #[test]
+    fn parse_host_tags_trims_whitespace() {
+        assert_eq!(parse_host_tags("  local ,  example.com  "), vec!["local", "example.com"]);
+    }
+
+    #[test]
+    fn parse_host_tags_empty_string_returns_empty_vec() {
+        assert!(parse_host_tags("").is_empty());
+        assert!(parse_host_tags("  ").is_empty());
+    }
+
+    #[test]
+    fn parse_host_tags_normalizes_ssh_keys() {
+        assert_eq!(parse_host_tags("deploy@Example.COM"), vec!["example.com"]);
+    }
+
+    #[test]
+    fn parse_host_tags_deduplicates() {
+        assert_eq!(parse_host_tags("local, local"), vec!["local"]);
     }
 }

--- a/clients/rttx/src/form_dialog.rs
+++ b/clients/rttx/src/form_dialog.rs
@@ -1,0 +1,73 @@
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+/// Shared scaffolding for add/edit form dialogs (bookmarks, commands, etc.).
+///
+/// Builds the dialog chrome — header bar, save button, status label, content
+/// box, and toolbar view — so callers only supply the form-specific widgets
+/// and the save callback.
+#[derive(Debug)]
+pub struct FormDialog {
+    pub dialog: adw::Dialog,
+    pub save_button: gtk4::Button,
+    pub status_label: gtk4::Label,
+    pub content_box: gtk4::Box,
+}
+
+impl FormDialog {
+    /// Create a new form dialog.
+    ///
+    /// `is_edit` controls the title ("Edit …" vs "New …") and button label
+    /// ("Save" vs "Add").
+    #[must_use]
+    pub fn new(entity_name: &str, is_edit: bool, content_width: i32) -> Self {
+        let title =
+            if is_edit { format!("Edit {entity_name}") } else { format!("New {entity_name}") };
+        let button_label = if is_edit { "Save" } else { "Add" };
+
+        let dialog = adw::Dialog::builder().title(title).content_width(content_width).build();
+
+        let header = adw::HeaderBar::new();
+        let save_button = gtk4::Button::with_label(button_label);
+        save_button.add_css_class("suggested-action");
+        header.pack_end(&save_button);
+
+        let status_label = gtk4::Label::new(None);
+        status_label.set_xalign(0.0);
+        status_label.add_css_class("dim-label");
+
+        let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+        content_box.set_margin_start(18);
+        content_box.set_margin_end(18);
+        content_box.set_margin_top(18);
+        content_box.set_margin_bottom(18);
+
+        let toolbar_view = adw::ToolbarView::new();
+        toolbar_view.add_top_bar(&header);
+        toolbar_view.set_content(Some(&content_box));
+
+        dialog.set_child(Some(&toolbar_view));
+
+        Self { dialog, save_button, status_label, content_box }
+    }
+
+    /// Append the status label to the content box. Call after adding all
+    /// form-specific widgets so the label appears at the bottom.
+    pub fn finish_layout(&self) {
+        self.content_box.append(&self.status_label);
+    }
+
+    /// Present the dialog as a child of `parent`.
+    pub fn present(&self, parent: &impl IsA<gtk4::Widget>) {
+        self.dialog.present(Some(parent));
+    }
+}
+
+/// Read the trimmed text from an `EntryRow`, returning `None` for blank input.
+#[must_use]
+pub fn entry_value(row: &adw::EntryRow) -> Option<String> {
+    let text = row.text();
+    let trimmed = text.trim();
+    if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+}

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -6,6 +6,7 @@ pub mod commands_window;
 pub mod config;
 pub mod daemon;
 pub mod daemon_bridge;
+pub mod form_dialog;
 pub mod host;
 pub mod preferences;
 pub mod runtime;

--- a/clients/rttx/tests/commands_integration.rs
+++ b/clients/rttx/tests/commands_integration.rs
@@ -21,3 +21,40 @@ fn invalid_command_json_returns_empty_list() {
     std::fs::write(&path, "{not-json").unwrap();
     assert!(commands::load_from(&path).is_empty());
 }
+
+#[test]
+fn commands_with_host_tags_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("commands.json");
+
+    let mut command = SavedCommand::new("Remote deploy", "cargo build");
+    command.host_tags = vec!["local".into(), "example.com".into()];
+
+    commands::save_to(&[command.clone()], &path).unwrap();
+    let loaded = commands::load_from(&path);
+    assert_eq!(loaded, vec![command]);
+}
+
+#[test]
+fn legacy_commands_without_host_tags_load_and_migrate() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("commands.json");
+
+    let json = r#"[{
+        "uuid": "abc-123",
+        "title": "Old command",
+        "body": "echo hello",
+        "default_run_mode": "run"
+    }]"#;
+    std::fs::write(&path, json).unwrap();
+
+    let mut loaded = commands::load_from(&path);
+    assert!(loaded[0].host_tags.is_empty(), "legacy commands load with empty tags");
+
+    commands::migrate_legacy(&mut loaded);
+    assert_eq!(loaded[0].host_tags, vec!["local"], "migration tags with local");
+
+    commands::save_to(&loaded, &path).unwrap();
+    let reloaded = commands::load_from(&path);
+    assert_eq!(reloaded[0].host_tags, vec!["local"], "migrated tags persist");
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.8',
+  version: '0.2.9',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Implements two related issues from the RFC-016 workspace management v2 roadmap:

### #429 — Command host tags
Adds `host_tags: Vec<String>` to `SavedCommand` so commands can be scoped to specific hosts (or left empty for global visibility), matching the tagging system designed in RFC-016 section 6.

- Backward-compatible deserialization via `#[serde(default)]`
- `matches_query()` now searches host tags
- `is_visible_on()` filters commands by host key
- `migrate_legacy()` tags untagged commands with `"local"`
- Command form now includes a host tags entry row with comma-separated input
- `parse_host_tags()` normalizes SSH keys and deduplicates

### #100 — Shared form dialog builder
Extracts common dialog scaffolding (header bar, save button, status label, content box, toolbar view) into a `form_dialog` module. Both `bookmarks_window` and `commands_window` now use `FormDialog::new()`, reducing duplication.

### Version bump
Patch version bumped to 0.2.9 (>3 source files changed).

## Manual verification steps

1. Run `RTTX_DEV_MODE=1 cargo run -p rttx`
2. Open the command form (right sidebar → Add command)
3. Verify the host tags field appears below the run mode dropdown
4. Create a command with tags `local, example.com` — verify it saves
5. Edit the command — verify tags are pre-filled as `local, example.com`
6. Create a command with empty tags — verify it saves as global
7. Open the bookmark form — verify it still works identically

## Tests added

### Unit tests (commands.rs)
- `new_command_has_empty_host_tags`
- `host_tags_roundtrip_via_file`
- `legacy_json_without_host_tags_deserializes_with_empty_vec`
- `matches_query_searches_host_tags`
- `is_visible_on_global_command_visible_everywhere`
- `is_visible_on_tagged_command_visible_only_on_matching_host`
- `is_visible_on_multi_tagged_command`
- `migrate_legacy_tags_untagged_commands_with_local`
- `migrate_legacy_preserves_existing_tags`

### Unit tests (commands_window.rs)
- `parse_host_tags_splits_on_comma`
- `parse_host_tags_trims_whitespace`
- `parse_host_tags_empty_string_returns_empty_vec`
- `parse_host_tags_normalizes_ssh_keys`
- `parse_host_tags_deduplicates`

### Integration tests (commands_integration.rs)
- `commands_with_host_tags_roundtrip`
- `legacy_commands_without_host_tags_load_and_migrate`

## Tests run

- `cargo build --workspace` (with VTE 0.76 flags) ✅
- `cargo test -p rttx -p rttx-server -p rttx-proto` ✅ (all pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (970 tests pass, 0 failures)
- `./run_ui_tests.sh` — 7 pre-existing failures (same on mainline), 0 new failures

## Limitations

- Host-tag-based sidebar filtering is not yet implemented (depends on #428 Places model)
- Migration is not auto-triggered on load; callers must invoke `migrate_legacy()` explicitly

Fixes #429
Fixes #100