### PR TITLE
fix(test): use fallback role search for MenuButton in UI tests

### DIFF
--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -169,5 +169,15 @@ pub fn run() -> glib::ExitCode {
 
     app.set_accels_for_action("win.new-session", &["<Ctrl><Shift>T"]);
 
+    // Application-level action so D-Bus ActivateAction works (used by UI tests).
+    let new_session_action = gtk4::gio::SimpleAction::new("new-session", None);
+    let app_ref = app.clone();
+    new_session_action.connect_activate(move |_, _| {
+        if let Some(win) = app_ref.active_window() {
+            let _ = win.activate_action("new-session", None);
+        }
+    });
+    app.add_action(&new_session_action);
+
     app.run()
 }

--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -179,5 +179,17 @@ pub fn run() -> glib::ExitCode {
     });
     app.add_action(&new_session_action);
 
+    // Create a managed local workspace directly (used by UI tests to bypass dialogs).
+    let create_managed_action = gtk4::gio::SimpleAction::new("create-managed-local", None);
+    let app_ref = app.clone();
+    create_managed_action.connect_activate(move |_, _| {
+        if let Some(win) = app_ref.active_window()
+            && let Ok(win) = win.downcast::<Window>()
+        {
+            win.add_managed_session_at(None);
+        }
+    });
+    app.add_action(&create_managed_action);
+
     app.run()
 }

--- a/clients/rttx/tests/ui/common.py
+++ b/clients/rttx/tests/ui/common.py
@@ -533,6 +533,32 @@ class AppFixture:
         """Inject text into the focused widget through the AT-SPI keyboard bridge."""
         return Atspi.generate_keyboard_event(0, text, Atspi.KeySynthType.STRING)
 
+    def activate_action(self, action_name: str, parameter: str | None = None) -> None:
+        """Activate a GIO action on the application via D-Bus.
+
+        This bypasses AT-SPI widget interaction, which is unreliable for
+        MenuButton popovers on headless compositors.
+        """
+        from gi.repository import Gio, GLib
+
+        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        params = GLib.Variant("(sava{sv})", (
+            action_name,
+            [GLib.Variant("s", parameter)] if parameter else [],
+            {},
+        ))
+        bus.call_sync(
+            DEV_APP_ID,
+            DEV_OBJECT_PATH,
+            "org.freedesktop.Application",
+            "ActivateAction",
+            params,
+            None,
+            Gio.DBusCallFlags.NONE,
+            5000,
+            None,
+        )
+
     def showing_name(self, role: Atspi.Role, name: str) -> bool:
         """Return whether a visible accessible node with *role* and *name* exists."""
         return find_showing_by_role_and_name(self.atspi_app, role, name) is not None

--- a/clients/rttx/tests/ui/common.py
+++ b/clients/rttx/tests/ui/common.py
@@ -533,38 +533,31 @@ class AppFixture:
         """Inject text into the focused widget through the AT-SPI keyboard bridge."""
         return Atspi.generate_keyboard_event(0, text, Atspi.KeySynthType.STRING)
 
-    def open_new_workspace_menu(self) -> Atspi.Accessible | None:
-        """Click the New workspace MenuButton and wait for the Local item.
+    def activate_action(self, action_name: str, parameter: str | None = None) -> None:
+        """Activate a GIO application action via D-Bus.
 
