### PR TITLE
Daemon owns terminal response semantics (RFC-020)

### DIFF
--- a/designs/RFC-020-terminal-response-ownership.md
+++ b/designs/RFC-020-terminal-response-ownership.md
@@ -1,0 +1,228 @@
+# RFC-020: Terminal Response Ownership
+
+| Field         | Value                                    |
+|---------------|------------------------------------------|
+| Status        | Accepted                                 |
+| Author(s)     | Illya Yalovyy                            |
+| Supersedes    | —                                        |
+| Superseded by | —                                        |
+
+---
+
+## Summary
+
+The daemon must be the single authoritative owner of terminal response semantics so that
+applications behave identically whether or not a GUI client is attached.
+
+---
+
+## Goals
+
+- **G1** — Daemon answers all terminal queries that applications depend on, without requiring an
+  attached client.
+- **G2** — Detached persistent sessions never hang or misconfigure applications because no client
+  VTE is present to generate responses.
+- **G3** — Responses are consistent regardless of client attachment state.
+
+## Non-Goals
+
+- **NG1** — Full cell-grid terminal emulation in the daemon. The daemon only needs to answer
+  queries, not render.
+- **NG2** — Matching VTE's exact response strings byte-for-byte. Reasonable xterm-compatible
+  responses are sufficient.
+- **NG3** — Handling DCS (Device Control String) passthrough or Sixel graphics.
+
+---
+
+## Background & Motivation
+
+In a normal GNOME Terminal session, VTE owns the PTY and answers all terminal queries directly.
+In rttx's daemon architecture, the daemon owns the PTY while the client VTE is a renderer and
+input producer. This splits responsibility for terminal responses:
+
+1. An application writes a query (e.g., `CSI c` for device attributes) to its stdout.
+2. The daemon reads it from the PTY master side and feeds it to `PaneScreen`.
+3. The daemon broadcasts the output to attached clients as Delta messages.
+4. The client VTE processes the output and may generate a response via `commit`.
+5. The client forwards the commit data back to the daemon as Input.
+6. The daemon writes it to the PTY.
+
+If no client is attached at step 4, steps 5–6 never happen and the application hangs waiting for
+a response. Even with a client attached, there is a round-trip latency penalty and a window where
+the response races with other input.
+
+### Current state
+
+The daemon's `ScreenPerformer` currently handles:
+
+| Query | Response | Status |
+|-------|----------|--------|
+| DSR 5 (operating status) | `CSI 0 n` | ✅ Daemon answers |
+| DSR 6 (cursor position) | `CSI row ; col R` | ✅ Daemon answers |
+| DECSET/DECRST 1 | Application cursor keys mode tracking | ✅ Tracked |
+| DECSET/DECRST 1000/1002/1003 | Mouse tracking mode | ✅ Tracked |
+| DECSET/DECRST 1006 | SGR mouse mode | ✅ Tracked |
+| DECSET/DECRST 2004 | Bracketed paste mode | ✅ Tracked |
+| DECKPAM/DECKPNM | Application keypad mode | ✅ Tracked |
+
+The following are **not** handled by the daemon and currently depend on client VTE:
+
+| Query | Response | Risk |
+|-------|----------|------|
+| DA1 (primary device attributes, `CSI c`) | `CSI ? 64 ; ... c` | Applications hang if detached |
+| DA2 (secondary device attributes, `CSI > c`) | `CSI > 1 ; ... c` | Applications hang if detached |
+| DA3 (tertiary device attributes, `CSI = c`) | `DCS ! \| ... ST` | Rare, low risk |
+| XTVERSION (`CSI > 0 q`) | `DCS > \| ... ST` | Rare, low risk |
+| DECRQM (`CSI ? Ps $ p`) | `CSI ? Ps ; Pm $ y` | vim, tmux use this |
+| DSR 6 with DECOM | Adjusted CPR | Edge case |
+| DECSET/DECRST 1004 (focus events) | Focus in/out sequences | Not tracked |
+| DECSET/DECRST 25 (cursor visibility) | — | Not tracked |
+| DECSET/DECRST 12 (cursor blink) | — | Not tracked |
+| OSC 10/11 (fg/bg color query) | `OSC 10;rgb:... ST` | Rare, theme detection |
+| OSC 52 (clipboard) | Clipboard data | Security-sensitive |
+
+### Practical impact
+
+The highest-impact gaps are DA1 and DA2. Many applications (bash, zsh, vim, tmux, fish, neovim)
+send DA1 during startup to detect terminal capabilities. If the daemon cannot answer, these
+applications hang until a client attaches and the VTE response round-trips back.
+
+DECRQM is used by vim and tmux to query specific mode states. Focus event tracking (1004) is
+used by neovim and tmux to detect window focus changes.
+
+---
+
+## User Impact
+
+| Audience     | Impact |
+|--------------|--------|
+| End users    | Persistent sessions work reliably when detached; no hangs on reattach |
+| Contributors | Clear ownership model for where terminal responses live |
+| Packagers    | None |
+
+---
+
+## Considered Options
+
+### Option A — Daemon answers all queries
+
+The daemon generates responses for DA1, DA2, and DECRQM directly in `ScreenPerformer`, using
+xterm-compatible response strings. No client involvement needed.
+
+**Pros**: Detached sessions always work. No round-trip latency. Single source of truth.
+**Cons**: Must maintain response tables. Cannot leverage VTE's own response logic.
+
+### Option B — Proxy responses from attached VTE, queue queries when detached
+
+When a client is attached, let VTE answer naturally. When detached, queue queries and replay
+them when a client attaches.
+
+**Pros**: Leverages VTE's exact responses.
+**Cons**: Detached sessions still hang until reattach. Queue management is complex. Response
+timing is unpredictable.
+
+### Option C — Hybrid: daemon answers critical queries, VTE handles the rest
+
+The daemon answers DA1, DA2, DSR, and DECRQM. OSC color queries and clipboard are left to the
+client VTE since they depend on actual GUI state.
+
+**Pros**: Covers the practical cases. Keeps daemon simple. GUI-dependent queries stay with GUI.
+**Cons**: Some edge cases still depend on client attachment.
+
+---
+
+## Decision
+
+**Chosen option: Option C (hybrid)**
+
+DA1, DA2, and DECRQM are the queries that cause real application hangs. These have well-defined
+xterm-compatible responses that the daemon can generate without GUI state. OSC color queries and
+clipboard operations genuinely depend on the client and are rare enough that the current
+proxy-via-commit behavior is acceptable.
+
+Focus event tracking (DECSET 1004) should be tracked as mode state so the daemon can inform
+newly-attached clients, but the actual focus in/out sequences are generated by the client since
+only the GUI knows focus state.
+
+---
+
+## Design
+
+### Phase 1: DA1 and DA2 responses (high priority)
+
+Add DA1 and DA2 response generation to `ScreenPerformer::csi_dispatch`:
+
+- **DA1** (`CSI c` or `CSI 0 c`): respond with `CSI ? 64 ; 1 ; 2 ; 6 ; 22 c`
+  (VT420 with 132-column, printer, selective erase, ANSI color).
+  This matches what VTE sends and is what applications expect from a modern terminal.
+
+- **DA2** (`CSI > c` or `CSI > 0 c`): respond with `CSI > 65 ; 0 ; 0 c`
+  (VT520-family, version 0). This is a safe generic response.
+
+Both are generated as pending replies and written to the PTY by the existing reply mechanism.
+
+### Phase 2: DECRQM responses (medium priority)
+
+Add DECRQM (`CSI ? Ps $ p`) handling for modes the daemon already tracks:
+
+| Mode | Description | Source |
+|------|-------------|--------|
+| 1 | Application cursor keys | `application_cursor_keys` |
+| 1000 | Mouse tracking (basic) | `mouse_tracking_mode` |
+| 1002 | Mouse tracking (button-event) | `mouse_tracking_mode` |
+| 1003 | Mouse tracking (any-event) | `mouse_tracking_mode` |
+| 1004 | Focus events | `focus_event_mode` (new) |
+| 1006 | SGR mouse mode | `sgr_mouse_mode` |
+| 2004 | Bracketed paste | `bracketed_paste_mode` |
+
+Response format: `CSI ? Ps ; Pm $ y` where Pm is 1 (set), 2 (reset), or 0 (not recognized).
+
+### Phase 3: Focus event mode tracking
+
+Add `focus_event_mode` field to `ScreenPerformer` to track DECSET/DECRST 1004. This does not
+generate focus sequences (that is the client's job) but allows DECRQM to report the mode state
+and lets the daemon inform newly-attached clients whether the application expects focus events.
+
+### Phase 4: Cursor visibility tracking
+
+Add `cursor_visible` field to track DECSET/DECRST 25. This is informational for client
+reconnection — when a client attaches, it should know whether the cursor is supposed to be
+visible.
+
+---
+
+## Goals Alignment
+
+| Goal | How addressed |
+|------|---------------|
+| G1   | DA1, DA2, DSR, and DECRQM answered by daemon directly |
+| G2   | No client needed for critical query responses |
+| G3   | Same response regardless of attachment state |
+
+---
+
+## Development Plan
+
+- [x] **Step 1** — RFC and investigation (this document)
+- [ ] **Step 2** — DA1 and DA2 responses in `ScreenPerformer` with tests *(#462)*
+- [ ] **Step 3** — Focus event mode tracking (DECSET 1004) with tests *(#463)*
+- [ ] **Step 4** — DECRQM responses for tracked modes with tests *(#464)*
+- [ ] **Step 5** — Cursor visibility tracking (DECSET 25) *(#465)*
+
+---
+
+## Open Questions
+
+- [ ] **Q1** — Should the daemon suppress DA1/DA2 queries from reaching the client VTE to avoid
+  duplicate responses? Current design: yes, the daemon answers and the raw bytes still reach the
+  client for display, but VTE should not generate a second response because VTE only responds to
+  queries on its own PTY, not to replayed output.
+
+---
+
+## References
+
+- [VTE source — response handling](https://gitlab.gnome.org/GNOME/vte)
+- [xterm ctlseqs — Device Attributes](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html)
+- [ECMA-48 — Control Functions](https://ecma-international.org/publications-and-standards/standards/ecma-48/)
+- GitHub issue #461

--- a/designs/RFC-020-terminal-response-ownership.md
+++ b/designs/RFC-020-terminal-response-ownership.md
@@ -2,7 +2,7 @@
 
 | Field         | Value                                    |
 |---------------|------------------------------------------|
-| Status        | Accepted                                 |
+| Status        | Implemented                              |
 | Author(s)     | Illya Yalovyy                            |
 | Supersedes    | —                                        |
 | Superseded by | —                                        |
@@ -204,10 +204,10 @@ visible.
 ## Development Plan
 
 - [x] **Step 1** — RFC and investigation (this document)
-- [ ] **Step 2** — DA1 and DA2 responses in `ScreenPerformer` with tests *(#462)*
-- [ ] **Step 3** — Focus event mode tracking (DECSET 1004) with tests *(#463)*
-- [ ] **Step 4** — DECRQM responses for tracked modes with tests *(#464)*
-- [ ] **Step 5** — Cursor visibility tracking (DECSET 25) *(#465)*
+- [x] **Step 2** — DA1 and DA2 responses in `ScreenPerformer` with tests *(#498)*
+- [x] **Step 3** — Focus event mode tracking (DECSET 1004) with tests *(#499)*
+- [x] **Step 4** — DECRQM responses for tracked modes with tests *(#500)*
+- [x] **Step 5** — Cursor visibility tracking (DECSET 25) *(#501)*
 
 ---
 

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -39,6 +39,10 @@ struct ScreenPerformer {
     mouse_tracking_mode: u16,
     /// Whether SGR mouse mode (DECSET 1006) is active.
     sgr_mouse_mode: bool,
+    /// Whether focus event mode (DECSET 1004) is active.
+    focus_event_mode: bool,
+    /// Whether the cursor is visible (DECSET 25, default true).
+    cursor_visible: bool,
 }
 
 impl PaneScreen {
@@ -60,6 +64,8 @@ impl PaneScreen {
                 application_keypad: false,
                 mouse_tracking_mode: 0,
                 sgr_mouse_mode: false,
+                focus_event_mode: false,
+                cursor_visible: true,
             },
         }
     }
@@ -155,6 +161,18 @@ impl PaneScreen {
     pub const fn sgr_mouse_mode(&self) -> bool {
         self.performer.sgr_mouse_mode
     }
+
+    /// Whether focus event mode (DECSET 1004) is currently active.
+    #[must_use]
+    pub const fn focus_event_mode(&self) -> bool {
+        self.performer.focus_event_mode
+    }
+
+    /// Whether the cursor is visible (DECSET 25, default true).
+    #[must_use]
+    pub const fn cursor_visible(&self) -> bool {
+        self.performer.cursor_visible
+    }
 }
 
 /// Return restart-safe scrollback bytes for a reconstructed pane.
@@ -239,6 +257,7 @@ impl vte::Perform for ScreenPerformer {
             for param_slice in params {
                 match param_slice.first().copied() {
                     Some(1) => self.application_cursor_keys = enabled,
+                    Some(25) => self.cursor_visible = enabled,
                     Some(1000) => {
                         self.mouse_tracking_mode = if enabled { 1000 } else { 0 };
                     }
@@ -248,11 +267,41 @@ impl vte::Perform for ScreenPerformer {
                     Some(1003) => {
                         self.mouse_tracking_mode = if enabled { 1003 } else { 0 };
                     }
+                    Some(1004) => self.focus_event_mode = enabled,
                     Some(1006) => self.sgr_mouse_mode = enabled,
                     Some(2004) => self.bracketed_paste_mode = enabled,
                     _ => {}
                 }
             }
+            return;
+        }
+
+        // DECRQM — Request Mode (CSI ? Ps $ p) → DECRPM (CSI ? Ps ; Pm $ y)
+        // Pm: 0=not recognized, 1=set, 2=reset
+        if intermediates == b"?$" && action == 'p' {
+            let mode = first_param;
+            let is_set = match mode {
+                1 => Some(self.application_cursor_keys),
+                25 => Some(self.cursor_visible),
+                1000 | 1002 | 1003 => Some(self.mouse_tracking_mode == mode),
+                1004 => Some(self.focus_event_mode),
+                1006 => Some(self.sgr_mouse_mode),
+                2004 => Some(self.bracketed_paste_mode),
+                _ => None,
+            };
+            let pm = match is_set {
+                Some(true) => 1,
+                Some(false) => 2,
+                None => 0,
+            };
+            let reply = format!("\x1b[?{mode};{pm}$y");
+            self.pending_replies.push(reply.into_bytes());
+            return;
+        }
+
+        // DA2 — Secondary Device Attributes (CSI > c)
+        if intermediates == b">" && action == 'c' {
+            self.pending_replies.push(b"\x1b[>65;0;0c".to_vec());
             return;
         }
 
@@ -286,6 +335,11 @@ impl vte::Perform for ScreenPerformer {
                 }
                 _ => {}
             },
+            // DA1 — Primary Device Attributes (CSI c / CSI 0 c)
+            'c' if intermediates.is_empty() && first_param <= 1 => {
+                // VT420 with 132-column, printer, selective erase, ANSI color
+                self.pending_replies.push(b"\x1b[?64;1;2;6;22c".to_vec());
+            }
             _ => {}
         }
     }
@@ -674,5 +728,188 @@ mod tests {
         screen.feed(b"\x1b[?1l");
         assert!(!screen.application_cursor_keys());
         assert_eq!(screen.mouse_tracking_mode(), 1003);
+    }
+
+    // --- DA1 (Primary Device Attributes) ---
+
+    #[test]
+    fn da1_generates_response() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[c");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0], b"\x1b[?64;1;2;6;22c");
+    }
+
+    #[test]
+    fn da1_explicit_zero_param_generates_response() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[0c");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0], b"\x1b[?64;1;2;6;22c");
+    }
+
+    #[test]
+    fn da1_nonzero_param_ignored() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[2c");
+        assert!(screen.take_pending_replies().is_empty());
+    }
+
+    // --- DA2 (Secondary Device Attributes) ---
+
+    #[test]
+    fn da2_generates_response() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[>c");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0], b"\x1b[>65;0;0c");
+    }
+
+    #[test]
+    fn da2_explicit_zero_param_generates_response() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[>0c");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0], b"\x1b[>65;0;0c");
+    }
+
+    // --- Focus event mode (DECSET 1004) ---
+
+    #[test]
+    fn focus_event_mode_default_off() {
+        let screen = PaneScreen::new(1024);
+        assert!(!screen.focus_event_mode());
+    }
+
+    #[test]
+    fn decset_1004_enables_focus_event_mode() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1004h");
+        assert!(screen.focus_event_mode());
+    }
+
+    #[test]
+    fn decrst_1004_disables_focus_event_mode() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1004h");
+        screen.feed(b"\x1b[?1004l");
+        assert!(!screen.focus_event_mode());
+    }
+
+    // --- Cursor visibility (DECSET 25) ---
+
+    #[test]
+    fn cursor_visible_default_on() {
+        let screen = PaneScreen::new(1024);
+        assert!(screen.cursor_visible());
+    }
+
+    #[test]
+    fn decrst_25_hides_cursor() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?25l");
+        assert!(!screen.cursor_visible());
+    }
+
+    #[test]
+    fn decset_25_shows_cursor() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?25l");
+        screen.feed(b"\x1b[?25h");
+        assert!(screen.cursor_visible());
+    }
+
+    // --- DECRQM (Request Mode) ---
+
+    #[test]
+    fn decrqm_reports_bracketed_paste_set() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?2004h");
+        screen.feed(b"\x1b[?2004$p");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0], b"\x1b[?2004;1$y");
+    }
+
+    #[test]
+    fn decrqm_reports_bracketed_paste_reset() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?2004$p");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0], b"\x1b[?2004;2$y");
+    }
+
+    #[test]
+    fn decrqm_reports_unknown_mode() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?9999$p");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0], b"\x1b[?9999;0$y");
+    }
+
+    #[test]
+    fn decrqm_reports_application_cursor_keys() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1h");
+        screen.feed(b"\x1b[?1$p");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0], b"\x1b[?1;1$y");
+    }
+
+    #[test]
+    fn decrqm_reports_cursor_visible() {
+        let mut screen = PaneScreen::new(1024);
+        // Default is visible (set)
+        screen.feed(b"\x1b[?25$p");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies[0], b"\x1b[?25;1$y");
+    }
+
+    #[test]
+    fn decrqm_reports_focus_event_mode() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1004h");
+        screen.feed(b"\x1b[?1004$p");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies[0], b"\x1b[?1004;1$y");
+    }
+
+    #[test]
+    fn decrqm_reports_mouse_tracking_mode() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1003h");
+        // Query 1003 — should be set
+        screen.feed(b"\x1b[?1003$p");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies[0], b"\x1b[?1003;1$y");
+        // Query 1000 — should be reset (1003 is active, not 1000)
+        screen.feed(b"\x1b[?1000$p");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies[0], b"\x1b[?1000;2$y");
+    }
+
+    // --- Detached session scenario ---
+
+    #[test]
+    fn da1_and_dsr_work_without_client_attachment() {
+        let mut screen = PaneScreen::new(1024);
+        // Simulate application startup sequence without any client
+        screen.feed(b"\x1b[c"); // DA1
+        screen.feed(b"\x1b[>c"); // DA2
+        screen.feed(b"\x1b[5n"); // DSR status
+        screen.feed(b"\x1b[6n"); // DSR cursor
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies.len(), 4);
+        assert_eq!(replies[0], b"\x1b[?64;1;2;6;22c"); // DA1
+        assert_eq!(replies[1], b"\x1b[>65;0;0c"); // DA2
+        assert_eq!(replies[2], b"\x1b[0n"); // status OK
+        assert_eq!(replies[3], b"\x1b[1;1R"); // cursor at 1,1
     }
 }

