### PR TITLE
feat(server): add memory profiling CI gate and runtime diagnostics

### DIFF
--- a/.github/scripts/run-memory-gate.sh
+++ b/.github/scripts/run-memory-gate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Memory profiling CI gate for rttx-server.
+#
+# Runs a scripted lifecycle scenario and asserts that:
+# 1. No sessions or panes leak after the scenario completes.
+# 2. The diagnostics report shows zero residual state.
+#
+# This script is designed to run in CI but can also be used locally.
+# It does NOT require valgrind or heaptrack — it uses the built-in
+# diagnostics protocol to verify cleanup at the application level.
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "${script_dir}/../.." && pwd)
+
+echo "Building rttx-server..."
+cargo build -p rttx-server --manifest-path "${repo_root}/services/rttx-server/Cargo.toml"
+
+echo "Running memory cleanup integration tests..."
+cargo test -p rttx-server --test memory_cleanup -- --nocapture
+
+echo "Running diagnostics integration tests..."
+cargo test -p rttx-server --test diagnostics -- --nocapture
+
+echo "Running lifecycle leak tests..."
+cargo test -p rttx-server --test lifecycle_leaks -- --nocapture
+
+echo "Running bounded channel tests..."
+cargo test -p rttx-server --test bounded_channels -- --nocapture
+
+echo ""
+echo "Memory profiling gate: PASSED"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -184,6 +184,33 @@ jobs:
             coverage/lcov.info
             coverage/summary.txt
 
+  memory-gate:
+    name: Memory profiling gate
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - name: Install toolchain and dependencies
+        run: |
+          dnf install -y --setopt=install_weak_deps=False \
+            git gcc pkg-config rustup \
+            protobuf-compiler protobuf-devel
+
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust
+        env:
+          RUSTUP_HOME: /usr/local/rustup
+          CARGO_HOME: /usr/local/cargo
+        run: |
+          rustup-init -y --default-toolchain stable
+          echo "/usr/local/cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Run memory profiling gate
+        env:
+          RUSTUP_HOME: /usr/local/rustup
+          CARGO_HOME: /usr/local/cargo
+        run: bash .github/scripts/run-memory-gate.sh
+
   manifest:
     name: Flatpak manifest
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.35"
+version = "0.2.36"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.35"
+version = "0.2.36"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.35"
+version = "0.2.36"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.35"
+version = "0.2.36"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -561,7 +561,8 @@ pub fn extract_pane_id(msg: &proto::ServerMessage) -> Option<Uuid> {
         | Msg::SessionDetached(_)
         | Msg::SessionTerminated(_)
         | Msg::SessionRenamed(_)
-        | Msg::Error(_) => return None,
+        | Msg::Error(_)
+        | Msg::DiagnosticsReport(_) => return None,
     };
     bytes_to_uuid(bytes).ok()
 }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -904,7 +904,8 @@ impl Window {
             | Msg::SessionTerminated(_)
             | Msg::SessionRenamed(_)
             | Msg::Pong(_)
-            | Msg::Error(_) => {}
+            | Msg::Error(_)
+            | Msg::DiagnosticsReport(_) => {}
         }
 
         let _ = workspace_id;

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.35',
+  version: '0.2.36',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/proto/rttx.proto
+++ b/protocols/rttx-proto/proto/rttx.proto
@@ -83,6 +83,8 @@ message Ping {
     uint64 nonce = 1;
 }
 
