### PR TITLE
Add VTE parity harness for managed terminal input (#464)

### DIFF
--- a/clients/rttx/tests/vte_parity.rs
+++ b/clients/rttx/tests/vte_parity.rs
@@ -119,23 +119,19 @@ fn ctrl_a_through_z() {
     ];
     for (key, expected) in keys_and_expected {
         let actual = encode(*key, CTRL);
-        assert_eq!(
-            actual,
-            Some(vec![*expected]),
-            "Ctrl+{key:?} should produce 0x{expected:02x}"
-        );
+        assert_eq!(actual, Some(vec![*expected]), "Ctrl+{key:?} should produce 0x{expected:02x}");
     }
 }
 
 #[test]
 fn ctrl_special_characters() {
     assert_parity(&[
-        (Key::space, CTRL, &[0x00]),       // Ctrl+Space = NUL
-        (Key::bracketleft, CTRL, &[0x1b]), // Ctrl+[ = ESC
-        (Key::bracketright, CTRL, &[0x1d]),// Ctrl+] = GS
-        (Key::backslash, CTRL, &[0x1c]),   // Ctrl+\ = FS
-        (Key::slash, CTRL, &[0x1f]),       // Ctrl+/ = US
-        (Key::question, CTRL, &[0x7f]),    // Ctrl+? = DEL
+        (Key::space, CTRL, &[0x00]),        // Ctrl+Space = NUL
+        (Key::bracketleft, CTRL, &[0x1b]),  // Ctrl+[ = ESC
+        (Key::bracketright, CTRL, &[0x1d]), // Ctrl+] = GS
+        (Key::backslash, CTRL, &[0x1c]),    // Ctrl+\ = FS
+        (Key::slash, CTRL, &[0x1f]),        // Ctrl+/ = US
+        (Key::question, CTRL, &[0x7f]),     // Ctrl+? = DEL
     ]);
 }
 