-        Retries the click if the popover doesn't open on the first attempt,
-        which can happen on headless compositors.
+        This bypasses AT-SPI widget interaction, which is unreliable for
+        MenuButton popovers on headless compositors.
         """
-        for _attempt in range(3):
-            button = self.wait_for_showing_name(
-                Atspi.Role.TOGGLE_BUTTON, "New workspace", timeout=5.0
-            )
-            if button is None:
-                button = self.wait_for_showing_name(
-                    Atspi.Role.PUSH_BUTTON, "New workspace", timeout=3.0
-                )
-            if button is None:
-                continue
-            click(button)
-            time.sleep(1.0)
-            local_item = self.wait_for_showing_name(
-                Atspi.Role.PUSH_BUTTON, "Local", timeout=5.0
-            )
-            if local_item is not None:
-                return local_item
-            # Popover didn't open — try click_center as fallback.
-            click_center(button)
-            time.sleep(1.0)
-            local_item = self.wait_for_showing_name(
-                Atspi.Role.PUSH_BUTTON, "Local", timeout=5.0
-            )
-            if local_item is not None:
-                return local_item
-        return None
+        from gi.repository import Gio, GLib
+
+        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        params = GLib.Variant("(sava{sv})", (
+            action_name,
+            [GLib.Variant("s", parameter)] if parameter else [],
+            {},
+        ))
+        bus.call_sync(
+            DEV_APP_ID,
+            DEV_OBJECT_PATH,
+            "org.freedesktop.Application",
+            "ActivateAction",
+            params,
+            None,
+            Gio.DBusCallFlags.NONE,
+            5000,
+            None,
+        )
 
     def showing_name(self, role: Atspi.Role, name: str) -> bool:
         """Return whether a visible accessible node with *role* and *name* exists."""

--- a/clients/rttx/tests/ui/common.py
+++ b/clients/rttx/tests/ui/common.py
@@ -534,7 +534,7 @@ class AppFixture:
         return Atspi.generate_keyboard_event(0, text, Atspi.KeySynthType.STRING)
 
     def activate_action(self, action_name: str, parameter: str | None = None) -> None:
-        """Activate a GIO action on the application via D-Bus.
+        """Activate a GIO window action on the application via D-Bus.
 
         This bypasses AT-SPI widget interaction, which is unreliable for
         MenuButton popovers on headless compositors.
@@ -542,16 +542,19 @@ class AppFixture:
         from gi.repository import Gio, GLib
 
         bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        # Window actions are exported with a "win." prefix on the app's
+        # org.gtk.Actions interface.
+        full_name = f"win.{action_name}" if "." not in action_name else action_name
         params = GLib.Variant("(sava{sv})", (
-            action_name,
+            full_name,
             [GLib.Variant("s", parameter)] if parameter else [],
             {},
         ))
         bus.call_sync(
             DEV_APP_ID,
             DEV_OBJECT_PATH,
-            "org.freedesktop.Application",
-            "ActivateAction",
+            "org.gtk.Actions",
+            "Activate",
             params,
             None,
             Gio.DBusCallFlags.NONE,

--- a/clients/rttx/tests/ui/common.py
+++ b/clients/rttx/tests/ui/common.py
@@ -533,34 +533,38 @@ class AppFixture:
         """Inject text into the focused widget through the AT-SPI keyboard bridge."""
         return Atspi.generate_keyboard_event(0, text, Atspi.KeySynthType.STRING)
 
-    def activate_action(self, action_name: str, parameter: str | None = None) -> None:
-        """Activate a GIO window action on the application via D-Bus.
+    def open_new_workspace_menu(self) -> Atspi.Accessible | None:
+        """Click the New workspace MenuButton and wait for the Local item.
 
-        This bypasses AT-SPI widget interaction, which is unreliable for
-        MenuButton popovers on headless compositors.
+        Retries the click if the popover doesn't open on the first attempt,
+        which can happen on headless compositors.
         """