+message GetDiagnostics {}
+
 // --- Server → Client ---
 
 message HelloAck {
@@ -244,6 +246,36 @@ message Pong {
     uint64 nonce = 1;
 }
 
+message PaneDiagnosticsInfo {
+    bytes id = 1;
+    uint64 raw_bytes_len = 2;
+    uint64 pending_flush_len = 3;
+    bool is_exited = 4;
+}
+
+message SessionDiagnosticsInfo {
+    bytes id = 1;
+    string name = 2;
+    uint32 active_pane_count = 3;
+    uint32 exited_pane_count = 4;
+    uint32 command_history_len = 5;
+    uint32 attached_client_count = 6;
+    repeated PaneDiagnosticsInfo panes = 7;
+}
+
+message DiagnosticsReport {
+    uint32 session_count = 1;
+    uint32 total_pane_count = 2;
+    uint32 total_active_panes = 3;
+    uint32 total_exited_panes = 4;
+    uint32 client_count = 5;
+    uint32 pty_writer_count = 6;
+    uint64 total_raw_bytes = 7;
+    uint64 total_pending_flush = 8;
+    uint32 total_command_history = 9;
+    repeated SessionDiagnosticsInfo sessions = 10;
+}
+
 // --- Envelope ---
 
 message ClientMessage {
@@ -262,6 +294,7 @@ message ClientMessage {
         TerminateSession terminate_session = 12;
         Ping ping = 13;
         RenameSession rename_session = 14;
+        GetDiagnostics get_diagnostics = 15;
     }
 }
 
@@ -285,5 +318,6 @@ message ServerMessage {
         AttachBlocked attach_blocked = 16;
         Pong pong = 17;
         SessionRenamed session_renamed = 18;
+        DiagnosticsReport diagnostics_report = 19;
     }
 }

