### PR TITLE
fix(server): release mutex before broadcasting in PTY read loop

### DIFF
--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -50,10 +50,7 @@ fn send_to_collected(
 ) {
     for (client_id, sender) in senders {
         if let Err(mpsc::error::TrySendError::Full(_)) = sender.try_send(msg.clone()) {
-            tracing::warn!(
-                "Client {} push channel full — dropping message",
-                short_id(*client_id),
-            );
+            tracing::warn!("Client {} push channel full — dropping message", short_id(*client_id),);
         }
     }
 }
@@ -318,9 +315,7 @@ impl Server {
         session
             .attached_clients
             .keys()
-            .filter_map(|&cid| {
-                self.client_senders.get(&cid).map(|s| (cid, s.clone()))
-            })
+            .filter_map(|&cid| self.client_senders.get(&cid).map(|s| (cid, s.clone())))
             .collect()
     }
 

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -39,6 +39,25 @@ pub const PUSH_CHANNEL_BOUND: usize = 4096;
 /// Capacity for the per-client response channel (pong, snapshots).
 const RESP_CHANNEL_BOUND: usize = 256;
 
+/// Send a message to previously collected sender handles.
+///
+/// This is the lock-free counterpart of [`Server::broadcast_to_session`]:
+/// collect handles with [`Server::collect_session_senders`] while holding
+/// the mutex, then call this after releasing it.
+fn send_to_collected(
+    senders: &[(Uuid, mpsc::Sender<proto::ServerMessage>)],
+    msg: &proto::ServerMessage,
+) {
+    for (client_id, sender) in senders {
+        if let Err(mpsc::error::TrySendError::Full(_)) = sender.try_send(msg.clone()) {
+            tracing::warn!(
+                "Client {} push channel full — dropping message",
+                short_id(*client_id),
+            );
+        }
+    }
+}
+
 /// Shared mutable server state.
 pub struct Server {
     /// All active sessions.
@@ -283,6 +302,26 @@ impl Server {
             return;
         };
         self.broadcast_to_clients(session.attached_clients.keys().copied(), None, msg);
+    }
+
+    /// Collect cloned sender handles for all clients attached to a session.
+    ///
+    /// The returned senders can be used after releasing the server mutex via
+    /// [`send_to_collected`].
+    fn collect_session_senders(
+        &self,
+        session_id: Uuid,
+    ) -> Vec<(Uuid, mpsc::Sender<proto::ServerMessage>)> {
+        let Some(session) = self.sessions.get(&session_id) else {
+            return Vec::new();
+        };
+        session
+            .attached_clients
+            .keys()
+            .filter_map(|&cid| {
+                self.client_senders.get(&cid).map(|s| (cid, s.clone()))
+            })
+            .collect()
     }
 
     fn terminate_session(
@@ -847,27 +886,39 @@ fn spawn_pty_read_loop(
                         Ok(0) => break,
                         Ok(n) => {
                             let data = bytes::Bytes::copy_from_slice(&buf[..n]);
-                            let mut s = server.lock().await;
-                            let (new_cwd, new_title, pending_replies) = if let Some(session) = s.sessions.get_mut(&session_id)
-                                && let Some(pane) = session.panes.get_mut(&pane_id)
-                            {
-                                let result = pane.feed_output(&data);
-                                let cwd = result.new_cwd.and_then(|cwd| {
-                                    let rev = session.set_pane_cwd(pane_id, &cwd)?;
-                                    Some((cwd, rev))
-                                });
-                                let title = result.new_title.and_then(|title| {
-                                    let rev = session.set_pane_title(pane_id, title.clone())?;
-                                    Some((title, rev))
-                                });
-                                (cwd, title, result.pending_replies)
-                            } else {
-                                (None, None, Vec::new())
+
+                            // Phase 1: hold lock for state mutation and handle collection.
+                            let (new_cwd, new_title, pending_replies, pty_writer, senders) = {
+                                let mut s = server.lock().await;
+                                let (new_cwd, new_title, pending_replies) = if let Some(session) = s.sessions.get_mut(&session_id)
+                                    && let Some(pane) = session.panes.get_mut(&pane_id)
+                                {
+                                    let result = pane.feed_output(&data);
+                                    let cwd = result.new_cwd.and_then(|cwd| {
+                                        let rev = session.set_pane_cwd(pane_id, &cwd)?;
+                                        Some((cwd, rev))
+                                    });
+                                    let title = result.new_title.and_then(|title| {
+                                        let rev = session.set_pane_title(pane_id, title.clone())?;
+                                        Some((title, rev))
+                                    });
+                                    (cwd, title, result.pending_replies)
+                                } else {
+                                    (None, None, Vec::new())
+                                };
+                                let pty_writer = if pending_replies.is_empty() {
+                                    None
+                                } else {
+                                    s.pty_writers.get(&pane_id).cloned()
+                                };
+                                let senders = s.collect_session_senders(session_id);
+                                drop(s);
+                                (new_cwd, new_title, pending_replies, pty_writer, senders)
                             };
-                            // Write DSR replies back to the PTY before broadcasting.
-                            if !pending_replies.is_empty()
-                                && let Some(writer) = s.pty_writers.get(&pane_id)
-                            {
+                            // Lock released.
+
+                            // Phase 2: write DSR replies without the server lock.
+                            if let Some(writer) = pty_writer {
                                 let mut w = writer.lock().await;
                                 for reply in &pending_replies {
                                     if let Err(e) = w.write_all(reply).await {
@@ -882,15 +933,17 @@ fn spawn_pty_read_loop(
                                     );
                                 }
                             }
+
+                            // Phase 3: broadcast to clients without the server lock.
                             let msg = protocol::delta(session_id, pane_id, data);
-                            s.broadcast_to_session(session_id, &msg);
+                            send_to_collected(&senders, &msg);
                             if let Some((cwd, revision)) = new_cwd {
                                 let msg = protocol::cwd_changed(session_id, pane_id, cwd, revision);
-                                s.broadcast_to_session(session_id, &msg);
+                                send_to_collected(&senders, &msg);
                             }
                             if let Some((title, revision)) = new_title {
                                 let msg = protocol::title_changed(session_id, pane_id, title, revision);
-                                s.broadcast_to_session(session_id, &msg);
+                                send_to_collected(&senders, &msg);
                             }
                         }
                         Err(e) => {

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1430,10 +1430,7 @@ async fn collect_session_senders_returns_attached_client_senders() {
 #[tokio::test]
 async fn collect_session_senders_returns_empty_for_unknown_session() {
     let server = new_server();
-    let senders = server
-        .lock()
-        .await
-        .collect_session_senders(Uuid::new_v4());
+    let senders = server.lock().await.collect_session_senders(Uuid::new_v4());
     assert!(senders.is_empty());
 }
 
@@ -1447,10 +1444,7 @@ async fn send_to_collected_delivers_messages() {
     send_to_collected(&senders, &msg);
 
     let received = rx.try_recv().unwrap();
-    assert!(matches!(
-        received.msg,
-        Some(proto::server_message::Msg::Delta(_))
-    ));
+    assert!(matches!(received.msg, Some(proto::server_message::Msg::Delta(_))));
 }
 
 #[tokio::test]

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1392,3 +1392,79 @@ async fn client_writer_prioritizes_resp_over_push() {
         messages[0].msg
     );
 }
+
+// ── Lock-free broadcast via collected senders ───────────────────
+
+#[tokio::test]
+async fn collect_session_senders_returns_attached_client_senders() {
+    let server = new_server();
+    let client_a = Uuid::new_v4();
+    let client_b = Uuid::new_v4();
+    let (session_id, _) = setup_session_with_pane(&server, client_a).await;
+
+    // Attach a second client.
+    {
+        let mut s = server.lock().await;
+        s.sessions
+            .get_mut(&session_id)
+            .unwrap()
+            .attached_clients
+            .insert(client_b, crate::session::ClientRole::Writer);
+    }
+
+    let (tx_a, _rx_a) = mpsc::channel(16);
+    let (tx_b, _rx_b) = mpsc::channel(16);
+    {
+        let mut s = server.lock().await;
+        s.client_senders.insert(client_a, tx_a);
+        s.client_senders.insert(client_b, tx_b);
+    }
+
+    let senders = server.lock().await.collect_session_senders(session_id);
+    let ids: std::collections::HashSet<Uuid> = senders.iter().map(|(id, _)| *id).collect();
+    assert!(ids.contains(&client_a));
+    assert!(ids.contains(&client_b));
+    assert_eq!(senders.len(), 2);
+}
+
+#[tokio::test]
+async fn collect_session_senders_returns_empty_for_unknown_session() {
+    let server = new_server();
+    let senders = server
+        .lock()
+        .await
+        .collect_session_senders(Uuid::new_v4());
+    assert!(senders.is_empty());
+}
+
+#[tokio::test]
+async fn send_to_collected_delivers_messages() {
+    let (tx, mut rx) = mpsc::channel(16);
+    let client_id = Uuid::new_v4();
+    let senders = vec![(client_id, tx)];
+
+    let msg = protocol::delta(Uuid::new_v4(), Uuid::new_v4(), bytes::Bytes::from_static(b"hi"));
+    send_to_collected(&senders, &msg);
+
+    let received = rx.try_recv().unwrap();
+    assert!(matches!(
+        received.msg,
+        Some(proto::server_message::Msg::Delta(_))
+    ));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn send_to_collected_drops_when_channel_full() {
+    let (tx, rx) = mpsc::channel(1);
+    let client_id = Uuid::new_v4();
+    let senders = vec![(client_id, tx)];
+
+    let msg = protocol::delta(Uuid::new_v4(), Uuid::new_v4(), bytes::Bytes::from_static(b"a"));
+    send_to_collected(&senders, &msg);
+    // Channel is now full.
+    send_to_collected(&senders, &msg);
+
+    assert!(logs_contain("channel full"));
+    drop(rx);
+}

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -199,9 +199,12 @@ pub async fn attach_rw(client: &mut TestClient, session_id: &[u8]) -> proto::Sna
             })),
         })
         .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::Snapshot(s)) => s,
-        other => panic!("expected Snapshot, got {other:?}"),
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(s)) => return s,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
     }
 }
 
