### PR TITLE
feat: add/edit/delete places in right tools sidebar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.28"
+version = "0.2.29"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -10,6 +10,7 @@ pub mod form_dialog;
 pub mod host;
 pub mod new_workspace_dialog;
 pub mod places;
+pub mod places_window;
 pub mod preferences;
 pub mod runtime;
 pub mod session;

--- a/clients/rttx/src/places_window.rs
+++ b/clients/rttx/src/places_window.rs
@@ -1,0 +1,85 @@
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use crate::form_dialog::FormDialog;
+use crate::places::{self, Place};
+use crate::window::Window;
+
+pub fn show_form(parent: &Window, place: Option<&Place>) {
+    let existing_uuid = place.map(|p| p.uuid.clone());
+
+    let form = FormDialog::new("Place", place.is_some(), 480);
+
+    let name_row = adw::EntryRow::builder().title("Name").build();
+    let path_row = adw::EntryRow::builder().title("Path").build();
+    let host_tags_row =
+        adw::EntryRow::builder().title("Host tags (comma-separated, empty = global)").build();
+
+    let group = adw::PreferencesGroup::new();
+    group.add(&name_row);
+    group.add(&path_row);
+    group.add(&host_tags_row);
+
+    form.content_box.append(&group);
+    form.finish_layout();
+
+    if let Some(p) = place {
+        name_row.set_text(&p.name);
+        path_row.set_text(&p.path);
+        host_tags_row.set_text(&p.host_tags.join(", "));
+    }
+
+    let dialog = form.dialog.clone();
+    let status_label = form.status_label.clone();
+    let parent_for_save = parent.clone();
+    form.save_button.connect_clicked(move |_| {
+        let place = match build_place(&name_row, &path_row, &host_tags_row, existing_uuid.clone())
+        {
+            Ok(p) => p,
+            Err(msg) => {
+                status_label.set_text(&msg);
+                return;
+            }
+        };
+
+        let mut items = places::load();
+        if let Some(existing) = items.iter_mut().find(|i| i.uuid == place.uuid) {
+            *existing = place;
+        } else {
+            items.push(place);
+        }
+        if let Err(e) = places::save(&items) {
+            status_label.set_text(&format!("Failed to save: {e}"));
+            return;
+        }
+        parent_for_save.refresh_place_sidebar();
+        dialog.close();
+    });
+
+    form.present(parent);
+}
+
+fn build_place(
+    name_row: &adw::EntryRow,
+    path_row: &adw::EntryRow,
+    host_tags_row: &adw::EntryRow,
+    existing_uuid: Option<String>,
+) -> Result<Place, String> {
+    let name = name_row.text().trim().to_string();
+    if name.is_empty() {
+        return Err("Place name is required".into());
+    }
+
+    let path = path_row.text().trim().to_string();
+    if path.is_empty() {
+        return Err("Place path is required".into());
+    }
+
+    let mut place = Place::new(&name, &path);
+    if let Some(uuid) = existing_uuid {
+        place.uuid = uuid;
+    }
+    place.host_tags = crate::commands_window::parse_host_tags(&host_tags_row.text());
+    Ok(place)
+}

