### PR TITLE
ci: add test coverage metrics via cargo-llvm-cov

### DIFF
--- a/.github/scripts/run-coverage.sh
+++ b/.github/scripts/run-coverage.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Generate test coverage metrics for the rttx workspace.
+#
+# Covers rttx-server and rttx-proto (non-GTK packages that run reliably
+# in headless CI). The GTK client is excluded because its tests require
+# a display server and GTK global state isolation that conflict with
+# coverage instrumentation.
+#
+# Requires: cargo-llvm-cov (installed automatically if missing)
+#
+# Outputs:
+#   coverage/lcov.info   — LCOV report for downstream tools
+#   coverage/summary.txt — human-readable summary
+#   stdout               — GitHub Actions job summary (markdown table)
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "${script_dir}/../.." && pwd)
+coverage_dir="${repo_root}/coverage"
+
+mkdir -p "${coverage_dir}"
+
+if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+    echo "Installing cargo-llvm-cov…"
+    cargo install cargo-llvm-cov --locked
+fi
+
+# Ensure the llvm-tools component is available.
+rustup component add llvm-tools-preview 2>/dev/null || true
+
+# Clean previous coverage data.
+cargo llvm-cov clean --workspace
+
+# Run tests with coverage for non-GTK packages.
+# --lib and --tests cover unit + integration tests.
+cargo llvm-cov \
+    --manifest-path "${repo_root}/services/rttx-server/Cargo.toml" \
+    --no-report \
+    --lib --tests
+
+cargo llvm-cov \
+    --manifest-path "${repo_root}/protocols/rttx-proto/Cargo.toml" \
+    --no-report \
+    --lib --tests
+
+# Generate LCOV report.
+cargo llvm-cov report \
+    --manifest-path "${repo_root}/Cargo.toml" \
+    --lcov \
+    --output-path "${coverage_dir}/lcov.info"
+
+# Generate human-readable summary.
+cargo llvm-cov report \
+    --manifest-path "${repo_root}/Cargo.toml" \
+    | tee "${coverage_dir}/summary.txt"
+
+# Emit GitHub Actions job summary when running in CI.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo "## Test Coverage"
+        echo ""
+        echo "Packages measured: \`rttx-server\`, \`rttx-proto\`"
+        echo ""
+        echo '```'
+        cat "${coverage_dir}/summary.txt"
+        echo '```'
+        echo ""
+        echo "Full LCOV report uploaded as workflow artifact."
+    } >> "${GITHUB_STEP_SUMMARY}"
+fi

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -139,6 +139,51 @@ jobs:
         run: |
           dbus-run-session -- ./run_ui_tests.sh
 
+  coverage:
+    name: Test coverage
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - name: Install toolchain and dependencies
+        run: |
+          dnf install -y --setopt=install_weak_deps=False \
+            git gcc pkg-config rustup \
+            protobuf-compiler protobuf-devel \
+            gtk4-devel libadwaita-devel vte291-gtk4-devel
+
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust
+        env:
+          RUSTUP_HOME: /usr/local/rustup
+          CARGO_HOME: /usr/local/cargo
+        run: |
+          rustup-init -y --default-toolchain stable
+          echo "/usr/local/cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Install cargo-llvm-cov
+        env:
+          RUSTUP_HOME: /usr/local/rustup
+          CARGO_HOME: /usr/local/cargo
+        run: |
+          rustup component add llvm-tools-preview
+          cargo install cargo-llvm-cov --locked
+
+      - name: Generate coverage
+        env:
+          RUSTUP_HOME: /usr/local/rustup
+          CARGO_HOME: /usr/local/cargo
+        run: bash .github/scripts/run-coverage.sh
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage/lcov.info
+            coverage/summary.txt
+
   manifest:
     name: Flatpak manifest
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .kiro
 /.codex
 __pycache__/
+/coverage


### PR DESCRIPTION
## What changed and why

Adds a **coverage** CI job to the Quality workflow that measures line and function coverage for the `rttx-server` and `rttx-proto` packages using `cargo-llvm-cov`.

The GTK client is excluded because its tests require display server isolation (Broadway/headless) that conflicts with coverage instrumentation.

Coverage is **informational only** — no threshold enforcement, consistent with the project's crash-taxonomy-driven testing philosophy (RFC-003). The job produces:
- An LCOV report uploaded as a workflow artifact (for downstream tools or local inspection)
- A human-readable summary written to the GitHub Actions job summary

### Files changed
- `.github/scripts/run-coverage.sh` — new script that runs `cargo-llvm-cov` for daemon and protocol packages
- `.github/workflows/quality.yml` — new `coverage` job
- `.gitignore` — excludes local `coverage/` output directory

### Manual verification

Ran the coverage script locally:
```
bash .github/scripts/run-coverage.sh
```
Produced `coverage/lcov.info` (5386 lines) and `coverage/summary.txt` with per-file metrics. Current baseline: ~88% line coverage for daemon+protocol.

### Tests added
No new Rust tests — this is CI infrastructure only.

### Tests run
- `cargo build --workspace` (with VTE 0.76 flags for client) ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `bash .github/scripts/run-coverage.sh` ✅
- `bash .github/scripts/check-version-consistency.sh` ✅

### Limitations
- GTK client coverage is not measured (requires display server + GTK global state isolation)
- No coverage threshold enforcement (by design)

Fixes #88