### PR TITLE
fix: report SessionMissing when daemon session is gone (#478)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.23"
+version = "0.2.24"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -1062,15 +1062,19 @@ impl EndpointActor {
                         Err(ref error) => {
                             let problem = classify_connection_problem(error);
                             log::warn!("Reattach {workspace_id} failed during reconnect: {error}");
-                            self.emit_error(
-                                &workspace_id,
-                                ManagerOperation::OpenWorkspace,
-                                problem.clone(),
-                                error.to_string(),
-                            );
-                            if problem.is_transient() {
-                                any_transient_failure = true;
-                                break;
+                            if matches!(problem, ConnectionProblem::SessionMissing) {
+                                self.emit_status(&workspace_id, ConnectionStatus::SessionMissing);
+                            } else {
+                                self.emit_error(
+                                    &workspace_id,
+                                    ManagerOperation::OpenWorkspace,
+                                    problem.clone(),
+                                    error.to_string(),
+                                );
+                                if problem.is_transient() {
+                                    any_transient_failure = true;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -1256,7 +1260,8 @@ impl EndpointActor {
     /// When `existing_runtime_id` is provided, tries to reattach first.
     /// If the runtime no longer exists (daemon restarted, ephemeral gone),
     /// falls back to creating a fresh runtime so "Retry Connection" works.
-    /// Ownership conflicts and transport errors are reported immediately.
+    /// Ownership conflicts, transport errors, and missing sessions are
+    /// reported immediately.
     async fn resolve_and_attach_runtime(
         &mut self,
         workspace_id: &str,
@@ -1278,7 +1283,21 @@ impl EndpointActor {
                     self.handle_command_error(workspace_id, ManagerOperation::OpenWorkspace, error);
                     return Err(());
                 }
-                // Runtime gone — fall through to create a new one.
+                // Session gone on daemon — report as SessionMissing, don't create new.
+                Err(ref error)
+                    if matches!(
+                        classify_connection_problem(error),
+                        ConnectionProblem::SessionMissing
+                    ) =>
+                {
+                    log::warn!(
+                        "Session {runtime_id} no longer exists on daemon for workspace \
+                         {workspace_id}"
+                    );
+                    self.emit_status(workspace_id, ConnectionStatus::SessionMissing);
+                    return Err(());
+                }
+                // Runtime gone for other reasons — fall through to create a new one.
                 Err(error) => {
                     log::info!(
                         "Reattach to {runtime_id} failed for {workspace_id}: \
@@ -1499,6 +1518,10 @@ impl EndpointActor {
         error: &DaemonError,
     ) {
         let problem = classify_connection_problem(error);
+        if matches!(problem, ConnectionProblem::SessionMissing) {
+            self.emit_status(workspace_id, ConnectionStatus::SessionMissing);
+            return;
+        }
         self.emit_error(workspace_id, operation, problem.clone(), error.to_string());
         if problem.is_transient() {
             self.handle_disconnect();
@@ -1979,7 +2002,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_and_attach_falls_back_to_new_runtime_on_stale_id() {
+    async fn resolve_and_attach_reports_session_missing_on_stale_id() {
         let ((reader, writer), mut server_stream) = split_duplex_connection();
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let (self_tx, cmd_rx) = mpsc::unbounded_channel();
@@ -2002,13 +2025,11 @@ mod tests {
         };
 
         let stale_runtime = Uuid::new_v4();
-        let new_runtime = Uuid::new_v4();
-        let pane_id = Uuid::new_v4();
 
         let server = tokio::spawn(async move {
             let mut read_buf = BytesMut::new();
 
-            // 1. Receive AttachSession for the stale runtime — reply "not found".
+            // Receive AttachSession for the stale runtime — reply "not found".
             let msg = recv_client_message(&mut server_stream, &mut read_buf).await;
             assert!(
                 matches!(msg.msg, Some(proto::client_message::Msg::AttachSession(_))),
@@ -2024,55 +2045,6 @@ mod tests {
                 },
             )
             .await;
-
-            // 2. Receive CreateSession — reply with new runtime id.
-            let msg = recv_client_message(&mut server_stream, &mut read_buf).await;
-            assert!(
-                matches!(msg.msg, Some(proto::client_message::Msg::CreateSession(_))),
-                "expected CreateSession, got {msg:?}"
-            );
-            send_server_message(
-                &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::SessionCreated(proto::SessionCreated {
-                        session_id: rttx_proto::uuid_to_bytes(new_runtime),
-                        revision: 1,
-                    })),
-                },
-            )
-            .await;
-
-            // 3. Receive AttachSession for the new runtime — reply with snapshot.
-            let msg = recv_client_message(&mut server_stream, &mut read_buf).await;
-            assert!(
-                matches!(msg.msg, Some(proto::client_message::Msg::AttachSession(_))),
-                "expected AttachSession, got {msg:?}"
-            );
-            send_server_message(
-                &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::Snapshot(proto::Snapshot {
-                        session_id: rttx_proto::uuid_to_bytes(new_runtime),
-                        panes: vec![proto::PaneSnapshot {
-                            pane_id: rttx_proto::uuid_to_bytes(pane_id),
-                            title: "shell".into(),
-                            cwd: "/home".into(),
-                            cols: 80,
-                            rows: 24,
-                            scrollback: Vec::new(),
-                            exit_status: None,
-                            bracketed_paste_mode: false,
-                            application_cursor_keys: false,
-                            application_keypad: false,
-                            mouse_tracking_mode: 0,
-                            sgr_mouse_mode: false,
-                        }],
-                        revision: 2,
-                        current_client_role: proto::RuntimeClientRole::Writer as i32,
-                    })),
-                },
-            )
-            .await;
         });
 
         let result = actor
@@ -2084,19 +2056,23 @@ mod tests {
             )
             .await;
 
-        let (runtime_id, snapshot) = result.expect("should fall back to new runtime");
-        assert_eq!(runtime_id, new_runtime.to_string());
-        assert_eq!(snapshot.panes.len(), 1);
+        assert!(result.is_err(), "session-not-found should not fall back to new runtime");
 
-        // Verify no error events were emitted (the stale attach failure is
-        // handled internally, not surfaced as a workspace error).
+        // Should have emitted SessionMissing status, not a WorkspaceError.
+        let mut saw_session_missing = false;
         let mut saw_error = false;
         while let Ok(event) = event_rx.try_recv() {
-            if matches!(event, EndpointEvent::WorkspaceError { .. }) {
-                saw_error = true;
+            match event {
+                EndpointEvent::WorkspaceConnectionChanged {
+                    status: ConnectionStatus::SessionMissing,
+                    ..
+                } => saw_session_missing = true,
+                EndpointEvent::WorkspaceError { .. } => saw_error = true,
+                _ => {}
             }
         }
-        assert!(!saw_error, "stale-runtime fallback should not emit WorkspaceError");
+        assert!(saw_session_missing, "should emit SessionMissing status");
+        assert!(!saw_error, "should not emit WorkspaceError for missing session");
 
         server.await.expect("fake server task should complete");
     }

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -171,10 +171,15 @@ pub enum ConnectionStatus {
     Starting,
     Connecting,
     Connected,
-    Reconnecting { attempt: u32, retry_in_secs: u32 },
+    Reconnecting {
+        attempt: u32,
+        retry_in_secs: u32,
+    },
     Blocked(ConnectionProblem),
     Disconnected,
     Recovered,
+    /// The daemon has no record of this workspace's runtime.
+    SessionMissing,
 }
 
 impl ConnectionStatus {
@@ -191,6 +196,7 @@ impl ConnectionStatus {
             Self::Blocked(problem) => format!("Action Required: {}", problem.label()),
             Self::Disconnected => "Disconnected".into(),
             Self::Recovered => "Recovered".into(),
+            Self::SessionMissing => "Session no longer exists".into(),
         }
     }
 
@@ -210,6 +216,7 @@ impl ConnectionStatus {
             Self::Reconnecting { retry_in_secs, .. } => format!("Retry {retry_in_secs}s"),
             Self::Blocked(_) => "Action Required".into(),
             Self::Disconnected => "Disconnected".into(),
+            Self::SessionMissing => "Session Missing".into(),
         }
     }
 }
@@ -221,6 +228,7 @@ pub enum ConnectionProblem {
     VersionMismatch,
     OwnershipConflict,
     PermissionDenied,
+    SessionMissing,
     Protocol(String),
     UserActionRequired(String),
 }
@@ -240,6 +248,7 @@ impl ConnectionProblem {
             Self::VersionMismatch => "Version mismatch".into(),
             Self::OwnershipConflict => "Runtime already owned".into(),
             Self::PermissionDenied => "Permission denied".into(),
+            Self::SessionMissing => "Session no longer exists".into(),
             Self::Protocol(detail) | Self::UserActionRequired(detail) => detail.clone(),
         }
     }
@@ -251,13 +260,11 @@ pub fn classify_connection_problem(error: &DaemonError) -> ConnectionProblem {
     match error {
         DaemonError::VersionMismatch { .. } => ConnectionProblem::VersionMismatch,
         DaemonError::AttachBlocked(_) => ConnectionProblem::OwnershipConflict,
+        DaemonError::ServerError { code, .. } if *code == 4 => ConnectionProblem::SessionMissing,
         DaemonError::ServerError { code, message } if *code == 8 => {
             ConnectionProblem::UserActionRequired(message.clone())
         }
         DaemonError::ServerError { code, .. } if *code == 9 => ConnectionProblem::OwnershipConflict,
-        DaemonError::ServerError { code, message } if *code == 4 => {
-            ConnectionProblem::UserActionRequired(message.clone())
-        }
         DaemonError::ServerError { message, .. } => {
             ConnectionProblem::UserActionRequired(message.clone())
         }
@@ -278,6 +285,7 @@ pub enum ConnectionEvent {
     RetryScheduled { attempt: u32, retry_in_secs: u32 },
     Failed(ConnectionProblem),
     Recovered,
+    SessionMissing,
 }
 
 /// Advance a connection status without involving GTK or daemon I/O.
@@ -295,6 +303,7 @@ pub fn advance_connection_status(
         }
         ConnectionEvent::Recovered => ConnectionStatus::Recovered,
         ConnectionEvent::Failed(problem) => ConnectionStatus::Blocked(problem),
+        ConnectionEvent::SessionMissing => ConnectionStatus::SessionMissing,
     }
 }
 
@@ -441,6 +450,7 @@ pub const fn connection_icon(
             ("accent", tooltip)
         }
         ConnectionStatus::Disconnected => ("warning", "Disconnected from runtime"),
+        ConnectionStatus::SessionMissing => ("warning", "Session no longer exists on daemon"),
         ConnectionStatus::Blocked(_) => ("error", "Connection blocked"),
         _ => ("dim-label", "Connecting…"),
     };
@@ -1208,5 +1218,62 @@ mod tests {
         assert!(!items.show_edit_connection);
         assert!(!items.show_reconnect);
         assert!(!items.show_detach);
+    }
+
+    // ── SessionMissing state ────────────────────────────────────
+
+    #[test]
+    fn classify_session_not_found_as_session_missing() {
+        let problem = classify_connection_problem(&DaemonError::ServerError {
+            code: 4,
+            message: "session not found".into(),
+        });
+        assert_eq!(problem, ConnectionProblem::SessionMissing);
+        assert!(!problem.is_transient());
+    }
+
+    #[test]
+    fn session_missing_status_disables_input() {
+        assert!(!ConnectionStatus::SessionMissing.accepts_input());
+    }
+
+    #[test]
+    fn session_missing_label_describes_state() {
+        assert_eq!(ConnectionStatus::SessionMissing.short_label(), "Session Missing");
+        assert!(ConnectionStatus::SessionMissing.label().contains("no longer exists"));
+    }
+
+    #[test]
+    fn advance_to_session_missing() {
+        let status = advance_connection_status(
+            &ConnectionStatus::Connecting,
+            ConnectionEvent::SessionMissing,
+        );
+        assert_eq!(status, ConnectionStatus::SessionMissing);
+    }
+
+    #[test]
+    fn session_missing_icon_uses_warning_class() {
+        let icon =
+            connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::SessionMissing, true);
+        assert_eq!(icon.css_class, "warning");
+        assert!(icon.tooltip.contains("no longer exists"));
+    }
+
+    #[test]
+    fn session_missing_problem_label_is_nonempty() {
+        assert!(!ConnectionProblem::SessionMissing.label().is_empty());
+    }
+
+    #[test]
+    fn menu_items_session_missing_hides_reconnect() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: false,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: false,
+            is_disconnected: false,
+        });
+        assert!(!items.show_reconnect);
     }
 }

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1681,4 +1681,23 @@ mod tests {
 
         assert!(state.input_sync_targets("pane-1").is_empty());
     }