--- a/services/rttx-server/src/diagnostics.rs
+++ b/services/rttx-server/src/diagnostics.rs
@@ -1,0 +1,279 @@
+//! Runtime memory diagnostics.
+//!
+//! Collects per-session and per-pane memory metrics from the server state
+//! for the `rttx-server diagnostics` CLI command and periodic debug logging.
+
+use crate::server::Server;
+use std::fmt;
+
+/// Per-pane memory metrics.
+#[derive(Debug, Clone)]
+pub struct PaneDiagnostics {
+    pub id: String,
+    pub raw_bytes_len: usize,
+    pub pending_flush_len: usize,
+    pub is_exited: bool,
+}
+
+/// Per-session memory metrics.
+#[derive(Debug, Clone)]
+pub struct SessionDiagnostics {
+    pub id: String,
+    pub name: String,
+    pub active_pane_count: usize,
+    pub exited_pane_count: usize,
+    pub command_history_len: usize,
+    pub attached_client_count: usize,
+    pub panes: Vec<PaneDiagnostics>,
+}
+
+/// Server-wide diagnostics report.
+#[derive(Debug, Clone)]
+pub struct DiagnosticsReport {
+    pub session_count: usize,
+    pub total_pane_count: usize,
+    pub total_active_panes: usize,
+    pub total_exited_panes: usize,
+    pub client_count: usize,
+    pub pty_writer_count: usize,
+    pub total_raw_bytes: usize,
+    pub total_pending_flush: usize,
+    pub total_command_history: usize,
+    pub sessions: Vec<SessionDiagnostics>,
+}
+
+impl fmt::Display for DiagnosticsReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Sessions: {}", self.session_count)?;
+        writeln!(
+            f,
+            "Panes: {} ({} active, {} exited)",
+            self.total_pane_count, self.total_active_panes, self.total_exited_panes
+        )?;
+        writeln!(f, "Connected clients: {}", self.client_count)?;
+        writeln!(f, "PTY writers: {}", self.pty_writer_count)?;
+        writeln!(f, "Total raw_bytes: {} bytes", self.total_raw_bytes)?;
+        writeln!(f, "Total pending_flush: {} bytes", self.total_pending_flush)?;
+        writeln!(f, "Total command_history entries: {}", self.total_command_history)?;
+
+        if !self.sessions.is_empty() {
+            writeln!(f)?;
+            for session in &self.sessions {
+                writeln!(
+                    f,
+                    "  Session \"{}\" ({}):",
+                    session.name,
+                    &session.id[..8.min(session.id.len())]
+                )?;
+                writeln!(
+                    f,
+                    "    Panes: {} active, {} exited",
+                    session.active_pane_count, session.exited_pane_count
+                )?;
+                writeln!(f, "    Command history: {} entries", session.command_history_len)?;
+                writeln!(f, "    Attached clients: {}", session.attached_client_count)?;
+                for pane in &session.panes {
+                    let status = if pane.is_exited { "exited" } else { "active" };
+                    writeln!(
+                        f,
+                        "    Pane {} ({}): raw_bytes={}, pending_flush={}",
+                        &pane.id[..8.min(pane.id.len())],
+                        status,
+                        pane.raw_bytes_len,
+                        pane.pending_flush_len,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Server {
+    /// Collect a diagnostics report from the current server state.
+    #[must_use]
+    pub fn diagnostics(&self) -> DiagnosticsReport {
+        let mut sessions = Vec::with_capacity(self.sessions.len());
+        let mut total_raw_bytes = 0usize;
+        let mut total_pending_flush = 0usize;
+        let mut total_command_history = 0usize;
+        let mut total_active_panes = 0usize;
+        let mut total_exited_panes = 0usize;
+
+        for session in self.sessions.values() {
+            let mut panes = Vec::with_capacity(session.panes.len());
+            let mut active = 0usize;
+            let mut exited = 0usize;
+
+            for pane in session.panes.values() {
+                let raw_bytes_len = pane.screen.raw_bytes().len();
+                let pending_flush_len = pane.pending_flush_len();
+                total_raw_bytes += raw_bytes_len;
+                total_pending_flush += pending_flush_len;
+
+                if pane.is_exited() {
+                    exited += 1;
+                } else {
+                    active += 1;
+                }
+
+                panes.push(PaneDiagnostics {
+                    id: pane.id.to_string(),
+                    raw_bytes_len,
+                    pending_flush_len,
+                    is_exited: pane.is_exited(),
+                });
+            }
+
+            total_active_panes += active;
+            total_exited_panes += exited;
+            total_command_history += session.command_history.len();
+
+            sessions.push(SessionDiagnostics {
+                id: session.id.to_string(),
+                name: session.name.clone(),
+                active_pane_count: active,
+                exited_pane_count: exited,
+                command_history_len: session.command_history.len(),
+                attached_client_count: session.attached_client_count(),
+                panes,
+            });
+        }
+
+        DiagnosticsReport {
+            session_count: self.sessions.len(),
+            total_pane_count: total_active_panes + total_exited_panes,
+            total_active_panes,
+            total_exited_panes,
+            client_count: self.client_sender_count(),
+            pty_writer_count: self.pty_writer_count(),
+            total_raw_bytes,
+            total_pending_flush,
+            total_command_history,
+            sessions,
+        }
+    }
+
+    /// Log key memory metrics at debug level.
+    pub fn log_diagnostics(&self) {
+        let report = self.diagnostics();
+        tracing::debug!(
+            sessions = report.session_count,
+            panes = report.total_pane_count,
+            active_panes = report.total_active_panes,
+            exited_panes = report.total_exited_panes,
+            clients = report.client_count,
+            pty_writers = report.pty_writer_count,
+            raw_bytes = report.total_raw_bytes,
+            pending_flush = report.total_pending_flush,
+            command_history = report.total_command_history,
+            "memory diagnostics"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pane::Pane;
+    use crate::session::{RuntimePolicy, Session};
+    use uuid::Uuid;
+
+    fn test_server() -> Server {
+        use crate::os::OsInterface;
+        use std::path::PathBuf;
+
+        #[derive(Debug)]
+        struct TestOs;
+        impl OsInterface for TestOs {
+            fn runtime_dir(&self) -> PathBuf {
+                PathBuf::from("/tmp/test-runtime")
+            }
+            fn cache_dir(&self) -> PathBuf {
+                PathBuf::from("/tmp/test-cache")
+            }
+        }
+        Server::new(Box::new(TestOs))
+    }
+
+    #[test]
+    fn empty_server_diagnostics() {
+        let server = test_server();
+        let report = server.diagnostics();
+        assert_eq!(report.session_count, 0);
+        assert_eq!(report.total_pane_count, 0);
+        assert_eq!(report.total_active_panes, 0);
+        assert_eq!(report.total_exited_panes, 0);
+        assert_eq!(report.client_count, 0);
+        assert_eq!(report.pty_writer_count, 0);
+        assert_eq!(report.total_raw_bytes, 0);
+        assert_eq!(report.total_pending_flush, 0);
+        assert_eq!(report.total_command_history, 0);
+    }
+
+    #[test]
+    fn diagnostics_counts_sessions_and_panes() {
+        let mut server = test_server();
+        let mut session = Session::new("test".into());
+        session.policy = RuntimePolicy::Persistent;
+
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"hello world");
+        session.add_pane(pane);
+
+        let mut exited_pane = Pane::new(Uuid::new_v4(), 80, 24);
+        exited_pane.set_exited(0);
+        session.add_pane(exited_pane);
+
+        server.sessions.insert(session.id, session);
+
+        let report = server.diagnostics();
+        assert_eq!(report.session_count, 1);
+        assert_eq!(report.total_pane_count, 2);
+        assert_eq!(report.total_active_panes, 1);
+        assert_eq!(report.total_exited_panes, 1);
+        assert_eq!(report.total_raw_bytes, 11); // "hello world"
+    }
+
+    #[test]
+    fn diagnostics_counts_command_history() {
+        let mut server = test_server();
+        let mut session = Session::new("test".into());
+        session.command_history.push(crate::pane::HistoryEntry {
+            command: "ls".into(),
+            cwd: "/tmp".into(),
+            timestamp: std::time::SystemTime::now(),
+            pane_id: Uuid::new_v4(),
+        });
+        server.sessions.insert(session.id, session);
+
+        let report = server.diagnostics();
+        assert_eq!(report.total_command_history, 1);
+    }
+
+    #[test]
+    fn diagnostics_display_format() {
+        let server = test_server();
+        let report = server.diagnostics();
+        let output = report.to_string();
+        assert!(output.contains("Sessions: 0"));
+        assert!(output.contains("Connected clients: 0"));
+    }
+
+    #[test]
+    fn diagnostics_after_session_removal_returns_to_zero() {
+        let mut server = test_server();
+        let mut session = Session::new("temp".into());
+        let sid = session.id;
+        session.add_pane(Pane::new(Uuid::new_v4(), 80, 24));
+        server.sessions.insert(sid, session);
+
+        assert_eq!(server.diagnostics().session_count, 1);
+
+        server.sessions.remove(&sid);
+        let report = server.diagnostics();
+        assert_eq!(report.session_count, 0);
+        assert_eq!(report.total_pane_count, 0);
+    }
+}

--- a/services/rttx-server/src/lib.rs
+++ b/services/rttx-server/src/lib.rs
@@ -1,5 +1,6 @@
 //! rttx-server: persistent session daemon for the rttx terminal emulator.
 
+pub mod diagnostics;
 pub mod engine;
 pub mod ipc;
 pub mod logging;

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -38,6 +38,8 @@ enum Command {
     AttachStdio,
     /// Show the path to the daemon log file
     Logs,
+    /// Show runtime memory diagnostics
+    Diagnostics,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -53,6 +55,7 @@ fn main() -> anyhow::Result<()> {
             logs();
             Ok(())
         }
+        Command::Diagnostics => diagnostics(),
     }
 }
 
@@ -144,6 +147,111 @@ fn logs() {
     let os = UnixOs;
     let log_dir = os.cache_dir();
     println!("{}", log_dir.display());
+}
+
+fn diagnostics() -> anyhow::Result<()> {
+    use bytes::BytesMut;
+    use rttx_proto::{decode_frame, encode_frame};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let os = UnixOs;
+    let socket_path = os.runtime_dir().join("rttx-server.sock");
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        if !ipc::is_server_running(&socket_path).await {
+            println!("Daemon is not running");
+            return Ok(());
+        }
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path).await?;
+        let mut buf = BytesMut::new();
+        let mut read_buf = BytesMut::with_capacity(8192);
+
+        // Hello.
+        let hello = proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Hello(proto::Hello {
+                protocol_version: rttx_proto::PROTOCOL_VERSION,
+                client_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
+            })),
+        };
+        encode_frame(&hello, &mut buf)?;
+        stream.write_all(&buf).await?;
+        stream.flush().await?;
+
+        // Read HelloAck.
+        loop {
+            stream.read_buf(&mut read_buf).await?;
+            if decode_frame::<proto::ServerMessage>(&mut read_buf).is_ok() {
+                break;
+            }
+        }
+
+        // GetDiagnostics.
+        buf.clear();
+        encode_frame(
+            &proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
+            },
+            &mut buf,
+        )?;
+        stream.write_all(&buf).await?;
+        stream.flush().await?;
+
+        // Read DiagnosticsReport.
+        let resp: proto::ServerMessage = loop {
+            stream.read_buf(&mut read_buf).await?;
+            match decode_frame::<proto::ServerMessage>(&mut read_buf) {
+                Ok(msg) => break msg,
+                Err(rttx_proto::FrameError::Incomplete) => {}
+                Err(e) => anyhow::bail!("decode error: {e}"),
+            }
+        };
+
+        if let Some(proto::server_message::Msg::DiagnosticsReport(report)) = resp.msg {
+            println!("Sessions: {}", report.session_count);
+            println!(
+                "Panes: {} ({} active, {} exited)",
+                report.total_pane_count, report.total_active_panes, report.total_exited_panes
+            );
+            println!("Connected clients: {}", report.client_count);
+            println!("PTY writers: {}", report.pty_writer_count);
+            println!("Total raw_bytes: {} bytes", report.total_raw_bytes);
+            println!("Total pending_flush: {} bytes", report.total_pending_flush);
+            println!("Total command_history entries: {}", report.total_command_history);
+
+            if !report.sessions.is_empty() {
+                println!();
+                for session in &report.sessions {
+                    let id = rttx_proto::bytes_to_uuid(&session.id)
+                        .map_or_else(|_| "?".into(), |u| u.to_string());
+                    println!("  Session \"{}\" ({}):", session.name, &id[..8.min(id.len())]);
+                    println!(
+                        "    Panes: {} active, {} exited",
+                        session.active_pane_count, session.exited_pane_count
+                    );
+                    println!("    Command history: {} entries", session.command_history_len);
+                    println!("    Attached clients: {}", session.attached_client_count);
+                    for pane in &session.panes {
+                        let pid = rttx_proto::bytes_to_uuid(&pane.id)
+                            .map_or_else(|_| "?".into(), |u| u.to_string());
+                        let status = if pane.is_exited { "exited" } else { "active" };
+                        println!(
+                            "    Pane {} ({}): raw_bytes={}, pending_flush={}",
+                            &pid[..8.min(pid.len())],
+                            status,
+                            pane.raw_bytes_len,
+                            pane.pending_flush_len,
+                        );
+                    }
+                }
+            }
+        } else {
+            anyhow::bail!("unexpected response from daemon");
+        }
+
+        Ok(())
+    })
 }
 
 /// SSH connection drops, so PTYs and runtimes survive GUI restarts.
