### PR TITLE
feat: add New Workspace dialog with host-scoped place selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.9"
+version = "0.2.10"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -8,6 +8,7 @@ pub mod daemon;
 pub mod daemon_bridge;
 pub mod form_dialog;
 pub mod host;
+pub mod places;
 pub mod preferences;
 pub mod runtime;
 pub mod session;

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -8,6 +8,7 @@ pub mod daemon;
 pub mod daemon_bridge;
 pub mod form_dialog;
 pub mod host;
+pub mod new_workspace_dialog;
 pub mod places;
 pub mod preferences;
 pub mod runtime;

--- a/clients/rttx/src/new_workspace_dialog.rs
+++ b/clients/rttx/src/new_workspace_dialog.rs
@@ -22,9 +22,7 @@ pub fn show(window: &Window, host: &Host) {
     search_entry.set_margin_end(18);
     search_entry.set_margin_top(12);
 
-    let list_box = gtk4::ListBox::new();
-    list_box.set_selection_mode(gtk4::SelectionMode::None);
-    list_box.add_css_class("boxed-list");
+    let list_box = gtk4::Box::new(gtk4::Orientation::Vertical, 4);
     list_box.set_margin_start(18);
     list_box.set_margin_end(18);
     list_box.set_margin_top(12);
@@ -48,35 +46,38 @@ pub fn show(window: &Window, host: &Host) {
     dialog.set_child(Some(&toolbar_view));
 
     let host_key = host.key.clone();
-    populate_places(&list_box, &host_key, "");
+    populate_places(&list_box, &host_key, "", window, host, &dialog);
 
-    let list_for_search = list_box.clone();
     let host_key_for_search = host_key;
+    let win_for_search = window.clone();
+    let host_for_search = host.clone();
+    let dialog_for_search = dialog.clone();
     search_entry.connect_changed(move |entry| {
         let query = entry.text().to_string();
-        populate_places(&list_for_search, &host_key_for_search, &query);
-    });
-
-    let win = window.clone();
-    let host_clone = host.clone();
-    let dialog_ref = dialog.clone();
-    list_box.connect_row_activated(move |_, row| {
-        let Some(action_row) = row.child().and_then(|c| c.downcast::<adw::ActionRow>().ok()) else {
-            return;
-        };
-        let path = action_row.subtitle().map(|s| s.to_string()).unwrap_or_default();
-        let name = action_row.title().to_string();
-        dialog_ref.close();
-        create_workspace_at_place(&win, &host_clone, &name, &path);
+        populate_places(
+            &list_box,
+            &host_key_for_search,
+            &query,
+            &win_for_search,
+            &host_for_search,
+            &dialog_for_search,
+        );
     });
 
     dialog.present(Some(window));
     search_entry.grab_focus();
 }
 
-fn populate_places(list_box: &gtk4::ListBox, host_key: &str, query: &str) {
-    while let Some(row) = list_box.row_at_index(0) {
-        list_box.remove(&row);
+fn populate_places(
+    container: &gtk4::Box,
+    host_key: &str,
+    query: &str,
+    window: &Window,
+    host: &Host,
+    dialog: &adw::Dialog,
+) {
+    while let Some(child) = container.first_child() {
+        container.remove(&child);
     }
 
     let saved = places::load();
@@ -98,9 +99,9 @@ fn populate_places(list_box: &gtk4::ListBox, host_key: &str, query: &str) {
             label.add_css_class("dim-label");
             label.add_css_class("caption");
             label.set_margin_start(6);
-            label.set_margin_top(12);
-            label.set_margin_bottom(4);
-            list_box.append(&label);
+            label.set_margin_top(8);
+            label.set_margin_bottom(2);
+            container.append(&label);
         } else if !is_builtin && !has_saved {
             has_saved = true;
             let label = gtk4::Label::new(Some("Saved Places"));
@@ -108,18 +109,56 @@ fn populate_places(list_box: &gtk4::ListBox, host_key: &str, query: &str) {
             label.add_css_class("dim-label");
             label.add_css_class("caption");
             label.set_margin_start(6);
-            label.set_margin_top(12);
-            label.set_margin_bottom(4);
-            list_box.append(&label);
+            label.set_margin_top(8);
+            label.set_margin_bottom(2);
+            container.append(&label);
         }
 
-        let row = adw::ActionRow::builder()
-            .title(&place.name)
-            .subtitle(&place.path)
-            .activatable(true)
-            .build();
-        row.add_prefix(&gtk4::Image::from_icon_name(place_icon(place)));
-        list_box.append(&row);
+        let icon = gtk4::Image::from_icon_name(place_icon(place));
+        icon.set_margin_end(8);
+
+        let title_label = gtk4::Label::new(Some(&place.name));
+        title_label.set_xalign(0.0);
+        title_label.set_hexpand(true);
+        title_label.add_css_class("body");
+
+        let subtitle_label = gtk4::Label::new(Some(&place.path));
+        subtitle_label.set_xalign(0.0);
+        subtitle_label.add_css_class("dim-label");
+        subtitle_label.add_css_class("caption");
+
+        let text_box = gtk4::Box::new(gtk4::Orientation::Vertical, 2);
+        text_box.append(&title_label);
+        text_box.append(&subtitle_label);
+
+        let row_content = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+        row_content.set_margin_start(12);
+        row_content.set_margin_end(12);
+        row_content.set_margin_top(8);
+        row_content.set_margin_bottom(8);
+        row_content.append(&icon);
+        row_content.append(&text_box);
+
+        let button = gtk4::Button::new();
+        button.set_child(Some(&row_content));
+        button.add_css_class("flat");
+        button.update_property(&[gtk4::accessible::Property::Label(&place.name)]);
+
+        let win = window.clone();
+        let host_clone = host.clone();
+        let dialog_ref = dialog.clone();
+        let path = place.path.clone();
+        button.connect_clicked(move |_| {
+            dialog_ref.close();
+            let initial_cwd = resolve_place_path(&path);
+            if host_clone.is_local() {
+                win.add_managed_session_at(initial_cwd);
+            } else if let Some(ssh_target) = &host_clone.ssh_target {
+                win.add_remote_managed_session_at(ssh_target, initial_cwd);
+            }
+        });
+
+        container.append(&button);
     }
 }
 
@@ -130,15 +169,6 @@ fn place_icon(place: &Place) -> &'static str {
         "drive-harddisk-symbolic"
     } else {
         "folder-symbolic"
-    }
-}
-
-fn create_workspace_at_place(window: &Window, host: &Host, _name: &str, path: &str) {
-    let initial_cwd = resolve_place_path(path);
-    if host.is_local() {
-        window.add_managed_session_at(initial_cwd);
-    } else if let Some(ssh_target) = &host.ssh_target {
-        window.add_remote_managed_session_at(ssh_target, initial_cwd);
     }
 }
 

--- a/clients/rttx/src/new_workspace_dialog.rs
+++ b/clients/rttx/src/new_workspace_dialog.rs
@@ -1,0 +1,211 @@
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use crate::host::Host;
+use crate::places::{self, Place};
+use crate::window::Window;
+
+/// Show the New Workspace dialog for a specific host.
+///
+/// Lists built-in global places (Home, Root) plus saved places scoped to the
+/// host. The user picks a place to create a new daemon-backed workspace.
+pub fn show(window: &Window, host: &Host) {
+    let title = format!("New Workspace: {}", host.name);
+    let dialog = adw::Dialog::builder().title(&title).content_width(400).build();
+
+    let header = adw::HeaderBar::new();
+
+    let search_entry = gtk4::SearchEntry::new();
+    search_entry.set_placeholder_text(Some("Search places…"));
+    search_entry.set_margin_start(18);
+    search_entry.set_margin_end(18);
+    search_entry.set_margin_top(12);
+
+    let list_box = gtk4::ListBox::new();
+    list_box.set_selection_mode(gtk4::SelectionMode::None);
+    list_box.add_css_class("boxed-list");
+    list_box.set_margin_start(18);
+    list_box.set_margin_end(18);
+    list_box.set_margin_top(12);
+    list_box.set_margin_bottom(18);
+    list_box.update_property(&[gtk4::accessible::Property::Label("Places")]);
+
+    let scroll = gtk4::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .vexpand(true)
+        .min_content_height(200)
+        .child(&list_box)
+        .build();
+
+    let content = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+    content.append(&search_entry);
+    content.append(&scroll);
+
+    let toolbar_view = adw::ToolbarView::new();
+    toolbar_view.add_top_bar(&header);
+    toolbar_view.set_content(Some(&content));
+    dialog.set_child(Some(&toolbar_view));
+
+    let host_key = host.key.clone();
+    populate_places(&list_box, &host_key, "");
+
+    let list_for_search = list_box.clone();
+    let host_key_for_search = host_key;
+    search_entry.connect_changed(move |entry| {
+        let query = entry.text().to_string();
+        populate_places(&list_for_search, &host_key_for_search, &query);
+    });
+
+    let win = window.clone();
+    let host_clone = host.clone();
+    let dialog_ref = dialog.clone();
+    list_box.connect_row_activated(move |_, row| {
+        let Some(action_row) = row.child().and_then(|c| c.downcast::<adw::ActionRow>().ok())
+        else {
+            return;
+        };
+        let path = action_row.subtitle().map(|s| s.to_string()).unwrap_or_default();
+        let name = action_row.title().to_string();
+        dialog_ref.close();
+        create_workspace_at_place(&win, &host_clone, &name, &path);
+    });
+
+    dialog.present(Some(window));
+    search_entry.grab_focus();
+}
+
+fn populate_places(list_box: &gtk4::ListBox, host_key: &str, query: &str) {
+    while let Some(row) = list_box.row_at_index(0) {
+        list_box.remove(&row);
+    }
+
+    let saved = places::load();
+    let visible = places::visible_for_host(&saved, host_key);
+
+    let mut has_builtin = false;
+    let mut has_saved = false;
+
+    for place in &visible {
+        if !places::matches_query(place, query) {
+            continue;
+        }
+
+        let is_builtin = place.uuid.starts_with("builtin:");
+        if is_builtin && !has_builtin {
+            has_builtin = true;
+            let label = gtk4::Label::new(Some("Suggested"));
+            label.set_xalign(0.0);
+            label.add_css_class("dim-label");
+            label.add_css_class("caption");
+            label.set_margin_start(6);
+            label.set_margin_top(12);
+            label.set_margin_bottom(4);
+            list_box.append(&label);
+        } else if !is_builtin && !has_saved {
+            has_saved = true;
+            let label = gtk4::Label::new(Some("Saved Places"));
+            label.set_xalign(0.0);
+            label.add_css_class("dim-label");
+            label.add_css_class("caption");
+            label.set_margin_start(6);
+            label.set_margin_top(12);
+            label.set_margin_bottom(4);
+            list_box.append(&label);
+        }
+
+        let row = adw::ActionRow::builder()
+            .title(&place.name)
+            .subtitle(&place.path)
+            .activatable(true)
+            .build();
+        row.add_prefix(&gtk4::Image::from_icon_name(place_icon(place)));
+        list_box.append(&row);
+    }
+}
+
+fn place_icon(place: &Place) -> &'static str {
+    if place.uuid == "builtin:home" {
+        "user-home-symbolic"
+    } else if place.uuid == "builtin:root" {
+        "drive-harddisk-symbolic"
+    } else {
+        "folder-symbolic"
+    }
+}
+
+fn create_workspace_at_place(window: &Window, host: &Host, _name: &str, path: &str) {
+    let initial_cwd = resolve_place_path(path);
+    if host.is_local() {
+        window.add_managed_session_at(initial_cwd);
+    } else if let Some(ssh_target) = &host.ssh_target {
+        window.add_remote_managed_session_at(ssh_target, initial_cwd);
+    }
+}
+
+/// Resolve `~` to the actual home directory for local paths.
+fn resolve_place_path(path: &str) -> Option<String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() || trimmed == "~" {
+        return None; // Home — let the shell decide
+    }
+    if trimmed == "/" {
+        return Some("/".into());
+    }
+    if let Some(rest) = trimmed.strip_prefix("~/")
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return Some(format!("{home}/{rest}"));
+    }
+    Some(trimmed.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_tilde_returns_none_for_home() {
+        assert_eq!(resolve_place_path("~"), None);
+    }
+
+    #[test]
+    fn resolve_empty_returns_none() {
+        assert_eq!(resolve_place_path(""), None);
+    }
+
+    #[test]
+    fn resolve_root_returns_root() {
+        assert_eq!(resolve_place_path("/"), Some("/".into()));
+    }
+
+    #[test]
+    fn resolve_absolute_path_unchanged() {
+        assert_eq!(resolve_place_path("/srv/app"), Some("/srv/app".into()));
+    }
+
+    #[test]
+    fn resolve_tilde_prefix_expands_home() {
+        let result = resolve_place_path("~/projects");
+        assert!(result.is_some());
+        let resolved = result.unwrap();
+        assert!(resolved.ends_with("/projects"));
+        assert!(!resolved.starts_with('~'));
+    }
+
+    #[test]
+    fn place_icon_home_is_user_home() {
+        assert_eq!(place_icon(&places::builtin_home()), "user-home-symbolic");
+    }
+
+    #[test]
+    fn place_icon_root_is_drive() {
+        assert_eq!(place_icon(&places::builtin_root()), "drive-harddisk-symbolic");
+    }
+
+    #[test]
+    fn place_icon_saved_is_folder() {
+        let place = Place::new("rttx", "~/pro/rttx");
+        assert_eq!(place_icon(&place), "folder-symbolic");
+    }
+}