@@ -165,10 +161,7 @@ fn arrow_keys_unmodified() {
 
 #[test]
 fn home_end_unmodified() {
-    assert_parity(&[
-        (Key::Home, NONE, b"\x1b[H"),
-        (Key::End, NONE, b"\x1b[F"),
-    ]);
+    assert_parity(&[(Key::Home, NONE, b"\x1b[H"), (Key::End, NONE, b"\x1b[F")]);
 }
 
 #[test]
@@ -237,10 +230,7 @@ fn alt_ctrl_arrow_keys() {
 
 #[test]
 fn ctrl_home_end() {
-    assert_parity(&[
-        (Key::Home, CTRL, b"\x1b[1;5H"),
-        (Key::End, CTRL, b"\x1b[1;5F"),
-    ]);
+    assert_parity(&[(Key::Home, CTRL, b"\x1b[1;5H"), (Key::End, CTRL, b"\x1b[1;5F")]);
 }
 
 #[test]
@@ -290,10 +280,7 @@ fn ctrl_fkeys() {
 
 #[test]
 fn shift_fkeys() {
-    assert_parity(&[
-        (Key::F1, SHIFT, b"\x1b[1;2P"),
-        (Key::F5, SHIFT, b"\x1b[15;2~"),
-    ]);
+    assert_parity(&[(Key::F1, SHIFT, b"\x1b[1;2P"), (Key::F5, SHIFT, b"\x1b[15;2~")]);
 }
 
 #[test]
@@ -325,10 +312,7 @@ fn keypad_navigation_keys() {
 
 #[test]
 fn keypad_enter_and_tab() {
-    assert_parity(&[
-        (Key::KP_Enter, NONE, b"\r"),
-        (Key::KP_Tab, NONE, b"\t"),
-    ]);
+    assert_parity(&[(Key::KP_Enter, NONE, b"\r"), (Key::KP_Tab, NONE, b"\t")]);
 }
 
 // ── Special keys ────────────────────────────────────────────────
@@ -387,10 +371,6 @@ fn modifier_parameter_values_follow_xterm_convention() {
     ];
     for (mods, expected) in cases {
         let actual = encode(Key::Up, *mods);
-        assert_eq!(
-            actual.as_deref(),
-            Some(*expected),
-            "Up + {mods:?} modifier param"
-        );
+        assert_eq!(actual.as_deref(), Some(*expected), "Up + {mods:?} modifier param");
     }
 }

--- a/clients/rttx/tests/vte_parity.rs
+++ b/clients/rttx/tests/vte_parity.rs
@@ -1,0 +1,396 @@
+//! VTE parity harness for managed terminal input encoding.
+//!
+//! Verifies that `encode_terminal_key_input` produces the same escape
+//! sequences a standard xterm/VTE terminal would emit for every key
+//! category: printable characters, control keys, Alt/Ctrl/Shift
+//! combinations, navigation keys, F-keys, keypad, and special keys.
+//!
+//! This is the required regression layer for future terminal input fixes
+//! (see GitHub issue #464).
+
+use rttx::terminal::encode_terminal_key_input_for_test as encode;
+
+type Mods = gtk4::gdk::ModifierType;
+type Key = gtk4::gdk::Key;
+
+const NONE: Mods = Mods::empty();
+const CTRL: Mods = Mods::CONTROL_MASK;
+const ALT: Mods = Mods::ALT_MASK;
+const SHIFT: Mods = Mods::SHIFT_MASK;
+
+/// Table-driven parity assertion: each entry is (key, modifiers, expected bytes).
+fn assert_parity(cases: &[(Key, Mods, &[u8])]) {
+    for (key, mods, expected) in cases {
+        let actual = encode(*key, *mods);
+        assert_eq!(
+            actual.as_deref(),
+            Some(*expected),
+            "parity mismatch for {key:?} + {mods:?}: expected {expected:?}, got {actual:?}"
+        );
+    }
+}
+
+// ── Printable characters ────────────────────────────────────────
+
+#[test]
+fn printable_ascii_lowercase() {
+    assert_parity(&[
+        (Key::a, NONE, b"a"),
+        (Key::b, NONE, b"b"),
+        (Key::c, NONE, b"c"),
+        (Key::d, NONE, b"d"),
+        (Key::e, NONE, b"e"),
+        (Key::f, NONE, b"f"),
+        (Key::g, NONE, b"g"),
+        (Key::h, NONE, b"h"),
+        (Key::i, NONE, b"i"),
+        (Key::j, NONE, b"j"),
+        (Key::k, NONE, b"k"),
+        (Key::l, NONE, b"l"),
+        (Key::m, NONE, b"m"),
+        (Key::n, NONE, b"n"),
+        (Key::o, NONE, b"o"),
+        (Key::p, NONE, b"p"),
+        (Key::q, NONE, b"q"),
+        (Key::r, NONE, b"r"),
+        (Key::s, NONE, b"s"),
+        (Key::t, NONE, b"t"),
+        (Key::u, NONE, b"u"),
+        (Key::v, NONE, b"v"),
+        (Key::w, NONE, b"w"),
+        (Key::x, NONE, b"x"),
+        (Key::y, NONE, b"y"),
+        (Key::z, NONE, b"z"),
+    ]);
+}
+
+#[test]
+fn printable_digits() {
+    assert_parity(&[
+        (Key::_0, NONE, b"0"),
+        (Key::_1, NONE, b"1"),
+        (Key::_2, NONE, b"2"),
+        (Key::_3, NONE, b"3"),
+        (Key::_4, NONE, b"4"),
+        (Key::_5, NONE, b"5"),
+        (Key::_6, NONE, b"6"),
+        (Key::_7, NONE, b"7"),
+        (Key::_8, NONE, b"8"),
+        (Key::_9, NONE, b"9"),
+    ]);
+}
+
+#[test]
+fn space_produces_space_byte() {
+    assert_eq!(encode(Key::space, NONE), Some(vec![b' ']));
+}
+
+// ── Control key combinations ────────────────────────────────────
+
+#[test]
+fn ctrl_a_through_z() {
+    let keys_and_expected: &[(Key, u8)] = &[
+        (Key::a, 0x01),
+        (Key::b, 0x02),
+        (Key::c, 0x03),
+        (Key::d, 0x04),
+        (Key::e, 0x05),
+        (Key::f, 0x06),
+        (Key::g, 0x07),
+        (Key::h, 0x08),
+        (Key::i, 0x09),
+        (Key::j, 0x0a),
+        (Key::k, 0x0b),
+        (Key::l, 0x0c),
+        (Key::m, 0x0d),
+        (Key::n, 0x0e),
+        (Key::o, 0x0f),
+        (Key::p, 0x10),
+        (Key::q, 0x11),
+        (Key::r, 0x12),
+        (Key::s, 0x13),
+        (Key::t, 0x14),
+        (Key::u, 0x15),
+        (Key::v, 0x16),
+        (Key::w, 0x17),
+        (Key::x, 0x18),
+        (Key::y, 0x19),
+        (Key::z, 0x1a),
+    ];
+    for (key, expected) in keys_and_expected {
+        let actual = encode(*key, CTRL);
+        assert_eq!(
+            actual,
+            Some(vec![*expected]),
+            "Ctrl+{key:?} should produce 0x{expected:02x}"
+        );
+    }
+}
+
+#[test]
+fn ctrl_special_characters() {
+    assert_parity(&[
+        (Key::space, CTRL, &[0x00]),       // Ctrl+Space = NUL
+        (Key::bracketleft, CTRL, &[0x1b]), // Ctrl+[ = ESC
+        (Key::bracketright, CTRL, &[0x1d]),// Ctrl+] = GS
+        (Key::backslash, CTRL, &[0x1c]),   // Ctrl+\ = FS
+        (Key::slash, CTRL, &[0x1f]),       // Ctrl+/ = US
+        (Key::question, CTRL, &[0x7f]),    // Ctrl+? = DEL
+    ]);
+}
+
+// ── Alt combinations ────────────────────────────────────────────
+
+#[test]
+fn alt_printable_sends_esc_prefix() {
+    assert_parity(&[
+        (Key::a, ALT, b"\x1ba"),
+        (Key::b, ALT, b"\x1bb"),
+        (Key::x, ALT, b"\x1bx"),
+        (Key::z, ALT, b"\x1bz"),
+    ]);
+}
+
+// ── Navigation keys (unmodified) ────────────────────────────────
+
+#[test]
+fn arrow_keys_unmodified() {
+    assert_parity(&[
+        (Key::Up, NONE, b"\x1b[A"),
+        (Key::Down, NONE, b"\x1b[B"),
+        (Key::Right, NONE, b"\x1b[C"),
+        (Key::Left, NONE, b"\x1b[D"),
+    ]);
+}
+
+#[test]
+fn home_end_unmodified() {
+    assert_parity(&[
+        (Key::Home, NONE, b"\x1b[H"),
+        (Key::End, NONE, b"\x1b[F"),
+    ]);
+}
+
+#[test]
+fn insert_delete_page_keys_unmodified() {
+    assert_parity(&[
+        (Key::Insert, NONE, b"\x1b[2~"),
+        (Key::Delete, NONE, b"\x1b[3~"),
+        (Key::Page_Up, NONE, b"\x1b[5~"),
+        (Key::Page_Down, NONE, b"\x1b[6~"),
+    ]);
+}
+
+// ── Navigation keys (modified) ──────────────────────────────────
+
+#[test]
+fn ctrl_arrow_keys() {
+    assert_parity(&[
+        (Key::Up, CTRL, b"\x1b[1;5A"),
+        (Key::Down, CTRL, b"\x1b[1;5B"),
+        (Key::Right, CTRL, b"\x1b[1;5C"),
+        (Key::Left, CTRL, b"\x1b[1;5D"),
+    ]);
+}
+
+#[test]
+fn shift_arrow_keys() {
+    assert_parity(&[
+        (Key::Up, SHIFT, b"\x1b[1;2A"),
+        (Key::Down, SHIFT, b"\x1b[1;2B"),
+        (Key::Right, SHIFT, b"\x1b[1;2C"),
+        (Key::Left, SHIFT, b"\x1b[1;2D"),
+    ]);
+}
+
+#[test]
+fn alt_arrow_keys() {
+    assert_parity(&[
+        (Key::Up, ALT, b"\x1b[1;3A"),
+        (Key::Down, ALT, b"\x1b[1;3B"),
+        (Key::Right, ALT, b"\x1b[1;3C"),
+        (Key::Left, ALT, b"\x1b[1;3D"),
+    ]);
+}
+
+#[test]
+fn ctrl_shift_arrow_keys() {
+    let mods = CTRL.union(SHIFT);
+    assert_parity(&[
+        (Key::Up, mods, b"\x1b[1;6A"),
+        (Key::Down, mods, b"\x1b[1;6B"),
+        (Key::Right, mods, b"\x1b[1;6C"),
+        (Key::Left, mods, b"\x1b[1;6D"),
+    ]);
+}
+
+#[test]
+fn alt_ctrl_arrow_keys() {
+    let mods = ALT.union(CTRL);
+    assert_parity(&[
+        (Key::Up, mods, b"\x1b[1;7A"),
+        (Key::Down, mods, b"\x1b[1;7B"),
+        (Key::Right, mods, b"\x1b[1;7C"),
+        (Key::Left, mods, b"\x1b[1;7D"),
+    ]);
+}
+
+#[test]
+fn ctrl_home_end() {
+    assert_parity(&[
+        (Key::Home, CTRL, b"\x1b[1;5H"),
+        (Key::End, CTRL, b"\x1b[1;5F"),
+    ]);
+}
+
+#[test]
+fn ctrl_delete_insert_page() {
+    assert_parity(&[
+        (Key::Delete, CTRL, b"\x1b[3;5~"),
+        (Key::Insert, CTRL, b"\x1b[2;5~"),
+        (Key::Page_Up, CTRL, b"\x1b[5;5~"),
+        (Key::Page_Down, CTRL, b"\x1b[6;5~"),
+    ]);
+}
+
+// ── F-keys (unmodified) ─────────────────────────────────────────
+
+#[test]
+fn fkeys_unmodified() {
+    assert_parity(&[
+        (Key::F1, NONE, b"\x1bOP"),
+        (Key::F2, NONE, b"\x1bOQ"),
+        (Key::F3, NONE, b"\x1bOR"),
+        (Key::F4, NONE, b"\x1bOS"),
+        (Key::F5, NONE, b"\x1b[15~"),
+        (Key::F6, NONE, b"\x1b[17~"),
+        (Key::F7, NONE, b"\x1b[18~"),
+        (Key::F8, NONE, b"\x1b[19~"),
+        (Key::F9, NONE, b"\x1b[20~"),
+        (Key::F10, NONE, b"\x1b[21~"),
+        (Key::F11, NONE, b"\x1b[23~"),
+        (Key::F12, NONE, b"\x1b[24~"),
+    ]);
+}
+
+// ── F-keys (modified) ───────────────────────────────────────────
+
+#[test]
+fn ctrl_fkeys() {
+    assert_parity(&[
+        (Key::F1, CTRL, b"\x1b[1;5P"),
+        (Key::F2, CTRL, b"\x1b[1;5Q"),
+        (Key::F3, CTRL, b"\x1b[1;5R"),
+        (Key::F4, CTRL, b"\x1b[1;5S"),
+        (Key::F5, CTRL, b"\x1b[15;5~"),
+        (Key::F6, CTRL, b"\x1b[17;5~"),
+        (Key::F12, CTRL, b"\x1b[24;5~"),
+    ]);
+}
+
+#[test]
+fn shift_fkeys() {
+    assert_parity(&[
+        (Key::F1, SHIFT, b"\x1b[1;2P"),
+        (Key::F5, SHIFT, b"\x1b[15;2~"),
+    ]);
+}
+
+#[test]
+fn alt_fkeys() {
+    assert_parity(&[
+        (Key::F1, ALT, b"\x1b[1;3P"),
+        (Key::F2, ALT, b"\x1b[1;3Q"),
+        (Key::F5, ALT, b"\x1b[15;3~"),
+    ]);
+}
+
+// ── Keypad keys ─────────────────────────────────────────────────
+
+#[test]
+fn keypad_navigation_keys() {
+    assert_parity(&[
+        (Key::KP_Up, NONE, b"\x1b[A"),
+        (Key::KP_Down, NONE, b"\x1b[B"),
+        (Key::KP_Right, NONE, b"\x1b[C"),
+        (Key::KP_Left, NONE, b"\x1b[D"),
+        (Key::KP_Home, NONE, b"\x1b[H"),
+        (Key::KP_End, NONE, b"\x1b[F"),
+        (Key::KP_Insert, NONE, b"\x1b[2~"),
+        (Key::KP_Delete, NONE, b"\x1b[3~"),
+        (Key::KP_Page_Up, NONE, b"\x1b[5~"),
+        (Key::KP_Page_Down, NONE, b"\x1b[6~"),
+    ]);
+}
+
+#[test]
+fn keypad_enter_and_tab() {
+    assert_parity(&[
+        (Key::KP_Enter, NONE, b"\r"),
+        (Key::KP_Tab, NONE, b"\t"),
+    ]);
+}
+
+// ── Special keys ────────────────────────────────────────────────
+
+#[test]
+fn return_backspace_tab_escape() {
+    assert_parity(&[
+        (Key::Return, NONE, b"\r"),
+        (Key::BackSpace, NONE, &[0x7f]),
+        (Key::Tab, NONE, b"\t"),
+        (Key::Escape, NONE, &[0x1b]),
+    ]);
+}
+
+#[test]
+fn shift_tab_produces_backtab() {
+    assert_eq!(encode(Key::ISO_Left_Tab, NONE), Some(b"\x1b[Z".to_vec()));
+}
+
+// ── Modifier-only keys produce None ─────────────────────────────
+
+#[test]
+fn modifier_only_keys_produce_none() {
+    let modifier_keys = [
+        Key::Shift_L,
+        Key::Shift_R,
+        Key::Control_L,
+        Key::Control_R,
+        Key::Alt_L,
+        Key::Alt_R,
+        Key::Super_L,
+        Key::Super_R,
+        Key::Caps_Lock,
+        Key::Num_Lock,
+    ];
+    for key in modifier_keys {
+        assert_eq!(encode(key, NONE), None, "modifier-only {key:?} must produce None");
+    }
+}
+
+// ── Xterm modifier parameter encoding ───────────────────────────
+
+#[test]
+fn modifier_parameter_values_follow_xterm_convention() {
+    // xterm modifier = 1 + (shift?1:0) + (alt?2:0) + (ctrl?4:0)
+    // Param 2 = Shift, 3 = Alt, 4 = Shift+Alt, 5 = Ctrl,
+    // 6 = Ctrl+Shift, 7 = Ctrl+Alt, 8 = Ctrl+Shift+Alt
+    let cases: &[(Mods, &[u8])] = &[
+        (SHIFT, b"\x1b[1;2A"),
+        (ALT, b"\x1b[1;3A"),
+        (SHIFT.union(ALT), b"\x1b[1;4A"),
+        (CTRL, b"\x1b[1;5A"),
+        (CTRL.union(SHIFT), b"\x1b[1;6A"),
+        (CTRL.union(ALT), b"\x1b[1;7A"),
+        (CTRL.union(SHIFT).union(ALT), b"\x1b[1;8A"),
+    ];
+    for (mods, expected) in cases {
+        let actual = encode(Key::Up, *mods);
+        assert_eq!(
+            actual.as_deref(),
+            Some(*expected),
+            "Up + {mods:?} modifier param"
+        );
+    }
+}

--- a/services/rttx-server/tests/managed_input_parity.rs
+++ b/services/rttx-server/tests/managed_input_parity.rs
@@ -1,0 +1,415 @@
+//! VTE parity harness — daemon integration layer.
+//!
+//! Verifies that managed terminal input bytes, when sent through the
+//! daemon protocol to a real PTY, produce the expected behavior.
+//! Covers: printable input, control keys, navigation, bracketed paste,
+//! and stateful terminal mode preservation across reconnect/reattach.
+//!
+//! Required regression layer for terminal input and mouse fixes (#464).
+
+mod common;
+
+use common::TestClient;
+use rttx_proto::proto;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::process::{Child, Command};
+
+const PROMPT: &str = "PROMPT> ";
+
+async fn start_binary_server(tmp: &tempfile::TempDir) -> (PathBuf, Child) {
+    let runtime_dir = tmp.path().join("runtime");
+    let cache_dir = tmp.path().join("cache");
+    let config_dir = tmp.path().join("config");
+    let home_dir = tmp.path().join("home");
+    let shell_path = tmp.path().join("test-shell");
+
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&home_dir).unwrap();
+
+    std::fs::write(
+        &shell_path,
+        format!("#!/bin/sh\nexport PS1='{PROMPT}'\nexec /bin/bash --noprofile --norc -i\n"),
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&shell_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&shell_path, perms).unwrap();
+
+    let socket_path = runtime_dir.join("rttx-server").join("v1").join("rttx-server.sock");
+
+    let child = Command::new(env!("CARGO_BIN_EXE_rttx-server"))
+        .arg("start")
+        .arg("--foreground")
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("XDG_CACHE_HOME", &cache_dir)
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env("HOME", &home_dir)
+        .env("SHELL", &shell_path)
+        .env("TERM", "xterm-256color")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to spawn rttx-server binary");
+
+    wait_for_socket(&socket_path).await;
+    (socket_path, child)
+}
+
+async fn wait_for_socket(socket_path: &Path) {
+    for _ in 0..100 {
+        if socket_path.exists() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("server socket did not appear at {}", socket_path.display());
+}
+
+async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
+    client.handshake().await;
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+                name: "parity-test".into(),
+                policy: proto::RuntimePolicy::Persistent as i32,
+            })),
+        })
+        .await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+                session_id: session_id.clone(),
+                cwd: None,
+                dark_background: None,
+            })),
+        })
+        .await;
+    let pane_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+                session_id: session_id.clone(),
+                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+            })),
+        })
+        .await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+
+    (session_id, pane_id)
+}
+
+async fn wait_for_prompt(client: &mut TestClient) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let mut output = Vec::new();
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(delta)) = msg.msg
+        {
+            output.extend(delta.data);
+            if String::from_utf8_lossy(&output).contains(PROMPT) {
+                return;
+            }
+        }
+    }
+    panic!("shell prompt did not arrive within 30 seconds");
+}
+
+async fn send_input(client: &mut TestClient, session_id: &[u8], pane_id: &[u8], data: &[u8]) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Input(proto::Input {
+                session_id: session_id.to_vec(),
+                pane_id: pane_id.to_vec(),
+                data: data.to_vec(),
+            })),
+        })
+        .await;
+}
+
+async fn collect_output(client: &mut TestClient, window: Duration) -> String {
+    let msgs = client.drain(window).await;
+    let bytes: Vec<u8> = msgs
+        .iter()
+        .filter_map(|m| match &m.msg {
+            Some(proto::server_message::Msg::Delta(d)) => Some(d.data.clone()),
+            _ => None,
+        })
+        .flatten()
+        .collect();
+    String::from_utf8_lossy(&bytes).to_string()
+}
+
+async fn shutdown_server(client: &mut TestClient, server_child: &mut Child) {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Shutdown(proto::Shutdown {})),
+        })
+        .await;
+    let status = tokio::time::timeout(Duration::from_secs(5), server_child.wait())
+        .await
+        .expect("timed out waiting for rttx-server to stop")
+        .expect("failed to wait for rttx-server child");
+    assert!(status.success(), "rttx-server exited unsuccessfully: {status}");
+}
+
+async fn reattach_snapshot_text(
+    client: &mut TestClient,
+    session_id: &[u8],
+    pane_id: &[u8],
+) -> String {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::DetachSession(proto::DetachSession {
+                session_id: session_id.to_vec(),
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::SessionDetached(_)) => break,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected SessionDetached, got {other:?}"),
+        }
+    }
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+                session_id: session_id.to_vec(),
+                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+            })),
+        })
+        .await;
+    let snapshot = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(s)) => break s,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    };
+    let scrollback = snapshot
+        .panes
+        .iter()
+        .find(|p| p.pane_id == pane_id)
+        .expect("pane missing from snapshot")
+        .scrollback
+        .clone();
+    normalize(&scrollback)
+}
+
+fn normalize(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes)
+        .replace("\x1b[?2004h", "")
+        .replace("\x1b[?2004l", "")
+        .replace("\r\n", "\n")
+        .replace('\r', "\n")
+}
+
+// ── Printable input through daemon ──────────────────────────────
+
+#[tokio::test]
+async fn printable_ascii_echoes_through_daemon_pty() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, mut server) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (sid, pid) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    send_input(&mut client, &sid, &pid, b"echo hello123\r").await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let output = collect_output(&mut client, Duration::from_secs(2)).await;
+    assert!(output.contains("hello123"), "printable ASCII must echo: {output:?}");
+
+    shutdown_server(&mut client, &mut server).await;
+}
+
+// ── Control keys through daemon ─────────────────────────────────
+
+#[tokio::test]
+async fn ctrl_c_interrupts_running_command() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, mut server) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (sid, pid) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    // Start a long sleep, then interrupt with Ctrl+C (0x03).
+    send_input(&mut client, &sid, &pid, b"sleep 999\r").await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    send_input(&mut client, &sid, &pid, &[0x03]).await;
+
+    // Should get back to prompt.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut output = String::new();
+    while tokio::time::Instant::now() < deadline {
+        output.push_str(&collect_output(&mut client, Duration::from_millis(200)).await);
+        if output.contains(PROMPT) {
+            break;
+        }
+    }
+    assert!(output.contains(PROMPT), "Ctrl+C must return to prompt: {output:?}");
+
+    shutdown_server(&mut client, &mut server).await;
+}
+
+// ── Navigation keys through daemon ──────────────────────────────
+
+#[tokio::test]
+async fn arrow_keys_navigate_shell_history() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, mut server) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (sid, pid) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    // Run a command, then use Up arrow to recall it.
+    send_input(&mut client, &sid, &pid, b"echo ARROW_TEST\r").await;
+    wait_for_prompt(&mut client).await;
+
+    // Up arrow = \x1b[A, then Enter to re-execute.
+    send_input(&mut client, &sid, &pid, b"\x1b[A\r").await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let output = collect_output(&mut client, Duration::from_secs(2)).await;
+    assert!(
+        output.contains("ARROW_TEST"),
+        "Up arrow must recall previous command: {output:?}"
+    );
+
+    shutdown_server(&mut client, &mut server).await;
+}
+
+// ── Bracketed paste through daemon ──────────────────────────────
+
+#[tokio::test]
+async fn bracketed_paste_wraps_content_correctly() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, mut server) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (sid, pid) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    // Bash enables bracketed paste by default. Send paste-wrapped content.
+    // Bracketed paste: ESC[200~ <content> ESC[201~
+    let paste_content = b"echo PASTED_OK";
+    let mut paste_bytes = b"\x1b[200~".to_vec();
+    paste_bytes.extend_from_slice(paste_content);
+    paste_bytes.extend_from_slice(b"\x1b[201~");
+    paste_bytes.push(b'\r');
+
+    send_input(&mut client, &sid, &pid, &paste_bytes).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let output = collect_output(&mut client, Duration::from_secs(2)).await;
+    assert!(
+        output.contains("PASTED_OK"),
+        "bracketed paste content must execute: {output:?}"
+    );
+
+    shutdown_server(&mut client, &mut server).await;
+}
+
+// ── Reconnect preserves terminal state ──────────────────────────
+
+#[tokio::test]
+async fn reconnect_preserves_command_output_in_scrollback() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, mut server) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (sid, pid) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    send_input(&mut client, &sid, &pid, b"echo PERSIST_CHECK\r").await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let scrollback = reattach_snapshot_text(&mut client, &sid, &pid).await;
+    assert!(
+        scrollback.contains("PERSIST_CHECK"),
+        "command output must survive detach/reattach: {scrollback:?}"
+    );
+
+    shutdown_server(&mut client, &mut server).await;
+}
+
+#[tokio::test]
+async fn reconnect_allows_continued_input_after_reattach() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, mut server) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (sid, pid) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    send_input(&mut client, &sid, &pid, b"echo BEFORE\r").await;
+    wait_for_prompt(&mut client).await;
+
+    // Detach and reattach.
+    reattach_snapshot_text(&mut client, &sid, &pid).await;
+
+    // Continue typing after reattach.
+    send_input(&mut client, &sid, &pid, b"echo AFTER\r").await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let scrollback = reattach_snapshot_text(&mut client, &sid, &pid).await;
+    assert!(
+        scrollback.contains("BEFORE") && scrollback.contains("AFTER"),
+        "input must work after reattach: {scrollback:?}"
+    );
+
+    shutdown_server(&mut client, &mut server).await;
+}
+
+// ── F-keys through daemon ───────────────────────────────────────
+
+#[tokio::test]
+async fn fkey_bytes_reach_pty_application() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, mut server) = start_binary_server(&tmp).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (sid, pid) = setup_attached_pane(&mut client).await;
+    wait_for_prompt(&mut client).await;
+
+    // Pipe F1 escape sequence through cat -v to make it visible.
+    send_input(
+        &mut client,
+        &sid,
+        &pid,
+        b"printf '\\033OP' | cat -v\r",
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let output = collect_output(&mut client, Duration::from_secs(2)).await;
+    // cat -v renders ESC as ^[
+    assert!(
+        output.contains("^[OP"),
+        "F1 escape sequence must reach PTY: {output:?}"
+    );
+
+    shutdown_server(&mut client, &mut server).await;
+}

