### PR TITLE
fix: resolve GTK theme parser and GtkLabel measure() warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.31"
+version = "0.2.32"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -5,7 +5,7 @@ use libadwaita as adw;
 use crate::config;
 use crate::window::Window;
 
-pub(crate) const APP_CSS: &str = "\
+pub const APP_CSS: &str = "\
     .terminal-pane {
         border-radius: 10px;
         border: 1px solid alpha(@window_fg_color, 0.10);
@@ -75,7 +75,8 @@ const ACCENT_CSS_LIGHT: &str = "\
     .accent-orange { color: @orange_5; }";
 
 /// Return the accent color CSS for the current color scheme.
-pub(crate) const fn accent_css_for_dark(is_dark: bool) -> &'static str {
+#[must_use]
+pub const fn accent_css_for_dark(is_dark: bool) -> &'static str {
     if is_dark { ACCENT_CSS_DARK } else { ACCENT_CSS_LIGHT }
 }
 

--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -52,27 +52,32 @@ pub(crate) const APP_CSS: &str = "\
     }
     .session-row .subtitle {
         opacity: 0.55;
-    }
-    @media (prefers-color-scheme: dark) {
-        .accent-blue   { color: @blue_3; }
-        .accent-green  { color: @green_3; }
-        .accent-yellow { color: @yellow_3; }
-        .accent-red    { color: @red_3; }
-        .accent-purple { color: @purple_3; }
-        .accent-pink   { color: @pink_3; }
-        .accent-teal   { color: @teal_3; }
-        .accent-orange { color: @orange_3; }
-    }
-    @media (prefers-color-scheme: light) {
-        .accent-blue   { color: @blue_5; }
-        .accent-green  { color: @green_5; }
-        .accent-yellow { color: @yellow_5; }
-        .accent-red    { color: @red_5; }
-        .accent-purple { color: @purple_5; }
-        .accent-pink   { color: @pink_5; }
-        .accent-teal   { color: @teal_5; }
-        .accent-orange { color: @orange_5; }
     }";
