### PR TITLE
feat: input sync for daemon-backed managed panes (#463)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.22"
+version = "0.2.23"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -314,7 +314,7 @@ impl Window {
                     let win = self.clone();
                     let terminal_uuid = uuid.clone();
                     pane.request_clipboard_paste(move |bytes| {
-                        win.send_managed_terminal_input(&terminal_uuid, bytes);
+                        win.send_managed_terminal_input(&terminal_uuid, &bytes);
                     });
                 }
             }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -295,7 +295,7 @@ impl Window {
         let win = self.clone();
         let input_terminal_uuid = terminal_uuid.clone();
         pane_view.connect_input(move |bytes| {
-            win.send_managed_terminal_input(&input_terminal_uuid, bytes.to_vec());
+            win.send_managed_terminal_input(&input_terminal_uuid, bytes);
         });
 
         let win = self.clone();
@@ -378,14 +378,54 @@ impl Window {
         self.connect_managed_workspace(&session_state);
     }
 
-    pub(super) fn send_managed_terminal_input(&self, terminal_uuid: &str, data: Vec<u8>) {
+    pub(super) fn send_managed_terminal_input(&self, terminal_uuid: &str, data: &[u8]) {
+        let (primary, sync_targets) = {
+            let state = self.imp().state.borrow();
+            (
+                state
+                    .managed_terminal_binding(terminal_uuid)
+                    .map(|b| (b.workspace_id, b.endpoint, b.runtime_id, b.runtime_pane_id)),
+                state.input_sync_targets(terminal_uuid),
+            )
+        };
+        let Some((workspace_id, endpoint, runtime_id, runtime_pane_id)) = primary else {
+            return;
+        };
+        if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
+            manager.send_input(
+                &workspace_id,
+                &endpoint,
+                &runtime_id,
+                &runtime_pane_id,
+                data.to_vec(),
+            );
+            for target in &sync_targets {
+                manager.send_input(
+                    &target.workspace_id,
+                    &target.endpoint,
+                    &target.runtime_id,
+                    &target.runtime_pane_id,
+                    data.to_vec(),
+                );
+            }
+        }
+    }
+
+    /// Send input to a single managed pane without input-sync fan-out.
+    pub(super) fn send_managed_pane_input_direct(&self, terminal_uuid: &str, data: &[u8]) {
         let Some((workspace_id, endpoint, runtime_id, runtime_pane_id)) =
             self.managed_binding_for_terminal(terminal_uuid)
         else {
             return;
         };
         if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
-            manager.send_input(&workspace_id, &endpoint, &runtime_id, &runtime_pane_id, data);
+            manager.send_input(
+                &workspace_id,
+                &endpoint,
+                &runtime_id,
+                &runtime_pane_id,
+                data.to_vec(),
+            );
         }
     }
 

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -615,7 +615,7 @@ impl Window {
         let sent = self.imp().terminals.borrow().get(terminal_uuid).cloned().map_or_else(
             || {
                 if self.imp().persistent_terminals.borrow().contains_key(terminal_uuid) {
-                    self.send_managed_terminal_input(terminal_uuid, input.as_bytes().to_vec());
+                    self.send_managed_pane_input_direct(terminal_uuid, input.as_bytes());
                     true
                 } else {
                     false

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -263,6 +263,41 @@ impl WindowState {
         })
     }
 
+    /// Return managed bindings for all sibling panes when input sync is active.
+    ///
+    /// Returns an empty vec when input sync is off, the workspace is not
+    /// managed, or the source terminal has no routable binding.
+    #[must_use]
+    pub fn input_sync_targets(&self, source_uuid: &str) -> Vec<ManagedTerminalBinding> {
+        let session = self.sessions.iter().find(|s| {
+            s.input_sync && s.uses_managed_runtime() && s.layout.contains_terminal(source_uuid)
+        });
+        let Some(session) = session else {
+            return Vec::new();
+        };
+        let Some(runtime_id) = session.runtime.runtime_id.as_deref() else {
+            return Vec::new();
+        };
+        session
+            .layout
+            .terminal_uuids()
+            .into_iter()
+            .filter(|uuid| uuid != source_uuid)
+            .filter_map(|uuid| {
+                let pane_id = session.runtime.pane_bindings.get(&uuid)?;
+                if session.runtime.is_layout_pane_pending(&uuid) {
+                    return None;
+                }
+                Some(ManagedTerminalBinding {
+                    workspace_id: session.uuid.clone(),
+                    endpoint: session.runtime.endpoint.clone(),
+                    runtime_id: runtime_id.to_string(),
+                    runtime_pane_id: pane_id.clone(),
+                })
+            })
+            .collect()
+    }
+
     /// Resolve a runtime ID back to its workspace.
     #[must_use]
     pub fn workspace_for_runtime(
@@ -1578,5 +1613,72 @@ mod tests {
         let restore = &transition.pane_snapshot_restores[0];
         assert_eq!(restore.cols, 200);
         assert_eq!(restore.rows, 50);
+    }
+
+    #[test]
+    fn input_sync_targets_returns_siblings_when_enabled() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let mut session = managed_session_with_runtime(
+            "ws-1",
+            "Workspace",
+            hsplit(term("pane-1"), term("pane-2")),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some(&runtime_id),
+        );
+        session.input_sync = true;
+        session.runtime.bind_runtime_pane("pane-1", "daemon-pane-1");
+        session.runtime.bind_runtime_pane("pane-2", "daemon-pane-2");
+        let state = window_state(vec![session]);
+
+        let targets = state.input_sync_targets("pane-1");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].runtime_pane_id, "daemon-pane-2");
+    }
+
+    #[test]
+    fn input_sync_targets_empty_when_disabled() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let mut session = managed_session_with_runtime(
+            "ws-1",
+            "Workspace",
+            hsplit(term("pane-1"), term("pane-2")),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some(&runtime_id),
+        );
+        session.runtime.bind_runtime_pane("pane-1", "daemon-pane-1");
+        session.runtime.bind_runtime_pane("pane-2", "daemon-pane-2");
+        let state = window_state(vec![session]);
+
+        assert!(state.input_sync_targets("pane-1").is_empty());
+    }
+
+    #[test]
+    fn input_sync_targets_skips_pending_panes() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let mut session = managed_session_with_runtime(
+            "ws-1",
+            "Workspace",
+            hsplit(term("pane-1"), term("pane-2")),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some(&runtime_id),
+        );
+        session.input_sync = true;
+        session.runtime.bind_runtime_pane("pane-1", "daemon-pane-1");
+        // pane-2 stays pending (placeholder binding only)
+        let state = window_state(vec![session]);
+
+        assert!(state.input_sync_targets("pane-1").is_empty());
+    }
+
+    #[test]
+    fn input_sync_targets_empty_for_direct_workspace() {
+        let mut session = session("s1", "Direct", hsplit(term("pane-1"), term("pane-2")));
+        session.input_sync = true;
+        let state = window_state(vec![session]);
+
+        assert!(state.input_sync_targets("pane-1").is_empty());
     }
 }

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -1174,3 +1174,47 @@ fn rotate_layout_persists_through_serialization() {
     assert_eq!(restored.sessions[0].layout, vsplit(term("t1"), hsplit(term("t2"), term("t3"))));
     assert_eq!(restored.sessions[0].layout.terminal_uuids(), original_uuids);
 }
+
+#[test]
+fn input_sync_fan_out_targets_all_bound_managed_siblings() {
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+
+    let layout = hsplit(term("pane-1"), hsplit(term("pane-2"), term("pane-3")));
+    let terminal_uuids = layout.terminal_uuids();
+    let mut session = SessionState::new("Sync test".into());
+    session.uuid = "ws-sync".into();
+    session.layout = layout;
+    session.input_sync = true;
+    session.runtime = WorkspaceRuntime {
+        managed: true,
+        endpoint: RuntimeEndpoint::Local,
+        policy: WorkspacePolicy::Persistent,
+        runtime_id: Some("rt-1".into()),
+        pane_bindings: std::collections::BTreeMap::default(),
+        pending_layout_panes: std::collections::BTreeSet::default(),
+    };
+    session.runtime.ensure_placeholder_bindings(&terminal_uuids);
+    session.runtime.bind_runtime_pane("pane-1", "daemon-1");
+    session.runtime.bind_runtime_pane("pane-2", "daemon-2");
+    session.runtime.bind_runtime_pane("pane-3", "daemon-3");
+    session.sync_legacy_mode_from_runtime();
+
+    let state = WindowState { active_session_index: 0, sessions: vec![session], ..WindowState::default() };
+
+    let targets = state.input_sync_targets("pane-1");
+    assert_eq!(targets.len(), 2);
+    let target_pane_ids: Vec<&str> = targets.iter().map(|t| t.runtime_pane_id.as_str()).collect();
+    assert!(target_pane_ids.contains(&"daemon-2"));
+    assert!(target_pane_ids.contains(&"daemon-3"));
+
+    // Verify no targets when input sync is off.
+    let mut state_off = state.clone();
+    state_off.sessions[0].input_sync = false;
+    assert!(state_off.input_sync_targets("pane-1").is_empty());
+
+    // Verify serialization roundtrip preserves input_sync.
+    let json = serde_json::to_string(&state).unwrap();
+    let restored: WindowState = serde_json::from_str(&json).unwrap();
+    assert!(restored.sessions[0].input_sync);
+    assert_eq!(restored.input_sync_targets("pane-1").len(), 2);
+}

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -723,8 +723,8 @@ fn double_split_remote_session_keeps_all_panes_pending() {
 #[test]
 fn close_remote_workspace_prevents_resurrection_on_reconnect() {
     use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
-    use rttx::session::state::WindowState;
     use rttx::session::SessionState;
+    use rttx::session::state::WindowState;
 
     let runtime_id = uuid::Uuid::new_v4().to_string();
     let endpoint = RuntimeEndpoint::Remote { host: "prod-server".into() };
@@ -801,8 +801,8 @@ fn active_session_index_clamped_on_restore() {
 #[test]
 fn connection_status_survives_session_reorder() {
     use rttx::runtime::WorkspacePolicy;
-    use rttx::session::state::WindowState;
     use rttx::session::SessionState;
+    use rttx::session::state::WindowState;
 
     let mut state = WindowState::default();
     state.sessions.clear();
@@ -848,7 +848,7 @@ fn application_flags_enforce_single_instance() {
 #[test]
 fn connection_status_lifecycle_is_deterministic() {
     use rttx::runtime::{
-        advance_connection_status, ConnectionEvent, ConnectionProblem, ConnectionStatus,
+        ConnectionEvent, ConnectionProblem, ConnectionStatus, advance_connection_status,
     };
 
     let s = advance_connection_status(&ConnectionStatus::Connecting, ConnectionEvent::Connected);
@@ -1199,8 +1199,11 @@ fn input_sync_fan_out_targets_all_bound_managed_siblings() {
     session.runtime.bind_runtime_pane("pane-3", "daemon-3");
     session.sync_legacy_mode_from_runtime();
 
-    let state =
-        WindowState { active_session_index: 0, sessions: vec![session], ..WindowState::default() };
+    let state = WindowState {
+        active_session_index: 0,
+        sessions: vec![session],
+        ..WindowState::default()
+    };
 
     let targets = state.input_sync_targets("pane-1");
     assert_eq!(targets.len(), 2);

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -1199,11 +1199,8 @@ fn input_sync_fan_out_targets_all_bound_managed_siblings() {
     session.runtime.bind_runtime_pane("pane-3", "daemon-3");
     session.sync_legacy_mode_from_runtime();
 
-    let state = WindowState {
-        active_session_index: 0,
-        sessions: vec![session],
-        ..WindowState::default()
-    };
+    let state =
+        WindowState { active_session_index: 0, sessions: vec![session], ..WindowState::default() };
 
     let targets = state.input_sync_targets("pane-1");
     assert_eq!(targets.len(), 2);

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -723,8 +723,8 @@ fn double_split_remote_session_keeps_all_panes_pending() {
 #[test]
 fn close_remote_workspace_prevents_resurrection_on_reconnect() {
     use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
-    use rttx::session::SessionState;
     use rttx::session::state::WindowState;
+    use rttx::session::SessionState;
 
     let runtime_id = uuid::Uuid::new_v4().to_string();
     let endpoint = RuntimeEndpoint::Remote { host: "prod-server".into() };
@@ -801,8 +801,8 @@ fn active_session_index_clamped_on_restore() {
 #[test]
 fn connection_status_survives_session_reorder() {
     use rttx::runtime::WorkspacePolicy;
-    use rttx::session::SessionState;
     use rttx::session::state::WindowState;
+    use rttx::session::SessionState;
 
     let mut state = WindowState::default();
     state.sessions.clear();
@@ -848,7 +848,7 @@ fn application_flags_enforce_single_instance() {
 #[test]
 fn connection_status_lifecycle_is_deterministic() {
     use rttx::runtime::{
-        ConnectionEvent, ConnectionProblem, ConnectionStatus, advance_connection_status,
+        advance_connection_status, ConnectionEvent, ConnectionProblem, ConnectionStatus,
     };
 
     let s = advance_connection_status(&ConnectionStatus::Connecting, ConnectionEvent::Connected);
@@ -1199,7 +1199,8 @@ fn input_sync_fan_out_targets_all_bound_managed_siblings() {
     session.runtime.bind_runtime_pane("pane-3", "daemon-3");
     session.sync_legacy_mode_from_runtime();
 
-    let state = WindowState { active_session_index: 0, sessions: vec![session], ..WindowState::default() };
+    let state =
+        WindowState { active_session_index: 0, sessions: vec![session], ..WindowState::default() };
 
     let targets = state.input_sync_targets("pane-1");
     assert_eq!(targets.len(), 2);

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.22',
+  version: '0.2.23',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/tests/managed_input_parity.rs
+++ b/services/rttx-server/tests/managed_input_parity.rs
@@ -163,7 +163,7 @@ async fn shutdown_server(client: &mut TestClient, server_child: &mut Child) {
             msg: Some(proto::client_message::Msg::Shutdown(proto::Shutdown {})),
         })
         .await;
-    let status = tokio::time::timeout(Duration::from_secs(5), server_child.wait())
+    let status = tokio::time::timeout(Duration::from_secs(10), server_child.wait())
         .await
         .expect("timed out waiting for rttx-server to stop")
         .expect("failed to wait for rttx-server child");


### PR DESCRIPTION
## What changed and why

Input sync (Ctrl+Shift+I) was only wired for direct (non-daemon) workspaces. Managed panes sent input through `send_managed_terminal_input()` which bypassed the `forward_input()` fan-out logic, so enabling input sync on a daemon-backed workspace had no effect.

This PR routes managed pane keyboard input and clipboard paste through a new input-sync fan-out path that sends the same bytes to all sibling managed panes via daemon Input messages.

Programmatic input (recovery startup commands, sidebar bookmark/command execution) uses a separate `send_managed_pane_input_direct()` method that bypasses fan-out, since those are per-pane operations.

### Root cause

`send_managed_terminal_input()` resolved a single managed binding and sent input only to that pane. The `forward_input()` method that handled fan-out for direct terminals used `feed_child()` on VTE widgets, which only works for direct (non-daemon) terminals.

### Changes

- **`workspace_state.rs`**: Added `WindowState::input_sync_targets()` — pure-state method that returns managed bindings for all sibling panes when input sync is active, skipping pending/unbound panes and direct workspaces
- **`window/runtime.rs`**: Modified `send_managed_terminal_input()` to query `input_sync_targets()` and fan out input to all siblings. Added `send_managed_pane_input_direct()` for non-syncing programmatic input
- **`window/terminal.rs`**: Changed `send_input_to_terminal()` to use the non-syncing direct path
- **`window/actions.rs`**: Updated clipboard paste call site for `&[u8]` signature
- **Version bump**: 0.2.22 → 0.2.23 (user-facing behavior change)
- **Test fix**: Increased `managed_input_parity` shutdown timeout from 5s to 10s (pre-existing flakiness)

## Manual verification

1. Create a persistent workspace with 2+ panes (split)
2. Enable input sync (Ctrl+Shift+I)
3. Type in one pane — keystrokes appear in all panes
4. Disable input sync — keystrokes go to focused pane only
5. Sidebar commands and bookmark cd still target only the focused pane

## Tests added

- `input_sync_targets_returns_siblings_when_enabled` — verifies fan-out returns sibling bindings
- `input_sync_targets_empty_when_disabled` — verifies no fan-out when sync is off
- `input_sync_targets_skips_pending_panes` — verifies unbound panes are excluded
- `input_sync_targets_empty_for_direct_workspace` — verifies direct workspaces are unaffected

## Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --lib` — 502 passed, 0 failed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — all pass including GTK tests ✅
- `cargo test -p rttx-server --test managed_input_parity` — 12 passed ✅

Fixes #463