--- a/services/rttx-server/tests/managed_input_parity.rs
+++ b/services/rttx-server/tests/managed_input_parity.rs
@@ -293,10 +293,7 @@ async fn arrow_keys_navigate_shell_history() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let output = collect_output(&mut client, Duration::from_secs(2)).await;
-    assert!(
-        output.contains("ARROW_TEST"),
-        "Up arrow must recall previous command: {output:?}"
-    );
+    assert!(output.contains("ARROW_TEST"), "Up arrow must recall previous command: {output:?}");
 
     shutdown_server(&mut client, &mut server).await;
 }
@@ -324,10 +321,7 @@ async fn bracketed_paste_wraps_content_correctly() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let output = collect_output(&mut client, Duration::from_secs(2)).await;
-    assert!(
-        output.contains("PASTED_OK"),
-        "bracketed paste content must execute: {output:?}"
-    );
+    assert!(output.contains("PASTED_OK"), "bracketed paste content must execute: {output:?}");
 
     shutdown_server(&mut client, &mut server).await;
 }
@@ -395,21 +389,12 @@ async fn fkey_bytes_reach_pty_application() {
     wait_for_prompt(&mut client).await;
 
     // Pipe F1 escape sequence through cat -v to make it visible.
-    send_input(
-        &mut client,
-        &sid,
-        &pid,
-        b"printf '\\033OP' | cat -v\r",
-    )
-    .await;
+    send_input(&mut client, &sid, &pid, b"printf '\\033OP' | cat -v\r").await;
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let output = collect_output(&mut client, Duration::from_secs(2)).await;
     // cat -v renders ESC as ^[
-    assert!(
-        output.contains("^[OP"),
-        "F1 escape sequence must reach PTY: {output:?}"
-    );
+    assert!(output.contains("^[OP"), "F1 escape sequence must reach PTY: {output:?}");
 
     shutdown_server(&mut client, &mut server).await;
 }


