### PR TITLE
feat: replace top bar with New / Connect / Direct actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.16"
+version = "0.2.17"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -33,10 +33,14 @@ impl Window {
             ("toggle-pane-zoom", &["<Ctrl><Shift>Z"], Self::toggle_pane_zoom),
             ("rotate-layout", &["<Ctrl><Shift>R"], Self::rotate_layout),
             ("new-session", &["<Ctrl><Shift>T"], Self::add_session),
-            ("new-ephemeral-workspace", &["<Ctrl><Shift><Alt>T"], Self::add_ephemeral_session),
+            ("new-ephemeral-workspace", &[], Self::add_ephemeral_session),
             ("new-remote-workspace", &[], Self::show_new_remote_workspace_dialog),
             ("browse-remote-runtimes", &[], Self::show_browse_remote_runtimes_dialog),
-            ("connect-existing-local", &["<Ctrl><Shift>A"], Self::connect_existing_local),
+            ("connect-existing-local", &[], Self::connect_existing_local),
+            ("connect-to-existing", &["<Ctrl><Shift>A"], Self::connect_existing_local),
+            ("new-direct", &["<Ctrl><Shift>D"], |w| {
+                w.add_direct_session();
+            }),
             ("toggle-utility-sidebar", &["<Ctrl><Shift>B"], |w| {
                 let sidebar = &w.imp().utility_sidebar_box;
                 sidebar.set_visible(!sidebar.is_visible());

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -65,7 +65,9 @@ mod imp {
         pub command_scroll: gtk4::ScrolledWindow,
         pub command_empty: adw::StatusPage,
         pub toast_overlay: adw::ToastOverlay,
-        pub add_session_button: gtk4::Button,
+        pub new_button: gtk4::MenuButton,
+        pub connect_button: gtk4::MenuButton,
+        pub new_direct_button: gtk4::Button,
         pub state: RefCell<WindowState>,
         pub terminals: RefCell<HashMap<String, TerminalWidget>>,
         pub persistent_terminals: RefCell<HashMap<String, PersistentPaneView>>,
@@ -101,9 +103,27 @@ mod imp {
             toggle_sidebar.set_active(true);
             header.pack_start(&toggle_sidebar);
 
-            self.add_session_button.set_icon_name("list-add-symbolic");
-            self.add_session_button.set_tooltip_text(Some("New persistent workspace"));
-            header.pack_start(&self.add_session_button);
+            self.new_button.set_label("New");
+            self.new_button.set_tooltip_text(Some("New workspace"));
+            self.new_button.set_icon_name("list-add-symbolic");
+            self.new_button.add_css_class("flat");
+            self.new_button.update_property(&[gtk4::accessible::Property::Label("New workspace")]);
+            header.pack_start(&self.new_button);
+
+            self.connect_button.set_label("Connect");
+            self.connect_button.set_tooltip_text(Some("Connect to existing workspace"));
+            self.connect_button.set_icon_name("network-server-symbolic");
+            self.connect_button.add_css_class("flat");
+            self.connect_button
+                .update_property(&[gtk4::accessible::Property::Label("Connect to existing")]);
+            header.pack_start(&self.connect_button);
+
+            self.new_direct_button.set_label("Direct");
+            self.new_direct_button.set_tooltip_text(Some("New direct workspace"));
+            self.new_direct_button.add_css_class("flat");
+            self.new_direct_button
+                .update_property(&[gtk4::accessible::Property::Label("New direct workspace")]);
+            header.pack_start(&self.new_direct_button);
 
             if let Some(label) = config::badge_label() {
                 self.devel_badge.set_label(label);
@@ -125,11 +145,6 @@ mod imp {
             menu_button.set_icon_name("open-menu-symbolic");
 
             let menu = gtk4::gio::Menu::new();
-            menu.append(Some("New Persistent Workspace"), Some("win.new-session"));
-            menu.append(Some("New Ephemeral Workspace"), Some("win.new-ephemeral-workspace"));
-            menu.append(Some("New Remote Workspace"), Some("win.new-remote-workspace"));
-            menu.append(Some("Connect to Existing (Local)"), Some("win.connect-existing-local"));
-            menu.append(Some("Connect to Existing (Remote)"), Some("win.browse-remote-runtimes"));
             menu.append(Some("About rttx"), Some("win.about"));
             menu.append(Some("Bookmark This Workspace"), Some("win.bookmark-session"));
             menu.append(Some("Preferences"), Some("win.preferences"));
@@ -491,9 +506,11 @@ impl Window {
 
     fn setup_signals(&self) {
         let win = self.clone();
-        self.imp().add_session_button.connect_clicked(move |_| {
-            win.add_session();
+        self.imp().new_direct_button.connect_clicked(move |_| {
+            win.add_direct_session();
         });
+
+        self.setup_host_menu_buttons();
 
         let win = self.clone();
         self.imp().sidebar_list.connect_row_selected(move |_, row| {
@@ -550,6 +567,79 @@ impl Window {
         self.refresh_place_sidebar();
         self.refresh_bookmark_sidebar();
         self.refresh_command_sidebar();
+    }
+
+    fn setup_host_menu_buttons(&self) {
+        self.refresh_host_menus();
+
+        let win = self.clone();
+        self.imp().new_button.connect_notify_local(Some("active"), move |_, _| {
+            win.refresh_host_menus();
+        });
+
+        let win = self.clone();
+        self.imp().connect_button.connect_notify_local(Some("active"), move |_, _| {
+            win.refresh_host_menus();
+        });
+    }
+
+    fn refresh_host_menus(&self) {
+        let mut hosts: Vec<host::Host> = vec![host::Host::local()];
+        let saved = host::load();
+        let mut remotes: Vec<host::Host> =
+            saved.into_iter().filter(host::Host::is_remote).collect();
+        remotes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        hosts.extend(remotes);
+
+        let new_menu = gtk4::gio::Menu::new();
+        let connect_menu = gtk4::gio::Menu::new();
+
+        for host in &hosts {
+            let new_item = gtk4::gio::MenuItem::new(Some(&host.name), None);
+            new_item.set_action_and_target_value(
+                Some("win.new-for-host"),
+                Some(&host.key.to_variant()),
+            );
+            new_menu.append_item(&new_item);
+
+            let connect_item = gtk4::gio::MenuItem::new(Some(&host.name), None);
+            connect_item.set_action_and_target_value(
+                Some("win.connect-for-host"),
+                Some(&host.key.to_variant()),
+            );
+            connect_menu.append_item(&connect_item);
+        }
+
+        self.imp().new_button.set_menu_model(Some(&new_menu));
+        self.imp().connect_button.set_menu_model(Some(&connect_menu));
+
+        let new_action =
+            gtk4::gio::SimpleAction::new("new-for-host", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        new_action.connect_activate(move |_, param| {
+            let key: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            win.new_workspace_for_host(&key);
+        });
+        self.add_action(&new_action);
+
+        let connect_action =
+            gtk4::gio::SimpleAction::new("connect-for-host", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        connect_action.connect_activate(move |_, param| {
+            let key: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            win.connect_for_host(&key);
+        });
+        self.add_action(&connect_action);
+    }
+
+    fn new_workspace_for_host(&self, host_key: &str) {
+        let host = host::resolve(host_key, &host::load());
+        crate::new_workspace_dialog::show(self, &host);
+    }
+
+    fn connect_for_host(&self, host_key: &str) {
+        let host = host::resolve(host_key, &host::load());
+        self.request_connect_existing(&host);
     }
 
     fn append_session_row(&self, session_state: &SessionState) {

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -9,6 +9,22 @@ impl Window {
         self.add_managed_session(WorkspacePolicy::Ephemeral);
     }
 
+    pub(super) fn add_direct_session(&self) {
+        let imp = self.imp();
+        let count = imp.state.borrow().sessions.len() + 1;
+        let initial_cwd = self.resolve_default_session_folder();
+        let name = format!("Direct {count}");
+        let mut session_state = SessionState::new_with_initial_cwd(name, initial_cwd);
+        session_state.color = self.next_session_color();
+        imp.state.borrow_mut().sessions.push(session_state.clone());
+        self.build_session(&session_state, false);
+
+        let index = imp.state.borrow().sessions.len() as i32 - 1;
+        if let Some(row) = imp.sidebar_list.row_at_index(index) {
+            imp.sidebar_list.select_row(Some(&row));
+        }
+    }
+
     pub(super) fn show_new_remote_workspace_dialog(&self) {
         let dialog =
             adw::Dialog::builder().title("New Remote Workspace").content_width(440).build();
@@ -107,7 +123,7 @@ impl Window {
 
     /// Request session inventory for a host and show the Connect to Existing
     /// dialog when the response arrives.
-    fn request_connect_existing(&self, host: &crate::host::Host) {
+    pub(super) fn request_connect_existing(&self, host: &crate::host::Host) {
         if !self.ensure_connection_manager() {
             return;
         }

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -254,7 +254,7 @@ fn preferred_command_target_uuid_falls_back_to_visible_session() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
-fn add_session_button_has_plus_icon() {
+fn top_bar_has_new_connect_direct_buttons() {
     require_display!();
 
     let tmp = tempfile::TempDir::new().unwrap();
@@ -262,15 +262,25 @@ fn add_session_button_has_plus_icon() {
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
     let app =
-        adw::Application::builder().application_id("com.illya.rttx.add-session-icon-tests").build();
+        adw::Application::builder().application_id("com.illya.rttx.top-bar-buttons-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
 
     assert_eq!(
-        window.imp().add_session_button.icon_name().as_deref(),
-        Some("list-add-symbolic"),
-        "new session button should expose the plus icon"
+        window.imp().new_button.label().as_deref(),
+        Some("New"),
+        "New button should have 'New' label"
+    );
+    assert_eq!(
+        window.imp().connect_button.label().as_deref(),
+        Some("Connect"),
+        "Connect button should have 'Connect' label"
+    );
+    assert_eq!(
+        window.imp().new_direct_button.label().as_deref(),
+        Some("Direct"),
+        "Direct button should have 'Direct' label"
     );
 
     window.close();
@@ -4575,4 +4585,63 @@ fn open_place_action_resolves_tilde_path() {
 fn visible_session_host_key_defaults_to_local() {
     // The underlying logic defaults to LOCAL_KEY when no visible session is found.
     assert_eq!(crate::host::LOCAL_KEY, "local");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn new_direct_creates_non_managed_session() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.new-direct-session-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let initial_count = window.imp().state.borrow().sessions.len();
+
+    window.add_direct_session();
+
+    let state = window.imp().state.borrow();
+    assert_eq!(state.sessions.len(), initial_count + 1, "direct session should be added");
+    let new_session = state.sessions.last().unwrap();
+    assert!(!new_session.uses_managed_runtime(), "direct session should not use managed runtime");
+    assert!(
+        new_session.name.starts_with("Direct"),
+        "direct session name should start with 'Direct'"
+    );
+
+    window.close();
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn keyboard_shortcut_actions_are_registered() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.shortcut-actions-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    assert!(
+        window.lookup_action("connect-to-existing").is_some(),
+        "connect-to-existing action should be registered"
+    );
+    assert!(window.lookup_action("new-direct").is_some(), "new-direct action should be registered");
+    assert!(
+        window.lookup_action("new-session").is_some(),
+        "new-session action should be registered"
+    );
+
+    window.close();
 }

--- a/clients/rttx/tests/ui/common.py
+++ b/clients/rttx/tests/ui/common.py
@@ -109,6 +109,40 @@ def find_showing_by_role_and_name(
     return None
 
 
+def find_showing_by_name(
+    root: Atspi.Accessible,
+    name: str,
+    roles: list[Atspi.Role] | None = None,
+) -> Atspi.Accessible | None:
+    """Return the first visible node matching *name* across *roles*.
+
+    If *roles* is ``None``, searches PUSH_BUTTON, MENU_ITEM, and LABEL.
+    """
+    if roles is None:
+        roles = [Atspi.Role.PUSH_BUTTON, Atspi.Role.MENU_ITEM, Atspi.Role.LABEL]
+    for role in roles:
+        found = find_showing_by_role_and_name(root, role, name)
+        if found is not None:
+            return found
+    return None
+
+
+def wait_for_showing_by_name(
+    root: Atspi.Accessible,
+    name: str,
+    roles: list[Atspi.Role] | None = None,
+    timeout: float = 10.0,
+) -> Atspi.Accessible | None:
+    """Poll until a visible node with *name* appears across *roles*."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        found = find_showing_by_name(root, name, roles)
+        if found is not None:
+            return found
+        time.sleep(0.2)
+    return find_showing_by_name(root, name, roles)
+
+
 def find_app_by_pid(pid: int, timeout: float = 10.0) -> Atspi.Accessible | None:
     """Poll the AT-SPI desktop until the application with *pid* appears."""
     deadline = time.monotonic() + timeout
@@ -476,6 +510,12 @@ class AppFixture:
     def showing_terminals(self) -> list:
         """Return all visible TERMINAL-role nodes currently in the tree."""
         return [node for node in self.terminals() if is_showing(node)]
+
+    def wait_for_showing_by_name(
+        self, name: str, roles: list | None = None, timeout: float = 10.0
+    ) -> Atspi.Accessible | None:
+        """Wait until a visible node with *name* appears across *roles*."""
+        return wait_for_showing_by_name(self.atspi_app, name, roles, timeout=timeout)
 
     def window(self) -> Atspi.Accessible | None:
         """Return the first top-level window node."""

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -27,10 +27,8 @@ class TestManagedBlackBox(unittest.TestCase):
         self.assertIsNotNone(button, "New workspace button not visible")
         click(button)
         import time
-        time.sleep(0.5)
-        local_item = self.fixture.wait_for_showing_name(
-            Atspi.Role.MENU_ITEM, "Local", timeout=5.0
-        )
+        time.sleep(1.0)
+        local_item = self.fixture.wait_for_showing_by_name("Local", timeout=10.0)
         self.assertIsNotNone(local_item, "Local host item not visible in New menu")
         click(local_item)
 
@@ -151,10 +149,8 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
         self.assertIsNotNone(button, "New workspace button not visible")
         click(button)
         import time
-        time.sleep(0.5)
-        local_item = self.fixture.wait_for_showing_name(
-            Atspi.Role.MENU_ITEM, "Local", timeout=5.0
-        )
+        time.sleep(1.0)
+        local_item = self.fixture.wait_for_showing_by_name("Local", timeout=10.0)
         self.assertIsNotNone(local_item, "Local host item not visible in New menu")
         click(local_item)
 

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -22,10 +22,17 @@ class TestManagedBlackBox(unittest.TestCase):
 
     def _create_managed_workspace(self) -> None:
         button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "New persistent workspace"
+            Atspi.Role.TOGGLE_BUTTON, "New workspace"
         )
-        self.assertIsNotNone(button, "persistent workspace button not visible")
+        self.assertIsNotNone(button, "New workspace button not visible")
         click(button)
+        import time
+        time.sleep(0.5)
+        local_item = self.fixture.wait_for_showing_name(
+            Atspi.Role.MENU_ITEM, "Local", timeout=5.0
+        )
+        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
+        click(local_item)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(
@@ -139,10 +146,17 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
     def test_managed_pane_exit_is_visible_when_shell_exits(self) -> None:
         """A daemon PaneExited event must leave a clear, non-hanging pane."""
         button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "New persistent workspace"
+            Atspi.Role.TOGGLE_BUTTON, "New workspace"
         )
-        self.assertIsNotNone(button, "persistent workspace button not visible")
+        self.assertIsNotNone(button, "New workspace button not visible")
         click(button)
+        import time
+        time.sleep(0.5)
+        local_item = self.fixture.wait_for_showing_name(
+            Atspi.Role.MENU_ITEM, "Local", timeout=5.0
+        )
+        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
+        click(local_item)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -7,7 +7,7 @@ import gi
 gi.require_version("Atspi", "2.0")
 from gi.repository import Atspi
 
-from common import AppFixture, click, wait_for_name
+from common import AppFixture, click, click_center, wait_for_name
 
 
 class TestManagedBlackBox(unittest.TestCase):
@@ -25,10 +25,13 @@ class TestManagedBlackBox(unittest.TestCase):
             Atspi.Role.TOGGLE_BUTTON, "New workspace"
         )
         self.assertIsNotNone(button, "New workspace button not visible")
-        click(button)
+        click_center(button)
         import time
         time.sleep(1.0)
-        local_item = self.fixture.wait_for_showing_by_name("Local", timeout=10.0)
+        # gio::Menu items in a PopoverMenu appear as PUSH_BUTTON in AT-SPI.
+        local_item = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Local", timeout=10.0
+        )
         self.assertIsNotNone(local_item, "Local host item not visible in New menu")
         click(local_item)
 
@@ -147,10 +150,12 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
             Atspi.Role.TOGGLE_BUTTON, "New workspace"
         )
         self.assertIsNotNone(button, "New workspace button not visible")
-        click(button)
+        click_center(button)
         import time
         time.sleep(1.0)
-        local_item = self.fixture.wait_for_showing_by_name("Local", timeout=10.0)
+        local_item = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Local", timeout=10.0
+        )
         self.assertIsNotNone(local_item, "Local host item not visible in New menu")
         click(local_item)
 

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -130,10 +130,8 @@ class TestSidebarContentManaged(unittest.TestCase):
         self.assertIsNotNone(button, "New workspace button not visible")
         click(button)
         import time
-        time.sleep(0.5)
-        local_item = self.fixture.wait_for_showing_name(
-            Atspi.Role.MENU_ITEM, "Local", timeout=5.0
-        )
+        time.sleep(1.0)
+        local_item = self.fixture.wait_for_showing_by_name("Local", timeout=10.0)
         self.assertIsNotNone(local_item, "Local host item not visible in New menu")
         click(local_item)
 

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -13,7 +13,7 @@ import gi
 gi.require_version("Atspi", "2.0")
 from gi.repository import Atspi
 
-from common import AppFixture, click, find_all_by_role, wait_for_name, wait_for_role
+from common import AppFixture, click, click_center, find_all_by_role, wait_for_name, wait_for_role
 
 # Patterns that must never appear in a sidebar subtitle (RFC-015 exclusion list).
 FORBIDDEN_SUBTITLE_PATTERNS = [
@@ -128,10 +128,12 @@ class TestSidebarContentManaged(unittest.TestCase):
             Atspi.Role.TOGGLE_BUTTON, "New workspace"
         )
         self.assertIsNotNone(button, "New workspace button not visible")
-        click(button)
+        click_center(button)
         import time
         time.sleep(1.0)
-        local_item = self.fixture.wait_for_showing_by_name("Local", timeout=10.0)
+        local_item = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Local", timeout=10.0
+        )
         self.assertIsNotNone(local_item, "Local host item not visible in New menu")
         click(local_item)
 

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -125,10 +125,17 @@ class TestSidebarContentManaged(unittest.TestCase):
 
     def _create_managed_workspace(self) -> None:
         button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "New persistent workspace"
+            Atspi.Role.TOGGLE_BUTTON, "New workspace"
         )
-        self.assertIsNotNone(button, "persistent workspace button not visible")
+        self.assertIsNotNone(button, "New workspace button not visible")
         click(button)
+        import time
+        time.sleep(0.5)
+        local_item = self.fixture.wait_for_showing_name(
+            Atspi.Role.MENU_ITEM, "Local", timeout=5.0
+        )
+        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
+        click(local_item)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.16',
+  version: '0.2.17',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Replaces the single `add_session_button` (plus icon) in the header bar with three intent-driven controls per RFC-016 Section 1:

- **New** (MenuButton dropdown): Lists local host + saved remote hosts. Selecting a host opens the New Workspace dialog for that host.
- **Connect** (MenuButton dropdown): Lists local host + saved remote hosts. Selecting a host opens the Connect to Existing dialog for that host.
- **Direct** (Button): Creates a new direct (non-daemon) workspace immediately.

### Keyboard shortcuts

| Action | Shortcut |
|--------|----------|
| New workspace | Ctrl+Shift+T |
| Connect to existing | Ctrl+Shift+A |
| New direct | Ctrl+Shift+D |

Old workspace creation entries removed from the hamburger menu since they are now accessible from the top bar.

This supersedes PR #465 which had extensive merge conflicts with 16 subsequent PRs.

## Manual verification steps

1. Launch rttx — header bar shows New, Connect, Direct buttons
2. Click New → dropdown shows Local (and any saved remote hosts)
3. Click Local → opens New Workspace dialog
4. Click Connect → dropdown shows Local (and any saved remote hosts)
5. Click Direct → creates a direct workspace named 'Direct N'
6. Ctrl+Shift+T opens New Workspace dialog for local host
7. Ctrl+Shift+A triggers Connect to Existing for local host
8. Ctrl+Shift+D creates a direct workspace

## Tests added

- `top_bar_has_new_connect_direct_buttons` — GTK test verifying all three buttons exist with correct labels
- `new_direct_creates_non_managed_session` — GTK test verifying direct session creation produces a non-managed session
- `keyboard_shortcut_actions_are_registered` — GTK test verifying connect-to-existing, new-direct, and new-session actions are registered

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo build -p rttx-proto -p rttx-server` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (39 unit + 481 total passed, 0 failed)
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass including new ones)
- `./run_ui_tests.sh` — 12 failures, same count as baseline (pre-existing AT-SPI flakiness)

## Remaining limitations

- The New and Connect dropdowns currently show a flat list. Future work may add grouping or search.
- Ephemeral workspace creation is still available via the `new-ephemeral-workspace` action but no longer has a keyboard shortcut.

Fixes #425
Fixes #473