--- a/services/rttx-server/tests/device_attributes.rs
+++ b/services/rttx-server/tests/device_attributes.rs
@@ -1,0 +1,89 @@
+//! Integration test: DA1/DA2 device attribute responses are written back to the PTY.
+
+mod common;
+
+use common::{TestClient, start_test_server};
+use rttx_proto::proto;
+use std::time::Duration;
+
+async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+            name: "da-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    let create_pane = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            session_id: session_id.clone(),
+            cwd: None,
+            dark_background: None,
+        })),
+    };
+    client.send(&create_pane).await;
+    let pane_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+            session_id: session_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+
+    (session_id, pane_id)
+}
+
+#[tokio::test]
+async fn da1_request_gets_device_attributes_response() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+
+    client.drain(Duration::from_millis(500)).await;
+
+    // Send DA1 query and capture the response. The daemon should answer with
+    // CSI ? 64;1;2;6;22 c. We use `read -s -d c` to capture up to the trailing 'c'.
+    let script = r#"printf '\033[c'; read -s -d c REPLY; echo "DA1=$REPLY""#;
+    let input = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            session_id: session_id.clone(),
+            pane_id: pane_id.clone(),
+            data: format!("{script}\n").into_bytes(),
+        })),
+    };
+    client.send(&input).await;
+
+    let msgs = client.drain(Duration::from_secs(5)).await;
+    let output: Vec<u8> = msgs
+        .iter()
+        .filter_map(|m| match &m.msg {
+            Some(proto::server_message::Msg::Delta(d)) => Some(d.data.clone()),
+            _ => None,
+        })
+        .flatten()
+        .collect();
+    let output_str = String::from_utf8_lossy(&output);
+
+    assert!(
+        output_str.contains("DA1="),
+        "expected DA1 response echoed by script, got: {output_str}"
+    );
+}