@@ -215,9 +218,12 @@ pub async fn attach_ro(client: &mut TestClient, session_id: &[u8]) -> proto::Sna
             })),
         })
         .await;
-    match client.recv_or_timeout().await.msg {
-        Some(proto::server_message::Msg::Snapshot(s)) => s,
-        other => panic!("expected Snapshot, got {other:?}"),
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(s)) => return s,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
     }
 }
 

--- a/services/rttx-server/tests/lock_free_broadcast.rs
+++ b/services/rttx-server/tests/lock_free_broadcast.rs
@@ -1,0 +1,45 @@
+//! Regression test: PTY read loop broadcasts Deltas after releasing the
+//! server mutex (#558).
+//!
+//! Verifies that two clients attached to the same session both receive
+//! Delta messages from a pane. This exercises the `send_to_collected`
+//! path where sender handles are cloned under the lock and used after
+//! releasing it.
+
+mod common;
+
+use common::*;
+use rttx_proto::proto;
+use std::time::Duration;
+
+#[tokio::test]
+async fn both_clients_receive_deltas_after_lock_free_broadcast() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    // Client A creates and attaches to a session.
+    let mut client_a = TestClient::connect(&sock).await;
+    client_a.handshake().await;
+    let sid = create_session(&mut client_a, "broadcast-test", proto::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client_a, &sid).await;
+    let pane_id = create_pane(&mut client_a, &sid).await;
+
+    // Client B attaches read-only to the same session.
+    let mut client_b = TestClient::connect(&sock).await;
+    client_b.handshake().await;
+    attach_ro(&mut client_b, &sid).await;
+
+    // Send input that produces output.
+    send_input(&mut client_a, &sid, &pane_id, b"echo LOCKFREE\n").await;
+
+    // Both clients should receive at least one Delta containing the output.
+    let has_delta = |msgs: &[proto::ServerMessage]| {
+        msgs.iter().any(|m| matches!(&m.msg, Some(proto::server_message::Msg::Delta(_))))
+    };
+
+    let msgs_a = client_a.drain(Duration::from_secs(3)).await;
+    let msgs_b = client_b.drain(Duration::from_secs(3)).await;
+
+    assert!(has_delta(&msgs_a), "client A should receive Deltas");
+    assert!(has_delta(&msgs_b), "client B should receive Deltas");
+}

