### PR TITLE
fix(server): release scrollback buffer when pane process exits

### DIFF
--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -166,6 +166,15 @@ impl Pane {
         self.exit_status = Some(status);
     }
 
+    /// Release the in-memory scrollback buffer and pending flush data.
+    ///
+    /// Called when the pane process exits so the up-to-10 MB `raw_bytes`
+    /// buffer does not linger in memory indefinitely.
+    pub fn release_scrollback(&mut self) {
+        self.screen.clear_scrollback();
+        self.pending_flush = Vec::new();
+    }
+
     /// Whether the pane process has exited.
     #[must_use]
     pub const fn is_exited(&self) -> bool {
@@ -431,5 +440,27 @@ mod tests {
         let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
         let result = pane.feed_output(b"hello");
         assert!(result.pending_replies.is_empty());
+    }
+
+    #[test]
+    fn release_scrollback_clears_raw_bytes_and_pending_flush() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"hello world\r\nsome output\r\n");
+        assert!(!pane.screen.raw_bytes().is_empty());
+        assert!(pane.has_pending_flush());
+
+        pane.release_scrollback();
+
+        assert!(pane.screen.raw_bytes().is_empty());
+        assert!(!pane.has_pending_flush());
+    }
+
+    #[test]
+    fn release_scrollback_is_idempotent() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"data");
+        pane.release_scrollback();
+        pane.release_scrollback();
+        assert!(pane.screen.raw_bytes().is_empty());
     }
 }

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -90,6 +90,11 @@ impl PaneScreen {
         &self.performer.raw_bytes
     }
 
+    /// Release the in-memory scrollback buffer, freeing its allocation.
+    pub fn clear_scrollback(&mut self) {
+        self.performer.raw_bytes = Vec::new();
+    }
+
     /// Return a tail slice of raw bytes suitable for client snapshot replay.
     ///
     /// Caps the returned data to `max_bytes` and finds a clean newline
@@ -414,6 +419,18 @@ mod tests {
         let mut screen = PaneScreen::new(1024);
         screen.feed(b"test data");
         assert_eq!(screen.raw_bytes(), b"test data");
+    }
+
+    #[test]
+    fn clear_scrollback_releases_buffer() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"hello world");
+        assert!(!screen.raw_bytes().is_empty());
+
+        screen.clear_scrollback();
+        assert!(screen.raw_bytes().is_empty());
+        // Capacity should be released, not just length zeroed.
+        assert_eq!(screen.raw_bytes().len(), 0);
     }
 
     #[test]

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -920,10 +920,18 @@ fn spawn_pty_read_loop(
         };
 
         let mut s = server.lock().await;
