### PR TITLE
fix: remove stale HashMap entries after workspace reconciliation

### DIFF
--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -575,8 +575,18 @@ impl Window {
             session::schedule_initial_paned_ratios(&content, &session_state.layout);
         }
 
+        self.remove_stale_terminal_map_entries(imp);
         self.refresh_sidebar_subtitle(session_uuid);
         self.sync_sidebar_to_visible_session();
+    }
+
+    /// Remove terminal map entries that no longer belong to any workspace layout.
+    fn remove_stale_terminal_map_entries(&self, imp: &imp::Window) {
+        let live_uuids: std::collections::HashSet<String> =
+            imp.state.borrow().sessions.iter().flat_map(|s| s.layout.terminal_uuids()).collect();
+
+        imp.terminals.borrow_mut().retain(|uuid, _| live_uuids.contains(uuid));
+        imp.persistent_terminals.borrow_mut().retain(|uuid, _| live_uuids.contains(uuid));
     }
 
     fn detach_terminals_from_detached_tree(widget: &gtk4::Widget) {

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -4996,3 +4996,113 @@ fn managed_pane_closures_use_weak_window_refs() {
 
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn rebuild_session_content_removes_stale_persistent_terminal_entries() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.stale-hashmap-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let session_state = crate::test_helpers::managed_session(
+        "workspace-stale",
+        "Stale Test",
+        crate::test_helpers::hsplit(
+            LayoutNode::new_terminal_with_uuid("pane-a"),
+            LayoutNode::new_terminal_with_uuid("pane-b"),
+        ),
+    );
+    window.imp().state.borrow_mut().sessions.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    assert_eq!(
+        window.imp().persistent_terminals.borrow().len(),
+        2,
+        "both panes should be materialized"
+    );
+
+    // Simulate reconciliation that removes pane-b from the layout.
+    let reduced_state = {
+        let mut state = window.imp().state.borrow_mut();
+        let session = state.sessions.iter_mut().find(|s| s.uuid == "workspace-stale").unwrap();
+        session.layout = LayoutNode::new_terminal_with_uuid("pane-a");
+        session.clone()
+    };
+
+    window.rebuild_session_content("workspace-stale", &reduced_state);
+
+    assert_eq!(
+        window.imp().persistent_terminals.borrow().len(),
+        1,
+        "stale pane-b entry should be removed after rebuild"
+    );
+    assert!(
+        window.imp().persistent_terminals.borrow().contains_key("pane-a"),
+        "surviving pane-a should remain in the map"
+    );
+    assert!(
+        !window.imp().persistent_terminals.borrow().contains_key("pane-b"),
+        "removed pane-b should not remain in the map"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn rebuild_session_content_preserves_terminals_from_other_workspaces() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.stale-cross-workspace-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    let session_a = crate::test_helpers::managed_session(
+        "workspace-a",
+        "Workspace A",
+        LayoutNode::new_terminal_with_uuid("pane-a1"),
+    );
+    let session_b = crate::test_helpers::managed_session(
+        "workspace-b",
+        "Workspace B",
+        LayoutNode::new_terminal_with_uuid("pane-b1"),
+    );
+    {
+        let mut state = window.imp().state.borrow_mut();
+        state.sessions.push(session_a.clone());
+        state.sessions.push(session_b.clone());
+    }
+    window.build_session(&session_a, false);
+    window.build_session(&session_b, false);
+
+    assert_eq!(window.imp().persistent_terminals.borrow().len(), 2);
+
+    // Rebuild workspace-a — workspace-b's pane must survive.
+    window.rebuild_session_content("workspace-a", &session_a);
+
+    assert_eq!(
+        window.imp().persistent_terminals.borrow().len(),
+        2,
+        "terminals from other workspaces must not be removed"
+    );
+    assert!(window.imp().persistent_terminals.borrow().contains_key("pane-a1"));
+    assert!(window.imp().persistent_terminals.borrow().contains_key("pane-b1"));
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -36,6 +36,7 @@ pub struct ManagedWorkspaceOpenResult {
     pub panes_to_create: Vec<String>,
     pub snapshot_restores: Vec<WorkspacePaneRestore>,
     pub skipped_runtime_panes: Vec<String>,
+    pub previous_layout_terminals: Vec<String>,
 }
 
 /// Pure connection-status update derived from an endpoint event.
@@ -115,7 +116,16 @@ impl WindowState {
                     panes_to_create,
                     snapshot_restores,
                     skipped_runtime_panes,
+                    previous_layout_terminals,
                 } = opened;
+
+                let new_terminal_set: BTreeSet<_> =
+                    session_state.layout.terminal_uuids().into_iter().collect();
+                for old_uuid in &previous_layout_terminals {
+                    if !new_terminal_set.contains(old_uuid) {
+                        transition.removed_layout_terminals.push(old_uuid.clone());
+                    }
+                }
 
                 transition.rebuilt_workspaces.push(ManagedWorkspaceRebuild {
                     workspace_id: workspace_id.clone(),
@@ -509,6 +519,7 @@ impl WindowState {
             panes_to_create,
             snapshot_restores,
             skipped_runtime_panes,
+            previous_layout_terminals: layout_terminal_uuids,
         })
     }
 }
@@ -1787,6 +1798,84 @@ mod tests {
                 workspace_id: "workspace-1".into(),
                 status: ConnectionStatus::SessionMissing,
             }],
+        );
+    }
+
+    #[test]
+    fn workspace_opened_returns_previous_layout_terminals() {
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+        let first_runtime_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+        let mut session = managed_session_with_runtime(
+            "workspace-1",
+            "Workspace",
+            hsplit(term("left"), term("right")),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some(runtime_id),
+        );
+        session.runtime.bind_runtime_pane("left", first_runtime_pane);
+        let mut state = window_state(vec![session]);
+
+        let opened = state
+            .apply_managed_workspace_opened(
+                "workspace-1",
+                runtime_id,
+                &snapshot(
+                    runtime_id,
+                    vec![pane_snapshot(first_runtime_pane, "Shell", "/srv", b"")],
+                ),
+            )
+            .expect("should reconcile");
+
+        assert_eq!(
+            opened.previous_layout_terminals,
+            vec!["left".to_string(), "right".to_string()],
+            "previous_layout_terminals should capture the pre-reconciliation UUIDs",
+        );
+    }
+
+    #[test]
+    fn reconcile_workspace_opened_emits_removed_for_stale_terminals() {
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+        let runtime_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+        let mut session = managed_session_with_runtime(
+            "workspace-1",
+            "Workspace",
+            hsplit(term("left"), term("right")),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some(runtime_id),
+        );
+        session.runtime.bind_runtime_pane("left", runtime_pane);
+        let mut state = window_state(vec![session]);
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "workspace-1".into(),
+            runtime_id: runtime_id.into(),
+            snapshot: snapshot(runtime_id, vec![pane_snapshot(runtime_pane, "Shell", "/srv", b"")]),
+        });
+
+        // Both "left" and "right" were in the previous layout. After
+        // reconciliation, "left" is matched to runtime_pane and "right"
+        // stays disconnected but remains in the layout (it gets a
+        // pane_create_request). So no terminals are removed.
+        assert!(
+            !transition.removed_layout_terminals.contains(&"left".to_string()),
+            "matched terminal should not be marked as removed",
+        );
+        assert!(
+            !transition.removed_layout_terminals.contains(&"right".to_string()),
+            "disconnected terminal stays in layout and should not be removed",
+        );
+        assert_eq!(
+            transition.rebuilt_workspaces.len(),
+            1,
+            "workspace should be rebuilt after reconciliation",
+        );
+        assert_eq!(
+            transition.rebuilt_workspaces[0].session_state.layout.terminal_uuids(),
+            vec!["left".to_string(), "right".to_string()],
+            "both terminals should remain in the reconciled layout",
         );
     }
 }

