### PR TITLE
feat: rework right sidebar with host selector, search, and tagged content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.11"
+version = "0.2.12"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -74,6 +74,12 @@ pub fn is_visible_on(command: &SavedCommand, host_key: &str) -> bool {
     command.host_tags.is_empty() || command.host_tags.iter().any(|tag| tag == host_key)
 }
 
+/// Collect commands visible on `host_key`: matching saved commands.
+#[must_use]
+pub fn visible_for_host(saved: &[SavedCommand], host_key: &str) -> Vec<SavedCommand> {
+    saved.iter().filter(|c| is_visible_on(c, host_key)).cloned().collect()
+}
+
 /// Migrate legacy commands that lack host tags by tagging them with `"local"`.
 pub fn migrate_legacy(commands: &mut [SavedCommand]) {
     for command in commands.iter_mut() {
@@ -277,6 +283,26 @@ mod tests {
         assert!(is_visible_on(&command, "local"));
         assert!(is_visible_on(&command, "example.com"));
         assert!(!is_visible_on(&command, "other.com"));
+    }
+
+    #[test]
+    fn visible_for_host_returns_matching_commands() {
+        let mut local_cmd = SavedCommand::new("Local", "echo local");
+        local_cmd.host_tags = vec!["local".into()];
+        let mut remote_cmd = SavedCommand::new("Remote", "echo remote");
+        remote_cmd.host_tags = vec!["example.com".into()];
+        let global_cmd = SavedCommand::new("Global", "echo global");
+
+        let saved = vec![local_cmd, remote_cmd, global_cmd];
+        let visible = visible_for_host(&saved, "local");
+        let names: Vec<&str> = visible.iter().map(|c| c.title.as_str()).collect();
+        assert_eq!(names, vec!["Local", "Global"]);
+    }
+
+    #[test]
+    fn visible_for_host_with_no_commands_returns_empty() {
+        let visible = visible_for_host(&[], "local");
+        assert!(visible.is_empty());
     }
 
     #[test]

--- a/clients/rttx/src/new_workspace_dialog.rs
+++ b/clients/rttx/src/new_workspace_dialog.rs
@@ -172,6 +172,12 @@ fn place_icon(place: &Place) -> &'static str {
     }
 }
 
+/// Public wrapper for `resolve_place_path` used by the sidebar.
+#[must_use]
+pub fn resolve_place_path_public(path: &str) -> Option<String> {
+    resolve_place_path(path)
+}
+
 /// Resolve `~` to the actual home directory for local paths.
 fn resolve_place_path(path: &str) -> Option<String> {
     let trimmed = path.trim();

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -53,6 +53,15 @@ impl RuntimeEndpoint {
             Self::Remote { host } => format!("remote:{host}"),
         }
     }
+
+    /// Host key compatible with the host model for place/command filtering.
+    #[must_use]
+    pub fn host_key(&self) -> String {
+        match self {
+            Self::Local => crate::host::LOCAL_KEY.into(),
+            Self::Remote { host } => crate::host::normalize_ssh_key(host),
+        }
+    }
 }
 
 /// Persisted managed-runtime metadata attached to a workspace.
@@ -1099,6 +1108,23 @@ mod tests {
         assert_ne!(local.key(), remote.key());
         assert_eq!(local.key(), "local");
         assert!(remote.key().contains("host"));
+    }
+
+    #[test]
+    fn host_key_local_returns_local_key() {
+        assert_eq!(RuntimeEndpoint::Local.host_key(), crate::host::LOCAL_KEY);
+    }
+
+    #[test]
+    fn host_key_remote_normalizes_ssh_target() {
+        let endpoint = RuntimeEndpoint::Remote { host: "deploy@example.com".into() };
+        assert_eq!(endpoint.host_key(), "example.com");
+    }
+
+    #[test]
+    fn host_key_remote_bare_hostname() {
+        let endpoint = RuntimeEndpoint::Remote { host: "dev-box".into() };
+        assert_eq!(endpoint.host_key(), "dev-box");
     }
 
     #[test]

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -11,6 +11,8 @@ use crate::bookmarks::Bookmark;
 use crate::color_scheme;
 use crate::commands::{self, CommandRunMode, SavedCommand};
 use crate::config;