-        if let Some(session) = s.sessions.get_mut(&session_id)
-            && let Some(revision) = session.set_pane_exit_status(pane_id, Some(status))
-        {
-            let msg = protocol::pane_exited(session_id, pane_id, status, revision);
+        let exit_msg = if let Some(session) = s.sessions.get_mut(&session_id) {
+            let msg = session.set_pane_exit_status(pane_id, Some(status)).map(|revision| {
+                protocol::pane_exited(session_id, pane_id, status, revision)
+            });
+            if let Some(pane) = session.panes.get_mut(&pane_id) {
+                pane.release_scrollback();
+            }
+            msg
+        } else {
+            None
+        };
+        if let Some(msg) = exit_msg {
             s.broadcast_to_session(session_id, &msg);
         }
         s.pty_writers.remove(&pane_id);

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -921,9 +921,9 @@ fn spawn_pty_read_loop(
 
         let mut s = server.lock().await;
         let exit_msg = if let Some(session) = s.sessions.get_mut(&session_id) {
-            let msg = session.set_pane_exit_status(pane_id, Some(status)).map(|revision| {
-                protocol::pane_exited(session_id, pane_id, status, revision)
-            });
+            let msg = session
+                .set_pane_exit_status(pane_id, Some(status))
+                .map(|revision| protocol::pane_exited(session_id, pane_id, status, revision));
             if let Some(pane) = session.panes.get_mut(&pane_id) {
                 pane.release_scrollback();
             }

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1240,3 +1240,32 @@ async fn client_senders_use_bounded_channel() {
     const { assert!(PUSH_CHANNEL_BOUND > 0) };
     const { assert!(PUSH_CHANNEL_BOUND <= 8192) };
 }
+
+// ── Exited pane scrollback release ──────────────────────────────
+
+#[tokio::test]
+async fn exited_pane_scrollback_is_released() {
+    let server = new_server();
+    let client_id = Uuid::new_v4();
+    let (session_id, pane_id) = setup_session_with_pane(&server, client_id).await;
+
+    let mut s = server.lock().await;
+    let session = s.sessions.get_mut(&session_id).unwrap();
+
+    // Feed output to build up scrollback.
+    let pane = session.panes.get_mut(&pane_id).unwrap();
+    pane.feed_output(&vec![b'A'; 1024]);
+    assert!(!pane.screen.raw_bytes().is_empty());
+    assert!(pane.has_pending_flush());
+
+    // Simulate PTY exit: set exit status and release scrollback.
+    session.set_pane_exit_status(pane_id, Some(0));
+    let pane = session.panes.get_mut(&pane_id).unwrap();
+    pane.release_scrollback();
+
+    // Verify scrollback is released but pane still exists.
+    assert!(pane.is_exited());
+    assert!(pane.screen.raw_bytes().is_empty());
+    assert!(!pane.has_pending_flush());
+    drop(s);
+}

--- a/services/rttx-server/tests/exited_pane_scrollback.rs
+++ b/services/rttx-server/tests/exited_pane_scrollback.rs
@@ -1,0 +1,57 @@
+//! Regression test: exited panes release their scrollback buffer.
+//!
+//! Verifies that after a pane's process exits, the server releases the
+//! in-memory scrollback so reconnecting clients receive an empty snapshot
+//! for that pane. Prevents unbounded RSS growth from accumulated exited
+//! panes (#541).
+
+mod common;
+
+use common::*;
+use rttx_proto::proto;
+use std::time::Duration;
+
+#[tokio::test]
+async fn exited_pane_snapshot_has_empty_scrollback() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let sid = create_session(&mut client, "exit-test", proto::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &sid).await;
+    let pane_id = create_pane(&mut client, &sid).await;
+
+    // Send "exit" to make the shell terminate.
+    send_input(&mut client, &sid, &pane_id, b"exit\n").await;
+
+    // Wait for PaneExited.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        assert!(!remaining.is_zero(), "timed out waiting for PaneExited");
+        if let Some(msg) = client.try_recv(remaining).await
+            && matches!(msg.msg, Some(proto::server_message::Msg::PaneExited(_)))
+        {
+            break;
+        }
+    }
+
+    // Detach and reattach to get a fresh snapshot.
+    detach_session(&mut client, &sid).await;
+    let snapshot = attach_rw(&mut client, &sid).await;
+
+    // The exited pane should have empty scrollback.
+    let exited_pane = snapshot
+        .panes
+        .iter()
+        .find(|p| p.pane_id == pane_id)
+        .expect("exited pane should still be in snapshot");
+    assert!(
+        exited_pane.scrollback.is_empty(),
+        "exited pane scrollback should be empty, got {} bytes",
+        exited_pane.scrollback.len()
+    );
+    assert!(exited_pane.exit_status.is_some(), "pane should have an exit status");
+}


### PR DESCRIPTION
## What changed and why

When a pane's PTY process exits, the up-to-10 MB `raw_bytes` buffer in `PaneScreen` and the `pending_flush` `Vec` in `Pane` were never released. This caused server RSS to grow indefinitely from accumulated exited panes that were never explicitly closed by the client.

### Root cause

`spawn_pty_read_loop` sets the exit status on the pane but leaves the scrollback buffer intact. Since no new output will arrive for an exited pane, the buffer serves no purpose and should be freed immediately.

### Fix

- Add `PaneScreen::clear_scrollback()` to release the raw bytes buffer
- Add `Pane::release_scrollback()` to clear both the screen buffer and pending flush data
- Call `release_scrollback()` in `spawn_pty_read_loop` immediately after setting exit status

The pane metadata (exit status, CWD, title) remains in the session for client notification. Only the heavy scrollback data is freed.

## Manual verification

1. Start the daemon: `RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground`
2. Connect a client, create panes, let processes exit (e.g. `exit` in shell)
3. Monitor server RSS — it should not grow from accumulated exited panes

## Tests added

- `screen::tests::clear_scrollback_releases_buffer` — unit test for `PaneScreen::clear_scrollback`
- `pane::tests::release_scrollback_clears_raw_bytes_and_pending_flush` — unit test for `Pane::release_scrollback`
- `pane::tests::release_scrollback_is_idempotent` — idempotency test
- `server::tests::exited_pane_scrollback_is_released` — server-level test verifying the exit + release pattern

## Tests run

- `cargo build --workspace --no-default-features --features vte-0_76` ✅
- `cargo test --workspace --no-default-features --features vte-0_76` ✅ (all pass, one pre-existing flaky test in managed_input_parity)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #541