### PR TITLE
fix(terminal): position context menu adjacent to pointer instead of under it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.24"
+version = "0.2.25"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -6,6 +6,10 @@ pub mod widget;
 
 use gtk4::prelude::*;
 
+/// Context menu alignment: Start so the left edge aligns with the pointer,
+/// preventing immediate item activation on button release (#480).
+pub(crate) const CONTEXT_MENU_HALIGN: gtk4::Align = gtk4::Align::Start;
+
 /// Populate a `gio::Menu` with places visible on the given host key.
 ///
 /// Each item triggers `win.open-place` with the place path as parameter.
@@ -886,6 +890,18 @@ mod pane_passive_tests {
         let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
         let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
         assert!(!ctrl.intersects(shift), "Ctrl and Shift masks must not overlap");
+    }
+
+    /// Context menu must use Start alignment so the popover's left edge
+    /// aligns with the pointer, preventing immediate item activation on
+    /// button release. Regression for #480.
+    #[test]
+    fn context_menu_halign_is_start() {
+        assert_eq!(
+            super::CONTEXT_MENU_HALIGN,
+            gtk4::Align::Start,
+            "context menu must open adjacent to the pointer, not centered on it"
+        );
     }
 }
 

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -215,7 +215,7 @@ mod imp {
 
             let context_menu = gtk4::PopoverMenu::from_model(Some(&menu));
             context_menu.set_has_arrow(false);
-            context_menu.set_halign(gtk4::Align::Start);
+            context_menu.set_halign(crate::terminal::CONTEXT_MENU_HALIGN);
             context_menu.set_parent(obj.upcast_ref::<gtk4::Widget>());
 
             let right_click = gtk4::GestureClick::new();

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -215,6 +215,7 @@ mod imp {
 
             let context_menu = gtk4::PopoverMenu::from_model(Some(&menu));
             context_menu.set_has_arrow(false);
+            context_menu.set_halign(gtk4::Align::Start);
             context_menu.set_parent(obj.upcast_ref::<gtk4::Widget>());
 
             let right_click = gtk4::GestureClick::new();

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -242,6 +242,7 @@ mod imp {
 
             let context_menu = gtk4::PopoverMenu::from_model(Some(&menu));
             context_menu.set_has_arrow(false);
+            context_menu.set_halign(gtk4::Align::Start);
             context_menu.set_parent(obj.upcast_ref::<gtk4::Widget>());
 
             let right_click = gtk4::GestureClick::new();

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -242,7 +242,7 @@ mod imp {
 
             let context_menu = gtk4::PopoverMenu::from_model(Some(&menu));
             context_menu.set_has_arrow(false);
-            context_menu.set_halign(gtk4::Align::Start);
+            context_menu.set_halign(crate::terminal::CONTEXT_MENU_HALIGN);
             context_menu.set_parent(obj.upcast_ref::<gtk4::Widget>());
 
             let right_click = gtk4::GestureClick::new();

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -996,6 +996,41 @@ fn terminal_context_menu_has_places_submenu() {
     assert!(found_places, "context menu must contain a Places submenu");
 }
 
+/// Regression for #480: the context menu popover must use halign=Start so its
+/// left edge aligns with the pointer position. Without this, the popover
+/// centers on the click point and the pointer lands on a menu item, causing
+/// immediate activation on button release.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn direct_terminal_context_menu_popover_uses_start_halign() {
+    require_display!();
+
+    let term = rttx::terminal::widget::TerminalWidget::new("t-halign", None);
+    let popover = find_popover_child(term.upcast_ref::<gtk4::Widget>())
+        .expect("context menu must be parented");
+    assert_eq!(
+        popover.halign(),
+        gtk4::Align::Start,
+        "context menu popover must use halign=Start so the pointer is outside the menu on open"
+    );
+}
+
+/// Regression for #480: same as above but for persistent pane context menu.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn persistent_pane_context_menu_popover_uses_start_halign() {
+    require_display!();
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("p-halign", "s1");
+    let popover = find_popover_child(pane.upcast_ref::<gtk4::Widget>())
+        .expect("context menu must be parented");
+    assert_eq!(
+        popover.halign(),
+        gtk4::Align::Start,
+        "context menu popover must use halign=Start so the pointer is outside the menu on open"
+    );
+}
+
 // ── TerminalHandle tests ────────────────────────────────────────
 
 #[test]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.24',
+  version: '0.2.25',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Fixes #480.

The VTE context menu popover was centering itself on the click point, placing a menu item directly under the cursor. On button release, the hovered item would activate immediately, making the menu unusable for normal right-click workflows.

The fix adds `set_halign(gtk4::Align::Start)` to the context menu `PopoverMenu` in both `TerminalWidget` (direct panes) and `PersistentPaneView` (daemon-backed panes). This aligns the popover's left edge with the click point, matching GNOME convention where the pointer is outside the menu area when it appears.

## Root cause

`PopoverMenu` with default `halign=Fill` centers horizontally on the `pointing_to` rectangle. With a 1×1 rectangle at the click coordinates, the pointer ends up in the middle of the first menu item row.

## Manual verification

1. Open rttx with a terminal pane
2. Shift+right-click in the terminal area
3. The context menu should appear with its top-left corner at the pointer position
4. Releasing the mouse button should not activate any menu item
5. Menu items can be selected with a subsequent left-click

## Tests added

- `direct_terminal_context_menu_popover_uses_start_halign` — verifies the direct terminal popover has `halign=Start`
- `persistent_pane_context_menu_popover_uses_start_halign` — verifies the persistent pane popover has `halign=Start`

Both are GTK widget tests (`#[ignore]`) that run via `run-quality-tests.sh`.

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (all unit tests pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass, including both new tests)
