### PR TITLE
fix: cap command_history and prune dismissed_runtime_ids

### DIFF
--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -198,6 +198,12 @@ impl WindowState {
                 });
             }
             EndpointEvent::InventoryLoaded { endpoint, sessions } => {
+                let inventory_ids: std::collections::BTreeSet<String> = sessions
+                    .iter()
+                    .filter_map(|s| rttx_proto::bytes_to_uuid(&s.id).ok().map(|u| u.to_string()))
+                    .collect();
+                self.dismissed_runtime_ids.retain(|id| inventory_ids.contains(id));
+
                 let recovered = self.recover_managed_workspaces_from_inventory(endpoint, sessions);
                 if recovered.is_empty() {
                     return transition;
@@ -1397,7 +1403,11 @@ mod tests {
             );
         }
 
-        assert_eq!(state.dismissed_runtime_ids.len(), 5);
+        assert_eq!(
+            state.dismissed_runtime_ids.len(),
+            1,
+            "only the last dismissed ID should survive — earlier ones were pruned by inventory reconciliation"
+        );
     }
 
     #[test]
@@ -1876,6 +1886,39 @@ mod tests {
             transition.rebuilt_workspaces[0].session_state.layout.terminal_uuids(),
             vec!["left".to_string(), "right".to_string()],
             "both terminals should remain in the reconciled layout",
+        );
+    }
+
+    #[test]
+    fn dismissed_runtime_ids_pruned_after_inventory_reconciliation() {
+        let mut state = WindowState::default_for_test();
+        let stale_id = uuid::Uuid::new_v4().to_string();
+        let live_id = uuid::Uuid::new_v4().to_string();
+        let pane_id = uuid::Uuid::new_v4().to_string();
+
+        state.dismiss_runtime(&RuntimeEndpoint::Local, &stale_id);
+        state.dismiss_runtime(&RuntimeEndpoint::Local, &live_id);
+        assert_eq!(state.dismissed_runtime_ids.len(), 2);
+
+        // Inventory only contains live_id — stale_id was already removed by daemon.
+        let _transition = state.reconcile_endpoint_event(&EndpointEvent::InventoryLoaded {
+            endpoint: RuntimeEndpoint::Local,
+            sessions: vec![session_info(
+                &live_id,
+                "Still Running",
+                proto::RuntimePolicy::Persistent,
+                vec![pane_info(&pane_id, "bash", "/tmp")],
+                Some(&pane_id),
+            )],
+        });
+
+        assert!(
+            !state.dismissed_runtime_ids.contains(&stale_id),
+            "stale dismissed ID should be pruned after inventory reconciliation"
+        );
+        assert!(
+            state.dismissed_runtime_ids.contains(&live_id),
+            "live dismissed ID should be retained"
         );
     }
 }

--- a/clients/rttx/tests/session_lifecycle.rs
+++ b/clients/rttx/tests/session_lifecycle.rs
@@ -1259,3 +1259,51 @@ fn legacy_bookmark_sourced_pane_loads_after_removal() {
     let recovery = &state.sessions[0].terminal_recovery["t1"];
     assert_eq!(recovery.source, PaneSource::Manual);
 }
+
+/// Dismissed runtime IDs that are no longer in the daemon inventory
+/// should be pruned after inventory reconciliation.
+#[test]
+fn dismissed_runtime_ids_pruned_when_absent_from_inventory() {
+    use rttx::daemon_bridge::EndpointEvent;
+    use rttx::runtime::RuntimeEndpoint;
+
+    let mut state = WindowState::default();
+    let stale = uuid::Uuid::new_v4().to_string();
+    let live = uuid::Uuid::new_v4().to_string();
+    let pane = uuid::Uuid::new_v4().to_string();
+
+    state.dismiss_runtime(&RuntimeEndpoint::Local, &stale);
+    state.dismiss_runtime(&RuntimeEndpoint::Local, &live);
+    assert_eq!(state.dismissed_runtime_ids.len(), 2);
+
+    // Inventory contains only `live` — `stale` was already cleaned up by daemon.
+    let _transition = state.reconcile_endpoint_event(&EndpointEvent::InventoryLoaded {
+        endpoint: RuntimeEndpoint::Local,
+        sessions: vec![rttx_proto::proto::SessionInfo {
+            id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&live).unwrap()),
+            name: "Live".into(),
+            pane_count: 1,
+            has_attached_client: false,
+            active_pane_id: Some(rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane).unwrap())),
+            panes: vec![rttx_proto::proto::PaneInfo {
+                id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane).unwrap()),
+                title: "bash".into(),
+                cwd: "/tmp".into(),
+                cols: 80,
+                rows: 24,
+                exit_status: None,
+                reconstructed: false,
+            }],
+            policy: rttx_proto::proto::RuntimePolicy::Persistent as i32,
+            attached_client_count: 0,
+            reconstructed: false,
+            revision: 1,
+            current_client_role: rttx_proto::proto::RuntimeClientRole::Unattached as i32,
+            has_write_owner: false,
+            read_only_client_count: 0,
+        }],
+    });
+
+    assert!(!state.dismissed_runtime_ids.contains(&stale), "stale dismissed ID should be pruned");
+    assert!(state.dismissed_runtime_ids.contains(&live), "live dismissed ID should be retained");
+}

--- a/services/rttx-server/src/session.rs
+++ b/services/rttx-server/src/session.rs
@@ -10,6 +10,9 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 use uuid::Uuid;
 
+/// Maximum number of entries retained in per-session command history.
+pub const MAX_COMMAND_HISTORY: usize = 1000;
+
 /// Runtime retention policy for a session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -207,11 +210,18 @@ impl Session {
             })
             .collect();
 
+        let command_history = if persisted.command_history.len() > MAX_COMMAND_HISTORY {
+            persisted.command_history[persisted.command_history.len() - MAX_COMMAND_HISTORY..]
+                .to_vec()
+        } else {
+            persisted.command_history.clone()
+        };
+
         Self {
             id: persisted.id,
             name: persisted.name.clone(),
             active_pane_id: persisted.active_pane_id,
-            command_history: persisted.command_history.clone(),
+            command_history,
             policy: persisted.policy,
             reconstructed: true,
             revision: persisted.revision.max(default_session_revision()),
@@ -397,6 +407,15 @@ impl Session {
         self.panes.get(&pane_id)?;
         self.bump_revision();
         Some(self.revision())
+    }
+
+    /// Append a history entry, evicting the oldest if the cap is reached.
+    pub fn add_history_entry(&mut self, entry: HistoryEntry) {
+        self.command_history.push(entry);
+        if self.command_history.len() > MAX_COMMAND_HISTORY {
+            let excess = self.command_history.len() - MAX_COMMAND_HISTORY;
+            self.command_history.drain(..excess);
+        }
     }
 
     /// Update a pane's exit status and return the resulting session revision.
@@ -699,5 +718,44 @@ mod tests {
             Err(AttachError::UnsupportedTakeOver)
         );
         assert_eq!(session.revision(), 1);
+    }
+
+    fn make_history_entry(i: usize) -> HistoryEntry {
+        HistoryEntry {
+            command: format!("cmd-{i}"),
+            cwd: "/tmp".into(),
+            timestamp: SystemTime::UNIX_EPOCH,
+            pane_id: Uuid::new_v4(),
+        }
+    }
+
+    #[test]
+    fn add_history_entry_caps_at_max() {
+        let mut session = Session::new("test".into());
+        for i in 0..MAX_COMMAND_HISTORY + 50 {
+            session.add_history_entry(make_history_entry(i));
+        }
+        assert_eq!(session.command_history.len(), MAX_COMMAND_HISTORY);
+        assert_eq!(
+            session.command_history[0].command,
+            "cmd-50",
+            "oldest entries should be evicted"
+        );
+    }
+
+    #[test]
+    fn from_persisted_truncates_oversized_history() {
+        let mut session = Session::new("test".into());
+        session.command_history = (0..MAX_COMMAND_HISTORY + 200)
+            .map(make_history_entry)
+            .collect();
+        let persisted = session.to_persisted();
+        let restored = Session::from_persisted(&persisted);
+        assert_eq!(restored.command_history.len(), MAX_COMMAND_HISTORY);
+        assert_eq!(
+            restored.command_history[0].command,
+            "cmd-200",
+            "oldest entries should be dropped on load"
+        );
     }
 }

