### PR TITLE
feat: add "Add to Places" context menu action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.14"
+version = "0.2.15"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/places.rs
+++ b/clients/rttx/src/places.rs
@@ -25,6 +25,18 @@ impl Place {
         }
     }
 
+    /// Create a place from a working directory path.
+    ///
+    /// The display name is derived from the last path component.
+    /// `host_tags` scopes the place to specific hosts (empty = global).
+    #[must_use]
+    pub fn from_cwd(path: &str, host_tags: Vec<String>) -> Self {
+        let name = Path::new(path)
+            .file_name()
+            .map_or_else(|| path.to_string(), |n| n.to_string_lossy().into_owned());
+        Self { uuid: uuid::Uuid::new_v4().to_string(), name, path: path.to_string(), host_tags }
+    }
+
     /// Display string: name with path in parentheses when they differ.
     #[must_use]
     pub fn display_label(&self) -> String {
@@ -151,6 +163,27 @@ mod tests {
     }
 
     // ── Display label ───────────────────────────────────────────
+
+    #[test]
+    fn from_cwd_derives_name_from_last_component() {
+        let place = Place::from_cwd("/home/user/projects/rttx", vec![]);
+        assert_eq!(place.name, "rttx");
+        assert_eq!(place.path, "/home/user/projects/rttx");
+        assert!(place.host_tags.is_empty());
+    }
+
+    #[test]
+    fn from_cwd_root_path_uses_full_path_as_name() {
+        let place = Place::from_cwd("/", vec![]);
+        assert_eq!(place.name, "/");
+        assert_eq!(place.path, "/");
+    }
+
+    #[test]
+    fn from_cwd_preserves_host_tags() {
+        let place = Place::from_cwd("/srv/app", vec!["example.com".into()]);
+        assert_eq!(place.host_tags, vec!["example.com"]);
+    }
 
     #[test]
     fn display_label_shows_name_and_path_when_different() {

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -670,6 +670,13 @@ mod pane_passive_tests {
     fn persistent_pane_view_is_constructible_without_action_buttons() {
         let _size = std::mem::size_of::<super::persistent_widget::PersistentPaneView>();
     }
+
+    #[test]
+    fn place_from_cwd_derives_name_for_context_menu_action() {
+        let place = crate::places::Place::from_cwd("/home/user/projects/rttx", vec![]);
+        assert_eq!(place.name, "rttx");
+        assert_eq!(place.path, "/home/user/projects/rttx");
+    }
 }
 
 #[cfg(test)]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -196,6 +196,7 @@ mod imp {
             let session_section = gtk4::gio::Menu::new();
             session_section.append(Some("New Session"), Some("win.new-session"));
             session_section.append(Some("Toggle Input Sync"), Some("win.toggle-input-sync"));
+            session_section.append(Some("Add to Places"), Some("win.add-current-place"));
             session_section.append(Some("Add Host"), Some("win.add-current-host"));
             session_section.append(Some("Preferences"), Some("win.preferences"));
             let close_section = gtk4::gio::Menu::new();

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -226,6 +226,7 @@ mod imp {
             session_section.append(Some("New Session"), Some("win.new-session"));
             session_section.append(Some("Toggle Input Sync"), Some("win.toggle-input-sync"));
             session_section.append(Some("Bookmark Session"), Some("win.bookmark-session"));
+            session_section.append(Some("Add to Places"), Some("win.add-current-place"));
             session_section.append(Some("Add Host"), Some("win.add-current-host"));
             session_section.append(Some("Preferences"), Some("win.preferences"));
             let close_section = gtk4::gio::Menu::new();

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -43,6 +43,7 @@ impl Window {
             }),
             ("bookmark-session", &[], Self::do_bookmark_active_session),
             ("add-current-host", &[], Self::do_add_current_host),
+            ("add-current-place", &[], Self::do_add_current_path_to_places),
             ("add-bookmark", &[], |w| {
                 crate::bookmarks_window::show_form(w, None);
             }),

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -520,4 +520,36 @@ impl Window {
         self.rebuild_host_selector_model(None);
         self.show_toast(&format!("Host \"{}\" added", new_host.name));
     }
+
+    pub(super) fn do_add_current_path_to_places(&self) {
+        let Some(uuid) = self.focused_terminal_uuid() else { return };
+        let cwd = self.terminal_handle(&uuid).and_then(|t| t.current_directory());
+        let Some(cwd) = cwd else {
+            self.show_toast("No working directory available");
+            return;
+        };
+
+        let host_key = {
+            let state = self.imp().state.borrow();
+            let visible = self.imp().session_stack.visible_child_name();
+            visible
+                .and_then(|name| state.sessions.iter().find(|s| s.uuid == name.as_str()))
+                .map_or_else(|| host::LOCAL_KEY.into(), |s| s.runtime.endpoint.host_key())
+        };
+
+        let host_tags = if host_key == host::LOCAL_KEY { vec![] } else { vec![host_key] };
+
+        let place = crate::places::Place::from_cwd(&cwd, host_tags);
+        let label = place.display_label();
+        let mut places = crate::places::load();
+        places.push(place);
+        if let Err(e) = crate::places::save(&places) {
+            log::error!("Failed to save places: {e}");
+            self.show_toast("Failed to save place");
+            return;
+        }
+
+        self.refresh_place_sidebar();
+        self.show_toast(&format!("Place \"{label}\" added"));
+    }
 }

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -4355,3 +4355,136 @@ fn add_current_host_noop_for_local_session() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn add_current_path_to_places_saves_place_with_derived_name() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.add-place-cwd-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    let terminal_uuid = {
+        let state = window.imp().state.borrow();
+        state.sessions[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    if let Some(term) = window.imp().terminals.borrow().get(&terminal_uuid) {
+        term.set_current_directory_for_test(Some("/home/user/projects/rttx"));
+    }
+    window.imp().focused_terminal_uuid.replace(Some(terminal_uuid));
+
+    window.do_add_current_path_to_places();
+
+    let places = crate::places::load();
+    assert_eq!(places.len(), 1, "one place should be saved");
+    assert_eq!(places[0].name, "rttx");
+    assert_eq!(places[0].path, "/home/user/projects/rttx");
+    assert!(places[0].host_tags.is_empty(), "local session place should have no host tags");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn add_current_path_to_places_noop_without_cwd() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.add-place-no-cwd-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Don't set any CWD — terminal has no known directory
+    let terminal_uuid = {
+        let state = window.imp().state.borrow();
+        state.sessions[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    window.imp().focused_terminal_uuid.replace(Some(terminal_uuid));
+
+    window.do_add_current_path_to_places();
+
+    let places = crate::places::load();
+    assert!(places.is_empty(), "no place should be saved when CWD is unknown");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn add_current_path_to_places_tags_remote_host() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.add-place-remote-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Add a remote managed workspace and switch to it
+    let remote_session = SessionState::new_managed_remote(
+        "Remote Work".into(),
+        "deploy@builder.example.com",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+    let remote_uuid = remote_session.uuid.clone();
+    window.imp().state.borrow_mut().sessions.push(remote_session.clone());
+    window.build_session(&remote_session, false);
+    pump_events(50);
+
+    let state = window.imp().state.borrow();
+    let remote_idx = state.sessions.iter().position(|s| s.uuid == remote_uuid).unwrap();
+    drop(state);
+    window.switch_to_session(remote_idx);
+    pump_events(50);
+
+    // Set CWD on the persistent terminal
+    let terminal_uuid = {
+        let state = window.imp().state.borrow();
+        let session = state.sessions.iter().find(|s| s.uuid == remote_uuid).unwrap();
+        session.layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    if let Some(term) = window.imp().persistent_terminals.borrow().get(&terminal_uuid) {
+        term.set_current_directory(Some("/srv/app"));
+    }
+    window.imp().focused_terminal_uuid.replace(Some(terminal_uuid));
+
+    window.do_add_current_path_to_places();
+
+    let places = crate::places::load();
+    assert_eq!(places.len(), 1, "one place should be saved");
+    assert_eq!(places[0].name, "app");
+    assert_eq!(places[0].path, "/srv/app");
+    assert_eq!(
+        places[0].host_tags,
+        vec!["builder.example.com"],
+        "remote session place should be tagged with the host key"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/places_integration.rs
+++ b/clients/rttx/tests/places_integration.rs
@@ -1,0 +1,34 @@
+use rttx::places::{self, Place};
+use tempfile::TempDir;
+
+#[test]
+fn place_from_cwd_roundtrips_through_persistence() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("places.json");
+
+    let place = Place::from_cwd("/home/user/projects/rttx", vec!["local".into()]);
+    places::save_to(std::slice::from_ref(&place), &path).unwrap();
+
+    let loaded = places::load_from(&path);
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].name, "rttx");
+    assert_eq!(loaded[0].path, "/home/user/projects/rttx");
+    assert_eq!(loaded[0].host_tags, vec!["local"]);
+}
+
+#[test]
+fn place_from_cwd_visible_for_tagged_host() {
+    let place = Place::from_cwd("/srv/app", vec!["example.com".into()]);
+    let visible = places::visible_for_host(&[place], "example.com");
+    // Built-ins (Home, Root) + the saved place
+    assert_eq!(visible.len(), 3);
+    assert_eq!(visible[2].name, "app");
+}
+
+#[test]
+fn place_from_cwd_not_visible_for_other_host() {
+    let place = Place::from_cwd("/srv/app", vec!["example.com".into()]);
+    let visible = places::visible_for_host(&[place], "other.com");
+    // Only built-ins
+    assert_eq!(visible.len(), 2);
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.14',
+  version: '0.2.15',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds an "Add to Places" item to the terminal right-click context menu. When triggered, it saves the focused terminal's current working directory as a new Place.

- Name is auto-derived from the last path component (e.g. `/home/user/projects/rttx` → `rttx`)
- Local workspaces create a global place (no host tags)
- Remote workspaces tag the place with the host key so it appears only for that host
- Place sidebar refreshes immediately after saving
- Toast notification confirms the action

Closes #67

## Manual verification steps

1. Open rttx, `cd` to a directory
2. Right-click → "Add to Places"
3. Verify toast shows "Place \"dirname\" added"
4. Check Places sidebar shows the new entry
5. For remote workspaces, verify the place is tagged to that host

## Tests added

### Unit tests (places.rs)
- `from_cwd_derives_name_from_last_component`
- `from_cwd_root_path_uses_full_path_as_name`
- `from_cwd_preserves_host_tags`

### GTK widget tests (window/tests.rs)
- `add_current_path_to_places_saves_place_with_derived_name` — local session saves place with correct name and path
- `add_current_path_to_places_noop_without_cwd` — no place saved when CWD is unknown
- `add_current_path_to_places_tags_remote_host` — remote session tags place with host key

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 3 new GTK tests passed)
- All existing tests continue to pass

## Remaining limitations

- No duplicate detection — adding the same path twice creates two entries (can be addressed in a follow-up)