### PR TITLE
feat: add context menu action to save current SSH host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.13"
+version = "0.2.14"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -1128,6 +1128,13 @@ mod tests {
     }
 
     #[test]
+    fn remote_endpoint_host_key_matches_saved_host_key() {
+        let endpoint = RuntimeEndpoint::Remote { host: "deploy@builder.example.com".into() };
+        let host = crate::host::Host::remote("deploy@builder.example.com");
+        assert_eq!(endpoint.host_key(), host.key);
+    }
+
+    #[test]
     fn connection_presentation_for_starting_shows_starting_label() {
         let p = present_connection_status(&ConnectionStatus::Starting);
         assert_eq!(p.header_label, "Starting");

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -196,6 +196,7 @@ mod imp {
             let session_section = gtk4::gio::Menu::new();
             session_section.append(Some("New Session"), Some("win.new-session"));
             session_section.append(Some("Toggle Input Sync"), Some("win.toggle-input-sync"));
+            session_section.append(Some("Add Host"), Some("win.add-current-host"));
             session_section.append(Some("Preferences"), Some("win.preferences"));
             let close_section = gtk4::gio::Menu::new();
             close_section.append(Some("Close Pane"), Some("win.close-terminal"));

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -226,6 +226,7 @@ mod imp {
             session_section.append(Some("New Session"), Some("win.new-session"));
             session_section.append(Some("Toggle Input Sync"), Some("win.toggle-input-sync"));
             session_section.append(Some("Bookmark Session"), Some("win.bookmark-session"));
+            session_section.append(Some("Add Host"), Some("win.add-current-host"));
             session_section.append(Some("Preferences"), Some("win.preferences"));
             let close_section = gtk4::gio::Menu::new();
             close_section.append(Some("Close Pane"), Some("win.close-terminal"));

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -42,6 +42,7 @@ impl Window {
                 sidebar.set_visible(!sidebar.is_visible());
             }),
             ("bookmark-session", &[], Self::do_bookmark_active_session),
+            ("add-current-host", &[], Self::do_add_current_host),
             ("add-bookmark", &[], |w| {
                 crate::bookmarks_window::show_form(w, None);
             }),

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -482,4 +482,42 @@ impl Window {
         bookmark.directory = cwd;
         Some(bookmark)
     }
+
+    /// Extract the SSH target from the active session's remote endpoint.
+    ///
+    /// Returns `None` for local or unmanaged sessions.
+    pub(crate) fn ssh_target_for_active_session(&self) -> Option<String> {
+        let state = self.imp().state.borrow();
+        let visible = self.imp().session_stack.visible_child_name()?;
+        let session = state.sessions.iter().find(|s| s.uuid == visible.as_str())?;
+        match &session.runtime.endpoint {
+            RuntimeEndpoint::Remote { host } if session.runtime.is_managed() => Some(host.clone()),
+            _ => None,
+        }
+    }
+
+    pub(super) fn do_add_current_host(&self) {
+        let Some(ssh_target) = self.ssh_target_for_active_session() else {
+            self.show_toast("No SSH host in the active workspace");
+            return;
+        };
+
+        let new_host = host::Host::remote(&ssh_target);
+        let mut hosts = host::load();
+
+        if hosts.iter().any(|h| h.key == new_host.key) {
+            self.show_toast(&format!("Host \"{}\" is already saved", new_host.name));
+            return;
+        }
+
+        hosts.push(new_host.clone());
+        if let Err(e) = host::save(&hosts) {
+            log::error!("Failed to save hosts: {e}");
+            self.show_toast("Failed to save host");
+            return;
+        }
+
+        self.rebuild_host_selector_model(None);
+        self.show_toast(&format!("Host \"{}\" added", new_host.name));
+    }
 }

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -4218,3 +4218,140 @@ fn host_delete_button_hidden_for_all_hosts() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn add_current_host_saves_remote_host() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.add-current-host-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Add a remote managed workspace and switch to it
+    let remote_session = SessionState::new_managed_remote(
+        "Remote Work".into(),
+        "deploy@builder.example.com",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+    let remote_uuid = remote_session.uuid.clone();
+    window.imp().state.borrow_mut().sessions.push(remote_session.clone());
+    window.build_session(&remote_session, false);
+    pump_events(50);
+
+    let state = window.imp().state.borrow();
+    let remote_idx = state.sessions.iter().position(|s| s.uuid == remote_uuid).unwrap();
+    drop(state);
+    window.switch_to_session(remote_idx);
+    pump_events(50);
+
+    // Verify SSH target is detected
+    assert_eq!(
+        window.ssh_target_for_active_session().as_deref(),
+        Some("deploy@builder.example.com"),
+    );
+
+    // Trigger the action
+    window.do_add_current_host();
+
+    // Verify host was saved
+    let hosts = crate::host::load();
+    assert!(hosts.iter().any(|h| h.key == "builder.example.com"), "host should be saved");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn add_current_host_skips_duplicate() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.add-current-host-dup-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Pre-save the host
+    let existing = crate::host::Host::remote("deploy@builder.example.com");
+    crate::host::save(&[existing]).unwrap();
+
+    // Add a remote managed workspace and switch to it
+    let remote_session = SessionState::new_managed_remote(
+        "Remote Work".into(),
+        "deploy@builder.example.com",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+    let remote_uuid = remote_session.uuid.clone();
+    window.imp().state.borrow_mut().sessions.push(remote_session.clone());
+    window.build_session(&remote_session, false);
+    pump_events(50);
+
+    let state = window.imp().state.borrow();
+    let remote_idx = state.sessions.iter().position(|s| s.uuid == remote_uuid).unwrap();
+    drop(state);
+    window.switch_to_session(remote_idx);
+    pump_events(50);
+
+    // Trigger the action — should not duplicate
+    window.do_add_current_host();
+
+    let hosts = crate::host::load();
+    assert_eq!(
+        hosts.iter().filter(|h| h.key == "builder.example.com").count(),
+        1,
+        "host should not be duplicated"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn add_current_host_noop_for_local_session() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.add-current-host-local-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Default session is local — ssh_target should be None
+    assert!(window.ssh_target_for_active_session().is_none());
+
+    // Trigger the action — should not save anything
+    window.do_add_current_host();
+
+    let hosts = crate::host::load();
+    assert!(hosts.is_empty(), "no host should be saved for a local session");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/host_sidebar_tests.rs
+++ b/clients/rttx/tests/host_sidebar_tests.rs
@@ -77,3 +77,23 @@ fn endpoint_host_key_matches_place_and_command_tags() {
     cmd.host_tags = vec!["example.com".into()];
     assert!(commands::is_visible_on(&cmd, &host_key));
 }
+
+#[test]
+fn add_host_from_remote_endpoint_saves_and_deduplicates() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("hosts.json");
+
+    let ssh_target = "deploy@builder.example.com";
+    let new_host = host::Host::remote(ssh_target);
+
+    // First save succeeds
+    let mut hosts = host::load_from(&path);
+    assert!(!hosts.iter().any(|h| h.key == new_host.key));
+    hosts.push(new_host.clone());
+    host::save_to(&hosts, &path).unwrap();
+
+    // Duplicate detection prevents second save
+    let hosts = host::load_from(&path);
+    assert!(hosts.iter().any(|h| h.key == new_host.key));
+    assert_eq!(hosts.iter().filter(|h| h.key == "builder.example.com").count(), 1);
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.13',
+  version: '0.2.14',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds an "Add Host" item to the terminal context menu (both ephemeral and persistent pane widgets). When triggered, it extracts the SSH target from the active workspace's remote endpoint and saves it as a Host record.

**Behavior:**
- Available in the context menu of any terminal pane
- When the active workspace is connected to a remote host via SSH, creates a new Host record with the normalized host key
- If the host already exists, shows a toast notification instead of duplicating
- For local sessions, shows a toast explaining no SSH host is available

## Manual verification steps

1. Create a remote managed workspace (e.g., via New Remote Workspace)
2. Right-click in the terminal pane
3. Click "Add Host" — the host should be saved and appear in the host selector
4. Right-click again and click "Add Host" — should show "already saved" toast
5. Switch to a local workspace, right-click, click "Add Host" — should show "no SSH host" toast

## Tests added

- `add_current_host_saves_remote_host` — verifies host is saved for a remote managed workspace
- `add_current_host_skips_duplicate` — verifies duplicate detection
- `add_current_host_noop_for_local_session` — verifies no-op for local sessions

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 3 new GTK tests passed)

Fixes #68