--- a/clients/rttx/src/places_window.rs
+++ b/clients/rttx/src/places_window.rs
@@ -34,8 +34,7 @@ pub fn show_form(parent: &Window, place: Option<&Place>) {
     let status_label = form.status_label.clone();
     let parent_for_save = parent.clone();
     form.save_button.connect_clicked(move |_| {
-        let place = match build_place(&name_row, &path_row, &host_tags_row, existing_uuid.clone())
-        {
+        let place = match build_place(&name_row, &path_row, &host_tags_row, existing_uuid.clone()) {
             Ok(p) => p,
             Err(msg) => {
                 status_label.set_text(&msg);

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -50,6 +50,9 @@ impl Window {
             ("add-command", &[], |w| {
                 crate::commands_window::show_form(w, None);
             }),
+            ("add-place", &[], |w| {
+                crate::places_window::show_form(w, None);
+            }),
         ];
 
         for (name, accels, callback) in actions {
@@ -105,6 +108,29 @@ impl Window {
             }
         });
         self.add_action(&delete_command_action);
+
+        let edit_place_action =
+            gtk4::gio::SimpleAction::new("edit-place", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        edit_place_action.connect_activate(move |_, param| {
+            let uuid: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            let all_places = places::load();
+            if let Some(place) = all_places.iter().find(|p| p.uuid == uuid) {
+                crate::places_window::show_form(&win, Some(place));
+            }
+        });
+        self.add_action(&edit_place_action);
+
+        let delete_place_action =
+            gtk4::gio::SimpleAction::new("delete-place", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        delete_place_action.connect_activate(move |_, param| {
+            let uuid: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            if !uuid.is_empty() {
+                win.confirm_delete_place(uuid);
+            }
+        });
+        self.add_action(&delete_place_action);
 
         let open_place_action =
             gtk4::gio::SimpleAction::new("open-place", Some(glib::VariantTy::STRING));

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -66,18 +66,14 @@ impl Window {
 
     pub(super) fn confirm_delete_place(&self, uuid: String) {
         let win = self.clone();
-        self.confirm_delete(
-            "Delete Place?",
-            "The place will be permanently removed.",
-            move || {
-                let mut items = places::load();
-                items.retain(|p| p.uuid != uuid);
-                if let Err(e) = places::save(&items) {
-                    log::error!("Failed to delete place: {e}");
-                }
-                win.refresh_place_sidebar();
-            },
-        );
+        self.confirm_delete("Delete Place?", "The place will be permanently removed.", move || {
+            let mut items = places::load();
+            items.retain(|p| p.uuid != uuid);
+            if let Err(e) = places::save(&items) {
+                log::error!("Failed to delete place: {e}");
+            }
+            win.refresh_place_sidebar();
+        });
     }
 
     pub(super) fn confirm_delete_host(&self, host_key: String) {

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -64,6 +64,22 @@ impl Window {
         );
     }
 
+    pub(super) fn confirm_delete_place(&self, uuid: String) {
+        let win = self.clone();
+        self.confirm_delete(
+            "Delete Place?",
+            "The place will be permanently removed.",
+            move || {
+                let mut items = places::load();
+                items.retain(|p| p.uuid != uuid);
+                if let Err(e) = places::save(&items) {
+                    log::error!("Failed to delete place: {e}");
+                }
+                win.refresh_place_sidebar();
+            },
+        );
+    }
+
     pub(super) fn confirm_delete_host(&self, host_key: String) {
         let saved_hosts = host::load();
         let saved_places = places::load();

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -195,6 +195,22 @@ mod imp {
             host_row.append(&self.host_delete_button);
 
             // ── Places tab ───────────────────────────────────────
+            let add_place_button = gtk4::Button::builder()
+                .icon_name("list-add-symbolic")
+                .tooltip_text("New place")
+                .action_name("win.add-place")
+                .build();
+            let places_header = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
+            places_header.set_margin_start(12);
+            places_header.set_margin_end(12);
+            places_header.set_margin_top(12);
+            let places_title = gtk4::Label::new(Some("Places"));
+            places_title.set_xalign(0.0);
+            places_title.set_hexpand(true);
+            places_title.add_css_class("title-4");
+            places_header.append(&places_title);
+            places_header.append(&add_place_button);
+
             self.place_list.set_selection_mode(gtk4::SelectionMode::None);
             self.place_list.add_css_class("boxed-list");
             self.place_list.update_property(&[gtk4::accessible::Property::Label("Places")]);
@@ -213,6 +229,7 @@ mod imp {
             self.place_empty.set_vexpand(true);
 
             let places_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+            places_page.append(&places_header);
             places_page.append(&self.place_scroll);
             places_page.append(&self.place_empty);
 

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -165,6 +165,32 @@ impl Window {
             }
             action_row.set_activatable(true);
 
+            let is_builtin = place.uuid.starts_with("builtin:");
+            if !is_builtin {
+                let uuid = place.uuid.clone();
+                let edit_item = gtk4::gio::MenuItem::new(Some("Edit"), None);
+                edit_item.set_action_and_target_value(
+                    Some("win.edit-place"),
+                    Some(&uuid.to_variant()),
+                );
+                let delete_item = gtk4::gio::MenuItem::new(Some("Delete"), None);
+                delete_item.set_action_and_target_value(
+                    Some("win.delete-place"),
+                    Some(&uuid.to_variant()),
+                );
+                let menu = gtk4::gio::Menu::new();
+                menu.append_item(&edit_item);
+                menu.append_item(&delete_item);
+                let more_button = gtk4::MenuButton::builder()
+                    .icon_name("view-more-symbolic")
+                    .tooltip_text("More options")
+                    .valign(gtk4::Align::Center)
+                    .menu_model(&menu)
+                    .build();
+                more_button.add_css_class("flat");
+                action_row.add_suffix(&more_button);
+            }
+
             let win = self.clone();
             let path = place.path.clone();
             action_row.connect_activated(move |_| {

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -169,10 +169,8 @@ impl Window {
             if !is_builtin {
                 let uuid = place.uuid.clone();
                 let edit_item = gtk4::gio::MenuItem::new(Some("Edit"), None);
-                edit_item.set_action_and_target_value(
-                    Some("win.edit-place"),
-                    Some(&uuid.to_variant()),
-                );
+                edit_item
+                    .set_action_and_target_value(Some("win.edit-place"), Some(&uuid.to_variant()));
                 let delete_item = gtk4::gio::MenuItem::new(Some("Delete"), None);
                 delete_item.set_action_and_target_value(
                     Some("win.delete-place"),

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -1398,14 +1398,8 @@ fn tools_sidebar_uses_per_row_management_instead_of_manage_dialog() {
         window.lookup_action("delete-command").is_some(),
         "delete-command action should be registered"
     );
-    assert!(
-        window.lookup_action("add-place").is_some(),
-        "add-place action should be registered"
-    );
-    assert!(
-        window.lookup_action("edit-place").is_some(),
-        "edit-place action should be registered"
-    );
+    assert!(window.lookup_action("add-place").is_some(), "add-place action should be registered");
+    assert!(window.lookup_action("edit-place").is_some(), "edit-place action should be registered");
     assert!(
         window.lookup_action("delete-place").is_some(),
         "delete-place action should be registered"
@@ -4724,10 +4718,7 @@ fn place_sidebar_has_add_button_in_header() {
     window.present();
     pump_events(50);
 
-    assert!(
-        window.lookup_action("add-place").is_some(),
-        "add-place action should be registered"
-    );
+    assert!(window.lookup_action("add-place").is_some(), "add-place action should be registered");
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -1398,6 +1398,18 @@ fn tools_sidebar_uses_per_row_management_instead_of_manage_dialog() {
         window.lookup_action("delete-command").is_some(),
         "delete-command action should be registered"
     );
+    assert!(
+        window.lookup_action("add-place").is_some(),
+        "add-place action should be registered"
+    );
+    assert!(
+        window.lookup_action("edit-place").is_some(),
+        "edit-place action should be registered"
+    );
+    assert!(
+        window.lookup_action("delete-place").is_some(),
+        "delete-place action should be registered"
+    );
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
@@ -4618,6 +4630,103 @@ fn new_menu_includes_session_derived_hosts() {
     assert!(
         labels.contains(&"builder".into()),
         "menu should contain session-derived remote host; got: {labels:?}"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn place_sidebar_shows_edit_delete_for_user_places_not_builtins() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let user_place = crate::places::Place::new("MyProject", "~/projects/myproject");
+    crate::places::save_to(&[user_place], &tmp.path().join("rttx-devel/places.json")).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.place-sidebar-crud-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    window.refresh_place_sidebar();
+    pump_events(50);
+
+    let place_list = &window.imp().place_list;
+    let mut found_builtin_with_menu = false;
+    let mut found_user_with_menu = false;
+    let mut idx = 0;
+    while let Some(row) = place_list.row_at_index(idx) {
+        if let Some(action_row) = row.downcast_ref::<adw::ActionRow>() {
+            let title = action_row.title().to_string();
+            let has_menu = has_menu_button_suffix(action_row);
+            if title == "Home" || title == "Root" {
+                if has_menu {
+                    found_builtin_with_menu = true;
+                }
+            } else if title == "MyProject" && has_menu {
+                found_user_with_menu = true;
+            }
+        }
+        idx += 1;
+    }
+
+    assert!(!found_builtin_with_menu, "built-in places should not have edit/delete menu");
+    assert!(found_user_with_menu, "user places should have edit/delete menu");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+fn has_menu_button_suffix(action_row: &adw::ActionRow) -> bool {
+    let mut child = action_row.first_child();
+    while let Some(widget) = child {
+        if widget.downcast_ref::<gtk4::MenuButton>().is_some() {
+            return true;
+        }
+        if let Some(inner) = widget.first_child() {
+            let mut inner_child = Some(inner);
+            while let Some(w) = inner_child {
+                if w.downcast_ref::<gtk4::MenuButton>().is_some() {
+                    return true;
+                }
+                inner_child = w.next_sibling();
+            }
+        }
+        child = widget.next_sibling();
+    }
+    false
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn place_sidebar_has_add_button_in_header() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.place-sidebar-add-btn-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    assert!(
+        window.lookup_action("add-place").is_some(),
+        "add-place action should be registered"
     );
 
     window.close();

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.28',
+  version: '0.2.29',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

The Places tab in the right tools sidebar previously had no way to add, edit, or delete places manually. The only way to add a place was via the "Add Current Path" context action. This PR adds full CRUD operations for places, matching the existing Commands tab pattern.

## Changes

- **`places_window.rs`** — new form dialog for creating and editing places (name, path, host tags), following the same `FormDialog` pattern as `commands_window.rs`
- **`window/mod.rs`** — added a "Places" header with an "Add" button (`win.add-place`) to the places tab, matching the commands tab layout
- **`window/actions.rs`** — registered `add-place`, `edit-place`, and `delete-place` actions
- **`window/dialogs.rs`** — added `confirm_delete_place` with destructive confirmation dialog
- **`window/sidebar.rs`** — each non-builtin place row now has an overflow menu with Edit and Delete options; built-in places (Home, Root) have no menu
- Version bumped to 0.2.29

## Manual verification steps

1. Open rttx, toggle the right sidebar (Ctrl+Shift+B)
2. Switch to the Places tab
3. Click the "+" button → form dialog opens → fill name/path → Add
4. Verify the new place appears in the sidebar
5. Click the "⋮" menu on the new place → Edit → modify name → Save
6. Verify the place is updated
7. Click the "⋮" menu → Delete → confirm → place is removed
8. Verify built-in places (Home, Root) have no overflow menu

## Tests added

- `tools_sidebar_uses_per_row_management_instead_of_manage_dialog` — extended to assert `add-place`, `edit-place`, `delete-place` actions are registered
- `place_sidebar_shows_edit_delete_for_user_places_not_builtins` — verifies user places have overflow menu, built-ins do not
- `place_sidebar_has_add_button_in_header` — verifies the add-place action is registered

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (27 client + 142 server lib + integration tests)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (536 passed, 0 failed)
  - `place_sidebar_shows_edit_delete_for_user_places_not_builtins` — ok
  - `place_sidebar_has_add_button_in_header` — ok
  - `tools_sidebar_uses_per_row_management_instead_of_manage_dialog` — ok
- `./run_ui_tests.sh` — 7 pre-existing failures (same on mainline), 0 new failures

Fixes #518