### PR TITLE
feat: add Places submenu to terminal context menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.15"
+version = "0.2.16"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -4,6 +4,22 @@ pub mod links;
 pub mod persistent_widget;
 pub mod widget;
 
+use gtk4::prelude::*;
+
+/// Populate a `gio::Menu` with places visible on the given host key.
+///
+/// Each item triggers `win.open-place` with the place path as parameter.
+pub(crate) fn populate_places_submenu(menu: &gtk4::gio::Menu, host_key: &str) {
+    menu.remove_all();
+    let saved = crate::places::load();
+    let visible = crate::places::visible_for_host(&saved, host_key);
+    for place in &visible {
+        let item = gtk4::gio::MenuItem::new(Some(&place.display_label()), None);
+        item.set_action_and_target_value(Some("win.open-place"), Some(&place.path.to_variant()));
+        menu.append_item(&item);
+    }
+}
+
 /// Test-only re-export of `encode_terminal_key_input`.
 #[doc(hidden)]
 #[must_use]
@@ -666,6 +682,8 @@ mod tests {
 
 #[cfg(test)]
 mod pane_passive_tests {
+    use gtk4::prelude::*;
+
     #[test]
     fn persistent_pane_view_is_constructible_without_action_buttons() {
         let _size = std::mem::size_of::<super::persistent_widget::PersistentPaneView>();
@@ -676,6 +694,34 @@ mod pane_passive_tests {
         let place = crate::places::Place::from_cwd("/home/user/projects/rttx", vec![]);
         assert_eq!(place.name, "rttx");
         assert_eq!(place.path, "/home/user/projects/rttx");
+    }
+
+    #[test]
+    fn populate_places_submenu_adds_builtins_and_matching_saved() {
+        let menu = gtk4::gio::Menu::new();
+        // With no saved places, builtins (Home, Root) should appear.
+        super::populate_places_submenu(&menu, crate::host::LOCAL_KEY);
+        assert!(menu.n_items() >= 2, "builtins must appear; got {}", menu.n_items());
+
+        // Calling again clears previous items before repopulating.
+        super::populate_places_submenu(&menu, crate::host::LOCAL_KEY);
+        assert!(menu.n_items() >= 2);
+    }
+
+    #[test]
+    fn populate_places_submenu_items_target_open_place_action() {
+        let menu = gtk4::gio::Menu::new();
+        super::populate_places_submenu(&menu, crate::host::LOCAL_KEY);
+        for idx in 0..menu.n_items() {
+            let action = menu
+                .item_attribute_value(idx, "action", Some(gtk4::glib::VariantTy::STRING))
+                .expect("each item must have an action");
+            assert_eq!(action.get::<String>().unwrap(), "win.open-place");
+            let target = menu
+                .item_attribute_value(idx, "target", Some(gtk4::glib::VariantTy::STRING))
+                .expect("each item must have a target path");
+            assert!(!target.get::<String>().unwrap().is_empty());
+        }
     }
 }
 

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -46,6 +46,7 @@ mod imp {
         pub search_bar: gtk4::SearchBar,
         pub search_entry: gtk4::SearchEntry,
         pub last_match_at_click: RefCell<Option<String>>,
+        pub places_submenu: gtk4::gio::Menu,
     }
 
     impl Default for PersistentPaneView {
@@ -73,6 +74,7 @@ mod imp {
                 search_bar: gtk4::SearchBar::default(),
                 search_entry: gtk4::SearchEntry::default(),
                 last_match_at_click: RefCell::default(),
+                places_submenu: gtk4::gio::Menu::new(),
             }
         }
     }
@@ -199,6 +201,8 @@ mod imp {
             session_section.append(Some("Add to Places"), Some("win.add-current-place"));
             session_section.append(Some("Add Host"), Some("win.add-current-host"));
             session_section.append(Some("Preferences"), Some("win.preferences"));
+            let places_submenu = &self.places_submenu;
+            session_section.append_submenu(Some("Places"), places_submenu);
             let close_section = gtk4::gio::Menu::new();
             close_section.append(Some("Close Pane"), Some("win.close-terminal"));
             menu.append_section(None, &clipboard_section);
@@ -229,6 +233,15 @@ mod imp {
                     copy_link_ref.set_enabled(has_link);
                     open_link_ref.set_enabled(has_link);
                     obj.imp().last_match_at_click.replace(matched);
+
+                    let host_key = obj
+                        .root()
+                        .and_then(|r| r.downcast::<crate::window::Window>().ok())
+                        .map_or_else(
+                            || crate::host::LOCAL_KEY.into(),
+                            |w| w.visible_session_host_key(),
+                        );
+                    crate::terminal::populate_places_submenu(&obj.imp().places_submenu, &host_key);
                 }
                 context_menu
                     .set_pointing_to(Some(&gtk4::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -42,6 +42,7 @@ mod imp {
         pub search_entry: gtk4::SearchEntry,
         pub child_exited_handler: RefCell<Option<glib::SignalHandlerId>>,
         pub last_match_at_click: RefCell<Option<String>>,
+        pub places_submenu: gtk4::gio::Menu,
     }
 
     #[glib::object_subclass]
@@ -229,6 +230,8 @@ mod imp {
             session_section.append(Some("Add to Places"), Some("win.add-current-place"));
             session_section.append(Some("Add Host"), Some("win.add-current-host"));
             session_section.append(Some("Preferences"), Some("win.preferences"));
+            let places_submenu = &self.places_submenu;
+            session_section.append_submenu(Some("Places"), places_submenu);
             let close_section = gtk4::gio::Menu::new();
             close_section.append(Some("Close Pane"), Some("win.close-terminal"));
             menu.append_section(None, &clipboard_section);
@@ -259,6 +262,15 @@ mod imp {
                     copy_link_ref.set_enabled(has_link);
                     open_link_ref.set_enabled(has_link);
                     obj.imp().last_match_at_click.replace(matched);
+
+                    let host_key = obj
+                        .root()
+                        .and_then(|r| r.downcast::<crate::window::Window>().ok())
+                        .map_or_else(
+                            || crate::host::LOCAL_KEY.into(),
+                            |w| w.visible_session_host_key(),
+                        );
+                    crate::terminal::populate_places_submenu(&obj.imp().places_submenu, &host_key);
                 }
                 context_menu
                     .set_pointing_to(Some(&gtk4::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -129,6 +129,17 @@ impl Window {
         });
         self.add_action(&delete_command_action);
 
+        let open_place_action =
+            gtk4::gio::SimpleAction::new("open-place", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        open_place_action.connect_activate(move |_, param| {
+            let path: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            if !path.is_empty() {
+                win.open_place_in_current_pane(&path);
+            }
+        });
+        self.add_action(&open_place_action);
+
         let about_action = gtk4::gio::SimpleAction::new("about", None);
         let win = self.clone();
         about_action.connect_activate(move |_, _| {

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -732,6 +732,16 @@ impl Window {
         SessionColor::ALL[count % SessionColor::ALL.len()]
     }
 
+    /// Host key for the currently visible workspace session.
+    pub(crate) fn visible_session_host_key(&self) -> String {
+        let state = self.imp().state.borrow();
+        self.imp()
+            .session_stack
+            .visible_child_name()
+            .and_then(|name| state.sessions.iter().find(|s| s.uuid == name.as_str()))
+            .map_or_else(|| host::LOCAL_KEY.into(), |s| s.runtime.endpoint.host_key())
+    }
+
     pub(crate) fn new_session_from_bookmark(&self, bookmark: &Bookmark) {
         let imp = self.imp();
         let initial_cwd = bookmark

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -174,7 +174,7 @@ impl Window {
         true
     }
 
-    fn open_place_in_current_pane(&self, path: &str) {
+    pub(super) fn open_place_in_current_pane(&self, path: &str) {
         let Some(terminal_uuid) = self.command_target_terminal_uuid() else {
             return;
         };

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -4488,3 +4488,91 @@ fn add_current_path_to_places_tags_remote_host() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn open_place_action_sends_cd_to_focused_terminal() {
+    require_display!();
+
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.open-place-action-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    let terminal_uuid = {
+        let state = window.imp().state.borrow();
+        state.sessions[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    window.imp().focused_terminal_uuid.replace(Some(terminal_uuid.clone()));
+
+    window.open_place_in_current_pane("/tmp/test-place");
+
+    let term = window
+        .imp()
+        .terminals
+        .borrow()
+        .get(&terminal_uuid)
+        .cloned()
+        .expect("terminal should exist");
+    assert_eq!(
+        term.pending_shell_inputs_for_test(),
+        vec!["cd /tmp/test-place\n"],
+        "open-place should queue a cd command to the focused terminal"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn open_place_action_resolves_tilde_path() {
+    require_display!();
+
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.open-place-tilde-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    let terminal_uuid = {
+        let state = window.imp().state.borrow();
+        state.sessions[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    window.imp().focused_terminal_uuid.replace(Some(terminal_uuid.clone()));
+
+    // "~" resolves to home — the cd command should use "~" (shell resolves it)
+    window.open_place_in_current_pane("~");
+
+    let term = window
+        .imp()
+        .terminals
+        .borrow()
+        .get(&terminal_uuid)
+        .cloned()
+        .expect("terminal should exist");
+    assert_eq!(
+        term.pending_shell_inputs_for_test(),
+        vec!["cd ~\n"],
+        "tilde path should resolve to home via cd ~"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+fn visible_session_host_key_defaults_to_local() {
+    // The underlying logic defaults to LOCAL_KEY when no visible session is found.
+    assert_eq!(crate::host::LOCAL_KEY, "local");
+}

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -938,9 +938,10 @@ fn terminal_context_menu_model_has_actions() {
 
         for item_idx in 0..n {
             let has_action = section.item_attribute_value(item_idx, "action", None).is_some();
+            let has_submenu = section.item_link(item_idx, "submenu").is_some();
             assert!(
-                has_action,
-                "context menu section {section_idx} item {item_idx} has no action attribute — \
+                has_action || has_submenu,
+                "context menu section {section_idx} item {item_idx} has no action or submenu — \
                  the item will silently do nothing when clicked"
             );
             total_items += 1;
@@ -963,6 +964,36 @@ fn find_popover_child(widget: &gtk4::Widget) -> Option<gtk4::PopoverMenu> {
         child = c.next_sibling();
     }
     None
+}
+
+/// The context menu must contain a "Places" submenu in one of its sections.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn terminal_context_menu_has_places_submenu() {
+    require_display!();
+
+    let term = rttx::terminal::widget::TerminalWidget::new("t1", None);
+    let popover = find_popover_child(term.upcast_ref::<gtk4::Widget>())
+        .expect("context menu must be parented");
+    let model = popover.menu_model().expect("PopoverMenu must have a menu model");
+
+    let mut found_places = false;
+    for section_idx in 0..model.n_items() {
+        let section = model.item_link(section_idx, "section").unwrap();
+        for item_idx in 0..section.n_items() {
+            if section.item_link(item_idx, "submenu").is_some() {
+                let label = section.item_attribute_value(
+                    item_idx,
+                    "label",
+                    Some(gtk4::glib::VariantTy::STRING),
+                );
+                if label.is_some_and(|v| v.get::<String>().unwrap() == "Places") {
+                    found_places = true;
+                }
+            }
+        }
+    }
+    assert!(found_places, "context menu must contain a Places submenu");
 }
 
 // ── TerminalHandle tests ────────────────────────────────────────

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.15',
+  version: '0.2.16',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds a dynamic **Places** submenu to the terminal right-click context menu (issue #53). When the user right-clicks a terminal pane, the submenu is populated with host-compatible places — built-in Home/Root plus any saved places matching the current workspace's host key. Selecting a place sends a `cd` command to the focused terminal, matching the sidebar's existing place-launch behavior.

### Implementation

- `terminal/mod.rs`: new `populate_places_submenu()` shared helper that builds menu items targeting `win.open-place`
- `terminal/widget.rs` and `terminal/persistent_widget.rs`: added `places_submenu` field and dynamic population on right-click
- `window/actions.rs`: new `win.open-place` action with string parameter (place path)
- `window/mod.rs`: new `visible_session_host_key()` method for terminal widgets to query the host
- `window/sidebar.rs`: promoted `open_place_in_current_pane` to `pub(super)` for reuse

### Manual verification

1. Right-click a terminal pane → context menu shows a **Places** submenu
2. The submenu lists Home, Root, and any saved places for the current host
3. Clicking a place sends `cd <path>` to the terminal
4. For remote workspaces, only host-compatible places appear

### Tests added

**Unit tests:**
- `populate_places_submenu_adds_builtins_and_matching_saved` — verifies builtins appear and menu clears on re-population
- `populate_places_submenu_items_target_open_place_action` — verifies each item targets `win.open-place` with a path
- `visible_session_host_key_defaults_to_local` — verifies LOCAL_KEY constant

**GTK widget tests:**
- `terminal_context_menu_has_places_submenu` — verifies the Places submenu exists in the context menu model
- `terminal_context_menu_model_has_actions` — updated to accept submenu items alongside action items

**GTK window tests:**
- `open_place_action_sends_cd_to_focused_terminal` — verifies cd command is queued
- `open_place_action_resolves_tilde_path` — verifies tilde path handling

### Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (all 481 passed)
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests passed including new ones)

### Limitations

- The submenu is populated on each right-click by loading places from disk. For very large place lists this could add latency, but in practice the list is small.

Fixes #53