--- a/services/rttx-server/tests/lock_free_broadcast.rs
+++ b/services/rttx-server/tests/lock_free_broadcast.rs
@@ -20,7 +20,8 @@ async fn both_clients_receive_deltas_after_lock_free_broadcast() {
     // Client A creates and attaches to a session.
     let mut client_a = TestClient::connect(&sock).await;
     client_a.handshake().await;
-    let sid = create_session(&mut client_a, "broadcast-test", proto::RuntimePolicy::Persistent).await;
+    let sid =
+        create_session(&mut client_a, "broadcast-test", proto::RuntimePolicy::Persistent).await;
     attach_rw(&mut client_a, &sid).await;
     let pane_id = create_pane(&mut client_a, &sid).await;
 


### PR DESCRIPTION
## What changed and why

Fixes #558 — reduces mutex hold time in `spawn_pty_read_loop()` by splitting the single lock-hold into three phases:

1. **Lock**: `feed_output()`, collect CWD/title changes, clone PTY writer handle and client sender handles. **Unlock**.
2. **No lock**: write DSR replies via cloned PTY writer.
3. **No lock**: broadcast Delta/CWD/title messages via collected senders.

Previously the server mutex was held for the entire duration of `feed_output()` + DSR reply writes (awaiting the PTY writer mutex) + `broadcast_to_session()` (iterating clients and calling `try_send()`). During burst output this lock was held almost continuously, blocking all other operations.

Now the mutex is held only for `feed_output()` + handle collection. DSR writes and broadcasts no longer block other PTY loops or client message handling.

### New code

- `send_to_collected()` — free function that sends to previously collected sender handles without needing the server mutex.
- `Server::collect_session_senders()` — collects cloned sender handles for a session's attached clients.

### Test helper fix

`attach_rw` and `attach_ro` now drain interleaved Deltas that may arrive between detach and the reattach Snapshot. With the lock released before broadcast, a Delta can land slightly after a detach response — this is expected and harmless (Deltas are best-effort).

## Manual verification

- Built workspace with `cargo build --workspace --no-default-features --features vte-0_76`
- Ran `cargo test --workspace --no-default-features --features vte-0_76` — all pass
- Ran `bash .github/scripts/run-clippy.sh` — clean
- Ran `bash .github/scripts/run-quality-tests.sh` — all pass including buffer_capacity, title_propagation, writer_priority integration tests

## Tests added

- `collect_session_senders_returns_attached_client_senders` — verifies correct sender collection for multi-client sessions
- `collect_session_senders_returns_empty_for_unknown_session` — verifies empty result for nonexistent sessions
- `send_to_collected_delivers_messages` — verifies lock-free broadcast delivers messages
- `send_to_collected_drops_when_channel_full` — verifies backpressure behavior matches `broadcast_to_session`

## Tests run

- `cargo test -p rttx-server --lib` — 212 passed
- `cargo test -p rttx-server --tests` — all integration tests passed (buffer_capacity, title_propagation, writer_priority, stdio_transport, etc.)
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed