### PR TITLE
fix: stop MenuButton popover from being dismissed on open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.17"
+version = "0.2.18"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -570,20 +570,28 @@ impl Window {
     }
 
     fn setup_host_menu_buttons(&self) {
+        let new_action =
+            gtk4::gio::SimpleAction::new("new-for-host", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        new_action.connect_activate(move |_, param| {
+            let key: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            win.new_workspace_for_host(&key);
+        });
+        self.add_action(&new_action);
+
+        let connect_action =
+            gtk4::gio::SimpleAction::new("connect-for-host", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        connect_action.connect_activate(move |_, param| {
+            let key: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            win.connect_for_host(&key);
+        });
+        self.add_action(&connect_action);
+
         self.refresh_host_menus();
-
-        let win = self.clone();
-        self.imp().new_button.connect_notify_local(Some("active"), move |_, _| {
-            win.refresh_host_menus();
-        });
-
-        let win = self.clone();
-        self.imp().connect_button.connect_notify_local(Some("active"), move |_, _| {
-            win.refresh_host_menus();
-        });
     }
 
-    fn refresh_host_menus(&self) {
+    pub(super) fn refresh_host_menus(&self) {
         let mut hosts: Vec<host::Host> = vec![host::Host::local()];
         let saved = host::load();
         let mut remotes: Vec<host::Host> =
@@ -612,24 +620,6 @@ impl Window {
 
         self.imp().new_button.set_menu_model(Some(&new_menu));
         self.imp().connect_button.set_menu_model(Some(&connect_menu));
-
-        let new_action =
-            gtk4::gio::SimpleAction::new("new-for-host", Some(glib::VariantTy::STRING));
-        let win = self.clone();
-        new_action.connect_activate(move |_, param| {
-            let key: String = param.and_then(glib::Variant::get).unwrap_or_default();
-            win.new_workspace_for_host(&key);
-        });
-        self.add_action(&new_action);
-
-        let connect_action =
-            gtk4::gio::SimpleAction::new("connect-for-host", Some(glib::VariantTy::STRING));
-        let win = self.clone();
-        connect_action.connect_activate(move |_, param| {
-            let key: String = param.and_then(glib::Variant::get).unwrap_or_default();
-            win.connect_for_host(&key);
-        });
-        self.add_action(&connect_action);
     }
 
     fn new_workspace_for_host(&self, host_key: &str) {

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -70,6 +70,8 @@ impl Window {
 
         let target_idx = select_key.and_then(|key| keys.iter().position(|k| k == key)).unwrap_or(0);
         dd.set_selected(target_idx as u32);
+
+        self.refresh_host_menus();
     }
 
     pub(crate) fn refresh_place_sidebar(&self) {

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -288,6 +288,83 @@ fn top_bar_has_new_connect_direct_buttons() {
 
 #[test]
 #[ignore = "requires isolated GTK harness"]
+fn new_button_menu_model_survives_activation() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.new-btn-menu-survives-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    // Menu model must be present before any interaction.
+    let model_before = window.imp().new_button.menu_model();
+    assert!(model_before.is_some(), "New button should have a menu model");
+    assert!(
+        model_before.unwrap().n_items() > 0,
+        "New button menu should contain at least one host item"
+    );
+
+    // Simulate the MenuButton becoming active (popover opening).
+    window.imp().new_button.set_active(true);
+    pump_events(50);
+
+    // Menu model must still be present and non-empty after activation.
+    let model_after = window.imp().new_button.menu_model();
+    assert!(model_after.is_some(), "New button menu model must survive activation");
+    assert!(
+        model_after.unwrap().n_items() > 0,
+        "New button menu must still have items after activation"
+    );
+
+    // Same check for the Connect button.
+    let connect_model = window.imp().connect_button.menu_model();
+    assert!(connect_model.is_some(), "Connect button should have a menu model");
+    assert!(
+        connect_model.unwrap().n_items() > 0,
+        "Connect button menu should contain at least one host item"
+    );
+
+    window.imp().new_button.set_active(false);
+    window.close();
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn new_for_host_action_opens_dialog() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.new-for-host-action-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    // The new-for-host action must be registered.
+    assert!(
+        window.lookup_action("new-for-host").is_some(),
+        "new-for-host action should be registered"
+    );
+    assert!(
+        window.lookup_action("connect-for-host").is_some(),
+        "connect-for-host action should be registered"
+    );
+
+    window.close();
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
 fn initial_terminal_starts_shell_when_window_is_presented() {
     require_display!();
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.17',
+  version: '0.2.18',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

The **New** and **Connect to Existing** buttons in the header bar did nothing when clicked — the dropdown menu was immediately dismissed.

### Root cause

`refresh_host_menus()` was called from `connect_notify_local("active")` handlers on both `MenuButton` widgets. When the user clicked a button, `active` became `true`, triggering `set_menu_model()` which replaced the menu model and dismissed the popover immediately.

### Fix

- Register `new-for-host` and `connect-for-host` actions once during `setup_host_menu_buttons()` instead of re-creating them on every `refresh_host_menus()` call
- Remove the `connect_notify_local("active")` handlers that caused the popover dismissal
- Call `refresh_host_menus()` from `rebuild_host_selector_model()` so the dropdown menus stay in sync when hosts are added or deleted
- Bump version to 0.2.18

## Manual verification

1. Launch rttx
2. Click the **New** button → dropdown menu with "Local" appears
3. Select "Local" → New Workspace dialog opens
4. Click the **Connect** button → dropdown menu with "Local" appears
5. Select "Local" → Connect to Existing flow starts
6. Click the **Direct** button → direct workspace created immediately (unchanged)

## Tests added

- `new_button_menu_model_survives_activation` — verifies the menu model is present before and after the MenuButton becomes active (regression test for the popover dismissal bug)
- `new_for_host_action_opens_dialog` — verifies `new-for-host` and `connect-for-host` actions are registered

## Tests run

- `cargo build --workspace --exclude rttx` ✅
- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (481 passed, 0 failed)
  - `new_button_menu_model_survives_activation` ✅
  - `new_for_host_action_opens_dialog` ✅
  - `top_bar_has_new_connect_direct_buttons` ✅
- `./run_ui_tests.sh` — 7 pre-existing failures (same on mainline), 0 new failures

Fixes #489