### PR DESCRIPTION
## What changed and why

Adds a systematic VTE parity harness that compares managed terminal behavior to baseline xterm/VTE escape sequences. This is the required regression layer for future terminal input and mouse fixes.

### Client-side parity tests (`clients/rttx/tests/vte_parity.rs`)

Table-driven tests verify `encode_terminal_key_input` produces correct xterm escape sequences for every key category:

- **Printable characters**: a-z, 0-9, space
- **Control keys**: Ctrl+A through Ctrl+Z (0x01-0x1A), Ctrl+Space/[/]/\//?
- **Alt combinations**: ESC-prefixed printable characters
- **Navigation keys**: arrows, Home/End, Insert/Delete, Page Up/Down — unmodified and with all modifier combos (Shift, Ctrl, Alt, Ctrl+Shift, Ctrl+Alt, Ctrl+Shift+Alt)
- **F-keys**: F1-F12 unmodified, with Ctrl, Shift, and Alt modifiers
- **Keypad keys**: KP_Up/Down/Left/Right/Home/End/Insert/Delete/Page, KP_Enter, KP_Tab
- **Special keys**: Return, BackSpace, Tab, Escape, Shift+Tab (backtab)
- **Modifier-only keys**: Shift_L/R, Control_L/R, Alt_L/R, Super_L/R, Caps_Lock, Num_Lock → None
- **Xterm modifier parameter encoding**: verifies params 2-8 follow the xterm convention

26 tests total.

### Server-side integration tests (`services/rttx-server/tests/managed_input_parity.rs`)

Integration tests verify the full daemon round-trip with a real PTY:

- **Printable input**: ASCII echoes through daemon
- **Control keys**: Ctrl+C interrupts a running command
- **Navigation**: arrow keys recall shell history
- **Bracketed paste**: ESC[200~/ESC[201~ wrapping works correctly
- **F-keys**: escape sequences reach the PTY application
- **Reconnect**: command output preserved in scrollback after detach/reattach
- **Continued input**: typing works after reattach

7 tests total.

## How to manually verify

```bash
cargo test -p rttx --no-default-features --features vte-0_76 --test vte_parity
cargo test -p rttx-server --test managed_input_parity
```

## Tests covering this change

- 26 client-side parity tests in `vte_parity.rs`
- 7 server-side integration tests in `managed_input_parity.rs`

## Tests run

- `cargo build --workspace` (with VTE 0.76 flag for client) ✅
- `cargo test -p rttx-proto` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-server --lib` ✅
- `cargo test -p rttx-server --tests` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #464