### PR TITLE
fix(server): handle Ping in client_reader without acquiring the server mutex

### DIFF
--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -1139,6 +1139,15 @@ async fn client_reader(
             return Ok(());
         }
 
+        // Fast-path: respond to Ping without acquiring the server mutex.
+        // The heartbeat must never stall behind PTY I/O or session work.
+        if let Some(proto::client_message::Msg::Ping(ping)) = &msg.msg {
+            if resp_tx.send(protocol::pong(ping.nonce)).await.is_err() {
+                return Ok(());
+            }
+            continue;
+        }
+
         if let Some(response) = Server::handle_message(&server, client_id, msg).await
             && resp_tx.send(response).await.is_err()
         {

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -163,6 +163,24 @@ async fn ping_returns_pong_with_same_nonce() {
     }
 }
 
+#[tokio::test]
+async fn ping_fast_path_responds_without_handle_message() {
+    // Regression: #556 — client_reader intercepts Ping before
+    // handle_message so the server mutex is never acquired.
+    let msg = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Ping(proto::Ping { nonce: 99 })),
+    };
+    // Simulate the fast-path match used in client_reader.
+    let pong = match &msg.msg {
+        Some(proto::client_message::Msg::Ping(ping)) => protocol::pong(ping.nonce),
+        _ => panic!("expected Ping variant"),
+    };
+    match pong.msg {
+        Some(proto::server_message::Msg::Pong(p)) => assert_eq!(p.nonce, 99),
+        other => panic!("expected Pong, got {other:?}"),
+    }
+}
+
 // ── CreateSession ───────────────────────────────────────────────
 
 #[tokio::test]

--- a/services/rttx-server/tests/heartbeat.rs
+++ b/services/rttx-server/tests/heartbeat.rs
@@ -52,6 +52,63 @@ fn ping_roundtrip_still_works_for_attached_clients() {
 }
 
 #[test]
+fn ping_answered_while_mutex_held() {
+    // Regression test for #556: the client_reader fast-path must respond
+    // to Ping without acquiring the server mutex. If the mutex is held
+    // (e.g. by a long-running PTY read loop), Pong must still arrive
+    // promptly so the client heartbeat does not time out.
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (sock, _handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&sock).await;
+        client.handshake().await;
+
+        let session_id =
+            create_session(&mut client, "mutex-held", proto::RuntimePolicy::Persistent).await;
+        let _snapshot = attach_rw(&mut client, &session_id).await;
+
+        // Create a pane and trigger continuous output to keep the mutex busy.
+        let pane_id = common::create_pane(&mut client, &session_id).await;
+
+        // Generate a burst of PTY output that keeps the server busy.
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::Input(proto::Input {
+                    session_id: session_id.clone(),
+                    pane_id,
+                    data: bytes::Bytes::from_static(b"for i in $(seq 1 500); do echo line$i; done\n"),
+                })),
+            })
+            .await;
+
+        // Immediately send multiple pings — they must all be answered
+        // promptly even while PTY output is being processed.
+        for nonce in [100, 200, 300] {
+            client
+                .send(&proto::ClientMessage {
+                    msg: Some(proto::client_message::Msg::Ping(proto::Ping { nonce })),
+                })
+                .await;
+        }
+
+        // Collect all three pongs within a tight deadline.
+        let mut pong_nonces = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while pong_nonces.len() < 3 && tokio::time::Instant::now() < deadline {
+            match client.try_recv(std::time::Duration::from_secs(2)).await {
+                Some(msg) => {
+                    if let Some(proto::server_message::Msg::Pong(pong)) = msg.msg {
+                        pong_nonces.push(pong.nonce);
+                    }
+                }
+                None => break,
+            }
+        }
+        assert_eq!(pong_nonces, vec![100, 200, 300], "all pongs should arrive promptly");
+    });
+}
+
+#[test]
 fn ping_answered_during_pty_output() {
     // Regression test for #532: the server must answer pings even when
     // push messages (PTY deltas) are being sent concurrently. The old

--- a/services/rttx-server/tests/heartbeat.rs
+++ b/services/rttx-server/tests/heartbeat.rs
@@ -76,7 +76,9 @@ fn ping_answered_while_mutex_held() {
                 msg: Some(proto::client_message::Msg::Input(proto::Input {
                     session_id: session_id.clone(),
                     pane_id,
-                    data: bytes::Bytes::from_static(b"for i in $(seq 1 500); do echo line$i; done\n"),
+                    data: bytes::Bytes::from_static(
+                        b"for i in $(seq 1 500); do echo line$i; done\n",
+                    ),
                 })),
             })
             .await;


### PR DESCRIPTION
## What changed and why

Intercept Ping messages in `client_reader()` **before** calling `handle_message()`, so the heartbeat response bypasses the server mutex entirely. During burst PTY output the mutex can be held almost continuously, delaying Pong past the client's 6-second heartbeat timeout and causing spurious disconnects.

The existing Ping arm in `handle_message()` remains as a fallback for direct callers (including the unit test `ping_returns_pong_with_same_nonce`).

## Files changed

- `services/rttx-server/src/server.rs` — fast-path Ping interception in `client_reader()`
- `services/rttx-server/src/server/tests.rs` — pure-state unit test for the fast-path pattern
- `services/rttx-server/tests/heartbeat.rs` — integration regression test

## Manual verification

1. Build and run the server
2. Connect a client and generate heavy PTY output (e.g. `seq 1 100000`)
3. Observe that the client stays connected — no heartbeat timeouts

## Tests added

- `ping_fast_path_responds_without_handle_message` (unit) — validates the fast-path match pattern constructs correct Pong without `handle_message`
- `ping_answered_while_mutex_held` (integration) — sends multiple pings during burst PTY output and asserts all pongs arrive promptly with correct nonces

## Tests run

- `cargo test -p rttx-server --lib` — 207 passed
- `cargo test -p rttx-server --tests` — all integration tests passed
- `run-clippy.sh` — clean
- `run-quality-tests.sh` — all passed
- Runtime behavior gate: passes locally

Fixes #556