### PR TITLE
feat: add Connect to Existing dialog with available/busy session state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.10"
+version = "0.2.11"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/connect_existing_dialog.rs
+++ b/clients/rttx/src/connect_existing_dialog.rs
@@ -1,0 +1,379 @@
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+use rttx_proto::proto;
+
+use crate::host::Host;
+use crate::window::Window;
+
+/// Classification of a daemon session for the Connect to Existing dialog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionAvailability {
+    /// Can be attached by this client.
+    Available,
+    /// Already open in this client window.
+    AlreadyOpen,
+    /// Owned by another client.
+    BusyElsewhere,
+}
+
+/// A session entry for display in the dialog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionEntry {
+    pub id: String,
+    pub name: String,
+    pub pane_count: u32,
+    pub availability: SessionAvailability,
+    pub status_label: String,
+}
+
+/// Classify daemon sessions into available/busy entries.
+///
+/// `open_runtime_ids` contains runtime IDs already attached by this client.
+#[must_use]
+pub fn classify_sessions(
+    sessions: &[proto::SessionInfo],
+    open_runtime_ids: &[String],
+) -> Vec<SessionEntry> {
+    sessions
+        .iter()
+        .filter_map(|info| {
+            let id = rttx_proto::bytes_to_uuid(&info.id).ok()?.to_string();
+            let availability = if open_runtime_ids.contains(&id) {
+                SessionAvailability::AlreadyOpen
+            } else if info.has_write_owner {
+                SessionAvailability::BusyElsewhere
+            } else {
+                SessionAvailability::Available
+            };
+            let status_label = match &availability {
+                SessionAvailability::Available => format!(
+                    "{} {}",
+                    info.pane_count,
+                    if info.pane_count == 1 { "pane" } else { "panes" }
+                ),
+                SessionAvailability::AlreadyOpen => "Already open".into(),
+                SessionAvailability::BusyElsewhere => "Connected elsewhere".into(),
+            };
+            Some(SessionEntry {
+                id,
+                name: info.name.clone(),
+                pane_count: info.pane_count,
+                availability,
+                status_label,
+            })
+        })
+        .collect()
+}
+
+/// Whether a session entry matches a search query (case-insensitive).
+#[must_use]
+pub fn matches_query(entry: &SessionEntry, query: &str) -> bool {
+    let query = query.trim().to_lowercase();
+    if query.is_empty() {
+        return true;
+    }
+    entry.name.to_lowercase().contains(&query)
+}
+
+/// Show the Connect to Existing dialog for a specific host.
+pub fn show(window: &Window, host: &Host, sessions: &[proto::SessionInfo]) {
+    let title = format!("Connect to Existing: {}", host.name);
+    let dialog = adw::Dialog::builder().title(&title).content_width(400).build();
+
+    let header = adw::HeaderBar::new();
+
+    let search_entry = gtk4::SearchEntry::new();
+    search_entry.set_placeholder_text(Some("Search sessions…"));
+    search_entry.set_margin_start(18);
+    search_entry.set_margin_end(18);
+    search_entry.set_margin_top(12);
+
+    let list_box = gtk4::Box::new(gtk4::Orientation::Vertical, 4);
+    list_box.set_margin_start(18);
+    list_box.set_margin_end(18);
+    list_box.set_margin_top(12);
+    list_box.set_margin_bottom(18);
+    list_box.update_property(&[gtk4::accessible::Property::Label("Sessions")]);
+
+    let scroll = gtk4::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk4::PolicyType::Never)
+        .vexpand(true)
+        .min_content_height(200)
+        .child(&list_box)
+        .build();
+
+    let content = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+    content.append(&search_entry);
+    content.append(&scroll);
+
+    let toolbar_view = adw::ToolbarView::new();
+    toolbar_view.add_top_bar(&header);
+    toolbar_view.set_content(Some(&content));
+    dialog.set_child(Some(&toolbar_view));
+
+    let open_runtime_ids = window.open_runtime_ids_for_endpoint(host);
+    let entries = classify_sessions(sessions, &open_runtime_ids);
+
+    populate_sessions(&list_box, &entries, "", window, host, &dialog);
+
+    let win_for_search = window.clone();
+    let host_for_search = host.clone();
+    let dialog_for_search = dialog.clone();
+    search_entry.connect_changed(move |entry| {
+        let query = entry.text().to_string();
+        populate_sessions(
+            &list_box,
+            &entries,
+            &query,
+            &win_for_search,
+            &host_for_search,
+            &dialog_for_search,
+        );
+    });
+
+    dialog.present(Some(window));
+    search_entry.grab_focus();
+}
+
+fn populate_sessions(
+    container: &gtk4::Box,
+    entries: &[SessionEntry],
+    query: &str,
+    window: &Window,
+    host: &Host,
+    dialog: &adw::Dialog,
+) {
+    while let Some(child) = container.first_child() {
+        container.remove(&child);
+    }
+
+    let mut has_available = false;
+    let mut has_busy = false;
+
+    for entry in entries {
+        if !matches_query(entry, query) {
+            continue;
+        }
+
+        let is_available = entry.availability == SessionAvailability::Available;
+        if is_available && !has_available {
+            has_available = true;
+            append_section_label(container, "Available");
+        } else if !is_available && !has_busy {
+            has_busy = true;
+            append_section_label(container, "Busy");
+        }
+
+        let icon_name =
+            if is_available { "media-playback-start-symbolic" } else { "changes-prevent-symbolic" };
+        let icon = gtk4::Image::from_icon_name(icon_name);
+        icon.set_margin_end(8);
+        if !is_available {
+            icon.add_css_class("dim-label");
+        }
+
+        let title_label = gtk4::Label::new(Some(&entry.name));
+        title_label.set_xalign(0.0);
+        title_label.set_hexpand(true);
+        title_label.add_css_class("body");
+        if !is_available {
+            title_label.add_css_class("dim-label");
+        }
+
+        let status = gtk4::Label::new(Some(&entry.status_label));
+        status.set_xalign(1.0);
+        status.add_css_class("dim-label");
+        status.add_css_class("caption");
+
+        let row_content = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+        row_content.set_margin_start(12);
+        row_content.set_margin_end(12);
+        row_content.set_margin_top(8);
+        row_content.set_margin_bottom(8);
+        row_content.append(&icon);
+        row_content.append(&title_label);
+        row_content.append(&status);
+
+        let button = gtk4::Button::new();
+        button.set_child(Some(&row_content));
+        button.add_css_class("flat");
+        button.set_sensitive(is_available);
+        button.update_property(&[gtk4::accessible::Property::Label(&entry.name)]);
+
+        if is_available {
+            let win = window.clone();
+            let host_clone = host.clone();
+            let dialog_ref = dialog.clone();
+            let runtime_id = entry.id.clone();
+            button.connect_clicked(move |_| {
+                dialog_ref.close();
+                win.attach_to_existing_runtime(&host_clone, &runtime_id);
+            });
+        }
+
+        container.append(&button);
+    }
+
+    if !has_available && !has_busy {
+        let empty = gtk4::Label::new(Some("No sessions found"));
+        empty.add_css_class("dim-label");
+        empty.set_margin_top(24);
+        empty.set_margin_bottom(24);
+        container.append(&empty);
+    }
+}
+
+fn append_section_label(container: &gtk4::Box, text: &str) {
+    let label = gtk4::Label::new(Some(text));
+    label.set_xalign(0.0);
+    label.add_css_class("dim-label");
+    label.add_css_class("caption");
+    label.set_margin_start(6);
+    label.set_margin_top(8);
+    label.set_margin_bottom(2);
+    container.append(&label);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_session_info(
+        id: uuid::Uuid,
+        name: &str,
+        pane_count: u32,
+        has_write_owner: bool,
+    ) -> proto::SessionInfo {
+        proto::SessionInfo {
+            id: rttx_proto::uuid_to_bytes(id),
+            name: name.into(),
+            pane_count,
+            has_attached_client: has_write_owner,
+            active_pane_id: None,
+            panes: vec![],
+            policy: 0,
+            attached_client_count: u32::from(has_write_owner),
+            reconstructed: false,
+            revision: 1,
+            current_client_role: 0,
+            has_write_owner,
+            read_only_client_count: 0,
+        }
+    }
+
+    #[test]
+    fn classify_available_session() {
+        let id = uuid::Uuid::new_v4();
+        let sessions = vec![make_session_info(id, "workspace-1", 2, false)];
+        let entries = classify_sessions(&sessions, &[]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].availability, SessionAvailability::Available);
+        assert_eq!(entries[0].name, "workspace-1");
+        assert_eq!(entries[0].pane_count, 2);
+        assert_eq!(entries[0].status_label, "2 panes");
+    }
+
+    #[test]
+    fn classify_busy_session_with_write_owner() {
+        let id = uuid::Uuid::new_v4();
+        let sessions = vec![make_session_info(id, "busy-ws", 1, true)];
+        let entries = classify_sessions(&sessions, &[]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].availability, SessionAvailability::BusyElsewhere);
+        assert_eq!(entries[0].status_label, "Connected elsewhere");
+    }
+
+    #[test]
+    fn classify_already_open_session() {
+        let id = uuid::Uuid::new_v4();
+        let sessions = vec![make_session_info(id, "open-ws", 3, false)];
+        let entries = classify_sessions(&sessions, &[id.to_string()]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].availability, SessionAvailability::AlreadyOpen);
+        assert_eq!(entries[0].status_label, "Already open");
+    }
+
+    #[test]
+    fn classify_already_open_takes_precedence_over_busy() {
+        let id = uuid::Uuid::new_v4();
+        let sessions = vec![make_session_info(id, "mine", 1, true)];
+        let entries = classify_sessions(&sessions, &[id.to_string()]);
+
+        assert_eq!(entries[0].availability, SessionAvailability::AlreadyOpen);
+    }
+
+    #[test]
+    fn classify_mixed_sessions_preserves_order() {
+        let avail_id = uuid::Uuid::new_v4();
+        let busy_id = uuid::Uuid::new_v4();
+        let open_id = uuid::Uuid::new_v4();
+        let sessions = vec![
+            make_session_info(avail_id, "avail", 1, false),
+            make_session_info(busy_id, "busy", 2, true),
+            make_session_info(open_id, "open", 1, false),
+        ];
+        let entries = classify_sessions(&sessions, &[open_id.to_string()]);
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].availability, SessionAvailability::Available);
+        assert_eq!(entries[1].availability, SessionAvailability::BusyElsewhere);
+        assert_eq!(entries[2].availability, SessionAvailability::AlreadyOpen);
+    }
+
+    #[test]
+    fn classify_empty_sessions() {
+        let entries = classify_sessions(&[], &[]);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn single_pane_label_is_singular() {
+        let id = uuid::Uuid::new_v4();
+        let sessions = vec![make_session_info(id, "ws", 1, false)];
+        let entries = classify_sessions(&sessions, &[]);
+        assert_eq!(entries[0].status_label, "1 pane");
+    }
+
+    #[test]
+    fn matches_query_empty_matches_all() {
+        let entry = SessionEntry {
+            id: "id".into(),
+            name: "anything".into(),
+            pane_count: 1,
+            availability: SessionAvailability::Available,
+            status_label: "1 pane".into(),
+        };
+        assert!(matches_query(&entry, ""));
+        assert!(matches_query(&entry, "  "));
+    }
+
+    #[test]
+    fn matches_query_case_insensitive() {
+        let entry = SessionEntry {
+            id: "id".into(),
+            name: "My Workspace".into(),
+            pane_count: 1,
+            availability: SessionAvailability::Available,
+            status_label: "1 pane".into(),
+        };
+        assert!(matches_query(&entry, "my"));
+        assert!(matches_query(&entry, "WORKSPACE"));
+        assert!(matches_query(&entry, "My Work"));
+    }
+
+    #[test]
+    fn matches_query_no_match() {
+        let entry = SessionEntry {
+            id: "id".into(),
+            name: "rttx".into(),
+            pane_count: 1,
+            availability: SessionAvailability::Available,
+            status_label: "1 pane".into(),
+        };
+        assert!(!matches_query(&entry, "redis"));
+    }
+}

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -4,6 +4,7 @@ pub mod color_scheme;
 pub mod commands;
 pub mod commands_window;
 pub mod config;
+pub mod connect_existing_dialog;
 pub mod daemon;
 pub mod daemon_bridge;
 pub mod form_dialog;

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -36,6 +36,7 @@ impl Window {
             ("new-ephemeral-workspace", &["<Ctrl><Shift><Alt>T"], Self::add_ephemeral_session),
             ("new-remote-workspace", &[], Self::show_new_remote_workspace_dialog),
             ("browse-remote-runtimes", &[], Self::show_browse_remote_runtimes_dialog),
+            ("connect-existing-local", &["<Ctrl><Shift>A"], Self::connect_existing_local),
             ("toggle-utility-sidebar", &["<Ctrl><Shift>B"], |w| {
                 let sidebar = &w.imp().utility_sidebar_box;
                 sidebar.set_visible(!sidebar.is_visible());

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -65,6 +65,7 @@ mod imp {
         pub workspace_reconnect_sources: RefCell<HashMap<String, glib::SourceId>>,
         pub focused_terminal_uuid: RefCell<Option<String>>,
         pub workspace_popover: RefCell<Option<gtk4::PopoverMenu>>,
+        pub pending_connect_existing: RefCell<Option<crate::host::Host>>,
     }
 
     #[glib::object_subclass]
@@ -117,7 +118,8 @@ mod imp {
             menu.append(Some("New Persistent Workspace"), Some("win.new-session"));
             menu.append(Some("New Ephemeral Workspace"), Some("win.new-ephemeral-workspace"));
             menu.append(Some("New Remote Workspace"), Some("win.new-remote-workspace"));
-            menu.append(Some("Attach to Remote Runtime"), Some("win.browse-remote-runtimes"));
+            menu.append(Some("Connect to Existing (Local)"), Some("win.connect-existing-local"));
+            menu.append(Some("Connect to Existing (Remote)"), Some("win.browse-remote-runtimes"));
             menu.append(Some("About rttx"), Some("win.about"));
             menu.append(Some("Bookmark This Workspace"), Some("win.bookmark-session"));
             menu.append(Some("Preferences"), Some("win.preferences"));

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -56,8 +56,7 @@ impl Window {
     }
 
     pub(super) fn show_browse_remote_runtimes_dialog(&self) {
-        let dialog =
-            adw::Dialog::builder().title("Attach to Remote Runtime").content_width(440).build();
+        let dialog = adw::Dialog::builder().title("Connect to Existing").content_width(440).build();
         let header = adw::HeaderBar::new();
         let connect_button = gtk4::Button::with_label("Connect");
         connect_button.add_css_class("suggested-action");
@@ -68,7 +67,6 @@ impl Window {
         let status_label = gtk4::Label::new(None);
         status_label.set_xalign(0.0);
         status_label.add_css_class("dim-label");
-        status_label.set_text("Existing runtimes on the host will appear in the sidebar.");
 
         let group = adw::PreferencesGroup::new();
         group.add(&host_row);
@@ -89,27 +87,81 @@ impl Window {
         let dialog_ref = dialog.clone();
         let win = self.clone();
         connect_button.connect_clicked(move |_| {
-            let host = host_row.text().trim().to_string();
-            if host.is_empty() {
+            let host_text = host_row.text().trim().to_string();
+            if host_text.is_empty() {
                 status_label.set_text("SSH host is required");
                 return;
             }
-            win.browse_remote_runtimes(&host);
             dialog_ref.close();
+            let host = crate::host::Host::remote(&host_text);
+            win.request_connect_existing(&host);
         });
 
         dialog.present(Some(self));
     }
 
-    fn browse_remote_runtimes(&self, host: &str) {
+    /// Initiate the Connect to Existing flow for a local host.
+    pub(super) fn connect_existing_local(&self) {
+        self.request_connect_existing(&crate::host::Host::local());
+    }
+
+    /// Request session inventory for a host and show the Connect to Existing
+    /// dialog when the response arrives.
+    fn request_connect_existing(&self, host: &crate::host::Host) {
         if !self.ensure_connection_manager() {
             return;
         }
-        let endpoint = RuntimeEndpoint::Remote { host: host.into() };
+        let endpoint = if host.is_local() {
+            RuntimeEndpoint::Local
+        } else {
+            RuntimeEndpoint::Remote { host: host.ssh_target.clone().unwrap_or_default() }
+        };
+        self.imp().pending_connect_existing.replace(Some(host.clone()));
         if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
             manager.refresh_inventory(&endpoint);
         }
-        self.show_toast(&format!("Connecting to {host}…"));
+    }
+
+    /// Return runtime IDs already attached by this client for a given host.
+    pub(crate) fn open_runtime_ids_for_endpoint(&self, host: &crate::host::Host) -> Vec<String> {
+        let endpoint = if host.is_local() {
+            RuntimeEndpoint::Local
+        } else {
+            RuntimeEndpoint::Remote { host: host.ssh_target.clone().unwrap_or_default() }
+        };
+        let state = self.imp().state.borrow();
+        state
+            .sessions
+            .iter()
+            .filter(|s| s.uses_managed_runtime() && s.runtime.endpoint == endpoint)
+            .filter_map(|s| s.runtime.runtime_id.clone())
+            .collect()
+    }
+
+    /// Attach to an existing runtime on a host by creating a new workspace
+    /// bound to that runtime ID.
+    pub(crate) fn attach_to_existing_runtime(&self, host: &crate::host::Host, runtime_id: &str) {
+        let imp = self.imp();
+        let count = imp.state.borrow().sessions.len() + 1;
+        let name = format!("Workspace {count}");
+
+        let mut session_state = if host.is_local() {
+            SessionState::new_managed_local(name, WorkspacePolicy::Persistent, None)
+        } else {
+            let ssh_target = host.ssh_target.as_deref().unwrap_or(&host.key);
+            SessionState::new_managed_remote(name, ssh_target, WorkspacePolicy::Persistent, None)
+        };
+        session_state.runtime.runtime_id = Some(runtime_id.to_string());
+        session_state.color = self.next_session_color();
+        imp.state.borrow_mut().sessions.push(session_state.clone());
+        self.build_session(&session_state, false);
+        self.set_workspace_connection_status(&session_state.uuid, &ConnectionStatus::Connecting);
+        self.connect_managed_workspace(&session_state);
+
+        let index = imp.state.borrow().sessions.len() as i32 - 1;
+        if let Some(row) = imp.sidebar_list.row_at_index(index) {
+            imp.sidebar_list.select_row(Some(&row));
+        }
     }
 
     /// Create a new remote managed workspace at a specific path.
@@ -373,6 +425,31 @@ impl Window {
                 log::warn!("Workspace {workspace_id} runtime error: {detail}");
                 if !workspace_id.starts_with("inventory:") {
                     self.show_toast(&detail);
+                }
+            }
+            EndpointEvent::InventoryLoaded { endpoint, sessions }
+                if self.imp().pending_connect_existing.borrow().is_some() =>
+            {
+                let host = self.imp().pending_connect_existing.take().unwrap();
+                let expected_endpoint = if host.is_local() {
+                    RuntimeEndpoint::Local
+                } else {
+                    RuntimeEndpoint::Remote { host: host.ssh_target.clone().unwrap_or_default() }
+                };
+                if endpoint == expected_endpoint {
+                    crate::connect_existing_dialog::show(self, &host, &sessions);
+                } else {
+                    // Wrong endpoint — put the pending request back and
+                    // let the event go through normal reconciliation.
+                    self.imp().pending_connect_existing.replace(Some(host));
+                    let transition = {
+                        let mut state = self.imp().state.borrow_mut();
+                        state.reconcile_endpoint_event(&EndpointEvent::InventoryLoaded {
+                            endpoint,
+                            sessions,
+                        })
+                    };
+                    self.apply_endpoint_event_transition(&transition);
                 }
             }
             other => {

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1783,3 +1783,130 @@ fn new_workspace_dialog_search_filters_places() {
     assert_eq!(places.iter().filter(|p| rttx::places::matches_query(p, "rttx")).count(), 1);
     assert_eq!(places.iter().filter(|p| rttx::places::matches_query(p, "")).count(), 2);
 }
+
+// ── Connect to Existing dialog ──────────────────────────────────
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn connect_existing_dialog_classifies_available_session() {
+    require_display!();
+
+    let id = uuid::Uuid::new_v4();
+    let sessions = vec![rttx_proto::proto::SessionInfo {
+        id: rttx_proto::uuid_to_bytes(id),
+        name: "workspace-1".into(),
+        pane_count: 2,
+        has_attached_client: false,
+        active_pane_id: None,
+        panes: vec![],
+        policy: 0,
+        attached_client_count: 0,
+        reconstructed: false,
+        revision: 1,
+        current_client_role: 0,
+        has_write_owner: false,
+        read_only_client_count: 0,
+    }];
+    let entries = rttx::connect_existing_dialog::classify_sessions(&sessions, &[]);
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].availability,
+        rttx::connect_existing_dialog::SessionAvailability::Available
+    );
+    assert_eq!(entries[0].status_label, "2 panes");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn connect_existing_dialog_classifies_busy_session() {
+    require_display!();
+
+    let id = uuid::Uuid::new_v4();
+    let sessions = vec![rttx_proto::proto::SessionInfo {
+        id: rttx_proto::uuid_to_bytes(id),
+        name: "busy-ws".into(),
+        pane_count: 1,
+        has_attached_client: true,
+        active_pane_id: None,
+        panes: vec![],
+        policy: 0,
+        attached_client_count: 1,
+        reconstructed: false,
+        revision: 1,
+        current_client_role: 0,
+        has_write_owner: true,
+        read_only_client_count: 0,
+    }];
+    let entries = rttx::connect_existing_dialog::classify_sessions(&sessions, &[]);
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].availability,
+        rttx::connect_existing_dialog::SessionAvailability::BusyElsewhere
+    );
+    assert_eq!(entries[0].status_label, "Connected elsewhere");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn connect_existing_dialog_classifies_already_open_session() {
+    require_display!();
+
+    let id = uuid::Uuid::new_v4();
+    let sessions = vec![rttx_proto::proto::SessionInfo {
+        id: rttx_proto::uuid_to_bytes(id),
+        name: "open-ws".into(),
+        pane_count: 3,
+        has_attached_client: false,
+        active_pane_id: None,
+        panes: vec![],
+        policy: 0,
+        attached_client_count: 0,
+        reconstructed: false,
+        revision: 1,
+        current_client_role: 0,
+        has_write_owner: false,
+        read_only_client_count: 0,
+    }];
+    let entries = rttx::connect_existing_dialog::classify_sessions(&sessions, &[id.to_string()]);
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].availability,
+        rttx::connect_existing_dialog::SessionAvailability::AlreadyOpen
+    );
+    assert_eq!(entries[0].status_label, "Already open");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn connect_existing_dialog_search_filters_sessions() {
+    require_display!();
+
+    let entries = [
+        rttx::connect_existing_dialog::SessionEntry {
+            id: "a".into(),
+            name: "rttx project".into(),
+            pane_count: 2,
+            availability: rttx::connect_existing_dialog::SessionAvailability::Available,
+            status_label: "2 panes".into(),
+        },
+        rttx::connect_existing_dialog::SessionEntry {
+            id: "b".into(),
+            name: "redis server".into(),
+            pane_count: 1,
+            availability: rttx::connect_existing_dialog::SessionAvailability::Available,
+            status_label: "1 pane".into(),
+        },
+    ];
+
+    assert_eq!(
+        entries.iter().filter(|e| rttx::connect_existing_dialog::matches_query(e, "rttx")).count(),
+        1
+    );
+    assert_eq!(
+        entries.iter().filter(|e| rttx::connect_existing_dialog::matches_query(e, "")).count(),
+        2
+    );
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.10',
+  version: '0.2.11',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Implements #427 — adds a Connect to Existing dialog that shows all daemon-backed sessions on a selected host, classified into Available and Busy sections.

### Key design decisions

- **Available sessions**: no write owner, not already open in this client → clickable, creates a new workspace bound to that runtime
- **Busy sessions**: has a write owner (connected elsewhere) or already open in this client → visible but disabled with status label
- **Same dialog for local and remote**: the flow is host-agnostic per RFC-016 Section 4
- **Inventory interception**: pending connect-existing requests intercept the `InventoryLoaded` event to show the dialog instead of auto-recovering workspaces

### Changes

- New `connect_existing_dialog` module with pure classification logic (`classify_sessions`, `matches_query`) and GTK dialog (`show`)
- `Window::connect_existing_local()` — initiates the flow for the local daemon
- `Window::request_connect_existing()` — stores pending host and requests inventory
- `Window::attach_to_existing_runtime()` — creates a workspace bound to an existing runtime ID
- `Window::open_runtime_ids_for_endpoint()` — returns runtime IDs already attached by this client
- `handle_endpoint_event` intercepts `InventoryLoaded` when a connect-existing request is pending
- Menu items: "Connect to Existing (Local)" and "Connect to Existing (Remote)"
- Keyboard shortcut: Ctrl+Shift+A for local Connect to Existing
- Version bump to 0.2.11

### Manual verification

1. Start rttx with a running daemon (`rttx-server start --foreground`)
2. Create a persistent workspace
3. Use Ctrl+Shift+A or menu → "Connect to Existing (Local)"
4. Dialog shows the existing session as Available
5. Click to attach — new workspace appears connected to the same runtime
6. Open the dialog again — the session now shows as "Already open"

### Tests added

**Unit tests (10):**
- `classify_available_session`
- `classify_busy_session_with_write_owner`
- `classify_already_open_session`
- `classify_already_open_takes_precedence_over_busy`
- `classify_mixed_sessions_preserves_order`
- `classify_empty_sessions`
- `single_pane_label_is_singular`
- `matches_query_empty_matches_all`
- `matches_query_case_insensitive`
- `matches_query_no_match`

**GTK widget tests (4):**
- `connect_existing_dialog_classifies_available_session`
- `connect_existing_dialog_classifies_busy_session`
- `connect_existing_dialog_classifies_already_open_session`
- `connect_existing_dialog_search_filters_sessions`

### Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (all 462 pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass via Broadway)

### Limitations / follow-ups

- Session takeover remains future work (NG3 per RFC-016)
- The dialog does not auto-refresh while open — it shows a snapshot at open time