+use crate::host;
+use crate::places;
 use crate::preferences::{self, Preferences};
 use crate::runtime::{
     ConnectionPresentation, ConnectionStatus, RuntimeEndpoint, WorkspaceActionPresentation,
@@ -47,6 +49,12 @@ mod imp {
         pub sidebar_list: gtk4::ListBox,
         pub session_stack: gtk4::Stack,
         pub utility_sidebar_box: gtk4::Box,
+        pub sidebar_search_entry: gtk4::SearchEntry,
+        pub host_selector: gtk4::DropDown,
+        pub utility_stack: gtk4::Stack,
+        pub place_list: gtk4::ListBox,
+        pub place_scroll: gtk4::ScrolledWindow,
+        pub place_empty: adw::StatusPage,
         pub bookmark_search_entry: gtk4::SearchEntry,
         pub bookmark_list: gtk4::ListBox,
         pub bookmark_scroll: gtk4::ScrolledWindow,
@@ -66,6 +74,7 @@ mod imp {
         pub focused_terminal_uuid: RefCell<Option<String>>,
         pub workspace_popover: RefCell<Option<gtk4::PopoverMenu>>,
         pub pending_connect_existing: RefCell<Option<crate::host::Host>>,
+        pub host_selector_keys: RefCell<Vec<String>>,
     }
 
     #[glib::object_subclass]
@@ -147,21 +156,59 @@ mod imp {
                 .child(&self.sidebar_list)
                 .build();
 
+            // ── Unified search ────────────────────────────────────
+            self.sidebar_search_entry.set_placeholder_text(Some("Search…"));
+            self.sidebar_search_entry.set_margin_start(12);
+            self.sidebar_search_entry.set_margin_end(12);
+            self.sidebar_search_entry.set_margin_top(12);
+
+            // ── Host selector ────────────────────────────────────
+            let host_model = gtk4::StringList::new(&["Local"]);
+            self.host_selector.set_model(Some(&host_model));
+            self.host_selector.set_selected(0);
+            self.host_selector.set_margin_start(12);
+            self.host_selector.set_margin_end(12);
+            self.host_selector.set_margin_top(8);
+            self.host_selector.update_property(&[gtk4::accessible::Property::Label("Host")]);
+
+            // ── Places tab ───────────────────────────────────────
+            self.place_list.set_selection_mode(gtk4::SelectionMode::None);
+            self.place_list.add_css_class("boxed-list");
+            self.place_list.update_property(&[gtk4::accessible::Property::Label("Places")]);
+
+            self.place_scroll.set_hscrollbar_policy(gtk4::PolicyType::Never);
+            self.place_scroll.set_vexpand(true);
+            self.place_scroll.set_margin_start(12);
+            self.place_scroll.set_margin_end(12);
+            self.place_scroll.set_margin_bottom(12);
+            self.place_scroll.set_child(Some(&self.place_list));
+            self.place_scroll.set_visible(false);
+
+            self.place_empty.set_icon_name(Some("folder-symbolic"));
+            self.place_empty.set_title("No Places");
+            self.place_empty.set_description(Some("Save folder paths for quick navigation"));
+            self.place_empty.set_vexpand(true);
+
+            let places_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+            places_page.append(&self.place_scroll);
+            places_page.append(&self.place_empty);
+
+            // ── Bookmarks tab (legacy) ───────────────────────────
             let add_bookmark_button = gtk4::Button::builder()
                 .icon_name("list-add-symbolic")
                 .tooltip_text("New bookmark")
                 .action_name("win.add-bookmark")
                 .build();
-            let utility_header = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
-            utility_header.set_margin_start(12);
-            utility_header.set_margin_end(12);
-            utility_header.set_margin_top(12);
-            let utility_title = gtk4::Label::new(Some("Bookmarks"));
-            utility_title.set_xalign(0.0);
-            utility_title.set_hexpand(true);
-            utility_title.add_css_class("title-4");
-            utility_header.append(&utility_title);
-            utility_header.append(&add_bookmark_button);
+            let bookmark_header = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
+            bookmark_header.set_margin_start(12);
+            bookmark_header.set_margin_end(12);
+            bookmark_header.set_margin_top(12);
+            let bookmark_title = gtk4::Label::new(Some("Bookmarks"));
+            bookmark_title.set_xalign(0.0);
+            bookmark_title.set_hexpand(true);
+            bookmark_title.add_css_class("title-4");
+            bookmark_header.append(&bookmark_title);
+            bookmark_header.append(&add_bookmark_button);
 
             self.bookmark_search_entry.set_placeholder_text(Some("Search bookmarks"));
             self.bookmark_search_entry.set_margin_start(12);
@@ -184,6 +231,13 @@ mod imp {
             ));
             self.bookmark_empty.set_vexpand(true);
 
+            let bookmarks_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+            bookmarks_page.append(&bookmark_header);
+            bookmarks_page.append(&self.bookmark_search_entry);
+            bookmarks_page.append(&self.bookmark_scroll);
+            bookmarks_page.append(&self.bookmark_empty);
+
+            // ── Commands tab ─────────────────────────────────────
             let add_command_button = gtk4::Button::builder()
                 .icon_name("list-add-symbolic")
                 .tooltip_text("New command")
@@ -221,30 +275,28 @@ mod imp {
             ));
             self.command_empty.set_vexpand(true);
 
-            let bookmarks_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-            bookmarks_page.append(&utility_header);
-            bookmarks_page.append(&self.bookmark_search_entry);
-            bookmarks_page.append(&self.bookmark_scroll);
-            bookmarks_page.append(&self.bookmark_empty);
-
             let commands_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
             commands_page.append(&commands_header);
             commands_page.append(&self.command_search_entry);
             commands_page.append(&self.command_scroll);
             commands_page.append(&self.command_empty);
 
-            let utility_stack = gtk4::Stack::new();
-            utility_stack.add_titled(&bookmarks_page, Some("bookmarks"), "Bookmarks");
-            utility_stack.add_titled(&commands_page, Some("commands"), "Commands");
+            // ── Tab stack ────────────────────────────────────────
+            self.utility_stack.add_titled(&places_page, Some("places"), "Places");
+            self.utility_stack.add_titled(&bookmarks_page, Some("bookmarks"), "Bookmarks");
+            self.utility_stack.add_titled(&commands_page, Some("commands"), "Commands");
 
-            let utility_switcher = gtk4::StackSwitcher::builder().stack(&utility_stack).build();
+            let utility_switcher =
+                gtk4::StackSwitcher::builder().stack(&self.utility_stack).build();
             utility_switcher.set_margin_start(12);
             utility_switcher.set_margin_end(12);
-            utility_switcher.set_margin_top(12);
+            utility_switcher.set_margin_top(8);
 
             self.utility_sidebar_box.set_orientation(gtk4::Orientation::Vertical);
+            self.utility_sidebar_box.append(&self.sidebar_search_entry);
+            self.utility_sidebar_box.append(&self.host_selector);
             self.utility_sidebar_box.append(&utility_switcher);
-            self.utility_sidebar_box.append(&utility_stack);
+            self.utility_sidebar_box.append(&self.utility_stack);
             self.utility_sidebar_box.set_width_request(320);
 
             self.session_stack.set_hexpand(true);
@@ -441,12 +493,25 @@ impl Window {
         });
 
         let win = self.clone();