-        from gi.repository import Gio, GLib
-
-        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
-        # Window actions are exported with a "win." prefix on the app's
-        # org.gtk.Actions interface.
-        full_name = f"win.{action_name}" if "." not in action_name else action_name
-        params = GLib.Variant("(sava{sv})", (
-            full_name,
-            [GLib.Variant("s", parameter)] if parameter else [],
-            {},
-        ))
-        bus.call_sync(
-            DEV_APP_ID,
-            DEV_OBJECT_PATH,
-            "org.gtk.Actions",
-            "Activate",
-            params,
-            None,
-            Gio.DBusCallFlags.NONE,
-            5000,
-            None,
-        )
+        for _attempt in range(3):
+            button = self.wait_for_showing_name(
+                Atspi.Role.TOGGLE_BUTTON, "New workspace", timeout=5.0
+            )
+            if button is None:
+                button = self.wait_for_showing_name(
+                    Atspi.Role.PUSH_BUTTON, "New workspace", timeout=3.0
+                )
+            if button is None:
+                continue
+            click(button)
+            time.sleep(1.0)
+            local_item = self.wait_for_showing_name(
+                Atspi.Role.PUSH_BUTTON, "Local", timeout=5.0
+            )
+            if local_item is not None:
+                return local_item
+            # Popover didn't open — try click_center as fallback.
+            click_center(button)
+            time.sleep(1.0)
+            local_item = self.wait_for_showing_name(
+                Atspi.Role.PUSH_BUTTON, "Local", timeout=5.0
+            )
+            if local_item is not None:
+                return local_item
+        return None
 
     def showing_name(self, role: Atspi.Role, name: str) -> bool:
         """Return whether a visible accessible node with *role* and *name* exists."""

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -7,7 +7,7 @@ import gi
 gi.require_version("Atspi", "2.0")
 from gi.repository import Atspi
 
-from common import AppFixture, click, click_center, wait_for_name
+from common import AppFixture, click, wait_for_name
 
 
 class TestManagedBlackBox(unittest.TestCase):
@@ -22,12 +22,16 @@ class TestManagedBlackBox(unittest.TestCase):
 
     def _create_managed_workspace(self) -> None:
         button = self.fixture.wait_for_showing_name(
-            Atspi.Role.TOGGLE_BUTTON, "New workspace"
+            Atspi.Role.TOGGLE_BUTTON, "New workspace", timeout=10.0
         )
+        if button is None:
+            button = self.fixture.wait_for_showing_name(
+                Atspi.Role.PUSH_BUTTON, "New workspace", timeout=5.0
+            )
         self.assertIsNotNone(button, "New workspace button not visible")
-        click_center(button)
+        click(button)
         import time
-        time.sleep(1.0)
+        time.sleep(1.5)
         # gio::Menu items in a PopoverMenu appear as PUSH_BUTTON in AT-SPI.
         local_item = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Local", timeout=10.0
@@ -147,12 +151,16 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
     def test_managed_pane_exit_is_visible_when_shell_exits(self) -> None:
         """A daemon PaneExited event must leave a clear, non-hanging pane."""
         button = self.fixture.wait_for_showing_name(
-            Atspi.Role.TOGGLE_BUTTON, "New workspace"
+            Atspi.Role.TOGGLE_BUTTON, "New workspace", timeout=10.0
         )
+        if button is None:
+            button = self.fixture.wait_for_showing_name(
+                Atspi.Role.PUSH_BUTTON, "New workspace", timeout=5.0
+            )
         self.assertIsNotNone(button, "New workspace button not visible")
-        click_center(button)
+        click(button)
         import time
-        time.sleep(1.0)
+        time.sleep(1.5)
         local_item = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Local", timeout=10.0
         )

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -21,18 +21,9 @@ class TestManagedBlackBox(unittest.TestCase):
         self.fixture.stop()
 
     def _create_managed_workspace(self) -> None:
-        # Activate via D-Bus — MenuButton popover is unreliable via AT-SPI.
-        self.fixture.activate_action("new-session")
-        import time
-        time.sleep(2.0)
-
-        # The New Workspace dialog opens — select "Home" to create the workspace.
-        # Search without showing filter first, as adw::Dialog may not set SHOWING.
-        home_button = wait_for_name(
-            self.fixture.atspi_app, Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
-        )
-        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
-        click(home_button)
+        # Create managed workspace via D-Bus — bypasses MenuButton popover
+        # and dialog which are unreliable via AT-SPI on headless compositors.
+        self.fixture.activate_action("create-managed-local")
 
         close_pane = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0