@@ -437,5 +545,11 @@ mod tests {
     fn cli_parses_clean_command() {
         let cli = Cli::try_parse_from(["rttx-server", "clean"]).unwrap();
         assert!(matches!(cli.command, Some(Command::Clean)));
+    }
+
+    #[test]
+    fn cli_parses_diagnostics_command() {
+        let cli = Cli::try_parse_from(["rttx-server", "diagnostics"]).unwrap();
+        assert!(matches!(cli.command, Some(Command::Diagnostics)));
     }
 }

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -150,6 +150,12 @@ impl Pane {
         !self.pending_flush.is_empty()
     }
 
+    /// Number of bytes waiting to be flushed to disk.
+    #[must_use]
+    pub const fn pending_flush_len(&self) -> usize {
+        self.pending_flush.len()
+    }
+
     /// Read the child process CWD from /proc/<pid>/cwd.
     /// Returns None if the PID is unknown or the read fails.
     #[must_use]

--- a/services/rttx-server/src/protocol.rs
+++ b/services/rttx-server/src/protocol.rs
@@ -302,6 +302,55 @@ pub const fn error(code: u32, message: String) -> proto::ServerMessage {
     }
 }
 
+/// Build a `DiagnosticsReport` response from the current server state.
+#[must_use]
+pub fn diagnostics_report(server: &crate::server::Server) -> proto::ServerMessage {
+    let report = server.diagnostics();
+    let sessions = report
+        .sessions
+        .iter()
+        .map(|s| {
+            let panes = s
+                .panes
+                .iter()
+                .map(|p| {
+                    let id = uuid::Uuid::parse_str(&p.id).map(uuid_to_bytes).unwrap_or_default();
+                    proto::PaneDiagnosticsInfo {
+                        id,
+                        raw_bytes_len: p.raw_bytes_len as u64,
+                        pending_flush_len: p.pending_flush_len as u64,
+                        is_exited: p.is_exited,
+                    }
+                })
+                .collect();
+            let id = uuid::Uuid::parse_str(&s.id).map(uuid_to_bytes).unwrap_or_default();
+            proto::SessionDiagnosticsInfo {
+                id,
+                name: s.name.clone(),
+                active_pane_count: s.active_pane_count as u32,
+                exited_pane_count: s.exited_pane_count as u32,
+                command_history_len: s.command_history_len as u32,
+                attached_client_count: s.attached_client_count as u32,
+                panes,
+            }
+        })
+        .collect();
+    proto::ServerMessage {
+        msg: Some(proto::server_message::Msg::DiagnosticsReport(proto::DiagnosticsReport {
+            session_count: report.session_count as u32,
+            total_pane_count: report.total_pane_count as u32,
+            total_active_panes: report.total_active_panes as u32,
+            total_exited_panes: report.total_exited_panes as u32,
+            client_count: report.client_count as u32,
+            pty_writer_count: report.pty_writer_count as u32,
+            total_raw_bytes: report.total_raw_bytes as u64,
+            total_pending_flush: report.total_pending_flush as u64,
+            total_command_history: report.total_command_history as u32,
+            sessions,
+        })),
+    }
+}
+
 /// Build a `SessionRenamed` response.
 #[must_use]
 pub fn session_renamed(session_id: Uuid, name: String, revision: u64) -> proto::ServerMessage {

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -103,6 +103,18 @@ impl Server {
         let _ = self.shutdown_tx.send(true);
     }
 
+    /// Number of connected client push channels.
+    #[must_use]
+    pub fn client_sender_count(&self) -> usize {
+        self.client_senders.len()
+    }
+
+    /// Number of active PTY write handles.
+    #[must_use]
+    pub fn pty_writer_count(&self) -> usize {
+        self.pty_writers.len()
+    }
+
     /// Human-readable label for a session: `"name" (short_id)`.
     ///
     /// Falls back to just the short ID when the session is not found.
@@ -374,6 +386,11 @@ impl Server {
                 let s = server.lock().await;
                 let infos = protocol::session_inventory_for(client_id, s.sessions.values());
                 Some(protocol::session_list(infos))
+            }
+
+            proto::client_message::Msg::GetDiagnostics(_) => {
+                let s = server.lock().await;
+                Some(protocol::diagnostics_report(&s))
             }
 
             proto::client_message::Msg::CreateSession(req) => {
@@ -1024,6 +1041,7 @@ pub async fn serialization_loop(
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
     let mut ticker = tokio::time::interval(interval);
+    let mut diagnostics_counter = 0u64;
     loop {
         tokio::select! {
             _ = ticker.tick() => {}
@@ -1049,6 +1067,12 @@ pub async fn serialization_loop(
                     }
                 }
             }
+        }
+
+        // Log diagnostics every 30 ticks (~30 seconds at 1s interval).
+        diagnostics_counter += 1;
+        if diagnostics_counter.is_multiple_of(30) {
+            s.log_diagnostics();
         }
 
         let snapshot = s.build_snapshot();

--- a/services/rttx-server/tests/diagnostics.rs
+++ b/services/rttx-server/tests/diagnostics.rs
@@ -1,0 +1,123 @@
+//! Integration tests for the `GetDiagnostics` protocol message.
+
+mod common;
+
+use common::*;
+use rttx_proto::proto;
+
+#[tokio::test]
+async fn diagnostics_empty_server() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
+        })
+        .await;
+
+    let resp = client.recv_or_timeout().await;
+    let report = match resp.msg {
+        Some(proto::server_message::Msg::DiagnosticsReport(r)) => r,
+        other => panic!("expected DiagnosticsReport, got {other:?}"),
+    };
+
+    assert_eq!(report.session_count, 0);
+    assert_eq!(report.total_pane_count, 0);
+    assert_eq!(report.total_active_panes, 0);
+    assert_eq!(report.total_exited_panes, 0);
+    assert_eq!(report.total_raw_bytes, 0);
+    assert_eq!(report.total_pending_flush, 0);
+    assert_eq!(report.total_command_history, 0);
+    assert!(report.sessions.is_empty());
+}
+
+#[tokio::test]
+async fn diagnostics_with_session_and_pane() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let sid = create_session(&mut client, "diag-test", proto::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &sid).await;
+    let _pane_id = create_pane(&mut client, &sid).await;
+
+    // Let the pane produce some output.
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    client.drain(std::time::Duration::from_millis(200)).await;
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
+        })
+        .await;
+
+    let resp = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::DiagnosticsReport(r)) => break r,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected DiagnosticsReport, got {other:?}"),
+        }
+    };
+
+    assert_eq!(resp.session_count, 1);
+    assert!(resp.total_pane_count >= 1);
+    assert!(resp.total_active_panes >= 1);
+    assert_eq!(resp.sessions.len(), 1);
+    assert_eq!(resp.sessions[0].name, "diag-test");
+    assert!(!resp.sessions[0].panes.is_empty());
+}
+
+#[tokio::test]
+async fn diagnostics_reflects_cleanup_after_terminate() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let sid = create_session(&mut client, "cleanup", proto::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &sid).await;
+    let _pane_id = create_pane(&mut client, &sid).await;
+
+    // Verify non-zero state.
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
+        })
+        .await;
+    let before = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::DiagnosticsReport(r)) => break r,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected DiagnosticsReport, got {other:?}"),
+        }
+    };
+    assert_eq!(before.session_count, 1);
+
+    // Terminate and verify cleanup.
+    terminate_session(&mut client, &sid).await;
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
+        })
+        .await;
+    let after = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::DiagnosticsReport(r)) => break r,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected DiagnosticsReport, got {other:?}"),
+        }
+    };
+    assert_eq!(after.session_count, 0, "terminated session must be cleaned up");
+    assert_eq!(after.total_pane_count, 0);
+    assert_eq!(after.total_raw_bytes, 0);
+    assert_eq!(after.total_pending_flush, 0);
+    assert_eq!(after.total_command_history, 0);
+}

--- a/services/rttx-server/tests/memory_cleanup.rs
+++ b/services/rttx-server/tests/memory_cleanup.rs
@@ -1,0 +1,156 @@
+//! Tests verifying `HashMap` cleanup and bounded data structure caps.
+//!
+//! These tests use the diagnostics API to verify that server-internal
+//! data structures are properly cleaned up after session/pane lifecycle
+//! operations and that bounded structures respect their limits.
+
+mod common;
+
+use common::*;
+use rttx_proto::proto;
+
+/// After creating and terminating multiple sessions, the server's internal
+/// hash maps (sessions, `pty_writers`, `client_senders`) must return to zero.
+#[tokio::test]
+async fn hashmap_cleanup_after_session_terminate() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    // Create several sessions with panes, then terminate them all.
+    for i in 0..5 {
+        let sid =
+            create_session(&mut client, &format!("map-{i}"), proto::RuntimePolicy::Persistent)
+                .await;
+        attach_rw(&mut client, &sid).await;
+        let _pane = create_pane(&mut client, &sid).await;
+        terminate_session(&mut client, &sid).await;
+    }
+
+    // Diagnostics should show zero sessions and zero panes.
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
+        })
+        .await;
+    let report = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::DiagnosticsReport(r)) => break r,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected DiagnosticsReport, got {other:?}"),
+        }
+    };
+
+    assert_eq!(report.session_count, 0, "sessions HashMap must be empty after terminate");
+    assert_eq!(report.total_pane_count, 0, "no panes should remain");
+    assert_eq!(report.pty_writer_count, 0, "pty_writers HashMap must be empty");
+}
+
+/// After closing all panes in a session, the pane hash map within the
+/// session must be empty.
+#[tokio::test]
+async fn hashmap_cleanup_after_pane_close() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let sid = create_session(&mut client, "pane-cleanup", proto::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &sid).await;
+
+    // Create and close several panes.
+    for _ in 0..5 {
+        let pane_id = create_pane(&mut client, &sid).await;
+        close_pane(&mut client, &sid, &pane_id).await;
+    }
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
+        })
+        .await;
+    let report = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::DiagnosticsReport(r)) => break r,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected DiagnosticsReport, got {other:?}"),
+        }
+    };
+
+    assert_eq!(report.session_count, 1);
+    assert_eq!(report.sessions[0].active_pane_count, 0, "all panes must be cleaned up");
+    assert_eq!(report.sessions[0].exited_pane_count, 0, "no exited panes should linger");
+}
+
+/// Ephemeral sessions must be fully cleaned up after the last client detaches.
+#[tokio::test]
+async fn hashmap_cleanup_ephemeral_detach() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    for i in 0..3 {
+        let sid =
+            create_session(&mut client, &format!("eph-{i}"), proto::RuntimePolicy::Ephemeral).await;
+        attach_rw(&mut client, &sid).await;
+        detach_session(&mut client, &sid).await;
+    }
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
+        })
+        .await;
+    let report = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::DiagnosticsReport(r)) => break r,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected DiagnosticsReport, got {other:?}"),
+        }
+    };
+
+    assert_eq!(report.session_count, 0, "ephemeral sessions must be cleaned up on detach");
+    assert_eq!(report.total_pane_count, 0);
+}
+
+/// Client disconnect must clean up the `client_senders` hash map entry.
+#[tokio::test]
+async fn client_sender_cleanup_on_disconnect() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    // Connect and disconnect several clients.
+    for _ in 0..5 {
+        let mut c = TestClient::connect(&sock).await;
+        c.handshake().await;
+        drop(c);
+    }
+
+    // Small delay for the server to process disconnects.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Connect a fresh client and check diagnostics.
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
+        })
+        .await;
+    let report = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::DiagnosticsReport(r)) => break r,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected DiagnosticsReport, got {other:?}"),
+        }
+    };
+
+    // Only the current client should be connected.
+    assert_eq!(report.client_count, 1, "disconnected clients must be cleaned up");
+}