--- a/clients/rttx/tests/stale_terminal_cleanup.rs
+++ b/clients/rttx/tests/stale_terminal_cleanup.rs
@@ -1,0 +1,202 @@
+//! Integration test for #539: stale `HashMap` entries after workspace
+//! reconciliation must be cleaned up via `removed_layout_terminals`.
+
+use rttx::daemon_bridge::EndpointEvent;
+use rttx::runtime::{WorkspacePolicy, WorkspaceRuntime};
+use rttx::session::*;
+use rttx::workspace_state::EndpointEventTransition;
+
+fn term(id: &str) -> LayoutNode {
+    LayoutNode::Terminal { uuid: id.to_string(), profile: None, cwd: None, custom_title: None }
+}
+
+fn hsplit(first: LayoutNode, second: LayoutNode) -> LayoutNode {
+    LayoutNode::Split {
+        orientation: SplitOrientation::Horizontal,
+        ratio: 0.5,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+fn pane_snapshot(pane_id: &str, title: &str, cwd: &str) -> rttx_proto::proto::PaneSnapshot {
+    rttx_proto::proto::PaneSnapshot {
+        pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),
+        title: title.to_string(),
+        cwd: cwd.to_string(),
+        cols: 120,
+        rows: 40,
+        scrollback: Vec::new(),
+        exit_status: None,
+        bracketed_paste_mode: false,
+        application_cursor_keys: false,
+        application_keypad: false,
+        mouse_tracking_mode: 0,
+        sgr_mouse_mode: false,
+    }
+}
+
+fn snapshot(
+    runtime_id: &str,
+    panes: Vec<rttx_proto::proto::PaneSnapshot>,
+) -> rttx_proto::proto::Snapshot {
+    rttx_proto::proto::Snapshot {
+        session_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
+        panes,
+        revision: 1,
+        current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
+    }
+}
+
+fn managed_session(layout: LayoutNode, runtime_id: &str) -> SessionState {
+    let mut session =
+        SessionState::new_managed_local("Test".into(), WorkspacePolicy::Persistent, None);
+    session.uuid = "ws-1".into();
+    session.layout = layout;
+    session.runtime = WorkspaceRuntime::managed_local(
+        WorkspacePolicy::Persistent,
+        &session.layout.terminal_uuids(),
+    );
+    session.runtime.runtime_id = Some(runtime_id.into());
+    session.sync_legacy_mode_from_runtime();
+    session
+}
+
+fn live_terminal_uuids(state: &WindowState) -> Vec<String> {
+    state.sessions.iter().flat_map(|s| s.layout.terminal_uuids()).collect()
+}
+
+/// Collect all terminal UUIDs that the transition would remove from the
+/// `persistent_terminals` map (simulating what `apply_endpoint_event_transition` does).
+fn stale_uuids_from_transition(transition: &EndpointEventTransition) -> Vec<String> {
+    transition.removed_layout_terminals.clone()
+}
+
+/// After multiple reconnect cycles, the set of `removed_layout_terminals`
+/// combined with the live layout UUIDs must account for every terminal
+/// that was ever created — no UUID should be silently leaked.
+#[test]
+fn reconnect_cycles_never_leak_terminal_uuids() {
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let initial_pane = uuid::Uuid::new_v4().to_string();
+
+    let session = managed_session(term("initial"), runtime_id);
+    let mut state = WindowState { sessions: vec![session], ..WindowState::default() };
+
+    // Bind the initial terminal to a runtime pane.
+    state.sessions[0].runtime.bind_runtime_pane("initial", &initial_pane);
+
+    let mut all_ever_created: std::collections::BTreeSet<String> =
+        state.sessions[0].layout.terminal_uuids().into_iter().collect();
+    let mut all_removed: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    for _cycle in 0..5 {
+        let pane_a = uuid::Uuid::new_v4().to_string();
+        let pane_b = uuid::Uuid::new_v4().to_string();
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.into(),
+            snapshot: snapshot(
+                runtime_id,
+                vec![
+                    pane_snapshot(&pane_a, "Shell", "/home"),
+                    pane_snapshot(&pane_b, "Logs", "/var/log"),
+                ],
+            ),
+        });
+
+        // Track removed UUIDs.
+        for uuid in stale_uuids_from_transition(&transition) {
+            all_removed.insert(uuid);
+        }
+
+        // Track newly created UUIDs.
+        let current_uuids = live_terminal_uuids(&state);
+        for uuid in &current_uuids {
+            all_ever_created.insert(uuid.clone());
+        }
+    }
+
+    // Every UUID that was ever created must either be live or removed.
+    let live_set: std::collections::BTreeSet<String> =
+        live_terminal_uuids(&state).into_iter().collect();
+    for uuid in &all_ever_created {
+        assert!(
+            live_set.contains(uuid) || all_removed.contains(uuid),
+            "terminal UUID {uuid} was created but never removed and is not live — leaked"
+        );
+    }
+}
+
+/// Workspace reconciliation that produces a rebuild must not leave stale
+/// terminal UUIDs unaccounted for in the transition.
+#[test]
+fn workspace_opened_transition_accounts_for_all_previous_terminals() {
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+    let pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
+
+    let mut session = managed_session(hsplit(term("left"), term("right")), runtime_id);
+    session.runtime.bind_runtime_pane("left", pane_a);
+    session.runtime.bind_runtime_pane("right", pane_b);
+    let mut state = WindowState { sessions: vec![session], ..WindowState::default() };
+
+    let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+        workspace_id: "ws-1".into(),
+        runtime_id: runtime_id.into(),
+        snapshot: snapshot(
+            runtime_id,
+            vec![
+                pane_snapshot(pane_a, "Shell", "/home"),
+                pane_snapshot(pane_b, "Logs", "/var/log"),
+            ],
+        ),
+    });
+
+    let rebuilt = &transition.rebuilt_workspaces[0].session_state;
+    let live_uuids: std::collections::BTreeSet<_> =
+        rebuilt.layout.terminal_uuids().into_iter().collect();
+    let removed: std::collections::BTreeSet<_> =
+        transition.removed_layout_terminals.iter().cloned().collect();
+
+    // Both "left" and "right" should be accounted for (live, not removed).
+    assert!(live_uuids.contains("left"), "left should be live");
+    assert!(live_uuids.contains("right"), "right should be live");
+    assert!(removed.is_empty(), "no terminals should be removed when layout matches");
+}
+
+/// `PaneClosed` followed by `WorkspaceOpened` must not double-remove terminals.
+#[test]
+fn pane_closed_then_workspace_opened_does_not_double_remove() {
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+    let pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
+
+    let mut session = managed_session(hsplit(term("left"), term("right")), runtime_id);
+    session.runtime.bind_runtime_pane("left", pane_a);
+    session.runtime.bind_runtime_pane("right", pane_b);
+    let mut state = WindowState { sessions: vec![session], ..WindowState::default() };
+
+    // Close "left" pane.
+    let close_transition = state.reconcile_endpoint_event(&EndpointEvent::PaneClosed {
+        workspace_id: "ws-1".into(),
+        layout_terminal_uuid: "left".into(),
+        runtime_id: runtime_id.into(),
+        runtime_pane_id: pane_a.into(),
+    });
+    assert!(close_transition.removed_layout_terminals.contains(&"left".to_string()));
+
+    // Reconnect with only pane_b.
+    let open_transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+        workspace_id: "ws-1".into(),
+        runtime_id: runtime_id.into(),
+        snapshot: snapshot(runtime_id, vec![pane_snapshot(pane_b, "Logs", "/var/log")]),
+    });
+
+    // "left" was already removed by PaneClosed; it should not appear again.
+    assert!(
+        !open_transition.removed_layout_terminals.contains(&"left".to_string()),
+        "already-removed terminal should not be double-removed"
+    );
+}


### PR DESCRIPTION
## What changed and why

Fixes #539 — stale `persistent_terminals` and `terminals` HashMap entries were never cleaned up when workspace reconciliation changed terminal UUIDs.

### Changes

1. **`rebuild_session_content`** now calls `remove_stale_terminal_map_entries` after rebuilding the widget tree. This function collects all live terminal UUIDs across all sessions and removes entries from both `terminals` and `persistent_terminals` maps that no longer belong to any workspace layout.

2. **`reconcile_endpoint_event`** for `WorkspaceOpened` now tracks `previous_layout_terminals` (the pre-reconciliation UUIDs) and emits `removed_layout_terminals` for any UUIDs that disappear during reconciliation, ensuring cleanup happens before the rebuild.

3. **`ManagedWorkspaceOpenResult`** gains a `previous_layout_terminals` field so the caller can compute the set difference between old and new layouts.

### How to verify

1. Create a managed workspace with multiple panes
2. Disconnect and reconnect multiple times (simulating daemon restarts)
3. Verify `persistent_terminals` HashMap size matches visible pane count at all times

### Tests added

**Pure state tests** (in `workspace_state.rs`):
- `workspace_opened_returns_previous_layout_terminals` — verifies the new field captures pre-reconciliation UUIDs
- `reconcile_workspace_opened_emits_removed_for_stale_terminals` — verifies reconciliation behavior preserves layout terminals correctly

**GTK widget tests** (in `window/tests.rs`):
- `rebuild_session_content_removes_stale_persistent_terminal_entries` — verifies stale entries are cleaned up when a workspace layout shrinks
- `rebuild_session_content_preserves_terminals_from_other_workspaces` — verifies cross-workspace entries are not affected by a single workspace rebuild

### Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 520 passed, 0 failed
- `cargo test -p rttx-proto -p rttx-server` — all passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests passed including new ones

### Limitations

The `previous_layout_terminals` mechanism in `WorkspaceOpened` is currently a no-op in practice because `apply_managed_workspace_opened` only adds terminals (never removes them). The primary fix is the defensive `remove_stale_terminal_map_entries` cleanup in `rebuild_session_content`, which catches stale entries regardless of how they were created.