### PR TITLE
fix: preserve Alt prefix for Ctrl+Alt printable keys in managed encoder

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -664,23 +664,22 @@ mod tests {
     fn ctrl_alt_letter_preserves_alt_prefix() {
         let mods = gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::ALT_MASK;
         // Ctrl+Alt+a → ESC 0x01
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::a, mods),
-            Some(vec![0x1b, 0x01])
-        );
+        assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::a, mods), Some(vec![0x1b, 0x01]));
         // Ctrl+Alt+c → ESC 0x03
-        assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::c, mods),
-            Some(vec![0x1b, 0x03])
-        );
+        assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::c, mods), Some(vec![0x1b, 0x03]));
     }
 
     /// Ctrl+Alt+letter must be forwarded as `ForwardToPty` in managed mode. #457.
     #[test]
     fn managed_ctrl_alt_letter_forwards_to_pty() {
         let mods = gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::ALT_MASK;
-        let action =
-            terminal_key_action(TerminalInputBackend::Managed, gtk4::gdk::Key::a, mods, false, false);
+        let action = terminal_key_action(
+            TerminalInputBackend::Managed,
+            gtk4::gdk::Key::a,
+            mods,
+            false,
+            false,
+        );
         assert_eq!(action, TerminalKeyAction::ForwardToPty(vec![0x1b, 0x01]));
     }
 

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -197,7 +197,10 @@ fn encode_terminal_key_input(
         gtk4::gdk::Key::F12 => return Some(csi_tilde("24", m)),
         _ => {
             let ch = key.to_unicode()?;
-            if ctrl {
+            if ctrl && alt {
+                let ctrl_byte = encode_control_character(ch)?;
+                vec![0x1b, ctrl_byte]
+            } else if ctrl {
                 vec![encode_control_character(ch)?]
             } else if alt {
                 let mut prefixed = vec![0x1b];
@@ -653,6 +656,112 @@ mod tests {
         assert_eq!(
             encode_terminal_key_input(gtk4::gdk::Key::F1, none).as_deref(),
             Some(b"\x1bOP" as &[u8])
+        );
+    }
+
+    /// Ctrl+Alt+letter must produce ESC + control-char so Alt is not lost. #457.
+    #[test]
+    fn ctrl_alt_letter_preserves_alt_prefix() {
+        let mods = gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::ALT_MASK;
+        // Ctrl+Alt+a → ESC 0x01
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::a, mods),
+            Some(vec![0x1b, 0x01])
+        );
+        // Ctrl+Alt+c → ESC 0x03
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::c, mods),
+            Some(vec![0x1b, 0x03])
+        );
+    }
+
+    /// Ctrl+Alt+letter must be forwarded as `ForwardToPty` in managed mode. #457.
+    #[test]
+    fn managed_ctrl_alt_letter_forwards_to_pty() {
+        let mods = gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::ALT_MASK;
+        let action =
+            terminal_key_action(TerminalInputBackend::Managed, gtk4::gdk::Key::a, mods, false, false);
+        assert_eq!(action, TerminalKeyAction::ForwardToPty(vec![0x1b, 0x01]));
+    }
+
+    /// Keypad digits produce their ASCII digit in normal (numeric) mode. #457.
+    #[test]
+    fn keypad_digits_produce_ascii_in_normal_mode() {
+        let none = gtk4::gdk::ModifierType::empty();
+        let expected: &[(gtk4::gdk::Key, u8)] = &[
+            (gtk4::gdk::Key::KP_0, b'0'),
+            (gtk4::gdk::Key::KP_1, b'1'),
+            (gtk4::gdk::Key::KP_2, b'2'),
+            (gtk4::gdk::Key::KP_3, b'3'),
+            (gtk4::gdk::Key::KP_4, b'4'),
+            (gtk4::gdk::Key::KP_5, b'5'),
+            (gtk4::gdk::Key::KP_6, b'6'),
+            (gtk4::gdk::Key::KP_7, b'7'),
+            (gtk4::gdk::Key::KP_8, b'8'),
+            (gtk4::gdk::Key::KP_9, b'9'),
+        ];
+        for (key, byte) in expected {
+            assert_eq!(
+                encode_terminal_key_input(*key, none),
+                Some(vec![*byte]),
+                "KP digit {key:?} should produce ASCII digit"
+            );
+        }
+    }
+
+    /// Keypad operators produce their ASCII character in normal mode. #457.
+    #[test]
+    fn keypad_operators_produce_ascii_in_normal_mode() {
+        let none = gtk4::gdk::ModifierType::empty();
+        let expected: &[(gtk4::gdk::Key, &[u8])] = &[
+            (gtk4::gdk::Key::KP_Add, b"+"),
+            (gtk4::gdk::Key::KP_Subtract, b"-"),
+            (gtk4::gdk::Key::KP_Multiply, b"*"),
+            (gtk4::gdk::Key::KP_Divide, b"/"),
+            (gtk4::gdk::Key::KP_Decimal, b"."),
+        ];
+        for (key, bytes) in expected {
+            assert_eq!(
+                encode_terminal_key_input(*key, none),
+                Some(bytes.to_vec()),
+                "KP operator {key:?} should produce ASCII"
+            );
+        }
+    }
+
+    /// Modified Insert/Delete/PageUp/PageDown use xterm tilde format. #457.
+    #[test]
+    fn shift_tilde_keys_use_modified_format() {
+        let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Insert, shift).as_deref(),
+            Some(b"\x1b[2;2~" as &[u8])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Delete, shift).as_deref(),
+            Some(b"\x1b[3;2~" as &[u8])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Page_Up, shift).as_deref(),
+            Some(b"\x1b[5;2~" as &[u8])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Page_Down, shift).as_deref(),
+            Some(b"\x1b[6;2~" as &[u8])
+        );
+    }
+
+    /// Shift+Home/End use xterm modified letter format. #457.
+    #[test]
+    fn shift_home_end_uses_modified_format() {
+        let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Home, shift).as_deref(),
+            Some(b"\x1b[1;2H" as &[u8])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::End, shift).as_deref(),
+            Some(b"\x1b[1;2F" as &[u8])
         );
     }
 

