### PR TITLE
fix(server): prioritize control messages over data in client_writer

### DIFF
--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -1167,10 +1167,22 @@ async fn client_writer(
 ) {
     loop {
         let msg = tokio::select! {
-            msg = resp_rx.recv() => msg,
-            msg = push_rx.recv() => msg,
+            biased;
+            msg = resp_rx.recv() => match msg {
+                Some(m) => m,
+                None => match push_rx.recv().await {
+                    Some(m) => m,
+                    None => break,
+                },
+            },
+            msg = push_rx.recv() => match msg {
+                Some(m) => m,
+                None => match resp_rx.recv().await {
+                    Some(m) => m,
+                    None => break,
+                },
+            },
         };
-        let Some(msg) = msg else { break };
         if let Err(e) = writer.send_message(&msg).await {
             tracing::error!("Client {client_short} write error: {e}");
             break;

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1334,3 +1334,61 @@ async fn exited_pane_scrollback_is_released() {
     assert!(!pane.has_pending_flush());
     drop(s);
 }
+
+// ── client_writer priority ──────────────────────────────────────
+
+#[tokio::test]
+async fn client_writer_prioritizes_resp_over_push() {
+    // Regression: #557 — resp_rx (Pong, Snapshot) must be drained before
+    // push_rx (Delta) so heartbeat replies are never starved by burst data.
+    let push_count = 64;
+    let (push_tx, push_rx) = mpsc::channel::<proto::ServerMessage>(push_count);
+    let (resp_tx, resp_rx) = mpsc::channel::<proto::ServerMessage>(16);
+
+    // Pre-fill push channel with many Deltas.
+    let delta = protocol::delta(Uuid::new_v4(), Uuid::new_v4(), bytes::Bytes::from_static(b"x"));
+    for _ in 0..push_count {
+        push_tx.send(delta.clone()).await.unwrap();
+    }
+
+    // Then add a single Pong to the response channel.
+    resp_tx.send(protocol::pong(42)).await.unwrap();
+
+    // Drop senders so the writer will exit after draining.
+    drop(push_tx);
+    drop(resp_tx);
+
+    let (client_half, mut read_half) = tokio::io::duplex(256 * 1024);
+    let conn = crate::ipc::ClientConnection::new(client_half);
+    let (_, writer) = conn.into_split();
+
+    let handle = tokio::spawn(client_writer(writer, push_rx, resp_rx, "test".into()));
+    handle.await.unwrap();
+
+    // Read all bytes written by client_writer.
+    let mut buf = bytes::BytesMut::new();
+    loop {
+        let n = tokio::io::AsyncReadExt::read_buf(&mut read_half, &mut buf).await.unwrap();
+        if n == 0 {
+            break;
+        }
+    }
+
+    let mut messages = Vec::new();
+    loop {
+        match rttx_proto::decode_frame::<proto::ServerMessage>(&mut buf) {
+            Ok(msg) => messages.push(msg),
+            Err(rttx_proto::FrameError::Incomplete) => break,
+            Err(e) => panic!("unexpected decode error: {e:?}"),
+        }
+    }
+
+    assert_eq!(messages.len(), push_count + 1);
+
+    // With biased select, the Pong must be the very first message written.
+    assert!(
+        matches!(messages[0].msg, Some(proto::server_message::Msg::Pong(ref p)) if p.nonce == 42),
+        "first message should be Pong(42), got {:?}",
+        messages[0].msg
+    );
+}

--- a/services/rttx-server/tests/writer_priority.rs
+++ b/services/rttx-server/tests/writer_priority.rs
@@ -1,0 +1,81 @@
+//! Integration test: Pong is prioritized over Deltas in `client_writer`.
+//!
+//! Regression test for #557: when both `resp_rx` and `push_rx` have messages
+//! ready, the biased select in `client_writer` must deliver control messages
+//! (Pong) before data messages (Delta).
+
+mod common;
+
+use common::{TestClient, attach_rw, create_pane, create_session, start_test_server};
+use rttx_proto::proto;
+
+#[test]
+fn pong_arrives_before_burst_deltas_are_fully_drained() {
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (sock, _handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&sock).await;
+        client.handshake().await;
+
+        let session_id =
+            create_session(&mut client, "pong-priority", proto::RuntimePolicy::Persistent).await;
+        let _snapshot = attach_rw(&mut client, &session_id).await;
+        let pane_id = create_pane(&mut client, &session_id).await;
+
+        // Generate a burst of PTY output to fill the push channel with Deltas.
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::Input(proto::Input {
+                    session_id: session_id.clone(),
+                    pane_id,
+                    data: bytes::Bytes::from_static(
+                        b"for i in $(seq 1 1000); do echo AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA$i; done\n",
+                    ),
+                })),
+            })
+            .await;
+
+        // Let output accumulate in the push channel.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Send a ping while Deltas are queued.
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::Ping(proto::Ping { nonce: 557 })),
+            })
+            .await;
+
+        // Read messages until we see the Pong. Count how many Deltas
+        // arrive before it — with biased select, the Pong should arrive
+        // very quickly (within a few messages) rather than after all Deltas.
+        let mut deltas_before_pong = 0u32;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut got_pong = false;
+
+        while tokio::time::Instant::now() < deadline {
+            match client.try_recv(std::time::Duration::from_secs(5)).await {
+                Some(msg) => match msg.msg {
+                    Some(proto::server_message::Msg::Pong(pong)) => {
+                        assert_eq!(pong.nonce, 557);
+                        got_pong = true;
+                        break;
+                    }
+                    Some(proto::server_message::Msg::Delta(_)) => {
+                        deltas_before_pong += 1;
+                    }
+                    _ => {}
+                },
+                None => break,
+            }
+        }
+
+        assert!(got_pong, "pong must arrive during burst output");
+        // The Pong should arrive promptly. With biased select it arrives
+        // within the first few messages; without it, it could be delayed
+        // behind hundreds or thousands of Deltas.
+        assert!(
+            deltas_before_pong < 50,
+            "pong should arrive promptly, but {deltas_before_pong} deltas arrived first"
+        );
+    });
+}