--- a/services/rttx-server/src/session.rs
+++ b/services/rttx-server/src/session.rs
@@ -737,8 +737,7 @@ mod tests {
         }
         assert_eq!(session.command_history.len(), MAX_COMMAND_HISTORY);
         assert_eq!(
-            session.command_history[0].command,
-            "cmd-50",
+            session.command_history[0].command, "cmd-50",
             "oldest entries should be evicted"
         );
     }
@@ -746,15 +745,12 @@ mod tests {
     #[test]
     fn from_persisted_truncates_oversized_history() {
         let mut session = Session::new("test".into());
-        session.command_history = (0..MAX_COMMAND_HISTORY + 200)
-            .map(make_history_entry)
-            .collect();
+        session.command_history = (0..MAX_COMMAND_HISTORY + 200).map(make_history_entry).collect();
         let persisted = session.to_persisted();
         let restored = Session::from_persisted(&persisted);
         assert_eq!(restored.command_history.len(), MAX_COMMAND_HISTORY);
         assert_eq!(
-            restored.command_history[0].command,
-            "cmd-200",
+            restored.command_history[0].command, "cmd-200",
             "oldest entries should be dropped on load"
         );
     }

--- a/services/rttx-server/tests/serialization.rs
+++ b/services/rttx-server/tests/serialization.rs
@@ -68,3 +68,48 @@ fn corrupt_state_file_returns_error() {
     let result = load_state(&state_path);
     assert!(result.is_err());
 }
+
+#[test]
+fn oversized_command_history_truncated_on_resurrection() {
+    use rttx_server::pane::HistoryEntry;
+    use rttx_server::session::MAX_COMMAND_HISTORY;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let state_path = default_state_path(tmp.path());
+
+    let oversized_history: Vec<HistoryEntry> = (0..MAX_COMMAND_HISTORY + 300)
+        .map(|i| HistoryEntry {
+            command: format!("cmd-{i}"),
+            cwd: "/tmp".into(),
+            timestamp: SystemTime::UNIX_EPOCH,
+            pane_id: Uuid::new_v4(),
+        })
+        .collect();
+
+    let state = ServerState {
+        sessions: vec![PersistedSession {
+            id: Uuid::new_v4(),
+            name: "history-cap".into(),
+            panes: vec![],
+            active_pane_id: None,
+            command_history: oversized_history,
+            policy: RuntimePolicy::Persistent,
+            revision: 1,
+            created_at: SystemTime::now(),
+            last_active_at: SystemTime::now(),
+        }],
+        serialized_at: SystemTime::now(),
+        server_version: "0.1.0".into(),
+    };
+
+    write_state_atomic(&state, &state_path).unwrap();
+    let loaded = load_state(&state_path).unwrap().unwrap();
+    let session = Session::from_persisted(&loaded.sessions[0]);
+
+    assert_eq!(
+        session.command_history.len(),
+        MAX_COMMAND_HISTORY,
+        "oversized history should be truncated on resurrection"
+    );
+    assert_eq!(session.command_history[0].command, "cmd-300", "oldest entries should be dropped");
+}


### PR DESCRIPTION
## What changed and why

Fixes #542 — two data structures grew without bound:

1. **`Session.command_history`** (server) — unbounded `Vec<HistoryEntry>`, cloned every serialization tick. Now capped at 1000 entries with oldest-first eviction on insert (`add_history_entry`) and on load from persisted state (`from_persisted`).

2. **`WindowState.dismissed_runtime_ids`** (client) — `BTreeSet<String>` that accumulated UUIDs on workspace close but was never pruned. Now pruned after each `InventoryLoaded` reconciliation: IDs not present in the daemon inventory are removed.

## Manual verification

- Confirmed `command_history` stays at 1000 after inserting 1050 entries
- Confirmed `dismissed_runtime_ids` shrinks after inventory reconciliation with stale IDs absent

## Tests added

- `session::tests::add_history_entry_caps_at_max` — verifies cap enforcement on insert
- `session::tests::from_persisted_truncates_oversized_history` — verifies truncation on load
- `workspace_state::tests::dismissed_runtime_ids_pruned_after_inventory_reconciliation` — verifies stale IDs are pruned, live IDs retained
- Updated `repeated_close_and_inventory_cycles_stay_clean` to reflect new bounded behavior

## Tests run

- `cargo test -p rttx-server -p rttx-proto` — all pass
- `cargo test -p rttx --no-default-features --features vte-0_76` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — 521 passed, 0 failed