+
+const ACCENT_CSS_DARK: &str = "\
+    .accent-blue   { color: @blue_3; }
+    .accent-green  { color: @green_3; }
+    .accent-yellow { color: @yellow_3; }
+    .accent-red    { color: @red_3; }
+    .accent-purple { color: @purple_3; }
+    .accent-pink   { color: @pink_3; }
+    .accent-teal   { color: @teal_3; }
+    .accent-orange { color: @orange_3; }";
+
+const ACCENT_CSS_LIGHT: &str = "\
+    .accent-blue   { color: @blue_5; }
+    .accent-green  { color: @green_5; }
+    .accent-yellow { color: @yellow_5; }
+    .accent-red    { color: @red_5; }
+    .accent-purple { color: @purple_5; }
+    .accent-pink   { color: @pink_5; }
+    .accent-teal   { color: @teal_5; }
+    .accent-orange { color: @orange_5; }";
+
+/// Return the accent color CSS for the current color scheme.
+pub(crate) const fn accent_css_for_dark(is_dark: bool) -> &'static str {
+    if is_dark { ACCENT_CSS_DARK } else { ACCENT_CSS_LIGHT }
+}
 
 fn init_logging() {
     use tracing_subscriber::EnvFilter;
@@ -139,6 +144,19 @@ pub fn run() -> glib::ExitCode {
             &css,
             gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
         );
+
+        let accent_css = gtk4::CssProvider::new();
+        let is_dark = adw::StyleManager::default().is_dark();
+        accent_css.load_from_string(accent_css_for_dark(is_dark));
+        gtk4::style_context_add_provider_for_display(
+            &display,
+            &accent_css,
+            gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
+
+        adw::StyleManager::default().connect_dark_notify(move |mgr| {
+            accent_css.load_from_string(accent_css_for_dark(mgr.is_dark()));
+        });
 
         if !config::is_development() {
             return;

--- a/clients/rttx/src/session/state.rs
+++ b/clients/rttx/src/session/state.rs
@@ -852,30 +852,30 @@ mod module_boundary_tests {
     }
 
     #[test]
-    fn app_css_has_dark_and_light_rules_for_every_color() {
+    fn app_css_contains_no_unsupported_at_rules() {
         let css = crate::application::APP_CSS;
-        assert!(css.contains("prefers-color-scheme: dark"), "missing dark media query");
-        assert!(css.contains("prefers-color-scheme: light"), "missing light media query");
+        assert!(!css.contains("@media"), "GTK4 CSS does not support @media queries");
+    }
+
+    #[test]
+    fn accent_css_has_dark_and_light_rules_for_every_color() {
+        let dark = crate::application::accent_css_for_dark(true);
+        let light = crate::application::accent_css_for_dark(false);
         for color in SessionColor::ALL {
             let cls = color.css_class();
-            assert!(
-                css.matches(&format!(".{cls}")).count() >= 2,
-                ".{cls} should appear in both dark and light sections"
-            );
+            assert!(dark.contains(&format!(".{cls}")), ".{cls} missing from dark accent CSS");
+            assert!(light.contains(&format!(".{cls}")), ".{cls} missing from light accent CSS");
         }
     }
 
     #[test]
-    fn app_css_uses_different_palette_tiers_for_light_and_dark() {
-        let css = crate::application::APP_CSS;
-        // Dark mode uses _3 variants (good contrast on dark backgrounds)
-        assert!(css.contains("dark") && css.contains("@blue_3"));
-        // Light mode uses _5 variants (good contrast on light backgrounds)
-        assert!(css.contains("light") && css.contains("@blue_5"));
-        // Verify no _3 appears after the light query starts
-        let light_start = css.find("prefers-color-scheme: light").unwrap();
-        let light_section = &css[light_start..];
-        assert!(!light_section.contains("_3;"), "light section should not use _3 tier");
+    fn accent_css_uses_different_palette_tiers_for_light_and_dark() {
+        let dark = crate::application::accent_css_for_dark(true);
+        let light = crate::application::accent_css_for_dark(false);
+        assert!(dark.contains("@blue_3"), "dark should use _3 tier");
+        assert!(light.contains("@blue_5"), "light should use _5 tier");
+        assert!(!dark.contains("_5;"), "dark should not use _5 tier");
+        assert!(!light.contains("_3;"), "light should not use _3 tier");
     }
 
     #[test]

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -983,4 +983,11 @@ mod search_tests {
         let recovery: crate::session::PaneRecovery = serde_json::from_str(json).unwrap();
         assert_eq!(recovery.source, crate::session::PaneSource::Manual);
     }
+
+    #[test]
+    fn accent_css_for_dark_returns_distinct_variants() {
+        let dark = crate::application::accent_css_for_dark(true);
+        let light = crate::application::accent_css_for_dark(false);
+        assert_ne!(dark, light);
+    }
 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -108,6 +108,7 @@ mod imp {
             self.title_label.set_hexpand(true);
             self.title_label.set_xalign(0.0);
             self.title_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+            self.title_label.set_width_chars(0);
             self.title_label.set_label("Terminal (persistent)");
 
             self.status_label.set_xalign(1.0);

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -71,6 +71,7 @@ mod imp {
             self.title_label.set_hexpand(true);
             self.title_label.set_xalign(0.0);
             self.title_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+            self.title_label.set_width_chars(0);
             self.title_label.set_label("Terminal");
 
             self.split_h_button.set_icon_name("object-flip-horizontal-symbolic");

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2094,3 +2094,28 @@ fn direct_terminal_context_menu_gesture_is_capture_phase() {
     }
     assert!(found_right_click, "VTE must have a button-3 capture gesture for context menu");
 }
+
+#[test]
+#[ignore = "requires display backend"]
+fn app_css_loads_without_parser_errors() {
+    require_display!();
+    let display = gtk4::gdk::Display::default().unwrap();
+    let css = gtk4::CssProvider::new();
+    css.load_from_string(rttx::application::APP_CSS);
+    gtk4::style_context_add_provider_for_display(
+        &display,
+        &css,
+        gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
+
+    for is_dark in [true, false] {
+        let accent = gtk4::CssProvider::new();
+        accent.load_from_string(rttx::application::accent_css_for_dark(is_dark));
+        gtk4::style_context_add_provider_for_display(
+            &display,
+            &accent,
+            gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
+        gtk4::style_context_remove_provider_for_display(&display, &accent);
+    }
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.31',
+  version: '0.2.32',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Fixes #530

rttx produced three GTK warnings at startup:

1. **Theme parser errors** (lines 48, 58): `@media (prefers-color-scheme: dark/light)` queries are web CSS features not supported by GTK4's CSS parser.
2. **GtkLabel measure() warning**: Ellipsized title labels reported natural width < minimum width when panes were narrow.

### Changes

- **application.rs**: Split accent color CSS out of `APP_CSS` into separate `ACCENT_CSS_DARK` and `ACCENT_CSS_LIGHT` constants. A dedicated `CssProvider` is loaded at startup based on `AdwStyleManager::is_dark()` and updated via `connect_dark_notify` when the color scheme changes.
- **widget.rs, persistent_widget.rs**: Added `set_width_chars(0)` on ellipsized title labels so they can shrink gracefully in narrow panes.
- **state.rs**: Updated tests to verify the new accent CSS structure and added a regression test ensuring `APP_CSS` contains no `@media` queries.
- Version bumped to 0.2.32 (4 source files changed).

## Manual verification

1. Run `RTTX_DEV_MODE=1 cargo run -p rttx` — no theme parser warnings in stderr
2. Split panes until very narrow — no GtkLabel measure() warnings
3. Toggle dark/light mode — accent colors update correctly

## Tests added

- `app_css_contains_no_unsupported_at_rules` — regression test: APP_CSS must not contain `@media`
- `accent_css_has_dark_and_light_rules_for_every_color` — all 8 accent colors present in both dark and light CSS
- `accent_css_uses_different_palette_tiers_for_light_and_dark` — dark uses `_3` tier, light uses `_5` tier

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all tests pass, 0 failures)
