### PR TITLE
feat: add host deletion cleanup dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.12"
+version = "0.2.13"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/host.rs
+++ b/clients/rttx/src/host.rs
@@ -127,6 +127,62 @@ pub fn save_to(hosts: &[Host], path: &Path) -> Result<(), Box<dyn std::error::Er
     Ok(())
 }
 
+/// Items affected by deleting a host record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeletionAffected {
+    pub places: Vec<crate::places::Place>,
+    pub commands: Vec<crate::commands::SavedCommand>,
+}
+
+impl DeletionAffected {
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.places.is_empty() && self.commands.is_empty()
+    }
+}
+
+/// Compute places and commands that reference `host_key` in their tags.
+#[must_use]
+pub fn deletion_affected(
+    host_key: &str,
+    places: &[crate::places::Place],
+    commands: &[crate::commands::SavedCommand],
+) -> DeletionAffected {
+    DeletionAffected {
+        places: places
+            .iter()
+            .filter(|p| p.host_tags.iter().any(|t| t == host_key))
+            .cloned()
+            .collect(),
+        commands: commands
+            .iter()
+            .filter(|c| c.host_tags.iter().any(|t| t == host_key))
+            .cloned()
+            .collect(),
+    }
+}
+
+/// Apply cleanup: remove the given place UUIDs and command UUIDs, then
+/// remove the host from the saved hosts list.
+///
+/// Returns the updated `(hosts, places, commands)`.
+#[must_use]
+pub fn apply_deletion_cleanup(
+    host_key: &str,
+    hosts: &[Host],
+    places: &[crate::places::Place],
+    commands: &[crate::commands::SavedCommand],
+    place_uuids_to_delete: &[String],
+    command_uuids_to_delete: &[String],
+) -> (Vec<Host>, Vec<crate::places::Place>, Vec<crate::commands::SavedCommand>) {
+    let new_hosts: Vec<Host> = hosts.iter().filter(|h| h.key != host_key).cloned().collect();
+    let new_places: Vec<crate::places::Place> =
+        places.iter().filter(|p| !place_uuids_to_delete.contains(&p.uuid)).cloned().collect();
+    let new_commands: Vec<crate::commands::SavedCommand> =
+        commands.iter().filter(|c| !command_uuids_to_delete.contains(&c.uuid)).cloned().collect();
+    (new_hosts, new_places, new_commands)
+}
+
 /// Resolve a host key to a `Host`, checking saved hosts first, then
 /// returning the built-in local host or an ad-hoc remote host.
 #[must_use]
@@ -298,5 +354,109 @@ mod tests {
         let json = serde_json::to_string(&host).unwrap();
         let deserialized: Host = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, host);