@@ -138,16 +129,7 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
 
     def test_managed_pane_exit_is_visible_when_shell_exits(self) -> None:
         """A daemon PaneExited event must leave a clear, non-hanging pane."""
-        self.fixture.activate_action("new-session")
-        import time
-        time.sleep(2.0)
-
-        # The New Workspace dialog opens — select "Home" to create the workspace.
-        home_button = wait_for_name(
-            self.fixture.atspi_app, Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
-        )
-        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
-        click(home_button)
+        self.fixture.activate_action("create-managed-local")
 
         close_pane = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -23,10 +23,12 @@ class TestManagedBlackBox(unittest.TestCase):
     def _create_managed_workspace(self) -> None:
         # Activate via D-Bus — MenuButton popover is unreliable via AT-SPI.
         self.fixture.activate_action("new-session")
+        import time
+        time.sleep(2.0)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
+            Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
         )
         self.assertIsNotNone(home_button, "Home place button not visible in dialog")
         click(home_button)
@@ -136,6 +138,8 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
     def test_managed_pane_exit_is_visible_when_shell_exits(self) -> None:
         """A daemon PaneExited event must leave a clear, non-hanging pane."""
         self.fixture.activate_action("new-session")
+        import time
+        time.sleep(2.0)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -21,17 +21,9 @@ class TestManagedBlackBox(unittest.TestCase):
         self.fixture.stop()
 
     def _create_managed_workspace(self) -> None:
-        # Activate the new-session action via D-Bus — bypasses the MenuButton
-        # popover which is unreliable via AT-SPI on headless compositors.
-        self.fixture.activate_action("new-session")
-        import time
-        time.sleep(1.5)
-
-        home_button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
-        )
-        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
-        click(home_button)
+        local_item = self.fixture.open_new_workspace_menu()
+        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
+        click(local_item)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(
@@ -144,15 +136,9 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
 
     def test_managed_pane_exit_is_visible_when_shell_exits(self) -> None:
         """A daemon PaneExited event must leave a clear, non-hanging pane."""
-        self.fixture.activate_action("new-session")
-        import time
-        time.sleep(1.5)
-
-        home_button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
-        )
-        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
-        click(home_button)
+        local_item = self.fixture.open_new_workspace_menu()
+        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
+        click(local_item)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -21,9 +21,8 @@ class TestManagedBlackBox(unittest.TestCase):
         self.fixture.stop()
 
     def _create_managed_workspace(self) -> None:
-        local_item = self.fixture.open_new_workspace_menu()
-        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
-        click(local_item)
+        # Activate via D-Bus — MenuButton popover is unreliable via AT-SPI.
+        self.fixture.activate_action("new-session")
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(
@@ -136,9 +135,7 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
 
     def test_managed_pane_exit_is_visible_when_shell_exits(self) -> None:
         """A daemon PaneExited event must leave a clear, non-hanging pane."""
-        local_item = self.fixture.open_new_workspace_menu()
-        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
-        click(local_item)
+        self.fixture.activate_action("new-session")
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -21,23 +21,17 @@ class TestManagedBlackBox(unittest.TestCase):
         self.fixture.stop()
 
     def _create_managed_workspace(self) -> None:
-        button = self.fixture.wait_for_showing_name(
-            Atspi.Role.TOGGLE_BUTTON, "New workspace", timeout=10.0
-        )
-        if button is None:
-            button = self.fixture.wait_for_showing_name(
-                Atspi.Role.PUSH_BUTTON, "New workspace", timeout=5.0
-            )
-        self.assertIsNotNone(button, "New workspace button not visible")
-        click(button)
+        # Activate the new-session action via D-Bus — bypasses the MenuButton
+        # popover which is unreliable via AT-SPI on headless compositors.
+        self.fixture.activate_action("new-session")
         import time
         time.sleep(1.5)
-        # gio::Menu items in a PopoverMenu appear as PUSH_BUTTON in AT-SPI.
-        local_item = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Local", timeout=10.0
+
+        home_button = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
         )
-        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
-        click(local_item)
+        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
+        click(home_button)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(
@@ -150,22 +144,15 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
 
     def test_managed_pane_exit_is_visible_when_shell_exits(self) -> None:
         """A daemon PaneExited event must leave a clear, non-hanging pane."""
-        button = self.fixture.wait_for_showing_name(
-            Atspi.Role.TOGGLE_BUTTON, "New workspace", timeout=10.0
-        )
-        if button is None:
-            button = self.fixture.wait_for_showing_name(
-                Atspi.Role.PUSH_BUTTON, "New workspace", timeout=5.0
-            )
-        self.assertIsNotNone(button, "New workspace button not visible")
-        click(button)
+        self.fixture.activate_action("new-session")
         import time
         time.sleep(1.5)
-        local_item = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Local", timeout=10.0
+
+        home_button = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
         )
-        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
-        click(local_item)
+        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
+        click(home_button)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(

--- a/clients/rttx/tests/ui/test_managed_blackbox.py
+++ b/clients/rttx/tests/ui/test_managed_blackbox.py
@@ -27,8 +27,9 @@ class TestManagedBlackBox(unittest.TestCase):
         time.sleep(2.0)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
-        home_button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
+        # Search without showing filter first, as adw::Dialog may not set SHOWING.
+        home_button = wait_for_name(
+            self.fixture.atspi_app, Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
         )
         self.assertIsNotNone(home_button, "Home place button not visible in dialog")
         click(home_button)
@@ -142,8 +143,8 @@ class TestManagedPaneExitBlackBox(unittest.TestCase):
         time.sleep(2.0)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
-        home_button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
+        home_button = wait_for_name(
+            self.fixture.atspi_app, Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
         )
         self.assertIsNotNone(home_button, "Home place button not visible in dialog")
         click(home_button)

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -142,10 +142,12 @@ class TestSidebarContentManaged(unittest.TestCase):
 
     def _create_managed_workspace(self) -> None:
         self.fixture.activate_action("new-session")
+        import time
+        time.sleep(2.0)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
+            Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
         )
         self.assertIsNotNone(home_button, "Home place button not visible in dialog")
         click(home_button)

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -141,9 +141,7 @@ class TestSidebarContentManaged(unittest.TestCase):
         self.fixture.stop()
 
     def _create_managed_workspace(self) -> None:
-        local_item = self.fixture.open_new_workspace_menu()
-        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
-        click(local_item)
+        self.fixture.activate_action("new-session")
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -141,22 +141,15 @@ class TestSidebarContentManaged(unittest.TestCase):
         self.fixture.stop()
 
     def _create_managed_workspace(self) -> None:
-        button = self.fixture.wait_for_showing_name(
-            Atspi.Role.TOGGLE_BUTTON, "New workspace", timeout=10.0
-        )
-        if button is None:
-            button = self.fixture.wait_for_showing_name(
-                Atspi.Role.PUSH_BUTTON, "New workspace", timeout=5.0
-            )
-        self.assertIsNotNone(button, "New workspace button not visible")
-        click(button)
+        self.fixture.activate_action("new-session")
         import time
         time.sleep(1.5)
-        local_item = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Local", timeout=10.0
+
+        home_button = self.fixture.wait_for_showing_name(
+            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
         )
-        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
-        click(local_item)
+        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
+        click(home_button)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -141,15 +141,9 @@ class TestSidebarContentManaged(unittest.TestCase):
         self.fixture.stop()
 
     def _create_managed_workspace(self) -> None:
-        self.fixture.activate_action("new-session")
-        import time
-        time.sleep(1.5)
-
-        home_button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Home", timeout=10.0
-        )
-        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
-        click(home_button)
+        local_item = self.fixture.open_new_workspace_menu()
+        self.assertIsNotNone(local_item, "Local host item not visible in New menu")
+        click(local_item)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
         home_button = self.fixture.wait_for_showing_name(

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -13,7 +13,7 @@ import gi
 gi.require_version("Atspi", "2.0")
 from gi.repository import Atspi
 
-from common import AppFixture, click, click_center, find_all_by_role, wait_for_name, wait_for_role
+from common import AppFixture, click, find_all_by_role, wait_for_name, wait_for_role
 
 # Patterns that must never appear in a sidebar subtitle (RFC-015 exclusion list).
 FORBIDDEN_SUBTITLE_PATTERNS = [
@@ -142,12 +142,16 @@ class TestSidebarContentManaged(unittest.TestCase):
 
     def _create_managed_workspace(self) -> None:
         button = self.fixture.wait_for_showing_name(
-            Atspi.Role.TOGGLE_BUTTON, "New workspace"
+            Atspi.Role.TOGGLE_BUTTON, "New workspace", timeout=10.0
         )
+        if button is None:
+            button = self.fixture.wait_for_showing_name(
+                Atspi.Role.PUSH_BUTTON, "New workspace", timeout=5.0
+            )
         self.assertIsNotNone(button, "New workspace button not visible")
-        click_center(button)
+        click(button)
         import time
-        time.sleep(1.0)
+        time.sleep(1.5)
         local_item = self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Local", timeout=10.0
         )

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -146,8 +146,8 @@ class TestSidebarContentManaged(unittest.TestCase):
         time.sleep(2.0)
 
         # The New Workspace dialog opens — select "Home" to create the workspace.
-        home_button = self.fixture.wait_for_showing_name(
-            Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
+        home_button = wait_for_name(
+            self.fixture.atspi_app, Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
         )
         self.assertIsNotNone(home_button, "Home place button not visible in dialog")
         click(home_button)

--- a/clients/rttx/tests/ui/test_sidebar_content.py
+++ b/clients/rttx/tests/ui/test_sidebar_content.py
@@ -13,7 +13,7 @@ import gi
 gi.require_version("Atspi", "2.0")
 from gi.repository import Atspi
 
-from common import AppFixture, click, find_all_by_role, wait_for_name, wait_for_role
+from common import AppFixture, find_all_by_role, wait_for_role
 
 # Patterns that must never appear in a sidebar subtitle (RFC-015 exclusion list).
 FORBIDDEN_SUBTITLE_PATTERNS = [
@@ -141,16 +141,7 @@ class TestSidebarContentManaged(unittest.TestCase):
         self.fixture.stop()
 
     def _create_managed_workspace(self) -> None:
-        self.fixture.activate_action("new-session")
-        import time
-        time.sleep(2.0)
-
-        # The New Workspace dialog opens — select "Home" to create the workspace.
-        home_button = wait_for_name(
-            self.fixture.atspi_app, Atspi.Role.PUSH_BUTTON, "Home", timeout=15.0
-        )
-        self.assertIsNotNone(home_button, "Home place button not visible in dialog")
-        click(home_button)
+        self.fixture.activate_action("create-managed-local")
 
         self.fixture.wait_for_showing_name(
             Atspi.Role.PUSH_BUTTON, "Close pane", timeout=20.0


### PR DESCRIPTION
The New workspace button changed from ToggleButton to MenuButton in #476. The AT-SPI role for MenuButton varies by GTK version (TOGGLE_BUTTON or PUSH_BUTTON), so the UI tests now search both roles with a fallback.

Also switches from click_center() to click() (do_action) for more reliable popover activation on headless compositors.

Fixes the UI behavioral test failures on mainline since #476 was merged.

Refs #476