### PR TITLE
feat: add IMContext to managed pane key controller for compose/IME support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.21"
+version = "0.2.22"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -786,6 +786,52 @@ mod tests {
             );
         }
     }
+
+    /// Dead keys produce no direct encoding — the `IMContext` handles them. #462.
+    #[test]
+    fn dead_keys_produce_none_for_ime_handling() {
+        let none = gtk4::gdk::ModifierType::empty();
+        let dead_keys = [
+            gtk4::gdk::Key::dead_acute,
+            gtk4::gdk::Key::dead_grave,
+            gtk4::gdk::Key::dead_circumflex,
+            gtk4::gdk::Key::dead_tilde,
+            gtk4::gdk::Key::dead_diaeresis,
+        ];
+        for key in &dead_keys {
+            assert_eq!(
+                encode_terminal_key_input(*key, none),
+                None,
+                "dead key {key:?} must return None so IMContext handles it"
+            );
+        }
+    }
+
+    /// Dead keys must pass through in managed mode so the `IMContext` can
+    /// process the compose sequence. #462.
+    #[test]
+    fn managed_dead_keys_pass_through_for_ime() {
+        let none = gtk4::gdk::ModifierType::empty();
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::dead_acute,
+                none,
+                false,
+                false,
+            ),
+            TerminalKeyAction::PassThrough,
+        );
+    }
+
+    /// Control sequences must still be encoded even when `IMContext` is active,
+    /// because the `IMContext` does not consume modified keys. #462.
+    #[test]
+    fn control_keys_still_encoded_with_ime_active() {
+        let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
+        assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::c, ctrl), Some(vec![0x03]),);
+        assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::d, ctrl), Some(vec![0x04]),);
+    }
 }
 
 #[cfg(test)]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -700,9 +700,16 @@ impl PersistentPaneView {
     /// Connect a callback for keyboard and mouse input.
     ///
     /// The callback receives the raw terminal bytes to send to the daemon.
-    /// Keyboard input is intercepted by a Capture-phase key controller and
-    /// encoded manually.  Mouse input is handled by VTE natively — when the
-    /// remote application enables mouse tracking, VTE emits escape sequences
+    ///
+    /// Text input flows through a GTK `IMMulticontext` attached to the
+    /// capture-phase key controller.  The `IMContext` handles compose
+    /// sequences, dead keys, and system input methods — its `commit`
+    /// signal forwards the finished text to the daemon.  Control keys,
+    /// navigation, and function keys bypass the `IMContext` and are encoded
+    /// directly in the `key-pressed` handler.
+    ///
+    /// Mouse input is handled by VTE natively — when the remote
+    /// application enables mouse tracking, VTE emits escape sequences
     /// through the `commit` signal which are forwarded here.
     pub fn connect_input<F: Fn(&[u8]) + 'static>(&self, f: F) {
         let forward_input = std::rc::Rc::new(f);
@@ -718,9 +725,22 @@ impl PersistentPaneView {
             }
         });
 
+        // IMContext for compose / dead-key / IME support.
+        let im_context = gtk4::IMMulticontext::new();
+        let im_forward = std::rc::Rc::clone(&forward_input);
+        let im_pane_weak = self.downgrade();
+        im_context.connect_commit(move |_, text| {
+            if let Some(pane) = im_pane_weak.upgrade()
+                && pane.imp().accepts_input.get()
+            {
+                im_forward(text.as_bytes());
+            }
+        });
+
         let pane_weak = self.downgrade();
         let key_controller = gtk4::EventControllerKey::new();
         key_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
+        key_controller.set_im_context(Some(&im_context));
         key_controller.connect_key_pressed(move |_, key, _keycode, state| {
             let Some(pane) = pane_weak.upgrade() else {
                 return glib::Propagation::Proceed;
@@ -836,6 +856,17 @@ impl PersistentPaneView {
             .expect("input controller should be connected before test input is emitted")
             .emit_by_name::<bool>("key-pressed", &[&key, &0u32, &modifiers])
             .into()
+    }
+
+    #[doc(hidden)]
+    #[must_use]
+    pub fn has_im_context_for_test(&self) -> bool {
+        self.imp()
+            .input_key_controller
+            .borrow()
+            .as_ref()
+            .and_then(gtk4::EventControllerKey::im_context)
+            .is_some()
     }
 }
 

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1772,6 +1772,34 @@ fn persistent_pane_forwards_vte_commit_to_daemon_input() {
     window.close();
 }
 
+/// The key controller must have an IMContext set so compose sequences,
+/// dead keys, and system input methods work in managed panes. #462.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn persistent_pane_key_controller_has_im_context() {
+    require_display!();
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("ime-1", "runtime-1");
+    let window = gtk4::Window::new();
+    window.set_default_size(640, 320);
+    window.set_child(Some(&pane));
+    window.present();
+    pump_events(50);
+
+    let connected =
+        rttx::runtime::present_connection_status(&rttx::runtime::ConnectionStatus::Connected);
+    pane.set_connection_presentation(&rttx::runtime::ConnectionStatus::Connected, &connected);
+
+    pane.connect_input(|_| {});
+
+    assert!(
+        pane.has_im_context_for_test(),
+        "key controller must have an IMContext for compose/dead-key/IME support"
+    );
+
+    window.close();
+}
+
 // ── New Workspace dialog ────────────────────────────────────────
 
 #[test]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.21',
+  version: '0.2.22',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Managed panes intercept keyboard events at capture phase and encode them
manually via `encode_terminal_key_input()`. This bypasses GTK's input
method system, so compose sequences (dead keys like `dead_acute + e → é`),
CJK input methods, and emoji input do not work.

This PR attaches a GTK `IMMulticontext` to the capture-phase
`EventControllerKey`. The IMContext handles compose sequences, dead keys,
and system input methods — its `commit` signal forwards the finished text
to the daemon. Control keys, navigation, and function keys bypass the
IMContext and continue to be encoded directly in the `key-pressed` handler.

## How to manually verify

1. Open rttx with a managed workspace
2. Set a compose-capable keyboard layout (e.g. US International)
3. Type a dead key sequence: `dead_acute` then `e` → should produce `é`
4. Verify regular typing, Ctrl+C, arrow keys, F-keys still work
5. Verify mouse tracking still works (e.g. in `htop`)

## Tests added

Unit tests (`clients/rttx/src/terminal/mod.rs`):
- `dead_keys_produce_none_for_ime_handling` — dead keys return None from encoder
- `managed_dead_keys_pass_through_for_ime` — dead keys produce PassThrough in managed mode
- `control_keys_still_encoded_with_ime_active` — Ctrl+C/D still encode correctly

GTK widget test (`clients/rttx/tests/gtk_widget_tests.rs`):
- `persistent_pane_key_controller_has_im_context` — verifies IMContext is set on the key controller

## Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (all 498 lib tests pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass via Broadway)
- All new tests confirmed passing in quality test output

Fixes #462