### PR TITLE
feat: replace top bar with New / Connect to Existing / New Direct actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.9"
+version = "0.2.10"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -33,9 +33,15 @@ impl Window {
             ("toggle-pane-zoom", &["<Ctrl><Shift>Z"], Self::toggle_pane_zoom),
             ("rotate-layout", &["<Ctrl><Shift>R"], Self::rotate_layout),
             ("new-session", &["<Ctrl><Shift>T"], Self::add_session),
-            ("new-ephemeral-workspace", &["<Ctrl><Shift><Alt>T"], Self::add_ephemeral_session),
+            ("new-ephemeral-workspace", &[], Self::add_ephemeral_session),
             ("new-remote-workspace", &[], Self::show_new_remote_workspace_dialog),
             ("browse-remote-runtimes", &[], Self::show_browse_remote_runtimes_dialog),
+            ("connect-to-existing", &["<Ctrl><Shift>A"], |w| {
+                w.browse_local_runtimes();
+            }),
+            ("new-direct", &["<Ctrl><Shift>D"], |w| {
+                w.add_direct_session();
+            }),
             ("toggle-utility-sidebar", &["<Ctrl><Shift>B"], |w| {
                 let sidebar = &w.imp().utility_sidebar_box;
                 sidebar.set_visible(!sidebar.is_visible());

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -96,8 +96,7 @@ mod imp {
             self.new_button.set_tooltip_text(Some("New workspace"));
             self.new_button.set_icon_name("list-add-symbolic");
             self.new_button.add_css_class("flat");
-            self.new_button
-                .update_property(&[gtk4::accessible::Property::Label("New workspace")]);
+            self.new_button.update_property(&[gtk4::accessible::Property::Label("New workspace")]);
             header.pack_start(&self.new_button);
 
             self.connect_button.set_label("Connect");

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -35,12 +35,6 @@ mod runtime;
 mod sidebar;
 mod terminal;
 
-#[derive(Debug, Clone, Copy)]
-enum HostMenuAction {
-    New,
-    Connect,
-}
-
 mod imp {
     use super::*;
     use std::cell::RefCell;
@@ -485,33 +479,22 @@ impl Window {
     fn setup_host_menu_buttons(&self) {
         let imp = self.imp();
 
-        // "New" button: populate host menu on click, each item creates a
-        // new daemon-backed workspace for that host.
-        let new_popover = gtk4::Popover::new();
-        imp.new_button.set_popover(Some(&new_popover));
+        // Populate menus initially and refresh on popover show.
+        self.refresh_host_menus();
+
         let win = self.clone();
-        let popover_ref = new_popover.clone();
-        new_popover.connect_show(move |_| {
-            win.populate_host_popover(&popover_ref, HostMenuAction::New);
+        imp.new_button.connect_notify_local(Some("active"), move |_, _| {
+            win.refresh_host_menus();
         });
 
-        // "Connect to Existing" button: populate host menu on click, each
-        // item opens the browse-remote-runtimes flow for that host.
-        let connect_popover = gtk4::Popover::new();
-        imp.connect_button.set_popover(Some(&connect_popover));
         let win = self.clone();
-        let popover_ref = connect_popover.clone();
-        connect_popover.connect_show(move |_| {
-            win.populate_host_popover(&popover_ref, HostMenuAction::Connect);
+        imp.connect_button.connect_notify_local(Some("active"), move |_, _| {
+            win.refresh_host_menus();
         });
     }
 
-    fn populate_host_popover(&self, popover: &gtk4::Popover, action: HostMenuAction) {
+    fn refresh_host_menus(&self) {
         use crate::host::{self, Host};
-
-        let list_box = gtk4::ListBox::new();
-        list_box.set_selection_mode(gtk4::SelectionMode::None);
-        list_box.add_css_class("boxed-list");
 
         let mut hosts: Vec<Host> = vec![Host::local()];
         let saved = host::load();
@@ -519,56 +502,68 @@ impl Window {
         remotes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
         hosts.extend(remotes);
 
-        for host in hosts {
-            let row = adw::ActionRow::new();
-            row.set_title(&host.name);
-            if host.is_remote()
-                && let Some(ref target) = host.ssh_target
-            {
-                row.set_subtitle(target);
-            }
-            row.set_activatable(true);
+        let new_menu = gtk4::gio::Menu::new();
+        let connect_menu = gtk4::gio::Menu::new();
 
-            let win = self.clone();
-            let popover = popover.clone();
-            let host_key = host.key.clone();
-            let ssh_target = host.ssh_target.clone();
-            let is_local = host.is_local();
-            row.connect_activated(move |_| {
-                popover.popdown();
-                match action {
-                    HostMenuAction::New => {
-                        if is_local {
-                            win.add_managed_session(WorkspacePolicy::Persistent);
-                        } else if let Some(ref target) = ssh_target {
-                            win.add_remote_managed_session(target);
-                        } else {
-                            win.add_remote_managed_session(&host_key);
-                        }
-                    }
-                    HostMenuAction::Connect => {
-                        if is_local {
-                            win.browse_local_runtimes();
-                        } else if let Some(ref target) = ssh_target {
-                            win.browse_remote_runtimes(target);
-                        } else {
-                            win.browse_remote_runtimes(&host_key);
-                        }
-                    }
-                }
-            });
+        for host in &hosts {
+            let new_item = gtk4::gio::MenuItem::new(Some(&host.name), None);
+            new_item.set_action_and_target_value(
+                Some("win.new-for-host"),
+                Some(&host.key.to_variant()),
+            );
+            new_menu.append_item(&new_item);
 
-            list_box.append(&row);
+            let connect_item = gtk4::gio::MenuItem::new(Some(&host.name), None);
+            connect_item.set_action_and_target_value(
+                Some("win.connect-for-host"),
+                Some(&host.key.to_variant()),
+            );
+            connect_menu.append_item(&connect_item);
         }
 
-        let scroll = gtk4::ScrolledWindow::builder()
-            .hscrollbar_policy(gtk4::PolicyType::Never)
-            .max_content_height(400)
-            .propagate_natural_height(true)
-            .child(&list_box)
-            .build();
+        self.imp().new_button.set_menu_model(Some(&new_menu));
+        self.imp().connect_button.set_menu_model(Some(&connect_menu));
 
-        popover.set_child(Some(&scroll));
+        // Register host-specific actions.
+        let new_action =
+            gtk4::gio::SimpleAction::new("new-for-host", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        new_action.connect_activate(move |_, param| {
+            let key: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            win.new_workspace_for_host(&key);
+        });
+        self.add_action(&new_action);
+
+        let connect_action =
+            gtk4::gio::SimpleAction::new("connect-for-host", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        connect_action.connect_activate(move |_, param| {
+            let key: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            win.connect_for_host(&key);
+        });
+        self.add_action(&connect_action);
+    }
+
+    fn new_workspace_for_host(&self, host_key: &str) {
+        if host_key == crate::host::LOCAL_KEY {
+            self.add_managed_session(WorkspacePolicy::Persistent);
+        } else {
+            let saved = crate::host::load();
+            let host = crate::host::resolve(host_key, &saved);
+            let target = host.ssh_target.as_deref().unwrap_or(host_key);
+            self.add_remote_managed_session(target);
+        }
+    }
+
+    fn connect_for_host(&self, host_key: &str) {
+        if host_key == crate::host::LOCAL_KEY {
+            self.browse_local_runtimes();
+        } else {
+            let saved = crate::host::load();
+            let host = crate::host::resolve(host_key, &saved);
+            let target = host.ssh_target.as_deref().unwrap_or(host_key);
+            self.browse_remote_runtimes(target);
+        }
     }
 
     fn append_session_row(&self, session_state: &SessionState) {

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -35,6 +35,12 @@ mod runtime;
 mod sidebar;
 mod terminal;
 
+#[derive(Debug, Clone, Copy)]
+enum HostMenuAction {
+    New,
+    Connect,
+}
+
 mod imp {
     use super::*;
     use std::cell::RefCell;
@@ -56,7 +62,9 @@ mod imp {
         pub command_scroll: gtk4::ScrolledWindow,
         pub command_empty: adw::StatusPage,
         pub toast_overlay: adw::ToastOverlay,
-        pub add_session_button: gtk4::Button,
+        pub new_button: gtk4::MenuButton,
+        pub connect_button: gtk4::MenuButton,
+        pub new_direct_button: gtk4::Button,
         pub state: RefCell<WindowState>,
         pub terminals: RefCell<HashMap<String, TerminalWidget>>,
         pub persistent_terminals: RefCell<HashMap<String, PersistentPaneView>>,
@@ -90,9 +98,22 @@ mod imp {
             toggle_sidebar.set_active(true);
             header.pack_start(&toggle_sidebar);
 
-            self.add_session_button.set_icon_name("list-add-symbolic");
-            self.add_session_button.set_tooltip_text(Some("New persistent workspace"));
-            header.pack_start(&self.add_session_button);
+            self.new_button.set_label("New");
+            self.new_button.set_tooltip_text(Some("New workspace"));
+            self.new_button.set_icon_name("list-add-symbolic");
+            self.new_button.add_css_class("flat");
+            header.pack_start(&self.new_button);
+
+            self.connect_button.set_label("Connect");
+            self.connect_button.set_tooltip_text(Some("Connect to existing workspace"));
+            self.connect_button.set_icon_name("network-server-symbolic");
+            self.connect_button.add_css_class("flat");
+            header.pack_start(&self.connect_button);
+
+            self.new_direct_button.set_label("Direct");
+            self.new_direct_button.set_tooltip_text(Some("New direct workspace"));
+            self.new_direct_button.add_css_class("flat");
+            header.pack_start(&self.new_direct_button);
 
             if let Some(label) = config::badge_label() {
                 self.devel_badge.set_label(label);
@@ -114,10 +135,6 @@ mod imp {
             menu_button.set_icon_name("open-menu-symbolic");
 
             let menu = gtk4::gio::Menu::new();
-            menu.append(Some("New Persistent Workspace"), Some("win.new-session"));
-            menu.append(Some("New Ephemeral Workspace"), Some("win.new-ephemeral-workspace"));
-            menu.append(Some("New Remote Workspace"), Some("win.new-remote-workspace"));
-            menu.append(Some("Attach to Remote Runtime"), Some("win.browse-remote-runtimes"));
             menu.append(Some("About rttx"), Some("win.about"));
             menu.append(Some("Bookmark This Workspace"), Some("win.bookmark-session"));
             menu.append(Some("Preferences"), Some("win.preferences"));
@@ -426,9 +443,11 @@ impl Window {
 
     fn setup_signals(&self) {
         let win = self.clone();
-        self.imp().add_session_button.connect_clicked(move |_| {
-            win.add_session();
+        self.imp().new_direct_button.connect_clicked(move |_| {
+            win.add_direct_session();
         });
+
+        self.setup_host_menu_buttons();
 
         let win = self.clone();
         self.imp().sidebar_list.connect_row_selected(move |_, row| {
@@ -461,6 +480,95 @@ impl Window {
 
         self.refresh_bookmark_sidebar();
         self.refresh_command_sidebar();
+    }
+
+    fn setup_host_menu_buttons(&self) {
+        let imp = self.imp();
+
+        // "New" button: populate host menu on click, each item creates a
+        // new daemon-backed workspace for that host.
+        let new_popover = gtk4::Popover::new();
+        imp.new_button.set_popover(Some(&new_popover));
+        let win = self.clone();
+        let popover_ref = new_popover.clone();
+        new_popover.connect_show(move |_| {
+            win.populate_host_popover(&popover_ref, HostMenuAction::New);
+        });
+
+        // "Connect to Existing" button: populate host menu on click, each
+        // item opens the browse-remote-runtimes flow for that host.
+        let connect_popover = gtk4::Popover::new();
+        imp.connect_button.set_popover(Some(&connect_popover));
+        let win = self.clone();
+        let popover_ref = connect_popover.clone();
+        connect_popover.connect_show(move |_| {
+            win.populate_host_popover(&popover_ref, HostMenuAction::Connect);
+        });
+    }
+
+    fn populate_host_popover(&self, popover: &gtk4::Popover, action: HostMenuAction) {
+        use crate::host::{self, Host};
+
+        let list_box = gtk4::ListBox::new();
+        list_box.set_selection_mode(gtk4::SelectionMode::None);
+        list_box.add_css_class("boxed-list");
+
+        let mut hosts: Vec<Host> = vec![Host::local()];
+        let saved = host::load();
+        let mut remotes: Vec<Host> = saved.into_iter().filter(Host::is_remote).collect();
+        remotes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        hosts.extend(remotes);
+
+        for host in hosts {
+            let row = adw::ActionRow::new();
+            row.set_title(&host.name);
+            if host.is_remote()
+                && let Some(ref target) = host.ssh_target
+            {
+                row.set_subtitle(target);
+            }
+            row.set_activatable(true);
+
+            let win = self.clone();
+            let popover = popover.clone();
+            let host_key = host.key.clone();
+            let ssh_target = host.ssh_target.clone();
+            let is_local = host.is_local();
+            row.connect_activated(move |_| {
+                popover.popdown();
+                match action {
+                    HostMenuAction::New => {
+                        if is_local {
+                            win.add_managed_session(WorkspacePolicy::Persistent);
+                        } else if let Some(ref target) = ssh_target {
+                            win.add_remote_managed_session(target);
+                        } else {
+                            win.add_remote_managed_session(&host_key);
+                        }
+                    }
+                    HostMenuAction::Connect => {
+                        if is_local {
+                            win.browse_local_runtimes();
+                        } else if let Some(ref target) = ssh_target {
+                            win.browse_remote_runtimes(target);
+                        } else {
+                            win.browse_remote_runtimes(&host_key);
+                        }
+                    }
+                }
+            });
+
+            list_box.append(&row);
+        }
+
+        let scroll = gtk4::ScrolledWindow::builder()
+            .hscrollbar_policy(gtk4::PolicyType::Never)
+            .max_content_height(400)
+            .propagate_natural_height(true)
+            .child(&list_box)
+            .build();
+
+        popover.set_child(Some(&scroll));
     }
 
     fn append_session_row(&self, session_state: &SessionState) {

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -96,17 +96,23 @@ mod imp {
             self.new_button.set_tooltip_text(Some("New workspace"));
             self.new_button.set_icon_name("list-add-symbolic");
             self.new_button.add_css_class("flat");
+            self.new_button
+                .update_property(&[gtk4::accessible::Property::Label("New workspace")]);
             header.pack_start(&self.new_button);
 
             self.connect_button.set_label("Connect");
             self.connect_button.set_tooltip_text(Some("Connect to existing workspace"));
             self.connect_button.set_icon_name("network-server-symbolic");
             self.connect_button.add_css_class("flat");
+            self.connect_button
+                .update_property(&[gtk4::accessible::Property::Label("Connect to existing")]);
             header.pack_start(&self.connect_button);
 
             self.new_direct_button.set_label("Direct");
             self.new_direct_button.set_tooltip_text(Some("New direct workspace"));
             self.new_direct_button.add_css_class("flat");
+            self.new_direct_button
+                .update_property(&[gtk4::accessible::Property::Label("New direct workspace")]);
             header.pack_start(&self.new_direct_button);
 
             if let Some(label) = config::badge_label() {

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -9,6 +9,22 @@ impl Window {
         self.add_managed_session(WorkspacePolicy::Ephemeral);
     }
 
+    pub(super) fn add_direct_session(&self) {
+        let imp = self.imp();
+        let count = imp.state.borrow().sessions.len() + 1;
+        let initial_cwd = self.resolve_default_session_folder();
+        let name = format!("Direct {count}");
+        let mut session_state = SessionState::new_with_initial_cwd(name, initial_cwd);
+        session_state.color = self.next_session_color();
+        imp.state.borrow_mut().sessions.push(session_state.clone());
+        self.build_session(&session_state, false);
+
+        let index = imp.state.borrow().sessions.len() as i32 - 1;
+        if let Some(row) = imp.sidebar_list.row_at_index(index) {
+            imp.sidebar_list.select_row(Some(&row));
+        }
+    }
+
     pub(super) fn show_new_remote_workspace_dialog(&self) {
         let dialog =
             adw::Dialog::builder().title("New Remote Workspace").content_width(440).build();
@@ -100,7 +116,7 @@ impl Window {
         dialog.present(Some(self));
     }
 
-    fn browse_remote_runtimes(&self, host: &str) {
+    pub(super) fn browse_remote_runtimes(&self, host: &str) {
         if !self.ensure_connection_manager() {
             return;
         }
@@ -111,7 +127,17 @@ impl Window {
         self.show_toast(&format!("Connecting to {host}…"));
     }
 
-    fn add_remote_managed_session(&self, host: &str) {
+    pub(super) fn browse_local_runtimes(&self) {
+        if !self.ensure_connection_manager() {
+            return;
+        }
+        if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
+            manager.refresh_inventory(&RuntimeEndpoint::Local);
+        }
+        self.show_toast("Scanning local runtimes…");
+    }
+
+    pub(super) fn add_remote_managed_session(&self, host: &str) {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
         let endpoint = RuntimeEndpoint::Remote { host: host.to_string() };

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3917,10 +3917,7 @@ fn new_direct_creates_non_managed_session() {
     let state = window.imp().state.borrow();
     assert_eq!(state.sessions.len(), initial_count + 1, "direct session should be added");
     let new_session = state.sessions.last().unwrap();
-    assert!(
-        !new_session.uses_managed_runtime(),
-        "direct session should not use managed runtime"
-    );
+    assert!(!new_session.uses_managed_runtime(), "direct session should not use managed runtime");
     assert!(
         new_session.name.starts_with("Direct"),
         "direct session name should start with 'Direct'"
@@ -3938,9 +3935,8 @@ fn keyboard_shortcut_actions_are_registered() {
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.shortcut-actions-tests")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.shortcut-actions-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
@@ -3949,10 +3945,7 @@ fn keyboard_shortcut_actions_are_registered() {
         window.lookup_action("connect-to-existing").is_some(),
         "connect-to-existing action should be registered"
     );
-    assert!(
-        window.lookup_action("new-direct").is_some(),
-        "new-direct action should be registered"
-    );
+    assert!(window.lookup_action("new-direct").is_some(), "new-direct action should be registered");
     assert!(
         window.lookup_action("new-session").is_some(),
         "new-session action should be registered"

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -254,7 +254,7 @@ fn preferred_command_target_uuid_falls_back_to_visible_session() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn add_session_button_has_plus_icon() {
+fn top_bar_has_new_connect_direct_buttons() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
@@ -262,15 +262,25 @@ fn add_session_button_has_plus_icon() {
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
     let app =
-        adw::Application::builder().application_id("com.illya.rttx.add-session-icon-tests").build();
+        adw::Application::builder().application_id("com.illya.rttx.top-bar-buttons-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
 
     assert_eq!(
-        window.imp().add_session_button.icon_name().as_deref(),
-        Some("list-add-symbolic"),
-        "new session button should expose the plus icon"
+        window.imp().new_button.label().as_deref(),
+        Some("New"),
+        "New button should have 'New' label"
+    );
+    assert_eq!(
+        window.imp().connect_button.label().as_deref(),
+        Some("Connect"),
+        "Connect button should have 'Connect' label"
+    );
+    assert_eq!(
+        window.imp().new_direct_button.label().as_deref(),
+        Some("Direct"),
+        "Direct button should have 'Direct' label"
     );
 
     window.close();
@@ -3883,4 +3893,70 @@ fn swap_terminals_works_for_managed_panes() {
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn new_direct_creates_non_managed_session() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.new-direct-session-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let initial_count = window.imp().state.borrow().sessions.len();
+
+    window.add_direct_session();
+
+    let state = window.imp().state.borrow();
+    assert_eq!(state.sessions.len(), initial_count + 1, "direct session should be added");
+    let new_session = state.sessions.last().unwrap();
+    assert!(
+        !new_session.uses_managed_runtime(),
+        "direct session should not use managed runtime"
+    );
+    assert!(
+        new_session.name.starts_with("Direct"),
+        "direct session name should start with 'Direct'"
+    );
+
+    window.close();
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn keyboard_shortcut_actions_are_registered() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.shortcut-actions-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    assert!(
+        window.lookup_action("connect-to-existing").is_some(),
+        "connect-to-existing action should be registered"
+    );
+    assert!(
+        window.lookup_action("new-direct").is_some(),
+        "new-direct action should be registered"
+    );
+    assert!(
+        window.lookup_action("new-session").is_some(),
+        "new-session action should be registered"
+    );
+
+    window.close();
 }

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -28,11 +28,11 @@ class TestManagedBlackBox(unittest.TestCase):
         click(button)
         import time
         time.sleep(0.5)
-        local_row = self.fixture.wait_for_showing_name(
-            Atspi.Role.LIST_ITEM, "Local", timeout=5.0
+        local_item = self.fixture.wait_for_showing_name(
+            Atspi.Role.MENU_ITEM, "Local", timeout=5.0
         )
-        self.assertIsNotNone(local_row, "Local host row not visible in New menu")
-        click(local_row)
+        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
+        click(local_item)
 
         close_pane = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0
@@ -145,11 +145,11 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
         click(button)
         import time
         time.sleep(0.5)
-        local_row = self.fixture.wait_for_showing_name(
-            Atspi.Role.LIST_ITEM, "Local", timeout=5.0
+        local_item = self.fixture.wait_for_showing_name(
+            Atspi.Role.MENU_ITEM, "Local", timeout=5.0
         )
-        self.assertIsNotNone(local_row, "Local host row not visible in New menu")
-        click(local_row)
+        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
+        click(local_item)
 
         close_pane = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -22,10 +22,17 @@ class TestManagedBlackBox(unittest.TestCase):
 
     def _create_managed_workspace(self) -> None:
         button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "New persistent workspace"
+            Atspi.Role.TOGGLE_BUTTON, "New workspace"
         )
-        self.assertIsNotNone(button, "persistent workspace button not visible")
+        self.assertIsNotNone(button, "New workspace button not visible")
         click(button)
+        import time
+        time.sleep(0.5)
+        local_row = self.fixture.wait_for_showing_name(
+            Atspi.Role.LIST_ITEM, "Local", timeout=5.0
+        )
+        self.assertIsNotNone(local_row, "Local host row not visible in New menu")
+        click(local_row)
 
         close_pane = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0
@@ -132,10 +139,17 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
     def test_managed_pane_exit_is_visible_when_shell_exits(self) -> None:
         """A daemon PaneExited event must leave a clear, non-hanging pane."""
         button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "New persistent workspace"
+            Atspi.Role.TOGGLE_BUTTON, "New workspace"
         )
-        self.assertIsNotNone(button, "persistent workspace button not visible")
+        self.assertIsNotNone(button, "New workspace button not visible")
         click(button)
+        import time
+        time.sleep(0.5)
+        local_row = self.fixture.wait_for_showing_name(
+            Atspi.Role.LIST_ITEM, "Local", timeout=5.0
+        )
+        self.assertIsNotNone(local_row, "Local host row not visible in New menu")
+        click(local_row)
 
         close_pane = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -131,11 +131,11 @@ class TestSidebarContentManaged(unittest.TestCase):
         click(button)
         import time
         time.sleep(0.5)
-        local_row = self.fixture.wait_for_showing_name(
-            Atspi.Role.LIST_ITEM, "Local", timeout=5.0
+        local_item = self.fixture.wait_for_showing_name(
+            Atspi.Role.MENU_ITEM, "Local", timeout=5.0
         )
-        self.assertIsNotNone(local_row, "Local host row not visible in New menu")
-        click(local_row)
+        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
+        click(local_item)
         self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0
         )

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -125,10 +125,17 @@ class TestSidebarContentManaged(unittest.TestCase):
 
     def _create_managed_workspace(self) -> None:
         button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "New persistent workspace"
+            Atspi.Role.TOGGLE_BUTTON, "New workspace"
         )
-        self.assertIsNotNone(button, "persistent workspace button not visible")
+        self.assertIsNotNone(button, "New workspace button not visible")
         click(button)
+        import time
+        time.sleep(0.5)
+        local_row = self.fixture.wait_for_showing_name(
+            Atspi.Role.LIST_ITEM, "Local", timeout=5.0
+        )
+        self.assertIsNotNone(local_row, "Local host row not visible in New menu")
+        click(local_row)
         self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0
         )

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.9',
+  version: '0.2.10',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Replaces the single `add_session_button` (plus icon) in the header bar with three intent-driven controls per RFC-016 Section 1:

- **New** (MenuButton dropdown): Lists local host + saved remote hosts. Selecting a host creates a new daemon-backed workspace for that host.
- **Connect** (MenuButton dropdown): Lists local host + saved remote hosts. Selecting a host browses existing runtimes on that host.
- **Direct** (Button): Creates a new direct (non-daemon) workspace immediately.

### Keyboard shortcuts

| Action | Shortcut |
|--------|----------|
| New workspace | Ctrl+Shift+T |
| Connect to existing | Ctrl+Shift+A |
| New direct | Ctrl+Shift+D |

Old workspace creation entries removed from the hamburger menu since they are now accessible from the top bar.

## Manual verification steps

1. Launch rttx — header bar shows New, Connect, Direct buttons
2. Click New → dropdown shows Local (and any saved remote hosts)
3. Click Local → creates a new daemon-backed workspace
4. Click Connect → dropdown shows Local (and any saved remote hosts)
5. Click Direct → creates a direct workspace named 'Direct N'
6. Ctrl+Shift+T creates a new local workspace
7. Ctrl+Shift+A triggers local runtime scan
8. Ctrl+Shift+D creates a direct workspace

## Tests added

- `top_bar_has_new_connect_direct_buttons` — GTK test verifying all three buttons exist with correct labels
- `new_direct_creates_non_managed_session` — GTK test verifying direct session creation produces a non-managed session
- `keyboard_shortcut_actions_are_registered` — GTK test verifying connect-to-existing, new-direct, and new-session actions are registered

## Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (39 passed, 0 failed)
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass including new ones)
- `./run_ui_tests.sh` — pre-existing failures only (7 baseline → same set with updated AT-SPI tests)

## Remaining limitations

- The New and Connect dropdowns currently show a flat list. The New Workspace dialog (RFC-016 Section 3) and Connect to Existing dialog (RFC-016 Section 4) are separate issues.
- Ephemeral workspace creation is still available via the `new-ephemeral-workspace` action but no longer has a keyboard shortcut.

Fixes #425