### PR TITLE
fix: add "Add Host…" to top bar menus and include session-derived hosts

### DIFF
--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -628,10 +628,7 @@ impl Window {
         }
         drop(state);
 
-        let mut hosts: Vec<host::Host> = keys
-            .iter()
-            .map(|k| host::resolve(k, &saved))
-            .collect();
+        let mut hosts: Vec<host::Host> = keys.iter().map(|k| host::resolve(k, &saved)).collect();
         // Sort remotes alphabetically, keeping Local first
         hosts[1..].sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
 

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -599,16 +599,41 @@ impl Window {
         });
         self.add_action(&connect_action);
 
+        let add_host_action = gtk4::gio::SimpleAction::new("add-host", None);
+        let win = self.clone();
+        add_host_action.connect_activate(move |_, _| {
+            win.show_add_host_dialog();
+        });
+        self.add_action(&add_host_action);
+
         self.refresh_host_menus();
     }
 
     pub(super) fn refresh_host_menus(&self) {
-        let mut hosts: Vec<host::Host> = vec![host::Host::local()];
         let saved = host::load();
-        let mut remotes: Vec<host::Host> =
-            saved.into_iter().filter(host::Host::is_remote).collect();
-        remotes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-        hosts.extend(remotes);
+
+        let mut keys: Vec<String> = vec![host::LOCAL_KEY.into()];
+        for h in &saved {
+            if !keys.contains(&h.key) {
+                keys.push(h.key.clone());
+            }
+        }
+        // Include hosts from active sessions (matching sidebar behavior)
+        let state = self.imp().state.borrow();
+        for s in &state.sessions {
+            let k = s.runtime.endpoint.host_key();
+            if !keys.contains(&k) {
+                keys.push(k);
+            }
+        }
+        drop(state);
+
+        let mut hosts: Vec<host::Host> = keys
+            .iter()
+            .map(|k| host::resolve(k, &saved))
+            .collect();
+        // Sort remotes alphabetically, keeping Local first
+        hosts[1..].sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
 
         let new_menu = gtk4::gio::Menu::new();
         let connect_menu = gtk4::gio::Menu::new();
@@ -628,6 +653,9 @@ impl Window {
             );
             connect_menu.append_item(&connect_item);
         }
+
+        new_menu.append(Some("Add Host\u{2026}"), Some("win.add-host"));
+        connect_menu.append(Some("Add Host\u{2026}"), Some("win.add-host"));
 
         self.imp().new_button.set_menu_model(Some(&new_menu));
         self.imp().connect_button.set_menu_model(Some(&connect_menu));

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -4899,3 +4899,134 @@ fn host_add_button_has_correct_icon_and_tooltip() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn new_menu_includes_add_host_item() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.new-menu-add-host-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    let model = window.imp().new_button.menu_model().unwrap();
+    let n = model.n_items();
+    assert!(n >= 2, "New menu should have at least Local + Add Host…");
+
+    // Last item should be "Add Host…"
+    let last_label = model.item_attribute_value(n - 1, "label", None);
+    assert_eq!(
+        last_label.and_then(|v| v.get::<String>()),
+        Some("Add Host…".into()),
+        "last item in New menu should be 'Add Host…'"
+    );
+
+    // Connect menu should also have "Add Host…"
+    let connect_model = window.imp().connect_button.menu_model().unwrap();
+    let cn = connect_model.n_items();
+    let connect_last = connect_model.item_attribute_value(cn - 1, "label", None);
+    assert_eq!(
+        connect_last.and_then(|v| v.get::<String>()),
+        Some("Add Host…".into()),
+        "last item in Connect menu should be 'Add Host…'"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn new_menu_includes_saved_remote_hosts() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let config_dir = tmp.path().join("rttx-devel");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let hosts = vec![crate::host::Host::remote("deploy@example.com")];
+    crate::host::save_to(&hosts, &config_dir.join("hosts.json")).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.new-menu-saved-hosts-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    let model = window.imp().new_button.menu_model().unwrap();
+    // Should have: Local, example, Add Host…
+    assert!(model.n_items() >= 3, "New menu should have Local + remote host + Add Host…");
+
+    let labels: Vec<String> = (0..model.n_items())
+        .filter_map(|i| {
+            model.item_attribute_value(i, "label", None).and_then(|v| v.get::<String>())
+        })
+        .collect();
+    assert!(labels.contains(&"Local".into()), "menu should contain Local");
+    assert!(labels.contains(&"example".into()), "menu should contain saved remote host");
+    assert!(labels.contains(&"Add Host…".into()), "menu should contain Add Host…");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn new_menu_includes_session_derived_hosts() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.new-menu-session-hosts-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Add a remote managed workspace (not saved in hosts.json)
+    let remote_session = SessionState::new_managed_remote(
+        "Remote Work".into(),
+        "deploy@builder.example.com",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+    window.imp().state.borrow_mut().sessions.push(remote_session.clone());
+    window.build_session(&remote_session, false);
+    pump_events(50);
+
+    // Refresh menus to pick up session-derived hosts
+    window.refresh_host_menus();
+
+    let model = window.imp().new_button.menu_model().unwrap();
+    let labels: Vec<String> = (0..model.n_items())
+        .filter_map(|i| {
+            model.item_attribute_value(i, "label", None).and_then(|v| v.get::<String>())
+        })
+        .collect();
+    assert!(
+        labels.contains(&"builder".into()),
+        "menu should contain session-derived remote host; got: {labels:?}"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -4909,9 +4909,8 @@ fn new_menu_includes_add_host_item() {
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.new-menu-add-host-test")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.new-menu-add-host-test").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);


### PR DESCRIPTION
## What changed and why

The top bar "New" and "Connect" dropdown menus only showed hosts from `hosts.json`. Users without saved remote hosts saw only "Local" and had no way to create remote persistent workspaces from these menus.

### Changes

1. **Added "Add Host…" menu item** to both New and Connect dropdown menus, wired to the existing add-host dialog via a new `win.add-host` action
2. **Included session-derived hosts** in `refresh_host_menus`, matching the sidebar host selector behavior (`rebuild_host_selector_model`)

### Root cause

`refresh_host_menus` only loaded hosts from `host::load()` (saved hosts file) and did not include hosts from active workspace sessions. It also lacked an "Add Host…" affordance, unlike the sidebar which has a dedicated add button.

## Manual verification

1. Start rttx with no saved hosts
2. Click "New" dropdown → should show "Local" and "Add Host…"
3. Click "Add Host…" → add-host dialog opens
4. Add a remote host → menu refreshes to include the new host
5. Connect to a remote host via bookmark → host appears in the dropdown

## Tests added

- `new_menu_includes_add_host_item` — verifies both menus have "Add Host…" as the last item
- `new_menu_includes_saved_remote_hosts` — verifies saved remote hosts appear in the menu
- `new_menu_includes_session_derived_hosts` — verifies hosts from active sessions appear in the menu

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 3 new GTK tests passed)

Fixes #514