### PR DESCRIPTION
## What changed and why

The daemon now answers terminal queries that applications depend on, so detached persistent sessions never hang waiting for a client VTE to respond.

### RFC-020: Terminal Response Ownership

Added `designs/RFC-020-terminal-response-ownership.md` documenting the investigation, audit of all terminal response types, and a phased implementation plan.

### Implementation in `ScreenPerformer`

- **DA1** (`CSI c`): VT420-compatible response (`CSI ? 64;1;2;6;22 c`)
- **DA2** (`CSI > c`): VT520-family response (`CSI > 65;0;0 c`)
- **DECRQM** (`CSI ? Ps $ p`): Reports tracked mode state (set/reset/not-recognized)
- **DECSET/DECRST 1004**: Focus event mode tracking
- **DECSET/DECRST 25**: Cursor visibility tracking

All responses are generated as pending replies and written to the PTY by the existing reply mechanism. No protocol or client changes needed.

## How to manually verify

1. Start the daemon: `RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground`
2. Create a persistent workspace and detach
3. In the detached session, applications like vim, tmux, or fish that send DA1 during startup should not hang
4. Reattach — the session should be responsive

## Tests added (20 new tests)

DA1:
- `da1_generates_response`
- `da1_explicit_zero_param_generates_response`
- `da1_nonzero_param_ignored`

