### PR TITLE
fix: prevent workspace layout growth on repeated reconnect cycles

### DIFF
--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -388,14 +388,6 @@ impl WindowState {
         let session = self.sessions.iter_mut().find(|session| session.uuid == workspace_id)?;
 
         let had_runtime_id = session.runtime.runtime_id.is_some();
-        let had_only_placeholder_bindings =
-            session.layout.terminal_uuids().iter().all(|layout_terminal_uuid| {
-                session
-                    .runtime
-                    .pane_bindings
-                    .get(layout_terminal_uuid)
-                    .is_some_and(|runtime_pane_id| runtime_pane_id == layout_terminal_uuid)
-            });
         session.runtime.runtime_id = Some(runtime_id.to_string());
         session.sync_legacy_mode_from_runtime();
 
@@ -408,12 +400,11 @@ impl WindowState {
             &runtime_pane_uuids,
         );
 
-        // When all bindings were placeholders (state saved before PaneCreated
-        // events arrived), match disconnected layout terminals to unclaimed
-        // runtime panes by position so the panes reconnect instead of staying
-        // blank.
-        if had_only_placeholder_bindings
-            && !reconciliation.disconnected_layout_panes.is_empty()
+        // Match disconnected layout terminals to unclaimed runtime panes by
+        // position. This covers both placeholder bindings (state saved before
+        // PaneCreated arrived) and stale bindings (daemon restarted with new
+        // pane IDs), preventing layout growth on repeated reconnect cycles.
+        if !reconciliation.disconnected_layout_panes.is_empty()
             && !reconciliation.recovered_runtime_panes.is_empty()
         {
             let mut recovered =
@@ -435,20 +426,18 @@ impl WindowState {
         session.runtime.pending_layout_panes =
             reconciliation.disconnected_layout_panes.iter().cloned().collect();
 
-        let panes_to_create = if !had_runtime_id {
+        let panes_to_create = if had_runtime_id {
+            // Reconnecting: create panes for any layout terminals that
+            // couldn't be matched to existing runtime panes (covers both
+            // placeholder-only and stale-binding reconnects).
+            reconciliation.disconnected_layout_panes.clone()
+        } else {
             let mut placeholders = reconciliation.disconnected_layout_panes.clone();
             if let Some(initial_terminal_uuid) = layout_terminal_uuids.first() {
                 placeholders
                     .retain(|layout_terminal_uuid| layout_terminal_uuid != initial_terminal_uuid);
             }
             placeholders
-        } else if had_only_placeholder_bindings {
-            // Placeholder-only bindings: state was saved before PaneCreated
-            // events arrived. Create panes for any layout terminals that
-            // couldn't be matched to existing runtime panes.
-            reconciliation.disconnected_layout_panes.clone()
-        } else {
-            Vec::new()
         };
 
         let mut skipped_runtime_panes = Vec::new();
@@ -1680,6 +1669,106 @@ mod tests {
         let state = window_state(vec![session]);
 
         assert!(state.input_sync_targets("pane-1").is_empty());
+    }
+
+    /// Regression test for #547: repeated reconnect cycles must not grow the
+    /// layout. When bindings become stale (e.g. daemon restart assigns new
+    /// pane IDs), disconnected layout terminals should be matched to
+    /// unclaimed runtime panes by position instead of creating new splits.
+    #[test]
+    fn repeated_reconnect_cycles_do_not_grow_layout() {
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+
+        let session = managed_session_with_runtime(
+            "workspace-1",
+            "Home",
+            hsplit(term("left"), term("right")),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some(runtime_id),
+        );
+        let mut state = window_state(vec![session]);
+
+        // Simulate 5 reconnect cycles, each with fresh daemon pane IDs
+        // (as if the daemon restarted between cycles).
+        for cycle in 0..5 {
+            let pane_a = uuid::Uuid::new_v4().to_string();
+            let pane_b = uuid::Uuid::new_v4().to_string();
+            let snap = snapshot(
+                runtime_id,
+                vec![
+                    pane_snapshot(&pane_a, "Shell", "/home", b"$ ls"),
+                    pane_snapshot(&pane_b, "Logs", "/var/log", b"tail"),
+                ],
+            );
+
+            let opened = state
+                .apply_managed_workspace_opened("workspace-1", runtime_id, &snap)
+                .expect("workspace open should succeed");
+
+            assert_eq!(
+                opened.session_state.layout.terminal_count(),
+                2,
+                "cycle {cycle}: layout must stay at 2 terminals",
+            );
+            assert!(
+                opened.skipped_runtime_panes.is_empty(),
+                "cycle {cycle}: no runtime panes should be skipped",
+            );
+        }
+    }
+
+    /// When stale bindings can't match current runtime panes, disconnected
+    /// layout terminals should be positionally matched to unclaimed runtime
+    /// panes — not left blank while new splits are created.
+    #[test]
+    fn stale_bindings_reconnect_matches_by_position() {
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+        let old_pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+        let old_pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
+        let new_pane_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        let new_pane_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+        // Workspace has real (non-placeholder) bindings from a previous connection.
+        let mut session = managed_session_with_runtime(
+            "workspace-1",
+            "Workspace",
+            hsplit(term("left"), term("right")),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some(runtime_id),
+        );
+        session.runtime.bind_runtime_pane("left", old_pane_a);
+        session.runtime.bind_runtime_pane("right", old_pane_b);
+        let mut state = window_state(vec![session]);
+
+        // Daemon restarted — new pane IDs.
+        let snap = snapshot(
+            runtime_id,
+            vec![
+                pane_snapshot(new_pane_a, "Shell", "/home", b"$ ls"),
+                pane_snapshot(new_pane_b, "Logs", "/var/log", b"tail"),
+            ],
+        );
+
+        let opened = state
+            .apply_managed_workspace_opened("workspace-1", runtime_id, &snap)
+            .expect("workspace open should succeed");
+
+        assert_eq!(
+            opened.session_state.layout.terminal_count(),
+            2,
+            "layout must not grow when daemon pane count matches layout terminal count",
+        );
+        assert_eq!(
+            opened.session_state.runtime.pane_bindings.get("left").map(String::as_str),
+            Some(new_pane_a),
+        );
+        assert_eq!(
+            opened.session_state.runtime.pane_bindings.get("right").map(String::as_str),
+            Some(new_pane_b),
+        );
+        assert!(opened.skipped_runtime_panes.is_empty());
     }
 
     #[test]

--- a/clients/rttx/tests/reconnect_layout_stability.rs
+++ b/clients/rttx/tests/reconnect_layout_stability.rs
@@ -1,0 +1,105 @@
+//! Integration test for #547: workspace layout must not grow across
+//! repeated reconnect cycles with changing daemon pane IDs.
+
+use rttx::daemon_bridge::EndpointEvent;
+use rttx::runtime::{WorkspacePolicy, WorkspaceRuntime};
+use rttx::session::*;
+
+fn term(id: &str) -> LayoutNode {
+    LayoutNode::Terminal { uuid: id.to_string(), profile: None, cwd: None, custom_title: None }
+}
+
+fn hsplit(first: LayoutNode, second: LayoutNode) -> LayoutNode {
+    LayoutNode::Split {
+        orientation: SplitOrientation::Horizontal,
+        ratio: 0.5,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+fn pane_snapshot(pane_id: &str, title: &str, cwd: &str) -> rttx_proto::proto::PaneSnapshot {
+    rttx_proto::proto::PaneSnapshot {
+        pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),
+        title: title.to_string(),
+        cwd: cwd.to_string(),
+        cols: 120,
+        rows: 40,
+        scrollback: Vec::new(),
+        exit_status: None,
+        bracketed_paste_mode: false,
+        application_cursor_keys: false,
+        application_keypad: false,
+        mouse_tracking_mode: 0,
+        sgr_mouse_mode: false,
+    }
+}
+
+fn snapshot(
+    runtime_id: &str,
+    panes: Vec<rttx_proto::proto::PaneSnapshot>,
+) -> rttx_proto::proto::Snapshot {
+    rttx_proto::proto::Snapshot {
+        session_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
+        panes,
+        revision: 1,
+        current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
+    }
+}
+
+/// Regression test for #547: simulates 5 disconnect/reconnect cycles where
+/// the daemon restarts each time (new pane IDs). The layout must stay at
+/// exactly 2 terminals throughout.
+#[test]
+fn layout_stays_stable_across_reconnect_cycles_with_fresh_pane_ids() {
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+
+    let mut session =
+        SessionState::new_managed_local("Home".into(), WorkspacePolicy::Persistent, None);
+    session.uuid = "ws-1".into();
+    session.layout = hsplit(term("left"), term("right"));
+    session.runtime = WorkspaceRuntime::managed_local(
+        WorkspacePolicy::Persistent,
+        &session.layout.terminal_uuids(),
+    );
+    session.runtime.runtime_id = Some(runtime_id.into());
+    session.sync_legacy_mode_from_runtime();
+
+    let mut state = WindowState {
+        sessions: vec![session],
+        ..WindowState::default()
+    };
+
+    for cycle in 0..5 {
+        let pane_a = uuid::Uuid::new_v4().to_string();
+        let pane_b = uuid::Uuid::new_v4().to_string();
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.into(),
+            snapshot: snapshot(
+                runtime_id,
+                vec![
+                    pane_snapshot(&pane_a, "Shell", "/home"),
+                    pane_snapshot(&pane_b, "Logs", "/var/log"),
+                ],
+            ),
+        });
+
+        assert_eq!(
+            transition.rebuilt_workspaces.len(),
+            1,
+            "cycle {cycle}: workspace must be rebuilt",
+        );
+        let rebuilt = &transition.rebuilt_workspaces[0].session_state;
+        assert_eq!(
+            rebuilt.layout.terminal_count(),
+            2,
+            "cycle {cycle}: layout must stay at 2 terminals, not grow",
+        );
+        assert!(
+            transition.skipped_runtime_panes.is_empty(),
+            "cycle {cycle}: all runtime panes must be claimed",
+        );
+    }
+}

--- a/clients/rttx/tests/reconnect_layout_stability.rs
+++ b/clients/rttx/tests/reconnect_layout_stability.rs
@@ -65,10 +65,7 @@ fn layout_stays_stable_across_reconnect_cycles_with_fresh_pane_ids() {
     session.runtime.runtime_id = Some(runtime_id.into());
     session.sync_legacy_mode_from_runtime();
 
-    let mut state = WindowState {
-        sessions: vec![session],
-        ..WindowState::default()
-    };
+    let mut state = WindowState { sessions: vec![session], ..WindowState::default() };
 
     for cycle in 0..5 {
         let pane_a = uuid::Uuid::new_v4().to_string();


### PR DESCRIPTION
## What changed and why

Fixes #547.

`apply_managed_workspace_opened()` in `workspace_state.rs` had a positional matching block guarded by `had_only_placeholder_bindings`. This guard was too narrow: it only matched disconnected layout terminals to unclaimed runtime panes when all bindings were self-referencing placeholders (`uuid→uuid`).

When bindings were real but stale (e.g. daemon restarted with new pane IDs), the guard was false. The `recovered_runtime_panes` loop then added new horizontal splits for each unmatched daemon pane, growing the layout on every reconnect cycle. A workspace that started with 2 panes could grow to 5+ over several cycles.

### Root cause

The `had_only_placeholder_bindings` check prevented positional matching when bindings were real but stale. The `panes_to_create` logic also returned an empty vec for stale-binding reconnects, leaving disconnected layout terminals without daemon panes.

### Fix

- Remove the `had_only_placeholder_bindings` guard so positional matching always runs when there are both disconnected layout panes and unclaimed runtime panes
- Extend `panes_to_create` to cover all reconnect scenarios, not just placeholder-only

## Manual verification

1. Create a persistent local workspace with 2 panes
2. Kill the daemon (`rttx-server stop`)
3. Restart the daemon
4. Repeat 2-3 several times
5. Layout stays at 2 panes

## Tests added

- `repeated_reconnect_cycles_do_not_grow_layout` — simulates 5 reconnect cycles with fresh daemon pane IDs, asserts layout stays at 2 terminals
- `stale_bindings_reconnect_matches_by_position` — verifies that stale real bindings are replaced by positional matching to new runtime panes

Both tests fail before the fix and pass after.

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 517 passed, 0 failed
- `cargo test -p rttx-server` — all passed
- `cargo test -p rttx-proto` — all passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed, including both new tests