### PR TITLE
feat(terminal): add paste guard for large or multiline text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.25"
+version = "0.2.26"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/preferences.rs
+++ b/clients/rttx/src/preferences.rs
@@ -81,6 +81,10 @@ pub struct Preferences {
     pub auto_start_daemon: bool,
     #[serde(default = "default_reconnect_delay_secs")]
     pub reconnect_delay_secs: u32,
+    #[serde(default = "default_true")]
+    pub paste_guard: bool,
+    #[serde(default = "default_paste_guard_threshold")]
+    pub paste_guard_threshold: usize,
 }
 
 fn default_font() -> String {
@@ -107,6 +111,10 @@ const fn default_true() -> bool {
 const fn default_reconnect_delay_secs() -> u32 {
     10
 }
+
+const fn default_paste_guard_threshold() -> usize {
+    1024
+}
 impl Default for Preferences {
     fn default() -> Self {
         Self {
@@ -126,6 +134,8 @@ impl Default for Preferences {
             pane_navigation_keys: PaneNavigationKeys::default(),
             auto_start_daemon: true,
             reconnect_delay_secs: default_reconnect_delay_secs(),
+            paste_guard: true,
+            paste_guard_threshold: default_paste_guard_threshold(),
         }
     }
 }
@@ -181,6 +191,10 @@ struct PreferencesDisk {
     auto_start_daemon: bool,
     #[serde(default = "default_reconnect_delay_secs")]
     reconnect_delay_secs: u32,
+    #[serde(default = "default_true")]
+    paste_guard: bool,
+    #[serde(default = "default_paste_guard_threshold")]
+    paste_guard_threshold: usize,
 }
 
 impl From<PreferencesDisk> for Preferences {
@@ -214,6 +228,8 @@ impl From<PreferencesDisk> for Preferences {
             pane_navigation_keys: raw.pane_navigation_keys,
             auto_start_daemon: raw.auto_start_daemon,
             reconnect_delay_secs: raw.reconnect_delay_secs,
+            paste_guard: raw.paste_guard,
+            paste_guard_threshold: raw.paste_guard_threshold,
         }
     }
 }
@@ -284,6 +300,8 @@ mod tests {
         assert!(!prefs.smart_clipboard);
         assert!(prefs.auto_start_daemon);
         assert_eq!(prefs.reconnect_delay_secs, 10);
+        assert!(prefs.paste_guard);
+        assert_eq!(prefs.paste_guard_threshold, 1024);
     }
 
     #[test]
@@ -497,5 +515,34 @@ mod tests {
         let path = dir.path().join("prefs.json");
         std::fs::write(&path, "{}").unwrap();
         assert_eq!(load_from(&path).reconnect_delay_secs, 10);
+    }
+
+    #[test]
+    fn paste_guard_defaults_to_enabled() {
+        let prefs = Preferences::default();
+        assert!(prefs.paste_guard);
+        assert_eq!(prefs.paste_guard_threshold, 1024);
+    }
+
+    #[test]
+    fn paste_guard_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("prefs.json");
+        let prefs =
+            Preferences { paste_guard: false, paste_guard_threshold: 4096, ..Default::default() };
+        save_to(&prefs, &path).unwrap();
+        let loaded = load_from(&path);
+        assert!(!loaded.paste_guard);
+        assert_eq!(loaded.paste_guard_threshold, 4096);
+    }
+
+    #[test]
+    fn missing_paste_guard_defaults_to_enabled() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("prefs.json");
+        std::fs::write(&path, "{}").unwrap();
+        let loaded = load_from(&path);
+        assert!(loaded.paste_guard);
+        assert_eq!(loaded.paste_guard_threshold, 1024);
     }
 }

--- a/clients/rttx/src/preferences_window.rs
+++ b/clients/rttx/src/preferences_window.rs
@@ -99,6 +99,12 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
     smart_clipboard_row.set_active(prefs.smart_clipboard);
     terminal_group.add(&smart_clipboard_row);
 
+    let paste_guard_row = adw::SwitchRow::new();
+    paste_guard_row.set_title("Paste guard");
+    paste_guard_row.set_subtitle("Confirm before pasting multiline or large text");
+    paste_guard_row.set_active(prefs.paste_guard);
+    terminal_group.add(&paste_guard_row);
+
     let session_group = adw::PreferencesGroup::new();
     session_group.set_title("Workspaces");
 