DA2:
- `da2_generates_response`
- `da2_explicit_zero_param_generates_response`

Focus event mode:
- `focus_event_mode_default_off`
- `decset_1004_enables_focus_event_mode`
- `decrst_1004_disables_focus_event_mode`

Cursor visibility:
- `cursor_visible_default_on`
- `decrst_25_hides_cursor`
- `decset_25_shows_cursor`

DECRQM:
- `decrqm_reports_bracketed_paste_set`
- `decrqm_reports_bracketed_paste_reset`
- `decrqm_reports_unknown_mode`
- `decrqm_reports_application_cursor_keys`
- `decrqm_reports_cursor_visible`
- `decrqm_reports_focus_event_mode`
- `decrqm_reports_mouse_tracking_mode`

Detached scenario:
- `da1_and_dsr_work_without_client_attachment`

## Tests run

- `cargo test -p rttx-server` — all 62 screen tests pass, all integration tests pass
- `cargo test -p rttx-proto` — pass
- `cargo build -p rttx --no-default-features --features vte-0_76` — pass
- `bash .github/scripts/run-clippy.sh` — pass
- `bash .github/scripts/run-quality-tests.sh` — pass

## Follow-up issues

- #498 — DA1 and DA2 responses (implemented)
- #499 — Focus event mode tracking (implemented)
- #500 — DECRQM responses (implemented)
- #501 — Cursor visibility tracking (implemented)

Fixes #461