+        self.imp().sidebar_search_entry.connect_changed(move |_| {
+            win.refresh_place_sidebar();
+            win.refresh_bookmark_sidebar();
+            win.refresh_command_sidebar();
+        });
+
+        let win = self.clone();
         self.imp().bookmark_search_entry.connect_changed(move |_| {
             win.refresh_bookmark_sidebar();
         });
 
         let win = self.clone();
         self.imp().command_search_entry.connect_changed(move |_| {
+            win.refresh_command_sidebar();
+        });
+
+        let win = self.clone();
+        self.imp().host_selector.connect_selected_notify(move |_| {
+            win.refresh_place_sidebar();
             win.refresh_command_sidebar();
         });
 
@@ -461,6 +526,7 @@ impl Window {
             win.reapply_terminal_preferences();
         });
 
+        self.refresh_place_sidebar();
         self.refresh_bookmark_sidebar();
         self.refresh_command_sidebar();
     }
@@ -702,6 +768,7 @@ impl Window {
         {
             session_row.clear_activity();
         }
+        self.sync_host_selector_to_workspace(&uuid);
         self.focus_session_terminal(&uuid);
         if let Some(action) = self.lookup_action("toggle-input-sync")
             && let Ok(action) = action.downcast::<gtk4::gio::SimpleAction>()

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -1,6 +1,182 @@
 use super::*;
 
+/// Sentinel value for the "All Hosts" entry in the host selector.
+const ALL_HOSTS_LABEL: &str = "All Hosts";
+
 impl Window {
+    /// Return the host key currently selected in the host dropdown,
+    /// or `None` when "All Hosts" is selected.
+    fn selected_host_key(&self) -> Option<String> {
+        let dd = &self.imp().host_selector;
+        let idx = dd.selected() as usize;
+        let keys = self.imp().host_selector_keys.borrow();
+        keys.get(idx).cloned()
+    }
+
+    /// Rebuild the host selector model and select the entry matching `host_key`.
+    pub(crate) fn sync_host_selector_to_workspace(&self, session_uuid: &str) {
+        let host_key = {
+            let state = self.imp().state.borrow();
+            state
+                .sessions
+                .iter()
+                .find(|s| s.uuid == session_uuid)
+                .map_or_else(|| host::LOCAL_KEY.into(), |s| s.runtime.endpoint.host_key())
+        };
+        self.rebuild_host_selector_model(Some(&host_key));
+    }
+
+    /// Rebuild the host selector dropdown model from saved hosts + workspace endpoints.
+    fn rebuild_host_selector_model(&self, select_key: Option<&str>) {
+        let saved_hosts = host::load();
+        let state = self.imp().state.borrow();
+
+        let mut keys: Vec<String> = Vec::new();
+        keys.push(host::LOCAL_KEY.into());
+        for h in &saved_hosts {
+            if !keys.contains(&h.key) {
+                keys.push(h.key.clone());
+            }
+        }
+        for s in &state.sessions {
+            let k = s.runtime.endpoint.host_key();
+            if !keys.contains(&k) {
+                keys.push(k);
+            }
+        }
+        drop(state);
+
+        let mut labels: Vec<String> = keys
+            .iter()
+            .map(|k| {
+                let resolved = host::resolve(k, &saved_hosts);
+                resolved.name
+            })
+            .collect();
+        labels.push(ALL_HOSTS_LABEL.into());
+
+        // Store keys for index-based lookup (None for "All Hosts")
+        self.imp().host_selector_keys.replace(keys.clone());
+
+        let model = gtk4::StringList::new(&labels.iter().map(String::as_str).collect::<Vec<_>>());
+        let dd = &self.imp().host_selector;
+        dd.set_model(Some(&model));
+
+        let target_idx = select_key.and_then(|key| keys.iter().position(|k| k == key)).unwrap_or(0);
+        dd.set_selected(target_idx as u32);
+    }
+
+    pub(crate) fn refresh_place_sidebar(&self) {
+        let imp = self.imp();
+        while let Some(row) = imp.place_list.row_at_index(0) {
+            imp.place_list.remove(&row);
+        }
+
+        let query = imp.sidebar_search_entry.text();
+        let saved = places::load();
+        let saved_hosts = host::load();
+        let selected_key = self.selected_host_key();
+
+        let any_shown = selected_key.as_ref().map_or_else(
+            || {
+                // All Hosts view: group by host key
+                let mut shown = false;
+                let all_keys = self.collect_all_host_keys(&saved_hosts);
+                for key in &all_keys {
+                    let resolved = host::resolve(key, &saved_hosts);
+                    let visible: Vec<_> =
+                        saved.iter().filter(|p| p.host_tags.iter().any(|t| t == key)).collect();
+                    if !visible.is_empty() {
+                        let is_orphaned = !self.is_known_host_key(key, &saved_hosts);
+                        let label = if is_orphaned {
+                            format!("{} (orphaned)", resolved.name)
+                        } else {
+                            resolved.name.clone()
+                        };
+                        shown |= self.append_place_section(&label, &visible, query.as_str());
+                    }
+                }
+                let global_items: Vec<places::Place> = places::builtins()
+                    .into_iter()
+                    .chain(saved.iter().filter(|p| p.host_tags.is_empty()).cloned())
+                    .collect();
+                let global_refs: Vec<&places::Place> = global_items.iter().collect();
+                shown |= self.append_place_section("Global", &global_refs, query.as_str());
+                shown
+            },
+            |key| {
+                let visible = places::visible_for_host(&saved, key);
+                let (host_specific, global): (Vec<_>, Vec<_>) =
+                    visible.iter().partition(|p| !p.host_tags.is_empty());
+
+                let mut shown = false;
+                if !host_specific.is_empty() {
+                    let resolved = host::resolve(key, &saved_hosts);
+                    shown |=
+                        self.append_place_section(&resolved.name, &host_specific, query.as_str());
+                }
+                shown |= self.append_place_section("Global", &global, query.as_str());
+                shown
+            },
+        );
+
+        imp.place_scroll.set_visible(any_shown);
+        imp.place_empty.set_visible(!any_shown);
+    }
+
+    fn append_place_section(
+        &self,
+        section_label: &str,
+        items: &[&places::Place],
+        query: &str,
+    ) -> bool {
+        let imp = self.imp();
+        let filtered: Vec<_> = items.iter().filter(|p| places::matches_query(p, query)).collect();
+        if filtered.is_empty() {
+            return false;
+        }
+
+        let label = gtk4::Label::new(Some(section_label));
+        label.set_xalign(0.0);
+        label.add_css_class("dim-label");
+        label.add_css_class("caption");
+        label.set_margin_start(6);
+        label.set_margin_top(8);
+        label.set_margin_bottom(2);
+        let label_row = gtk4::ListBoxRow::new();
+        label_row.set_child(Some(&label));
+        label_row.set_selectable(false);
+        label_row.set_activatable(false);
+        imp.place_list.append(&label_row);
+
+        for place in &filtered {
+            let action_row = adw::ActionRow::new();
+            action_row.set_title(&place.name);
+            if place.name != place.path {
+                action_row.set_subtitle(&place.path);
+            }
+            action_row.set_activatable(true);
+
+            let win = self.clone();
+            let path = place.path.clone();
+            action_row.connect_activated(move |_| {
+                win.open_place_in_current_pane(&path);
+            });
+
+            imp.place_list.append(&action_row);
+        }
+        true
+    }
+
+    fn open_place_in_current_pane(&self, path: &str) {
+        let Some(terminal_uuid) = self.command_target_terminal_uuid() else {
+            return;
+        };
+        let resolved = crate::new_workspace_dialog::resolve_place_path_public(path);
+        let cd_path = resolved.as_deref().unwrap_or("~");
+        self.send_input_to_terminal(&terminal_uuid, &format!("cd {cd_path}\n"));
+    }
+
     pub(crate) fn refresh_bookmark_sidebar(&self) {
         let imp = self.imp();
         while let Some(row) = imp.bookmark_list.row_at_index(0) {
@@ -94,10 +270,27 @@ impl Window {
         }
 
         let query = imp.command_search_entry.text();
-        for command in commands::load()
-            .into_iter()
-            .filter(|command| commands::matches_query(command, query.as_str()))
-        {
+        let sidebar_query = imp.sidebar_search_entry.text();
+        let combined_query = if sidebar_query.is_empty() {
+            query.to_string()
+        } else if query.is_empty() {
+            sidebar_query.to_string()
+        } else {
+            format!("{sidebar_query} {query}")
+        };
+
+        let all_commands = commands::load();
+        let selected_key = self.selected_host_key();
+
+        let filtered: Vec<_> = match &selected_key {
+            Some(key) => commands::visible_for_host(&all_commands, key),
+            None => all_commands,
+        }
+        .into_iter()
+        .filter(|command| commands::matches_query(command, &combined_query))
+        .collect();
+
+        for command in &filtered {
             let action_row = adw::ActionRow::new();
             action_row.set_title(&command.title);
             action_row.set_subtitle(&command.preview());
@@ -163,14 +356,45 @@ impl Window {
             });
 
             let win = self.clone();
+            let command_clone = command.clone();
             insert_button.connect_clicked(move |_| {
-                win.execute_saved_command(&command, CommandRunMode::Insert);
+                win.execute_saved_command(&command_clone, CommandRunMode::Insert);
             });
         }
 
         let is_empty = imp.command_list.row_at_index(0).is_none();
         imp.command_scroll.set_visible(!is_empty);
         imp.command_empty.set_visible(is_empty);
+    }
+
+    /// Collect all host keys referenced by places and commands.
+    fn collect_all_host_keys(&self, saved_hosts: &[host::Host]) -> Vec<String> {
+        let mut keys: Vec<String> = Vec::new();
+        for h in saved_hosts {
+            if !keys.contains(&h.key) {
+                keys.push(h.key.clone());
+            }
+        }
+        for p in places::load() {
+            for tag in &p.host_tags {
+                if !keys.contains(tag) {
+                    keys.push(tag.clone());
+                }
+            }
+        }
+        for c in commands::load() {
+            for tag in &c.host_tags {
+                if !keys.contains(tag) {
+                    keys.push(tag.clone());
+                }
+            }
+        }
+        keys
+    }
+
+    /// Whether a host key is known (saved or is the local key).
+    fn is_known_host_key(&self, key: &str, saved_hosts: &[host::Host]) -> bool {
+        key == host::LOCAL_KEY || saved_hosts.iter().any(|h| h.key == key)
     }
 
     fn reorder_bookmark(&self, source_uuid: &str, target_uuid: &str) {

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3884,3 +3884,220 @@ fn swap_terminals_works_for_managed_panes() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn right_sidebar_has_host_selector_and_search() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.sidebar-host-selector-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    assert!(
+        window.imp().host_selector.is_visible(),
+        "host selector should be visible in the right sidebar"
+    );
+    assert!(
+        window.imp().sidebar_search_entry.is_visible(),
+        "unified search entry should be visible in the right sidebar"
+    );
+
+    // Host selector should default to "Local" for a local workspace
+    let model = window
+        .imp()
+        .host_selector
+        .model()
+        .and_then(|m| m.downcast::<gtk4::StringList>().ok())
+        .expect("host selector should have a StringList model");
+    let selected_idx = window.imp().host_selector.selected();
+    let selected_label = model.string(selected_idx).unwrap();
+    assert_eq!(selected_label.as_str(), "Local");
+
+    // "All Hosts" should be the last entry
+    let last_idx = model.n_items() - 1;
+    let last_label = model.string(last_idx).unwrap();
+    assert_eq!(last_label.as_str(), "All Hosts");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn right_sidebar_has_places_tab() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.sidebar-places-tab-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // The utility stack should have a "places" page
+    let stack = &window.imp().utility_stack;
+    assert!(stack.child_by_name("places").is_some(), "utility stack should have a Places tab");
+    assert!(
+        stack.child_by_name("bookmarks").is_some(),
+        "utility stack should have a Bookmarks tab"
+    );
+    assert!(stack.child_by_name("commands").is_some(), "utility stack should have a Commands tab");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn place_sidebar_shows_builtin_places_for_local_host() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.sidebar-builtin-places-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Place list should show built-in places (Home, Root) under Global section
+    // Section header + Home + Root = at least 3 rows
+    let place_count = window.imp().place_list.observe_children().n_items();
+    assert!(
+        place_count >= 3,
+        "place sidebar should show at least a section header and 2 built-in places, got {place_count}"
+    );
+    assert!(
+        window.imp().place_scroll.is_visible(),
+        "place scroll should be visible when places exist"
+    );
+    assert!(
+        !window.imp().place_empty.is_visible(),
+        "place empty state should be hidden when places exist"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_selector_auto_follows_workspace_switch() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.host-selector-auto-follow-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Add a remote managed workspace
+    let remote_session = SessionState::new_managed_remote(
+        "Remote Work".into(),
+        "deploy@example.com",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+    let remote_uuid = remote_session.uuid.clone();
+    window.imp().state.borrow_mut().sessions.push(remote_session.clone());
+    window.build_session(&remote_session, false);
+    pump_events(50);
+
+    // Switch to the remote workspace
+    let state = window.imp().state.borrow();
+    let remote_idx = state.sessions.iter().position(|s| s.uuid == remote_uuid).unwrap();
+    drop(state);
+    window.switch_to_session(remote_idx);
+    pump_events(50);
+
+    // Host selector should now show the remote host
+    let model = window
+        .imp()
+        .host_selector
+        .model()
+        .and_then(|m| m.downcast::<gtk4::StringList>().ok())
+        .expect("host selector should have a StringList model");
+    let selected_idx = window.imp().host_selector.selected();
+    let selected_label = model.string(selected_idx).unwrap();
+    assert_eq!(
+        selected_label.as_str(),
+        "example",
+        "host selector should auto-follow to the remote workspace host"
+    );
+
+    // Switch back to the first (local) workspace
+    window.switch_to_session(0);
+    pump_events(50);
+
+    let selected_idx = window.imp().host_selector.selected();
+    let selected_label = model.string(selected_idx).unwrap();
+    assert_eq!(
+        selected_label.as_str(),
+        "Local",
+        "host selector should auto-follow back to local when switching to local workspace"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn command_sidebar_filters_by_selected_host() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let mut local_cmd = crate::commands::SavedCommand::new("Local cmd", "echo local");
+    local_cmd.host_tags = vec!["local".into()];
+    let mut remote_cmd = crate::commands::SavedCommand::new("Remote cmd", "echo remote");
+    remote_cmd.host_tags = vec!["example.com".into()];
+    let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
+    crate::commands::save(&[local_cmd, remote_cmd, global_cmd]).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.command-host-filter-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Default is local host — should show local + global commands
+    let count = window.imp().command_list.observe_children().n_items();
+    assert_eq!(count, 2, "local host should show local + global commands, got {count}");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/host_sidebar_tests.rs
+++ b/clients/rttx/tests/host_sidebar_tests.rs
@@ -1,0 +1,79 @@
+#![allow(clippy::doc_markdown, clippy::items_after_statements)]
+
+//! Integration tests for the host-aware right sidebar.
+//!
+//! Validates that RuntimeEndpoint::host_key() correctly maps endpoints
+//! to host keys, and that commands::visible_for_host() filters correctly.
+
+use rttx::commands::{self, SavedCommand};
+use rttx::host;
+use rttx::places::{self, Place};
+use rttx::runtime::RuntimeEndpoint;
+
+#[test]
+fn host_key_local_endpoint_returns_local_key() {
+    assert_eq!(RuntimeEndpoint::Local.host_key(), host::LOCAL_KEY);
+}
+
+#[test]
+fn host_key_remote_endpoint_normalizes_ssh_target() {
+    let endpoint = RuntimeEndpoint::Remote { host: "deploy@example.com".into() };
+    assert_eq!(endpoint.host_key(), "example.com");
+}
+
+#[test]
+fn host_key_remote_endpoint_bare_hostname() {
+    let endpoint = RuntimeEndpoint::Remote { host: "dev-box".into() };
+    assert_eq!(endpoint.host_key(), "dev-box");
+}
+
+#[test]
+fn commands_visible_for_host_filters_by_tag() {
+    let mut local_cmd = SavedCommand::new("Local", "echo local");
+    local_cmd.host_tags = vec!["local".into()];
+    let mut remote_cmd = SavedCommand::new("Remote", "echo remote");
+    remote_cmd.host_tags = vec!["example.com".into()];
+    let global_cmd = SavedCommand::new("Global", "echo global");
+
+    let saved = vec![local_cmd, remote_cmd, global_cmd];
+
+    let local_visible = commands::visible_for_host(&saved, "local");
+    let names: Vec<&str> = local_visible.iter().map(|c| c.title.as_str()).collect();
+    assert_eq!(names, vec!["Local", "Global"]);
+
+    let remote_visible = commands::visible_for_host(&saved, "example.com");
+    let names: Vec<&str> = remote_visible.iter().map(|c| c.title.as_str()).collect();
+    assert_eq!(names, vec!["Remote", "Global"]);
+}
+
+#[test]
+fn places_visible_for_host_includes_builtins_and_tagged() {
+    let mut local_place = Place::new("rttx", "~/pro/rttx");
+    local_place.host_tags = vec!["local".into()];
+    let mut remote_place = Place::new("app", "/srv/app");
+    remote_place.host_tags = vec!["example.com".into()];
+
+    let saved = vec![local_place, remote_place];
+
+    let local_visible = places::visible_for_host(&saved, "local");
+    let names: Vec<&str> = local_visible.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, vec!["Home", "Root", "rttx"]);
+
+    let remote_visible = places::visible_for_host(&saved, "example.com");
+    let names: Vec<&str> = remote_visible.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, vec!["Home", "Root", "app"]);
+}
+
+#[test]
+fn endpoint_host_key_matches_place_and_command_tags() {
+    let endpoint = RuntimeEndpoint::Remote { host: "deploy@example.com".into() };
+    let host_key = endpoint.host_key();
+
+    let mut place = Place::new("app", "/srv/app");
+    place.host_tags = vec!["example.com".into()];
+    assert!(places::is_visible_on(&place, &host_key));
+
+    let mut cmd = SavedCommand::new("Deploy", "cargo build");
+    cmd.host_tags = vec!["example.com".into()];
+    assert!(commands::is_visible_on(&cmd, &host_key));
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.11',
+  version: '0.2.12',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Reworks the right sidebar per RFC-016 Section 7 and issue #430.

### Changes

- **Unified search bar** at the top of the right sidebar filters across the active tab (Places, Bookmarks, Commands)
- **Host selector dropdown** auto-follows the active workspace host — switching to a remote workspace selects that host, switching back selects Local
- **Places tab** shows host-specific and global places with section headers, filtered by the selected host
- **Commands tab** filters commands by the selected host key (host-specific + global)
- **All Hosts view** in the host selector shows all items grouped by host key, with orphaned tags clearly marked
- **`RuntimeEndpoint::host_key()`** derives a host key compatible with the host model for place/command filtering
- **`commands::visible_for_host()`** filters commands by host key (parallel to `places::visible_for_host()`)
- Version bumped to 0.2.12

### Manual verification

1. Launch rttx with `RTTX_DEV_MODE=1 cargo run -p rttx`
2. Right sidebar shows Search, Host selector, and Places/Bookmarks/Commands tabs
3. Host selector defaults to "Local" for local workspaces
4. Places tab shows built-in Home/Root under Global section
5. Add a remote workspace — host selector auto-follows
6. Switch back to local workspace — host selector returns to Local
7. Select "All Hosts" — shows all items grouped by host

### Tests added

**Unit tests:**
- `host_key_local_returns_local_key` — RuntimeEndpoint::Local returns "local"
- `host_key_remote_normalizes_ssh_target` — Remote endpoint normalizes SSH target
- `host_key_remote_bare_hostname` — Remote endpoint with bare hostname
- `visible_for_host_returns_matching_commands` — Commands filtered by host key
- `visible_for_host_with_no_commands_returns_empty` — Empty command list

**GTK widget tests:**
- `right_sidebar_has_host_selector_and_search` — Host selector and search visible
- `right_sidebar_has_places_tab` — Places/Bookmarks/Commands tabs exist
- `place_sidebar_shows_builtin_places_for_local_host` — Built-in places shown
- `host_selector_auto_follows_workspace_switch` — Auto-follow on workspace switch
- `command_sidebar_filters_by_selected_host` — Commands filtered by host

### Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 5 new GTK tests pass)

Fixes #430