+
+    #[test]
+    fn reconcile_session_missing_emits_status_update() {
+        let mut state = WindowState::default_for_test();
+
+        let transition =
+            state.reconcile_endpoint_event(&EndpointEvent::WorkspaceConnectionChanged {
+                workspace_id: "workspace-1".into(),
+                status: ConnectionStatus::SessionMissing,
+            });
+
+        assert_eq!(
+            transition.connection_status_updates,
+            vec![ConnectionStatusUpdate {
+                workspace_id: "workspace-1".into(),
+                status: ConnectionStatus::SessionMissing,
+            }],
+        );
+    }
 }

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -789,6 +789,7 @@ fn connection_icon_always_has_tooltip() {
         (&local, ConnectionStatus::Connecting),
         (&remote, ConnectionStatus::Recovered),
         (&remote, ConnectionStatus::Blocked(ConnectionProblem::PermissionDenied)),
+        (&local, ConnectionStatus::SessionMissing),
     ] {
         let icon = connection_icon(endpoint, &status, true);
         assert!(

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -867,6 +867,49 @@ fn connection_status_lifecycle_is_deterministic() {
     assert_eq!(s, ConnectionStatus::SessionMissing);
 }
 
+/// When a workspace's runtime is gone on the daemon, the reconciliation
+/// pipeline must emit `SessionMissing` without affecting sibling workspaces.
+/// Regression test for #478.
+#[test]
+fn session_missing_does_not_affect_sibling_workspaces() {
+    use rttx::daemon_bridge::EndpointEvent;
+    use rttx::runtime::{ConnectionStatus, WorkspacePolicy};
+    use rttx::session::SessionState;
+    use rttx::workspace_state::ConnectionStatusUpdate;
+
+    let runtime_a = uuid::Uuid::new_v4().to_string();
+    let runtime_b = uuid::Uuid::new_v4().to_string();
+
+    let mut session_a =
+        SessionState::new_managed_local("Workspace A".into(), WorkspacePolicy::Persistent, None);
+    session_a.runtime.runtime_id = Some(runtime_a);
+
+    let mut session_b =
+        SessionState::new_managed_local("Workspace B".into(), WorkspacePolicy::Persistent, None);
+    session_b.runtime.runtime_id = Some(runtime_b.clone());
+
+    let ws_a_id = session_a.uuid.clone();
+    let ws_b_id = session_b.uuid.clone();
+
+    let mut state = WindowState { sessions: vec![session_a, session_b], ..Default::default() };
+
+    // Workspace A gets SessionMissing — workspace B must not be affected.
+    let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceConnectionChanged {
+        workspace_id: ws_a_id.clone(),
+        status: ConnectionStatus::SessionMissing,
+    });
+
+    assert_eq!(transition.connection_status_updates.len(), 1);
+    assert_eq!(
+        transition.connection_status_updates[0],
+        ConnectionStatusUpdate { workspace_id: ws_a_id, status: ConnectionStatus::SessionMissing }
+    );
+
+    // Workspace B's runtime_id is untouched.
+    let session_b = state.sessions.iter().find(|s| s.uuid == ws_b_id).unwrap();
+    assert_eq!(session_b.runtime.runtime_id.as_deref(), Some(runtime_b.as_str()));
+}
+
 /// F-keys must produce xterm escape sequences for managed terminals. Regression for #293.
 #[test]
 fn managed_fkeys_encode_to_escape_sequences() {

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -862,6 +862,9 @@ fn connection_status_lifecycle_is_deterministic() {
         ConnectionEvent::Failed(ConnectionProblem::OwnershipConflict),
     );
     assert!(matches!(s, ConnectionStatus::Blocked(_)));
+
+    let s = advance_connection_status(&s, ConnectionEvent::SessionMissing);
+    assert_eq!(s, ConnectionStatus::SessionMissing);
 }
 
 /// F-keys must produce xterm escape sequences for managed terminals. Regression for #293.

--- a/designs/RFC-019-missing-session-handling.md
+++ b/designs/RFC-019-missing-session-handling.md
@@ -2,7 +2,7 @@
 
 | Field         | Value                                   |
 |---------------|-----------------------------------------|
-| Status        | Draft                                   |
+| Status        | Accepted                                |
 | Author(s)     | Illya Yalovyy                           |
 | Supersedes    | —                                       |
 | Superseded by | —                                       |

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.23',
+  version: '0.2.24',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

When the GUI tries to attach to a daemon runtime that no longer exists (deleted, timed out, killed by another client), the workspace now transitions to a clear `SessionMissing` state instead of silently creating a new runtime or breaking sibling workspaces on the same endpoint.

### Root cause

`ERR_SESSION_NOT_FOUND` (code 4) from the daemon was classified as `UserActionRequired`, a generic catch-all. In `resolve_and_attach_runtime`, this fell through to creating a new runtime — silently replacing the lost session. During reconnect, a session-not-found error could trigger endpoint-level disconnect, affecting all sibling workspaces.

### Changes

- **`ConnectionStatus::SessionMissing`** — new terminal state in the workspace state machine
- **`ConnectionProblem::SessionMissing`** — new error classification for code 4
- **`classify_connection_problem`** — maps `ERR_SESSION_NOT_FOUND` to `SessionMissing` (was `UserActionRequired`)
- **`resolve_and_attach_runtime`** — reports `SessionMissing` instead of falling back to create
- **Reconnect loop** — handles `SessionMissing` per-workspace without tearing down the shared endpoint
- **`handle_command_error`** — emits `SessionMissing` status directly, no endpoint teardown
- **UI presentation** — `SessionMissing` disables input, shows warning icon/CSS, hides Reconnect menu item
- **RFC-019** — moved from Draft to Accepted

Implements RFC-019 steps 1–3 (state, error classification, fault isolation).

## Manual verification

1. Start daemon and GUI in dev mode
2. Create two managed workspaces on the same endpoint
3. Kill one session on the daemon (`rttx-server` CLI or direct termination)
4. Observe: the affected workspace shows "Session Missing" state
5. Verify: the sibling workspace continues working normally
6. Verify: the affected workspace can be closed from the context menu

## Tests added

### Unit tests (runtime.rs)
- `classify_session_not_found_as_session_missing` — code 4 maps to SessionMissing
- `session_missing_status_disables_input` — input gated off
- `session_missing_label_describes_state` — labels are descriptive
- `advance_to_session_missing` — state machine transition
- `session_missing_icon_uses_warning_class` — sidebar icon presentation
- `session_missing_problem_label_is_nonempty` — problem label coverage
- `menu_items_session_missing_hides_reconnect` — no Reconnect for missing sessions

### Unit tests (workspace_state.rs)
- `reconcile_session_missing_emits_status_update` — status flows through reconciliation

### Integration tests (daemon_bridge.rs)
- `resolve_and_attach_reports_session_missing_on_stale_id` — replaces old fallback test

### Integration tests (session_lifecycle.rs, gtk_boundary_contracts.rs)
- `connection_status_lifecycle_is_deterministic` — extended with SessionMissing
- `connection_icon_always_has_tooltip` — extended with SessionMissing

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo build -p rttx-server` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-server -p rttx-proto` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

## Remaining work (follow-up PRs)

RFC-019 steps 4–7 are not included in this PR:
- Step 4: `reconcile_workspace_against_daemon` using ListSessions
- Step 5: Post-reconnect reconciliation
- Step 6: "Refresh sessions from daemon" menu action
- Step 7: Orphan cleanup dialog

These are additive features that build on the foundation laid here.

Fixes #478