--- a/clients/rttx/tests/vte_parity.rs
+++ b/clients/rttx/tests/vte_parity.rs
@@ -355,6 +355,17 @@ fn modifier_only_keys_produce_none() {
 
 // ── Xterm modifier parameter encoding ───────────────────────────
 
+/// Ctrl+Alt+letter must produce ESC + control-char. Regression for #457.
+#[test]
+fn ctrl_alt_printable_preserves_alt_prefix() {
+    let mods = CTRL.union(ALT);
+    assert_parity(&[
+        (Key::a, mods, &[0x1b, 0x01]),
+        (Key::c, mods, &[0x1b, 0x03]),
+        (Key::z, mods, &[0x1b, 0x1a]),
+    ]);
+}
+
 #[test]
 fn modifier_parameter_values_follow_xterm_convention() {
     // xterm modifier = 1 + (shift?1:0) + (alt?2:0) + (ctrl?4:0)


### PR DESCRIPTION
## What changed and why

Fixes #457 — the first mode-specific slice addressing the stateless key encoding bug.

When both Ctrl and Alt are held on a printable key, the managed encoder entered the `if ctrl` branch first and produced only the control character byte (e.g. `0x01` for Ctrl+a), losing the ESC prefix that represents Alt. The correct output is `ESC + control_char` (e.g. `\x1b\x01` for Ctrl+Alt+a), matching xterm and VTE behavior.

### Root cause

`encode_terminal_key_input()` checked `if ctrl` before `if ctrl && alt`, so the Alt modifier was silently dropped for all Ctrl+Alt+letter combinations.

### Fix

Added a `ctrl && alt` branch before the `ctrl`-only branch in the printable-key fallback of `encode_terminal_key_input()`.

## Tests added

- `ctrl_alt_letter_preserves_alt_prefix` — regression test: Ctrl+Alt+a → ESC 0x01, Ctrl+Alt+c → ESC 0x03
- `managed_ctrl_alt_letter_forwards_to_pty` — verifies managed terminal action layer forwards Ctrl+Alt correctly
- `keypad_digits_produce_ascii_in_normal_mode` — parity: KP_0–KP_9 produce ASCII digits
- `keypad_operators_produce_ascii_in_normal_mode` — parity: KP_Add/Subtract/Multiply/Divide/Decimal
- `shift_tilde_keys_use_modified_format` — parity: Shift+Insert/Delete/PageUp/PageDown
- `shift_home_end_uses_modified_format` — parity: Shift+Home/End

## Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --lib` — 492 passed, 0 failed ✅
- `cargo test -p rttx-proto` — 8 passed ✅
- `cargo test -p rttx-server --lib` — 108 passed ✅
- `cargo test -p rttx-server --tests` — all passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

All 27 terminal::tests pass (was 21 before this PR).

## Manual verification

Confirmed the regression test fails before the fix (`Some([1])` instead of `Some([27, 1])`) and passes after.

## Scope

This is the first mode-specific slice of #457. Application cursor mode and application keypad mode require terminal mode tracking and will be addressed in follow-up PRs.