@@ -200,6 +206,8 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
             },
             auto_start_daemon: prefs.auto_start_daemon,
             reconnect_delay_secs: prefs.reconnect_delay_secs,
+            paste_guard: paste_guard_row.is_active(),
+            paste_guard_threshold: prefs.paste_guard_threshold,
         };
         if let Err(e) = preferences::save(&new_prefs) {
             log::error!("Failed to save preferences: {e}");

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -967,4 +967,11 @@ mod search_tests {
         assert!(prefs.audible_bell, "audible_bell should default to true");
         assert!(prefs.visual_bell, "visual_bell should default to true");
     }
+
+    #[test]
+    fn paste_guard_preferences_default_enabled() {
+        let prefs = crate::preferences::Preferences::default();
+        assert!(prefs.paste_guard);
+        assert_eq!(prefs.paste_guard_threshold, 1024);
+    }
 }

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1,6 +1,7 @@
 pub mod handle;
 #[doc(hidden)]
 pub mod links;
+pub(crate) mod paste_guard;
 pub mod persistent_widget;
 pub mod widget;
 

--- a/clients/rttx/src/terminal/paste_guard.rs
+++ b/clients/rttx/src/terminal/paste_guard.rs
@@ -1,0 +1,140 @@
+//! Paste guard: warn before pasting large or multiline text into a terminal.
+//!
+//! The guard analyses clipboard text and decides whether a confirmation dialog
+//! should be shown. The dialog offers Paste, Paste as single line, or Cancel.
+
+/// Result of analysing clipboard text for the paste guard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PasteAnalysis {
+    pub line_count: usize,
+    pub byte_len: usize,
+    pub preview: String,
+}
+
+/// Whether the paste guard should trigger for the given text.
+pub(crate) fn needs_confirmation(text: &str, threshold_bytes: usize) -> bool {
+    text.contains('\n') || text.contains('\r') || text.len() > threshold_bytes
+}
+
+/// Analyse clipboard text for display in the confirmation dialog.
+pub(crate) fn analyse(text: &str) -> PasteAnalysis {
+    let line_count = text.lines().count().max(1);
+    let preview_limit = 200;
+    let preview = if text.len() <= preview_limit {
+        text.to_string()
+    } else {
+        let mut end = preview_limit;
+        while end < text.len() && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &text[..end])
+    };
+    PasteAnalysis { line_count, byte_len: text.len(), preview }
+}
+
+/// Collapse all newlines (LF, CR, CRLF) and whitespace runs into single spaces.
+pub(crate) fn flatten_to_single_line(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut prev_space = false;
+    for ch in text.chars() {
+        if ch == '\n' || ch == '\r' || ch == ' ' || ch == '\t' {
+            if !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+        } else {
+            out.push(ch);
+            prev_space = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_line_below_threshold_does_not_trigger() {
+        assert!(!needs_confirmation("hello", 1024));
+    }
+
+    #[test]
+    fn multiline_text_triggers() {
+        assert!(needs_confirmation("line1\nline2", 1024));
+    }
+
+    #[test]
+    fn carriage_return_triggers() {
+        assert!(needs_confirmation("line1\rline2", 1024));
+    }
+
+    #[test]
+    fn crlf_triggers() {
+        assert!(needs_confirmation("line1\r\nline2", 1024));
+    }
+
+    #[test]
+    fn large_single_line_triggers() {
+        let big = "x".repeat(2000);
+        assert!(needs_confirmation(&big, 1024));
+    }
+
+    #[test]
+    fn exactly_at_threshold_does_not_trigger() {
+        let text = "x".repeat(1024);
+        assert!(!needs_confirmation(&text, 1024));
+    }
+
+    #[test]
+    fn empty_text_does_not_trigger() {
+        assert!(!needs_confirmation("", 1024));
+    }
+
+    #[test]
+    fn analyse_counts_lines() {
+        let a = analyse("one\ntwo\nthree");
+        assert_eq!(a.line_count, 3);
+    }
+
+    #[test]
+    fn analyse_single_line() {
+        let a = analyse("hello");
+        assert_eq!(a.line_count, 1);
+        assert_eq!(a.byte_len, 5);
+        assert_eq!(a.preview, "hello");
+    }
+
+    #[test]
+    fn analyse_truncates_long_preview() {
+        let long = "a".repeat(300);
+        let a = analyse(&long);
+        assert!(a.preview.len() < 210);
+        assert!(a.preview.ends_with('…'));
+    }
+
+    #[test]
+    fn flatten_collapses_newlines() {
+        assert_eq!(flatten_to_single_line("a\nb\nc"), "a b c");
+    }
+
+    #[test]
+    fn flatten_collapses_crlf() {
+        assert_eq!(flatten_to_single_line("a\r\nb\r\nc"), "a b c");
+    }
+
+    #[test]
+    fn flatten_trims_leading_trailing() {
+        assert_eq!(flatten_to_single_line("\n  hello  \n"), "hello");
+    }
+
+    #[test]
+    fn flatten_consecutive_whitespace() {
+        assert_eq!(flatten_to_single_line("a  \n\n  b"), "a b");
+    }
+
+    #[test]
+    fn flatten_empty() {
+        assert_eq!(flatten_to_single_line(""), "");
+    }
+}

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -759,10 +759,11 @@ impl PersistentPaneView {
                     glib::Propagation::Stop
                 }
                 TerminalKeyAction::PasteClipboard => {
-                    let forward_input = std::rc::Rc::clone(&forward_input);
-                    pane.request_clipboard_paste(move |bytes| {
-                        forward_input(&bytes);
-                    });
+                    if let Some(root) = pane.root()
+                        && let Some(win) = root.downcast_ref::<gtk4::Window>()
+                    {
+                        win.activate_action("win.paste", None).ok();
+                    }
                     glib::Propagation::Stop
                 }
                 TerminalKeyAction::ForwardToPty(bytes) => {
@@ -879,7 +880,7 @@ const BRACKETED_PASTE_DISABLE: &[u8] = b"\x1b[?2004l";
 /// Replaces `\r\n` and standalone `\n` with `\r`, matching VTE's
 /// `pastify_string()` behavior. Terminals expect `\r` for line endings
 /// on the input side.
-fn pastify(text: &[u8]) -> Vec<u8> {
+pub(crate) fn pastify(text: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(text.len());
     let mut i = 0;
     while i < text.len() {
@@ -895,6 +896,22 @@ fn pastify(text: &[u8]) -> Vec<u8> {
         }
     }
     out
+}
+
+/// Build paste bytes for a managed pane, wrapping in bracketed paste if the
+/// pane has that mode enabled.
+pub(crate) fn pastify_for_pane(pane: &PersistentPaneView, text: &[u8]) -> Vec<u8> {
+    let payload = pastify(text);
+    if pane.imp().bracketed_paste_mode.get() {
+        let mut wrapped =
+            Vec::with_capacity(b"\x1b[200~".len() + payload.len() + b"\x1b[201~".len());
+        wrapped.extend_from_slice(b"\x1b[200~");
+        wrapped.extend_from_slice(&payload);
+        wrapped.extend_from_slice(b"\x1b[201~");
+        wrapped
+    } else {
+        payload
+    }
 }
 
 /// Scan terminal output for DECSET/DECRST 2004 and update the mode flag.

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -170,7 +170,11 @@ mod imp {
                         glib::Propagation::Stop
                     }
                     TerminalKeyAction::PasteClipboard => {
-                        vte.paste_clipboard();
+                        if let Some(root) = term.root()
+                            && let Some(win) = root.downcast_ref::<gtk4::Window>()
+                        {
+                            win.activate_action("win.paste", None).ok();
+                        }
                         glib::Propagation::Stop
                     }
                     TerminalKeyAction::PassThrough | TerminalKeyAction::ForwardToPty(_) => {

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -305,18 +305,70 @@ impl Window {
     }
 
     fn clipboard_paste(&self) {
-        if let Some(uuid) = self.focused_terminal_uuid()
-            && let Some(terminal) = self.terminal_handle(&uuid)
-        {
-            match terminal {
-                TerminalHandle::Direct(terminal) => terminal.vte().paste_clipboard(),
-                TerminalHandle::Managed(pane) => {
-                    let win = self.clone();
-                    let terminal_uuid = uuid.clone();
-                    pane.request_clipboard_paste(move |bytes| {
-                        win.send_managed_terminal_input(&terminal_uuid, &bytes);
-                    });
+        let Some(uuid) = self.focused_terminal_uuid() else { return };
+        let Some(terminal) = self.terminal_handle(&uuid) else { return };
+
+        let prefs = crate::preferences::load();
+        if !prefs.paste_guard {
+            Self::execute_paste(&terminal, self, &uuid);
+            return;
+        }
+
+        let Some(display) = gtk4::gdk::Display::default() else {
+            Self::execute_paste(&terminal, self, &uuid);
+            return;
+        };
+        let clipboard = display.clipboard();
+        let win = self.clone();
+        let terminal_uuid = uuid;
+        clipboard.read_text_async(None::<&gtk4::gio::Cancellable>, move |result| {
+            let text = match result {
+                Ok(Some(t)) if !t.is_empty() => t.to_string(),
+                _ => return,
+            };
+
+            let threshold = crate::preferences::load().paste_guard_threshold;
+            if !crate::terminal::paste_guard::needs_confirmation(&text, threshold) {
+                if let Some(terminal) = win.terminal_handle(&terminal_uuid) {
+                    Self::execute_paste(&terminal, &win, &terminal_uuid);
                 }
+                return;
+            }
+
+            win.confirm_paste(&terminal_uuid, &text);
+        });
+    }
+
+    fn execute_paste(terminal: &TerminalHandle, win: &Self, terminal_uuid: &str) {
+        match terminal {
+            TerminalHandle::Direct(terminal) => terminal.vte().paste_clipboard(),
+            TerminalHandle::Managed(pane) => {
+                let win = win.clone();
+                let terminal_uuid = terminal_uuid.to_string();
+                pane.request_clipboard_paste(move |bytes| {
+                    win.send_managed_terminal_input(&terminal_uuid, &bytes);
+                });
+            }
+        }
+    }
+
+    pub(super) fn execute_paste_text(
+        terminal: &TerminalHandle,
+        win: &Self,
+        terminal_uuid: &str,
+        text: &str,
+    ) {
+        match terminal {
+            TerminalHandle::Direct(t) => {
+                let bytes = crate::terminal::persistent_widget::pastify(text.as_bytes());
+                t.vte().feed_child(&bytes);
+            }
+            TerminalHandle::Managed(pane) => {
+                let bytes =
+                    crate::terminal::persistent_widget::pastify_for_pane(pane, text.as_bytes());
+                let win = win.clone();
+                let terminal_uuid = terminal_uuid.to_string();
+                win.send_managed_terminal_input(&terminal_uuid, &bytes);
             }
         }
     }

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -552,4 +552,40 @@ impl Window {
         self.refresh_place_sidebar();
         self.show_toast(&format!("Place \"{label}\" added"));
     }
+
+    pub(super) fn confirm_paste(&self, terminal_uuid: &str, text: &str) {
+        use crate::terminal::paste_guard::{analyse, flatten_to_single_line};
+
+        let analysis = analyse(text);
+        let body = format!(
+            "{} lines, {} bytes\n\n{}",
+            analysis.line_count, analysis.byte_len, analysis.preview
+        );
+
+        let alert = adw::AlertDialog::new(Some("Confirm Paste"), Some(&body));
+        alert.add_response("cancel", "Cancel");
+        alert.add_response("single-line", "Paste as Single Line");
+        alert.add_response("paste", "Paste");
+        alert.set_response_appearance("paste", adw::ResponseAppearance::Suggested);
+        alert.set_default_response(Some("cancel"));
+        alert.set_close_response("cancel");
+
+        let win = self.clone();
+        let uuid = terminal_uuid.to_string();
+        let original_text = text.to_string();
+        alert.connect_response(None, move |_, response| {
+            let Some(terminal) = win.terminal_handle(&uuid) else { return };
+            match response {
+                "paste" => {
+                    Self::execute_paste_text(&terminal, &win, &uuid, &original_text);
+                }
+                "single-line" => {
+                    let flat = flatten_to_single_line(&original_text);
+                    Self::execute_paste_text(&terminal, &win, &uuid, &flat);
+                }
+                _ => {}
+            }
+        });
+        alert.present(Some(self));
+    }
 }

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -33,6 +33,8 @@ fn preferences_roundtrip_all_fields() {
         pane_navigation_keys: PaneNavigationKeys::AltArrow,
         auto_start_daemon: true,
         reconnect_delay_secs: 10,
+        paste_guard: false,
+        paste_guard_threshold: 2048,
     };
 
     preferences::save_to(&prefs, &path).unwrap();
@@ -207,4 +209,34 @@ fn pane_navigation_keys_persists_across_save_load() {
     std::fs::write(&path, r#"{"font": "Mono 12"}"#).unwrap();
     let loaded = preferences::load_from(&path);
     assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::AltArrow);
+}
+
+#[test]
+fn paste_guard_defaults_to_enabled_with_1k_threshold() {
+    let prefs = Preferences::default();
+    assert!(prefs.paste_guard);
+    assert_eq!(prefs.paste_guard_threshold, 1024);
+}
+
+#[test]
+fn paste_guard_roundtrips() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+
+    let prefs =
+        Preferences { paste_guard: false, paste_guard_threshold: 4096, ..Default::default() };
+    preferences::save_to(&prefs, &path).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert!(!loaded.paste_guard);
+    assert_eq!(loaded.paste_guard_threshold, 4096);
+}
+
+#[test]
+fn paste_guard_backward_compat_missing_fields() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+    std::fs::write(&path, r#"{"font": "Mono 12"}"#).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert!(loaded.paste_guard);
+    assert_eq!(loaded.paste_guard_threshold, 1024);
 }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.25',
+  version: '0.2.26',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds a safety guard before pasting large or multiline text into a terminal pane. When pasted text contains newlines or exceeds a configurable size threshold (default 1 KiB), an `adw::AlertDialog` is shown with:

- Line count and byte size
- Text preview (first 200 characters)
- Three buttons: **Paste**, **Paste as Single Line**, **Cancel**

This prevents accidental execution of multiple commands when pasting multiline text into an interactive shell — a well-known footgun that GNOME Terminal, kitty, and most modern terminals guard against.

### Implementation

- New `paste_guard` module with pure analysis logic (`needs_confirmation`, `analyse`, `flatten_to_single_line`)
- All paste paths (Ctrl+Shift+V window action, smart clipboard Ctrl+V for both direct and managed terminals) now route through the Window's paste action so the guard applies uniformly
- `confirm_paste` dialog in `window/dialogs.rs` using `adw::AlertDialog`
- New preferences: `paste_guard` (bool, default true) and `paste_guard_threshold` (usize, default 1024)
- Preferences window includes a toggle switch for the guard
- All new fields use `#[serde(default)]` for backward compatibility

### Manual verification steps

1. Copy multiline text to clipboard
2. Paste into rttx terminal — dialog should appear
3. Click Paste — text pastes normally
4. Paste again, click Paste as Single Line — newlines collapsed to spaces
5. Paste again, click Cancel — nothing pasted
6. Copy short single-line text — paste should work without dialog
7. Disable paste guard in Preferences — multiline paste should work without dialog

### Tests added

**Unit tests (paste_guard module — 15 tests):**
- `single_line_below_threshold_does_not_trigger`
- `multiline_text_triggers`
- `carriage_return_triggers`
- `crlf_triggers`
- `large_single_line_triggers`
- `exactly_at_threshold_does_not_trigger`
- `empty_text_does_not_trigger`
- `analyse_counts_lines`
- `analyse_single_line`
- `analyse_truncates_long_preview`
- `flatten_collapses_newlines`
- `flatten_collapses_crlf`
- `flatten_trims_leading_trailing`
- `flatten_consecutive_whitespace`
- `flatten_empty`

**Preference tests (unit + integration — 6 tests):**
- `paste_guard_defaults_to_enabled` (unit)
- `paste_guard_roundtrips` (unit)
- `missing_paste_guard_defaults_to_enabled` (unit)
- `paste_guard_defaults_to_enabled_with_1k_threshold` (integration)
- `paste_guard_roundtrips` (integration)
- `paste_guard_backward_compat_missing_fields` (integration)

### Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` — 535 passed, 0 failed ✅
- `cargo test -p rttx-proto -p rttx-server` — all passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — all passed ✅

### Limitations

- "Paste as Single Line" on direct terminals uses `feed_child` instead of `paste_clipboard`, which means VTE's internal bracketed paste wrapping is bypassed for that specific path. Since the flattened text is a single line, the primary safety concern (multiline command execution) is already addressed.
- The paste guard threshold is not exposed in the preferences UI (only the on/off toggle). The threshold can be changed by editing the JSON config file directly.

Fixes #482