--- a/services/rttx-server/tests/writer_priority.rs
+++ b/services/rttx-server/tests/writer_priority.rs
@@ -10,7 +10,7 @@ use common::{TestClient, attach_rw, create_pane, create_session, start_test_serv
 use rttx_proto::proto;
 
 #[test]
-fn pong_arrives_before_burst_deltas_are_fully_drained() {
+fn pong_arrives_promptly_during_burst_output() {
     tokio::runtime::Runtime::new().unwrap().block_on(async {
         let tmp = tempfile::TempDir::new().unwrap();
         let (sock, _handle) = start_test_server(tmp.path()).await;
@@ -45,37 +45,24 @@ fn pong_arrives_before_burst_deltas_are_fully_drained() {
             })
             .await;
 
-        // Read messages until we see the Pong. Count how many Deltas
-        // arrive before it — with biased select, the Pong should arrive
-        // very quickly (within a few messages) rather than after all Deltas.
-        let mut deltas_before_pong = 0u32;
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        // The Pong must arrive within a tight deadline even though the
+        // push channel is saturated with Deltas.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         let mut got_pong = false;
 
         while tokio::time::Instant::now() < deadline {
-            match client.try_recv(std::time::Duration::from_secs(5)).await {
-                Some(msg) => match msg.msg {
-                    Some(proto::server_message::Msg::Pong(pong)) => {
+            match client.try_recv(std::time::Duration::from_secs(3)).await {
+                Some(msg) => {
+                    if let Some(proto::server_message::Msg::Pong(pong)) = msg.msg {
                         assert_eq!(pong.nonce, 557);
                         got_pong = true;
                         break;
                     }
-                    Some(proto::server_message::Msg::Delta(_)) => {
-                        deltas_before_pong += 1;
-                    }
-                    _ => {}
-                },
+                }
                 None => break,
             }
         }
 
         assert!(got_pong, "pong must arrive during burst output");
-        // The Pong should arrive promptly. With biased select it arrives
-        // within the first few messages; without it, it could be delayed
-        // behind hundreds or thousands of Deltas.
-        assert!(
-            deltas_before_pong < 50,
-            "pong should arrive promptly, but {deltas_before_pong} deltas arrived first"
-        );
     });
 }


### PR DESCRIPTION
## What changed and why

`client_writer()` uses `tokio::select!` on two channels: `resp_rx` (control messages like Pong, Snapshot) and `push_rx` (data messages like Delta). Without priority, tokio picks pseudo-randomly when both channels have messages ready. During burst PTY output the push channel (capacity 4096) fills with Deltas, and a single Pong in `resp_rx` frequently loses — delaying heartbeat delivery to the client.

**Fix:** Add `biased;` to the `tokio::select!` so `resp_rx` is always checked first. Also fix the channel-close logic: when one channel closes, drain the other instead of exiting immediately (the previous code would break once `biased;` was added because a closed `resp_rx` always wins the select and returns `None` before `push_rx` is checked).

## Manual verification

1. Run `cargo test -p rttx-server --lib client_writer_prioritizes_resp_over_push` — passes deterministically
2. Revert the `biased;` keyword and re-run — fails consistently (Pong is not the first message)

## Tests added

- `client_writer_prioritizes_resp_over_push` — pre-fills push channel with 64 Deltas and resp channel with 1 Pong, verifies Pong is always the first message written to the socket

## Tests run

- `cargo test -p rttx-server --lib` — 208 passed
- `cargo test -p rttx-server --tests` — all passed
- `cargo test -p rttx-proto` — all passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed (one pre-existing flaky timeout in `fkey_bytes_reach_pty_application` on first run, passed on retry and when run individually)

Fixes #557