--- a/clients/rttx/src/new_workspace_dialog.rs
+++ b/clients/rttx/src/new_workspace_dialog.rs
@@ -61,8 +61,7 @@ pub fn show(window: &Window, host: &Host) {
     let host_clone = host.clone();
     let dialog_ref = dialog.clone();
     list_box.connect_row_activated(move |_, row| {
-        let Some(action_row) = row.child().and_then(|c| c.downcast::<adw::ActionRow>().ok())
-        else {
+        let Some(action_row) = row.child().and_then(|c| c.downcast::<adw::ActionRow>().ok()) else {
             return;
         };
         let path = action_row.subtitle().map(|s| s.to_string()).unwrap_or_default();

--- a/clients/rttx/src/places.rs
+++ b/clients/rttx/src/places.rs
@@ -1,0 +1,277 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use crate::config;
+
+/// A saved navigation target — a directory path scoped to one or more hosts.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Place {
+    pub uuid: String,
+    pub name: String,
+    pub path: String,
+    /// Host keys this place is scoped to. Empty means global.
+    #[serde(default)]
+    pub host_tags: Vec<String>,
+}
+
+impl Place {
+    #[must_use]
+    pub fn new(name: impl Into<String>, path: impl Into<String>) -> Self {
+        Self {
+            uuid: uuid::Uuid::new_v4().to_string(),
+            name: name.into(),
+            path: path.into(),
+            host_tags: Vec::new(),
+        }
+    }
+
+    /// Display string: name with path in parentheses when they differ.
+    #[must_use]
+    pub fn display_label(&self) -> String {
+        if self.name == self.path || self.path.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{} ({})", self.name, self.path)
+        }
+    }
+}
+
+/// Built-in global place: user home directory.
+#[must_use]
+pub fn builtin_home() -> Place {
+    Place { uuid: "builtin:home".into(), name: "Home".into(), path: "~".into(), host_tags: vec![] }
+}
+
+/// Built-in global place: filesystem root.
+#[must_use]
+pub fn builtin_root() -> Place {
+    Place { uuid: "builtin:root".into(), name: "Root".into(), path: "/".into(), host_tags: vec![] }
+}
+
+/// All built-in global places, in display order.
+#[must_use]
+pub fn builtins() -> Vec<Place> {
+    vec![builtin_home(), builtin_root()]
+}
+
+/// Returns `true` if the place should be visible for the given host key.
+///
+/// Global places (empty `host_tags`) are visible everywhere.
+/// Tagged places are visible only when `host_key` matches one of their tags.
+#[must_use]
+pub fn is_visible_on(place: &Place, host_key: &str) -> bool {
+    place.host_tags.is_empty() || place.host_tags.iter().any(|tag| tag == host_key)
+}
+
+/// Collect places visible on `host_key`: built-ins first, then matching saved places.
+#[must_use]
+pub fn visible_for_host(saved: &[Place], host_key: &str) -> Vec<Place> {
+    let mut result = builtins();
+    result.extend(saved.iter().filter(|p| is_visible_on(p, host_key)).cloned());
+    result
+}
+
+#[must_use]
+pub fn matches_query(place: &Place, query: &str) -> bool {
+    let query = query.trim();
+    if query.is_empty() {
+        return true;
+    }
+    let query = query.to_ascii_lowercase();
+    place.name.to_ascii_lowercase().contains(&query)
+        || place.path.to_ascii_lowercase().contains(&query)
+}
+
+// ── Persistence ─────────────────────────────────────────────────
+
+fn places_path() -> PathBuf {
+    let mut path = config::config_dir_path();
+    path.push("places.json");
+    path
+}
+
+#[must_use]
+pub fn load() -> Vec<Place> {
+    load_from(&places_path())
+}
+
+pub fn save(places: &[Place]) -> Result<(), Box<dyn std::error::Error>> {
+    save_to(places, &places_path())
+}
+
+#[must_use]
+pub fn load_from(path: &Path) -> Vec<Place> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|data| serde_json::from_str::<Vec<Place>>(&data).ok())
+        .unwrap_or_default()
+}
+
+pub fn save_to(places: &[Place], path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(places)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    // ── Built-in places ─────────────────────────────────────────
+
+    #[test]
+    fn builtin_home_has_stable_uuid_and_global_tags() {
+        let home = builtin_home();
+        assert_eq!(home.uuid, "builtin:home");
+        assert_eq!(home.name, "Home");
+        assert_eq!(home.path, "~");
+        assert!(home.host_tags.is_empty());
+    }
+
+    #[test]
+    fn builtin_root_has_stable_uuid_and_global_tags() {
+        let root = builtin_root();
+        assert_eq!(root.uuid, "builtin:root");
+        assert_eq!(root.name, "Root");
+        assert_eq!(root.path, "/");
+        assert!(root.host_tags.is_empty());
+    }
+
+    #[test]
+    fn builtins_returns_home_then_root() {
+        let items = builtins();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].name, "Home");
+        assert_eq!(items[1].name, "Root");
+    }
+
+    // ── Display label ───────────────────────────────────────────
+
+    #[test]
+    fn display_label_shows_name_and_path_when_different() {
+        let place = Place::new("rttx", "~/pro/rttx");
+        assert_eq!(place.display_label(), "rttx (~/pro/rttx)");
+    }
+
+    #[test]
+    fn display_label_shows_only_name_when_same_as_path() {
+        let place = Place::new("/srv/app", "/srv/app");
+        assert_eq!(place.display_label(), "/srv/app");
+    }
+
+    #[test]
+    fn display_label_shows_only_name_when_path_empty() {
+        let place = Place { path: String::new(), ..Place::new("Home", "") };
+        assert_eq!(place.display_label(), "Home");
+    }
+
+    // ── Visibility ──────────────────────────────────────────────
+
+    #[test]
+    fn global_place_visible_on_any_host() {
+        let place = Place::new("Global", "/tmp");
+        assert!(is_visible_on(&place, "local"));
+        assert!(is_visible_on(&place, "example.com"));
+    }
+
+    #[test]
+    fn tagged_place_visible_only_on_matching_host() {
+        let mut place = Place::new("Local only", "/home/user");
+        place.host_tags = vec!["local".into()];
+        assert!(is_visible_on(&place, "local"));
+        assert!(!is_visible_on(&place, "example.com"));
+    }
+
+    #[test]
+    fn multi_tagged_place_visible_on_all_tagged_hosts() {
+        let mut place = Place::new("Multi", "/shared");
+        place.host_tags = vec!["local".into(), "example.com".into()];
+        assert!(is_visible_on(&place, "local"));
+        assert!(is_visible_on(&place, "example.com"));
+        assert!(!is_visible_on(&place, "other.com"));
+    }
+
+    // ── visible_for_host ────────────────────────────────────────
+
+    #[test]
+    fn visible_for_host_includes_builtins_and_matching_saved() {
+        let mut local_place = Place::new("rttx", "~/pro/rttx");
+        local_place.host_tags = vec!["local".into()];
+        let mut remote_place = Place::new("app", "/srv/app");
+        remote_place.host_tags = vec!["example.com".into()];
+        let global_place = Place::new("tmp", "/tmp");
+
+        let saved = vec![local_place, remote_place, global_place];
+        let visible = visible_for_host(&saved, "local");
+
+        let names: Vec<&str> = visible.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["Home", "Root", "rttx", "tmp"]);
+    }
+
+    #[test]
+    fn visible_for_host_with_no_saved_returns_only_builtins() {
+        let visible = visible_for_host(&[], "local");
+        assert_eq!(visible.len(), 2);
+        assert_eq!(visible[0].name, "Home");
+        assert_eq!(visible[1].name, "Root");
+    }
+
+    // ── Search ──────────────────────────────────────────────────
+
+    #[test]
+    fn matches_query_by_name() {
+        let place = Place::new("rttx", "~/pro/rttx");
+        assert!(matches_query(&place, "rttx"));
+        assert!(matches_query(&place, "RTT"));
+        assert!(!matches_query(&place, "redis"));
+    }
+
+    #[test]
+    fn matches_query_by_path() {
+        let place = Place::new("rttx", "~/pro/rttx");
+        assert!(matches_query(&place, "pro/rttx"));
+    }
+
+    #[test]
+    fn blank_query_matches_all() {
+        let place = Place::new("Anything", "/any");
+        assert!(matches_query(&place, ""));
+        assert!(matches_query(&place, "   "));
+    }
+
+    // ── Persistence ─────────────────────────────────────────────
+
+    #[test]
+    fn roundtrip_via_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("places.json");
+        let mut place = Place::new("rttx", "~/pro/rttx");
+        place.host_tags = vec!["local".into()];
+
+        save_to(&[place.clone()], &path).unwrap();
+        assert_eq!(load_from(&path), vec![place]);
+    }
+
+    #[test]
+    fn missing_file_returns_empty_list() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+        assert!(load_from(&path).is_empty());
+    }
+
+    #[test]
+    fn legacy_json_without_host_tags_deserializes_with_empty_vec() {
+        let json = r#"[{
+            "uuid": "abc",
+            "name": "Work",
+            "path": "/work"
+        }]"#;
+        let places: Vec<Place> = serde_json::from_str(json).unwrap();
+        assert!(places[0].host_tags.is_empty());
+    }
+}

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl Window {
     pub fn add_session(&self) {
-        self.add_managed_session(WorkspacePolicy::Persistent);
+        crate::new_workspace_dialog::show(self, &crate::host::Host::local());
     }
 
     pub(super) fn add_ephemeral_session(&self) {
@@ -13,7 +13,7 @@ impl Window {
         let dialog =
             adw::Dialog::builder().title("New Remote Workspace").content_width(440).build();
         let header = adw::HeaderBar::new();
-        let create_button = gtk4::Button::with_label("Create");
+        let create_button = gtk4::Button::with_label("Next");
         create_button.add_css_class("suggested-action");
         header.pack_end(&create_button);
 
@@ -42,13 +42,14 @@ impl Window {
         let dialog_ref = dialog.clone();
         let win = self.clone();
         create_button.connect_clicked(move |_| {
-            let host = host_row.text().trim().to_string();
-            if host.is_empty() {
+            let host_text = host_row.text().trim().to_string();
+            if host_text.is_empty() {
                 status_label.set_text("SSH host is required");
                 return;
             }
-            win.add_remote_managed_session(&host);
             dialog_ref.close();
+            let host = crate::host::Host::remote(&host_text);
+            crate::new_workspace_dialog::show(&win, &host);
         });
 
         dialog.present(Some(self));
@@ -111,13 +112,26 @@ impl Window {
         self.show_toast(&format!("Connecting to {host}…"));
     }
 
-    fn add_remote_managed_session(&self, host: &str) {
+    /// Create a new remote managed workspace at a specific path.
+    pub(crate) fn add_remote_managed_session_at(
+        &self,
+        host: &str,
+        initial_cwd: Option<String>,
+    ) {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
         let endpoint = RuntimeEndpoint::Remote { host: host.to_string() };
-        let name = crate::session::state::workspace_display_name(&endpoint, None, count);
-        let mut session_state =
-            SessionState::new_managed_remote(name, host, WorkspacePolicy::Persistent, None);
+        let name = crate::session::state::workspace_display_name(
+            &endpoint,
+            initial_cwd.as_deref(),
+            count,
+        );
+        let mut session_state = SessionState::new_managed_remote(
+            name,
+            host,
+            WorkspacePolicy::Persistent,
+            initial_cwd,
+        );
         session_state.color = self.next_session_color();
         imp.state.borrow_mut().sessions.push(session_state.clone());
         self.build_session(&session_state, false);
@@ -131,9 +145,21 @@ impl Window {
     }
 
     pub(super) fn add_managed_session(&self, policy: WorkspacePolicy) {
+        self.add_managed_session_at_with_policy(policy, self.resolve_default_session_folder());
+    }
+
+    /// Create a new local managed workspace at a specific path.
+    pub(crate) fn add_managed_session_at(&self, initial_cwd: Option<String>) {
+        self.add_managed_session_at_with_policy(WorkspacePolicy::Persistent, initial_cwd);
+    }
+
+    fn add_managed_session_at_with_policy(
+        &self,
+        policy: WorkspacePolicy,
+        initial_cwd: Option<String>,
+    ) {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
-        let initial_cwd = self.resolve_default_session_folder();
         let name = crate::session::state::workspace_display_name(
             &RuntimeEndpoint::Local,
             initial_cwd.as_deref(),

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -113,25 +113,14 @@ impl Window {
     }
 
     /// Create a new remote managed workspace at a specific path.
-    pub(crate) fn add_remote_managed_session_at(
-        &self,
-        host: &str,
-        initial_cwd: Option<String>,
-    ) {
+    pub(crate) fn add_remote_managed_session_at(&self, host: &str, initial_cwd: Option<String>) {
         let imp = self.imp();
         let count = imp.state.borrow().sessions.len() + 1;
         let endpoint = RuntimeEndpoint::Remote { host: host.to_string() };
-        let name = crate::session::state::workspace_display_name(
-            &endpoint,
-            initial_cwd.as_deref(),
-            count,
-        );
-        let mut session_state = SessionState::new_managed_remote(
-            name,
-            host,
-            WorkspacePolicy::Persistent,
-            initial_cwd,
-        );
+        let name =
+            crate::session::state::workspace_display_name(&endpoint, initial_cwd.as_deref(), count);
+        let mut session_state =
+            SessionState::new_managed_remote(name, host, WorkspacePolicy::Persistent, initial_cwd);
         session_state.color = self.next_session_color();
         imp.state.borrow_mut().sessions.push(session_state.clone());
         self.build_session(&session_state, false);

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1732,3 +1732,54 @@ fn persistent_pane_forwards_vte_commit_to_daemon_input() {
 
     window.close();
 }
+
+// ── New Workspace dialog ────────────────────────────────────────
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn new_workspace_dialog_shows_builtin_places_for_local_host() {
+    require_display!();
+
+    let host = rttx::host::Host::local();
+    let saved = rttx::places::visible_for_host(&[], &host.key);
+
+    // Built-in places should always include Home and Root
+    let names: Vec<&str> = saved.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, vec!["Home", "Root"]);
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn new_workspace_dialog_filters_places_by_host_key() {
+    require_display!();
+
+    let mut local_place = rttx::places::Place::new("rttx", "~/pro/rttx");
+    local_place.host_tags = vec!["local".into()];
+    let mut remote_place = rttx::places::Place::new("app", "/srv/app");
+    remote_place.host_tags = vec!["example.com".into()];
+    let global_place = rttx::places::Place::new("tmp", "/tmp");
+
+    let saved = vec![local_place, remote_place, global_place];
+
+    let local_visible = rttx::places::visible_for_host(&saved, "local");
+    let local_names: Vec<&str> = local_visible.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(local_names, vec!["Home", "Root", "rttx", "tmp"]);
+
+    let remote_visible = rttx::places::visible_for_host(&saved, "example.com");
+    let remote_names: Vec<&str> = remote_visible.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(remote_names, vec!["Home", "Root", "app", "tmp"]);
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn new_workspace_dialog_search_filters_places() {
+    require_display!();
+
+    let places = [
+        rttx::places::Place::new("rttx", "~/pro/rttx"),
+        rttx::places::Place::new("redis", "~/src/redis"),
+    ];
+
+    assert_eq!(places.iter().filter(|p| rttx::places::matches_query(p, "rttx")).count(), 1);
+    assert_eq!(places.iter().filter(|p| rttx::places::matches_query(p, "")).count(), 2);
+}

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -27,6 +27,13 @@ class TestManagedBlackBox(unittest.TestCase):
         self.assertIsNotNone(button, "persistent workspace button not visible")
         click(button)
 
+        # The New Workspace dialog opens — select "Home" to create the workspace.
+        home_button = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
+        )
+        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
+        click(home_button)
+
         close_pane = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0
         )
@@ -136,6 +143,13 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
         )
         self.assertIsNotNone(button, "persistent workspace button not visible")
         click(button)
+
+        # The New Workspace dialog opens — select "Home" to create the workspace.
+        home_button = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
+        )
+        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
+        click(home_button)
 
         close_pane = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -129,6 +129,14 @@ class TestSidebarContentManaged(unittest.TestCase):
         )
         self.assertIsNotNone(button, "persistent workspace button not visible")
         click(button)
+
+        # The New Workspace dialog opens — select "Home" to create the workspace.
+        home_button = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
+        )
+        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
+        click(home_button)
+
         self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0
         )

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.9',
+  version: '0.2.10',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Implements #426 — the New Workspace dialog from RFC-016 Section 3.

When the user creates a new workspace (Ctrl+Shift+T for local, or via the
New Remote Workspace menu), a dialog now opens showing places scoped to the
selected host. This replaces the previous behavior of immediately creating
a workspace.

### Changes

1. **Place model** (`places.rs`): New data model for host-scoped navigation
   targets. Places have a name, path, and host_tags (empty = global). Built-in
   global places (Home, Root) are always available. Persistence via
   `places.json`.

2. **New Workspace dialog** (`new_workspace_dialog.rs`): Adwaita dialog that
   shows built-in places (Suggested section) and saved places (Saved Places
   section) filtered by host key. Includes search/filter. Selecting a place
   creates a daemon-backed workspace at that path.

3. **Window wiring** (`window/runtime.rs`):
   - `add_session()` now opens the dialog for the local host
   - Remote workspace dialog chains into the New Workspace dialog
   - New `add_managed_session_at()` and `add_remote_managed_session_at()`
     methods for creating workspaces at specific paths

4. **Version bump** to 0.2.10 (4+ source files changed, UX change)

### Manual verification

1. Launch rttx in dev mode: `RTTX_DEV_MODE=1 cargo run -p rttx`
2. Press Ctrl+Shift+T — the New Workspace dialog opens showing Home and Root
3. Click Home — a new workspace opens in the home directory
4. Click Root — a new workspace opens at /
5. Use the search field to filter places
6. Menu → New Remote Workspace → enter a host → Next → dialog shows places

### Tests added

**Unit tests (places.rs)** — 17 tests:
- Built-in place construction and stability
- Display label formatting
- Host-scoped visibility (global, tagged, multi-tagged)
- `visible_for_host` composition
- Search/filter matching
- Persistence roundtrip
- Backward compatibility (missing host_tags)

**Unit tests (new_workspace_dialog.rs)** — 8 tests:
- Path resolution (~, /, absolute, ~/prefix)
- Icon selection for built-in and saved places

**GTK widget tests** — 3 tests:
- `new_workspace_dialog_shows_builtin_places_for_local_host`
- `new_workspace_dialog_filters_places_by_host_key`
- `new_workspace_dialog_search_filters_places`

### Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76`) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (452 passed)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests passed via Broadway)
- All 3 new GTK widget tests confirmed PASS in quality test output

### Limitations / follow-ups

- The top bar host dropdown (#425) is not yet implemented; the dialog is
  wired to the existing Ctrl+Shift+T action and menu items
- Place management UI (add/edit/delete places) is future work
- The dialog does not yet support keyboard navigation to select a place
  (Enter on a row works via `row-activated`)

Fixes #426