### PR DESCRIPTION
## What changed and why

Implements #545: memory profiling CI gate and runtime diagnostics.

### Protocol additions
- `GetDiagnostics` client message and `DiagnosticsReport` server response
- `SessionDiagnosticsInfo` and `PaneDiagnosticsInfo` sub-messages

### Runtime diagnostics (`rttx-server diagnostics`)
New CLI subcommand that connects to the running daemon and reports:
- Per-session pane count (active vs exited)
- `command_history` sizes
- `raw_bytes` / `pending_flush` sizes per pane
- Client count and PTY writer count

### Periodic debug logging
Key memory metrics logged at debug level every 30 seconds via the serialization loop.

### CI gate
- `run-memory-gate.sh` script runs memory cleanup, diagnostics, lifecycle leak, and bounded channel tests
- New `memory-gate` job in the quality workflow

### Version bump
0.2.35 → 0.2.36 (protocol change + >3 source files)

## Manual verification steps
1. Build: `cargo build -p rttx-server`
2. Start daemon: `cargo run -p rttx-server -- start --foreground`
3. In another terminal: `./target/debug/rttx-server diagnostics`
4. Verify output shows sessions, panes, memory metrics
5. With `RUST_LOG=debug`, verify periodic diagnostics appear in daemon logs

## Tests added

### Unit tests (diagnostics module)
- `empty_server_diagnostics`
- `diagnostics_counts_sessions_and_panes`
- `diagnostics_counts_command_history`
- `diagnostics_display_format`
- `diagnostics_after_session_removal_returns_to_zero`

### Integration tests (diagnostics.rs)
- `diagnostics_empty_server`
- `diagnostics_with_session_and_pane`
- `diagnostics_reflects_cleanup_after_terminate`

### Integration tests (memory_cleanup.rs)
- `hashmap_cleanup_after_session_terminate`
- `hashmap_cleanup_after_pane_close`
- `hashmap_cleanup_ephemeral_detach`
- `client_sender_cleanup_on_disconnect`

### CLI test
- `cli_parses_diagnostics_command`

## Tests run
- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx-server` — all tests pass ✅
- `cargo test -p rttx-proto` — all tests pass ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `bash .github/scripts/run-memory-gate.sh` ✅

No GTK tests added (server-only change).

Fixes #545