+    }
+
+    // ── Deletion affected ───────────────────────────────────────
+
+    #[test]
+    fn deletion_affected_finds_tagged_places_and_commands() {
+        let mut place = crate::places::Place::new("rttx", "~/pro/rttx");
+        place.host_tags = vec!["example.com".into()];
+        let global_place = crate::places::Place::new("tmp", "/tmp");
+
+        let mut cmd = crate::commands::SavedCommand::new("Deploy", "cargo build");
+        cmd.host_tags = vec!["example.com".into()];
+        let global_cmd = crate::commands::SavedCommand::new("Global", "echo hi");
+
+        let affected = deletion_affected(
+            "example.com",
+            &[place.clone(), global_place],
+            &[cmd.clone(), global_cmd],
+        );
+        assert_eq!(affected.places, vec![place]);
+        assert_eq!(affected.commands, vec![cmd]);
+    }
+
+    #[test]
+    fn deletion_affected_empty_when_no_tags_match() {
+        let place = crate::places::Place::new("rttx", "~/pro/rttx");
+        let cmd = crate::commands::SavedCommand::new("Build", "cargo build");
+        let affected = deletion_affected("example.com", &[place], &[cmd]);
+        assert!(affected.is_empty());
+    }
+
+    #[test]
+    fn deletion_affected_multi_tagged_item_included() {
+        let mut place = crate::places::Place::new("shared", "/shared");
+        place.host_tags = vec!["local".into(), "example.com".into()];
+        let affected = deletion_affected("example.com", &[place], &[]);
+        assert_eq!(affected.places.len(), 1);
+    }
+
+    // ── Apply deletion cleanup ──────────────────────────────────
+
+    #[test]
+    fn apply_cleanup_removes_selected_items_and_host() {
+        let host = Host::remote("deploy@example.com");
+        let mut place = crate::places::Place::new("rttx", "~/pro/rttx");
+        place.host_tags = vec!["example.com".into()];
+        let mut cmd = crate::commands::SavedCommand::new("Deploy", "cargo build");
+        cmd.host_tags = vec!["example.com".into()];
+        let place_uuid = place.uuid.clone();
+        let cmd_uuid = cmd.uuid.clone();
+
+        let (new_hosts, new_places, new_commands) = apply_deletion_cleanup(
+            "example.com",
+            &[host],
+            &[place],
+            &[cmd],
+            &[place_uuid],
+            &[cmd_uuid],
+        );
+        assert!(new_hosts.is_empty());
+        assert!(new_places.is_empty());
+        assert!(new_commands.is_empty());
+    }
+
+    #[test]
+    fn apply_cleanup_keeps_unchecked_items() {
+        let host = Host::remote("deploy@example.com");
+        let mut place = crate::places::Place::new("keep", "/keep");
+        place.host_tags = vec!["example.com".into()];
+        let mut cmd = crate::commands::SavedCommand::new("Keep", "echo keep");
+        cmd.host_tags = vec!["example.com".into()];
+
+        let (new_hosts, new_places, new_commands) = apply_deletion_cleanup(
+            "example.com",
+            &[host],
+            &[place.clone()],
+            &[cmd.clone()],
+            &[],
+            &[],
+        );
+        assert!(new_hosts.is_empty());
+        assert_eq!(new_places, vec![place]);
+        assert_eq!(new_commands, vec![cmd]);
+    }
+
+    #[test]
+    fn apply_cleanup_preserves_unrelated_items() {
+        let host = Host::remote("deploy@example.com");
+        let other_host = Host::remote("other@other.com");
+        let global_place = crate::places::Place::new("tmp", "/tmp");
+        let mut tagged_place = crate::places::Place::new("rttx", "~/pro/rttx");
+        tagged_place.host_tags = vec!["example.com".into()];
+        let tagged_uuid = tagged_place.uuid.clone();
+
+        let (new_hosts, new_places, _) = apply_deletion_cleanup(
+            "example.com",
+            &[host, other_host.clone()],
+            &[global_place.clone(), tagged_place],
+            &[],
+            &[tagged_uuid],
+            &[],
+        );
+        assert_eq!(new_hosts, vec![other_host]);
+        assert_eq!(new_places, vec![global_place]);
     }
 }

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -80,6 +80,160 @@ impl Window {
         );
     }
 
+    pub(super) fn confirm_delete_host(&self, host_key: String) {
+        let saved_hosts = host::load();
+        let saved_places = places::load();
+        let saved_commands = commands::load();
+        let affected = host::deletion_affected(&host_key, &saved_places, &saved_commands);
+
+        if affected.is_empty() {
+            let win = self.clone();
+            self.confirm_delete(
+                "Delete Host?",
+                "The host will be permanently removed.",
+                move || {
+                    let mut hosts = host::load();
+                    hosts.retain(|h| h.key != host_key);
+                    if let Err(e) = host::save(&hosts) {
+                        log::error!("Failed to delete host: {e}");
+                    }
+                    win.rebuild_host_selector_model(None);
+                    win.refresh_place_sidebar();
+                    win.refresh_command_sidebar();
+                },
+            );
+            return;
+        }
+
+        let resolved = host::resolve(&host_key, &saved_hosts);
+        let dialog = adw::Dialog::builder()
+            .title(format!("Delete Host: {}?", resolved.name))
+            .content_width(480)
+            .build();
+        let header = adw::HeaderBar::new();
+        let delete_button = gtk4::Button::with_label("Delete");
+        delete_button.add_css_class("destructive-action");
+        header.pack_end(&delete_button);
+
+        let cancel_button = gtk4::Button::with_label("Cancel");
+        header.pack_start(&cancel_button);
+
+        let description = gtk4::Label::new(Some(
+            "The following places and commands are tagged with this host. \
+             Checked items will be deleted. Uncheck items you want to keep \
+             (they will appear as orphaned).",
+        ));
+        description.set_wrap(true);
+        description.set_xalign(0.0);
+        description.add_css_class("dim-label");
+
+        let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+        content_box.set_margin_start(18);
+        content_box.set_margin_end(18);
+        content_box.set_margin_top(12);
+        content_box.set_margin_bottom(18);
+        content_box.append(&description);
+
+        let mut place_checks: Vec<(String, gtk4::CheckButton)> = Vec::new();
+        let mut command_checks: Vec<(String, gtk4::CheckButton)> = Vec::new();
+
+        if !affected.places.is_empty() {
+            let group = adw::PreferencesGroup::new();
+            group.set_title("Places");
+            for place in &affected.places {
+                let check = gtk4::CheckButton::new();
+                check.set_active(true);
+                let row = adw::ActionRow::builder()
+                    .title(&place.name)
+                    .subtitle(&place.path)
+                    .activatable_widget(&check)
+                    .build();
+                row.add_prefix(&check);
+                group.add(&row);
+                place_checks.push((place.uuid.clone(), check));
+            }
+            content_box.append(&group);
+        }
+
+        if !affected.commands.is_empty() {
+            let group = adw::PreferencesGroup::new();
+            group.set_title("Commands");
+            for cmd in &affected.commands {
+                let check = gtk4::CheckButton::new();
+                check.set_active(true);
+                let row = adw::ActionRow::builder()
+                    .title(&cmd.title)
+                    .subtitle(cmd.preview())
+                    .activatable_widget(&check)
+                    .build();
+                row.add_prefix(&check);
+                group.add(&row);
+                command_checks.push((cmd.uuid.clone(), check));
+            }
+            content_box.append(&group);
+        }
+
+        let scroll = gtk4::ScrolledWindow::builder()
+            .hscrollbar_policy(gtk4::PolicyType::Never)
+            .vexpand(true)
+            .max_content_height(400)
+            .propagate_natural_height(true)
+            .child(&content_box)
+            .build();
+
+        let toolbar_view = adw::ToolbarView::new();
+        toolbar_view.add_top_bar(&header);
+        toolbar_view.set_content(Some(&scroll));
+        dialog.set_child(Some(&toolbar_view));
+
+        let dialog_ref = dialog.clone();
+        cancel_button.connect_clicked(move |_| {
+            dialog_ref.close();
+        });
+
+        let dialog_ref = dialog.clone();
+        let win = self.clone();
+        delete_button.connect_clicked(move |_| {
+            let place_uuids: Vec<String> = place_checks
+                .iter()
+                .filter(|(_, check)| check.is_active())
+                .map(|(uuid, _)| uuid.clone())
+                .collect();
+            let command_uuids: Vec<String> = command_checks
+                .iter()
+                .filter(|(_, check)| check.is_active())
+                .map(|(uuid, _)| uuid.clone())
+                .collect();
+
+            let hosts = host::load();
+            let places_data = places::load();
+            let commands_data = commands::load();
+            let (new_hosts, new_places, new_commands) = host::apply_deletion_cleanup(
+                &host_key,
+                &hosts,
+                &places_data,
+                &commands_data,
+                &place_uuids,
+                &command_uuids,
+            );
+            if let Err(e) = host::save(&new_hosts) {
+                log::error!("Failed to save hosts: {e}");
+            }
+            if let Err(e) = places::save(&new_places) {
+                log::error!("Failed to save places: {e}");
+            }
+            if let Err(e) = commands::save(&new_commands) {
+                log::error!("Failed to save commands: {e}");
+            }
+            win.rebuild_host_selector_model(None);
+            win.refresh_place_sidebar();
+            win.refresh_command_sidebar();
+            dialog_ref.close();
+        });
+
+        dialog.present(Some(self));
+    }
+
     pub(super) fn show_about_window(&self) {
         let about = adw::AboutWindow::new();
         about.set_transient_for(Some(self));

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -51,6 +51,7 @@ mod imp {
         pub utility_sidebar_box: gtk4::Box,
         pub sidebar_search_entry: gtk4::SearchEntry,
         pub host_selector: gtk4::DropDown,
+        pub host_delete_button: gtk4::Button,
         pub utility_stack: gtk4::Stack,
         pub place_list: gtk4::ListBox,
         pub place_scroll: gtk4::ScrolledWindow,
@@ -166,10 +167,20 @@ mod imp {
             let host_model = gtk4::StringList::new(&["Local"]);
             self.host_selector.set_model(Some(&host_model));
             self.host_selector.set_selected(0);
-            self.host_selector.set_margin_start(12);
-            self.host_selector.set_margin_end(12);
-            self.host_selector.set_margin_top(8);
+            self.host_selector.set_hexpand(true);
             self.host_selector.update_property(&[gtk4::accessible::Property::Label("Host")]);
+
+            self.host_delete_button.set_icon_name("user-trash-symbolic");
+            self.host_delete_button.set_tooltip_text(Some("Delete selected host"));
+            self.host_delete_button.add_css_class("flat");
+            self.host_delete_button.set_visible(false);
+
+            let host_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
+            host_row.set_margin_start(12);
+            host_row.set_margin_end(12);
+            host_row.set_margin_top(8);
+            host_row.append(&self.host_selector);
+            host_row.append(&self.host_delete_button);
 
             // ── Places tab ───────────────────────────────────────
             self.place_list.set_selection_mode(gtk4::SelectionMode::None);
@@ -294,7 +305,7 @@ mod imp {
 
             self.utility_sidebar_box.set_orientation(gtk4::Orientation::Vertical);
             self.utility_sidebar_box.append(&self.sidebar_search_entry);
-            self.utility_sidebar_box.append(&self.host_selector);
+            self.utility_sidebar_box.append(&host_row);
             self.utility_sidebar_box.append(&utility_switcher);
             self.utility_sidebar_box.append(&self.utility_stack);
             self.utility_sidebar_box.set_width_request(320);
@@ -513,6 +524,16 @@ impl Window {
         self.imp().host_selector.connect_selected_notify(move |_| {
             win.refresh_place_sidebar();
             win.refresh_command_sidebar();
+            win.update_host_delete_button_visibility();
+        });
+
+        let win = self.clone();
+        self.imp().host_delete_button.connect_clicked(move |_| {
+            if let Some(key) = win.selected_host_key()
+                && key != host::LOCAL_KEY
+            {
+                win.confirm_delete_host(key);
+            }
         });
 
         let win = self.clone();

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -6,7 +6,7 @@ const ALL_HOSTS_LABEL: &str = "All Hosts";
 impl Window {
     /// Return the host key currently selected in the host dropdown,
     /// or `None` when "All Hosts" is selected.
-    fn selected_host_key(&self) -> Option<String> {
+    pub(super) fn selected_host_key(&self) -> Option<String> {
         let dd = &self.imp().host_selector;
         let idx = dd.selected() as usize;
         let keys = self.imp().host_selector_keys.borrow();
@@ -26,8 +26,14 @@ impl Window {
         self.rebuild_host_selector_model(Some(&host_key));
     }
 
+    /// Show the delete button only when a deletable remote host is selected.
+    pub(crate) fn update_host_delete_button_visibility(&self) {
+        let visible = self.selected_host_key().is_some_and(|key| key != host::LOCAL_KEY);
+        self.imp().host_delete_button.set_visible(visible);
+    }
+
     /// Rebuild the host selector dropdown model from saved hosts + workspace endpoints.
-    fn rebuild_host_selector_model(&self, select_key: Option<&str>) {
+    pub(super) fn rebuild_host_selector_model(&self, select_key: Option<&str>) {
         let saved_hosts = host::load();
         let state = self.imp().state.borrow();
 

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -4101,3 +4101,120 @@ fn command_sidebar_filters_by_selected_host() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_delete_button_hidden_for_local_host() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.host-delete-local-test").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Default selection is "Local" — delete button should be hidden
+    assert!(
+        !window.imp().host_delete_button.is_visible(),
+        "delete button should be hidden when Local host is selected"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_delete_button_visible_for_remote_host() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    // Save a remote host so it appears in the selector
+    let config_dir = tmp.path().join("rttx-devel");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let hosts = vec![crate::host::Host::remote("deploy@example.com")];
+    crate::host::save_to(&hosts, &config_dir.join("hosts.json")).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.host-delete-remote-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Select the remote host (index 1: Local=0, example=1, All Hosts=2)
+    window.imp().host_selector.set_selected(1);
+    pump_events(50);
+
+    assert!(
+        window.imp().host_delete_button.is_visible(),
+        "delete button should be visible when a remote host is selected"
+    );
+
+    // Switch back to Local
+    window.imp().host_selector.set_selected(0);
+    pump_events(50);
+
+    assert!(
+        !window.imp().host_delete_button.is_visible(),
+        "delete button should be hidden again when Local is selected"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_delete_button_hidden_for_all_hosts() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    // Save a remote host so "All Hosts" is not the only extra entry
+    let config_dir = tmp.path().join("rttx-devel");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let hosts = vec![crate::host::Host::remote("deploy@example.com")];
+    crate::host::save_to(&hosts, &config_dir.join("hosts.json")).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.host-delete-allhosts-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Select "All Hosts" (last entry)
+    let model = window
+        .imp()
+        .host_selector
+        .model()
+        .and_then(|m| m.downcast::<gtk4::StringList>().ok())
+        .unwrap();
+    let last_idx = model.n_items() - 1;
+    window.imp().host_selector.set_selected(last_idx);
+    pump_events(50);
+
+    assert!(
+        !window.imp().host_delete_button.is_visible(),
+        "delete button should be hidden when All Hosts is selected"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.12',
+  version: '0.2.13',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

When a user deletes a host record that has tagged places or commands, an immediate cleanup dialog is now presented (per RFC-016 Section 7).

### Dialog behavior
- Shows all affected places and commands with checkboxes
- All items pre-checked for cleanup (deletion)
- User unchecks items they want to keep
- Kept items appear as orphaned in the All Hosts sidebar view
- Cleanup is explicit and immediate, not deferred

### UI changes
- Added a delete button (trash icon) next to the host selector dropdown
- Button is only visible when a remote host is selected (hidden for Local and All Hosts)
- When no items are affected, a simple confirmation dialog is shown
- When items are affected, a full cleanup dialog with Places and Commands sections is shown

## Manual verification steps
1. Save a remote host with tagged places and commands
2. Select the remote host in the host selector
3. Click the trash icon button
4. Verify the cleanup dialog shows all affected items with checkboxes
5. Uncheck some items and click Delete
6. Verify unchecked items remain as orphaned, checked items are deleted
7. Verify the host is removed from the selector

## Tests added

### Unit tests (host.rs)
- `deletion_affected_finds_tagged_places_and_commands`
- `deletion_affected_empty_when_no_tags_match`
- `deletion_affected_multi_tagged_item_included`
- `apply_cleanup_removes_selected_items_and_host`
- `apply_cleanup_keeps_unchecked_items`
- `apply_cleanup_preserves_unrelated_items`

### GTK widget tests (window/tests.rs)
- `host_delete_button_hidden_for_local_host`
- `host_delete_button_visible_for_remote_host`
- `host_delete_button_hidden_for_all_hosts`

## Tests run
- `cargo build --workspace` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 473 passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests passed ✅

Fixes #431