### PR TITLE
feat: add button to manually add new hosts to the hosts list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.26"
+version = "0.2.27"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -234,6 +234,74 @@ impl Window {
         dialog.present(Some(self));
     }
 
+    pub(super) fn show_add_host_dialog(&self) {
+        let dialog = adw::Dialog::builder().title("Add Host").content_width(360).build();
+        let header = adw::HeaderBar::new();
+
+        let add_button = gtk4::Button::with_label("Add");
+        add_button.add_css_class("suggested-action");
+        add_button.set_sensitive(false);
+        header.pack_end(&add_button);
+
+        let entry = adw::EntryRow::builder().title("SSH target (e.g. user@host)").build();
+
+        let group = adw::PreferencesGroup::new();
+        group.add(&entry);
+
+        let content = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+        content.set_margin_start(18);
+        content.set_margin_end(18);
+        content.set_margin_top(18);
+        content.set_margin_bottom(18);
+        content.append(&group);
+
+        let toolbar_view = adw::ToolbarView::new();
+        toolbar_view.add_top_bar(&header);
+        toolbar_view.set_content(Some(&content));
+        dialog.set_child(Some(&toolbar_view));
+
+        let add_ref = add_button.clone();
+        entry.connect_changed(move |e| {
+            add_ref.set_sensitive(!e.text().trim().is_empty());
+        });
+
+        let dialog_ref = dialog.clone();
+        let win = self.clone();
+        let entry_ref = entry.clone();
+        let commit = move || {
+            let text = entry_ref.text();
+            let ssh_target = text.trim();
+            if ssh_target.is_empty() {
+                return;
+            }
+            let new_host = host::Host::remote(ssh_target);
+            let mut hosts = host::load();
+            if hosts.iter().any(|h| h.key == new_host.key) {
+                win.show_toast(&format!("Host \"{}\" already exists", new_host.name));
+                dialog_ref.close();
+                return;
+            }
+            hosts.push(new_host.clone());
+            if let Err(e) = host::save(&hosts) {
+                log::error!("Failed to save hosts: {e}");
+                win.show_toast("Failed to save host");
+                dialog_ref.close();
+                return;
+            }
+            win.rebuild_host_selector_model(Some(&new_host.key));
+            win.refresh_place_sidebar();
+            win.refresh_command_sidebar();
+            win.show_toast(&format!("Host \"{}\" added", new_host.name));
+            dialog_ref.close();
+        };
+
+        let commit_for_button = commit.clone();
+        add_button.connect_clicked(move |_| commit_for_button());
+        entry.connect_entry_activated(move |_| commit());
+
+        dialog.present(Some(self));
+    }
+
     pub(super) fn show_about_window(&self) {
         let about = adw::AboutWindow::new();
         about.set_transient_for(Some(self));

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -51,6 +51,7 @@ mod imp {
         pub utility_sidebar_box: gtk4::Box,
         pub sidebar_search_entry: gtk4::SearchEntry,
         pub host_selector: gtk4::DropDown,
+        pub host_add_button: gtk4::Button,
         pub host_delete_button: gtk4::Button,
         pub utility_stack: gtk4::Stack,
         pub place_list: gtk4::ListBox,
@@ -190,11 +191,16 @@ mod imp {
             self.host_delete_button.add_css_class("flat");
             self.host_delete_button.set_visible(false);
 
+            self.host_add_button.set_icon_name("list-add-symbolic");
+            self.host_add_button.set_tooltip_text(Some("Add host"));
+            self.host_add_button.add_css_class("flat");
+
             let host_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
             host_row.set_margin_start(12);
             host_row.set_margin_end(12);
             host_row.set_margin_top(8);
             host_row.append(&self.host_selector);
+            host_row.append(&self.host_add_button);
             host_row.append(&self.host_delete_button);
 
             // ── Places tab ───────────────────────────────────────
@@ -551,6 +557,11 @@ impl Window {
             {
                 win.confirm_delete_host(key);
             }
+        });
+
+        let win = self.clone();
+        self.imp().host_add_button.connect_clicked(move |_| {
+            win.show_add_host_dialog();
         });
 
         let win = self.clone();

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -4839,3 +4839,63 @@ fn managed_pane_focus_change_updates_sidebar_subtitle() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_add_button_visible_in_host_row() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.host-add-button-visible-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    assert!(
+        window.imp().host_add_button.is_visible(),
+        "add host button should always be visible in the host row"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_add_button_has_correct_icon_and_tooltip() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.host-add-button-icon-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    assert_eq!(
+        window.imp().host_add_button.icon_name().unwrap(),
+        "list-add-symbolic",
+        "add host button should use the list-add-symbolic icon"
+    );
+    assert_eq!(
+        window.imp().host_add_button.tooltip_text().unwrap().as_str(),
+        "Add host",
+        "add host button should have the correct tooltip"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/host_sidebar_tests.rs
+++ b/clients/rttx/tests/host_sidebar_tests.rs
@@ -97,3 +97,28 @@ fn add_host_from_remote_endpoint_saves_and_deduplicates() {
     assert!(hosts.iter().any(|h| h.key == new_host.key));
     assert_eq!(hosts.iter().filter(|h| h.key == "builder.example.com").count(), 1);
 }
+
+#[test]
+fn add_host_rejects_blank_ssh_target() {
+    let blank_targets = ["", "  ", "\t\n"];
+    for target in blank_targets {
+        let trimmed = target.trim();
+        assert!(trimmed.is_empty(), "blank target should be rejected before creating a host");
+    }
+}
+
+#[test]
+fn add_host_detects_duplicate_by_normalized_key() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("hosts.json");
+
+    let host_a = host::Host::remote("deploy@example.com");
+    host::save_to(&[host_a], &path).unwrap();
+
+    let hosts = host::load_from(&path);
+    let host_b = host::Host::remote("root@Example.COM");
+    assert!(
+        hosts.iter().any(|h| h.key == host_b.key),
+        "different user and case should still match the same host key"
+    );
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.26',
+  version: '0.2.27',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds a "+" button next to the host selector dropdown in the right sidebar, allowing users to proactively add remote hosts before connecting to them. Previously, hosts could only appear in the selector when a remote workspace was connected or via the "Add current SSH host" context menu action from an active remote session.

Clicking the button opens an Adwaita dialog with an SSH target entry field. On confirmation:
- The host is saved to `hosts.json`
- The host selector is rebuilt and selects the new host
- A toast confirms the action
- Duplicate hosts are detected by normalized key and rejected with a toast

Fixes #512

## Manual verification steps

1. Open rttx
2. In the right sidebar, observe the "+" button next to the host selector dropdown
3. Click it — an "Add Host" dialog appears
4. Enter an SSH target (e.g. `user@example.com`) and click "Add" or press Enter
5. The host appears in the host selector and is selected
6. Try adding the same host again — a "Host already exists" toast appears
7. Try submitting with blank input — the Add button is disabled

## Tests added

### GTK widget tests (`window::tests`)
- `host_add_button_visible_in_host_row` — verifies the button is visible in the sidebar
- `host_add_button_has_correct_icon_and_tooltip` — verifies icon and tooltip

### Integration tests (`host_sidebar_tests`)
- `add_host_rejects_blank_ssh_target` — blank input validation
- `add_host_detects_duplicate_by_normalized_key` — duplicate detection across user/case variations

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76 -p rttx-server -p rttx-proto` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76 -p rttx-server -p rttx-proto` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (both new GTK tests ran and passed)

## Remaining limitations

None. The feature is self-contained.