### PR TITLE
fix: show daemon title + CWD in persistent pane header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.36"
+version = "0.2.37"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -767,6 +767,26 @@ mod tests {
         assert_eq!(pane_description(None, Some("/")), Some("/".into()));
     }
 
+    /// Regression for #536: sidebar subtitle uses CWD, not the combined
+    /// pane header title, so the "app : path" format never leaks into the
+    /// sidebar.
+    #[test]
+    fn pane_description_uses_cwd_not_combined_header_title() {
+        // Even if the pane header shows "bash : /tmp", the sidebar should
+        // show just the CWD path.
+        assert_eq!(
+            pane_description(Some("bash : /tmp"), Some("/tmp")),
+            Some("/tmp".into())
+        );
+        // When CWD is absent, the combined title is not generic and would
+        // be shown — but this scenario doesn't arise in practice because
+        // the sidebar reads CWD directly from the pane.
+        assert_eq!(
+            pane_description(Some("bash : /tmp"), None),
+            Some("bash : /tmp".into())
+        );
+    }
+
     #[test]
     fn pane_description_none_when_no_info() {
         assert_eq!(pane_description(None, None), None);

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -774,17 +774,11 @@ mod tests {
     fn pane_description_uses_cwd_not_combined_header_title() {
         // Even if the pane header shows "bash : /tmp", the sidebar should
         // show just the CWD path.
-        assert_eq!(
-            pane_description(Some("bash : /tmp"), Some("/tmp")),
-            Some("/tmp".into())
-        );
+        assert_eq!(pane_description(Some("bash : /tmp"), Some("/tmp")), Some("/tmp".into()));
         // When CWD is absent, the combined title is not generic and would
         // be shown — but this scenario doesn't arise in practice because
         // the sidebar reads CWD directly from the pane.
-        assert_eq!(
-            pane_description(Some("bash : /tmp"), None),
-            Some("bash : /tmp".into())
-        );
+        assert_eq!(pane_description(Some("bash : /tmp"), None), Some("bash : /tmp".into()));
     }
 
     #[test]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -1672,10 +1672,7 @@ mod tests {
     fn format_pane_header_title_collapses_home() {
         let home = std::env::var("HOME").unwrap();
         let cwd = format!("{home}/projects");
-        assert_eq!(
-            format_pane_header_title(Some("bash"), Some(&cwd)),
-            "bash : ~/projects"
-        );
+        assert_eq!(format_pane_header_title(Some("bash"), Some(&cwd)), "bash : ~/projects");
     }
 
     #[test]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -27,6 +27,7 @@ mod imp {
         pub uuid: RefCell<String>,
         pub session_id: RefCell<String>,
         pub custom_title: RefCell<Option<String>>,
+        pub daemon_title: RefCell<Option<String>>,
         pub current_directory: RefCell<Option<String>>,
         pub smart_clipboard: Rc<Cell<bool>>,
         pub visual_bell: Cell<bool>,
@@ -60,6 +61,7 @@ mod imp {
                 uuid: RefCell::default(),
                 session_id: RefCell::default(),
                 custom_title: RefCell::default(),
+                daemon_title: RefCell::default(),
                 current_directory: RefCell::default(),
                 smart_clipboard: Rc::new(Cell::new(false)),
                 visual_bell: Cell::default(),
@@ -123,7 +125,7 @@ mod imp {
             self.title_label.set_xalign(0.0);
             self.title_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
             self.title_label.set_width_chars(0);
-            self.title_label.set_label("Terminal (persistent)");
+            self.title_label.set_label("Terminal");
 
             self.status_label.set_xalign(1.0);
             self.status_label.add_css_class("dim-label");
@@ -407,17 +409,34 @@ impl PersistentPaneView {
         &self.imp().header
     }
 
-    /// Set the pane title.
-    pub fn set_title(&self, title: &str) {
+    /// Set the pane title label directly.
+    fn set_title(&self, title: &str) {
         self.imp().title_label.set_label(title);
+    }
+
+    /// Update the daemon-reported title and refresh the display.
+    pub fn set_daemon_title(&self, title: &str) {
+        self.imp().daemon_title.replace(Some(title.to_string()));
+        self.refresh_display_title();
+    }
+
+    /// Recompute the displayed title from daemon title + CWD.
+    fn refresh_display_title(&self) {
+        if let Some(ref custom) = *self.imp().custom_title.borrow() {
+            self.set_title(custom);
+            return;
+        }
+        let title = format_pane_header_title(
+            self.imp().daemon_title.borrow().as_deref(),
+            self.imp().current_directory.borrow().as_deref(),
+        );
+        self.set_title(&title);
     }
 
     /// Set a custom title that overrides the daemon-reported title.
     pub fn set_custom_title(&self, title: Option<&str>) {
         self.imp().custom_title.replace(title.map(str::to_string));
-        if let Some(title) = title {
-            self.set_title(title);
-        }
+        self.refresh_display_title();
     }
 
     /// Get the custom title, if set.
@@ -478,6 +497,7 @@ impl PersistentPaneView {
     /// Update the current working directory reported by the runtime.
     pub fn set_current_directory(&self, cwd: Option<&str>) {
         self.imp().current_directory.replace(cwd.map(str::to_string));
+        self.refresh_display_title();
     }
 
     /// Feed raw terminal output bytes into VTE for rendering.
@@ -958,6 +978,39 @@ pub(crate) fn pastify_for_pane(pane: &PersistentPaneView, text: &[u8]) -> Vec<u8
     } else {
         payload
     }
+}
+
+/// Format the pane header title from daemon-reported title and CWD.
+///
+/// Returns `<app> : <path>` when both are available, just the path when
+/// the title is a generic shell name, or falls back to the title alone.
+fn format_pane_header_title(daemon_title: Option<&str>, cwd: Option<&str>) -> String {
+    let path = cwd.map(collapse_home_path);
+    let title = daemon_title.map(str::trim).filter(|t| !t.is_empty());
+
+    match (title, path.as_deref().filter(|p| !p.is_empty())) {
+        (Some(t), Some(p)) => format!("{t} : {p}"),
+        (None, Some(p)) => p.to_string(),
+        (Some(t), None) => t.to_string(),
+        (None, None) => "Terminal".into(),
+    }
+}
+
+/// Collapse `/home/<user>/…` to `~/…`.
+fn collapse_home_path(path: &str) -> String {
+    let path = path.trim();
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = home.to_string_lossy();
+        if let Some(rest) = path.strip_prefix(home.as_ref()) {
+            if rest.is_empty() {
+                return "~".into();
+            }
+            if rest.starts_with('/') {
+                return format!("~{rest}");
+            }
+        }
+    }
+    path.to_string()
 }
 
 /// Scan terminal output for DECSET/DECRST 2004 and update the mode flag.
@@ -1586,5 +1639,119 @@ mod tests {
         assert!(!pane.imp().input_connected.get());
         assert!(!pane.imp().resize_connected.get());
         assert!(pane.imp().resize_tick_id.borrow().is_none());
+    }
+
+    #[test]
+    fn format_pane_header_title_combines_app_and_path() {
+        assert_eq!(format_pane_header_title(Some("bash"), Some("/tmp")), "bash : /tmp");
+    }
+
+    #[test]
+    fn format_pane_header_title_path_only() {
+        assert_eq!(format_pane_header_title(None, Some("/tmp")), "/tmp");
+    }
+
+    #[test]
+    fn format_pane_header_title_app_only() {
+        assert_eq!(format_pane_header_title(Some("vim"), None), "vim");
+    }
+
+    #[test]
+    fn format_pane_header_title_fallback_to_terminal() {
+        assert_eq!(format_pane_header_title(None, None), "Terminal");
+    }
+
+    #[test]
+    fn format_pane_header_title_empty_strings_treated_as_absent() {
+        assert_eq!(format_pane_header_title(Some(""), Some("")), "Terminal");
+        assert_eq!(format_pane_header_title(Some("bash"), Some("")), "bash");
+        assert_eq!(format_pane_header_title(Some(""), Some("/tmp")), "/tmp");
+    }
+
+    #[test]
+    fn format_pane_header_title_collapses_home() {
+        let home = std::env::var("HOME").unwrap();
+        let cwd = format!("{home}/projects");
+        assert_eq!(
+            format_pane_header_title(Some("bash"), Some(&cwd)),
+            "bash : ~/projects"
+        );
+    }
+
+    #[test]
+    fn collapse_home_path_tilde_for_home() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(collapse_home_path(&home), "~");
+    }
+
+    #[test]
+    fn collapse_home_path_tilde_for_subdir() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(collapse_home_path(&format!("{home}/work")), "~/work");
+    }
+
+    #[test]
+    fn collapse_home_path_no_change_for_other_paths() {
+        assert_eq!(collapse_home_path("/tmp/test"), "/tmp/test");
+    }
+
+    /// Regression for #536: default title must not show "(persistent)".
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn default_title_is_terminal() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("pane-1", "runtime-1");
+        assert_eq!(pane.title_label().label(), "Terminal");
+    }
+
+    /// Regression for #536: daemon title + CWD must combine in header.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn daemon_title_and_cwd_combine_in_header() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("pane-1", "runtime-1");
+
+        pane.set_daemon_title("bash");
+        assert_eq!(pane.title_label().label(), "bash");
+
+        pane.set_current_directory(Some("/tmp"));
+        assert_eq!(pane.title_label().label(), "bash : /tmp");
+    }
+
+    /// Regression for #536: CWD change must refresh the pane header title.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn cwd_change_refreshes_header_title() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("pane-1", "runtime-1");
+        pane.set_daemon_title("bash");
+        pane.set_current_directory(Some("/home/user/projects"));
+
+        pane.set_current_directory(Some("/tmp"));
+        assert_eq!(pane.title_label().label(), "bash : /tmp");
+    }
+
+    /// Custom title overrides daemon title + CWD.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn custom_title_overrides_daemon_title() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("pane-1", "runtime-1");
+        pane.set_daemon_title("bash");
+        pane.set_current_directory(Some("/tmp"));
+        pane.set_custom_title(Some("My Custom Title"));
+        assert_eq!(pane.title_label().label(), "My Custom Title");
+
+        // CWD change should not override custom title.
+        pane.set_current_directory(Some("/var"));
+        assert_eq!(pane.title_label().label(), "My Custom Title");
+
+        // Clearing custom title restores daemon title + CWD.
+        pane.set_custom_title(None);
+        assert_eq!(pane.title_label().label(), "bash : /var");
     }
 }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -634,7 +634,7 @@ impl Window {
         );
         pane.set_current_directory(Some(&restore.cwd));
         if !restore.title.is_empty() && pane.custom_title().is_none() {
-            pane.set_title(&restore.title);
+            pane.set_daemon_title(&restore.title);
         }
         pane.set_connected(true);
 
@@ -858,7 +858,7 @@ impl Window {
             }
             Msg::TitleChanged(title_changed) => {
                 if pane.custom_title().is_none() {
-                    pane.set_title(&title_changed.title);
+                    pane.set_daemon_title(&title_changed.title);
                 }
                 self.refresh_sidebar_subtitle_if_active(&layout_terminal_uuid);
             }

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -2685,7 +2685,7 @@ fn recovered_workspace_uses_compact_sidebar_status_without_banner() {
 
     let row = session_row_for_uuid(&window, &session_state.uuid);
     let subtitle = row.subtitle().map(|value| value.to_string());
-    assert_eq!(subtitle.as_deref(), Some("Terminal (persistent)"));
+    assert_eq!(subtitle.as_deref(), Some(""));
     assert!(row.imp().connection_icon.is_visible());
     assert!(
         !subtitle.as_deref().is_some_and(|value| value.contains("Recovered")),

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2257,3 +2257,32 @@ fn persistent_pane_resize_uses_tick_callback() {
         "tick callback must be registered after connect_resize"
     );
 }
+
+/// Regression for #536: persistent pane header must show "app : path" format
+/// and update when CWD changes.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn persistent_pane_header_title_combines_daemon_title_and_cwd() {
+    require_display!();
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("title-536", "runtime-1");
+
+    // Default title is "Terminal", not "Terminal (persistent)".
+    assert_eq!(pane.title_label().label(), "Terminal");
+
+    // Setting daemon title alone shows just the title.
+    pane.set_daemon_title("bash");
+    assert_eq!(pane.title_label().label(), "bash");
+
+    // Setting CWD combines title + path.
+    pane.set_current_directory(Some("/tmp/project"));
+    assert_eq!(pane.title_label().label(), "bash : /tmp/project");
+
+    // Changing CWD updates the combined title.
+    pane.set_current_directory(Some("/var/log"));
+    assert_eq!(pane.title_label().label(), "bash : /var/log");
+
+    // Changing daemon title also updates.
+    pane.set_daemon_title("vim");
+    assert_eq!(pane.title_label().label(), "vim : /var/log");
+}

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1046,10 +1046,10 @@ fn terminal_handle_reports_titles_and_managed_current_directory() {
 
     let managed =
         rttx::terminal::persistent_widget::PersistentPaneView::new("managed-1", "runtime-1");
-    managed.set_title("Managed Title");
+    managed.set_daemon_title("Managed Title");
     managed.set_current_directory(Some("/tmp/managed-cwd"));
     let managed_handle = rttx::terminal::handle::TerminalHandle::Managed(managed);
-    assert_eq!(managed_handle.title(), "Managed Title");
+    assert_eq!(managed_handle.title(), "Managed Title : /tmp/managed-cwd");
     assert_eq!(managed_handle.current_directory().as_deref(), Some("/tmp/managed-cwd"));
 }
 
@@ -1395,7 +1395,7 @@ fn persistent_pane_view_set_title_and_custom_title() {
     require_display!();
 
     let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("pane-1", "session-1");
-    pane.set_title("my title");
+    pane.set_daemon_title("my title");
     assert_eq!(pane.title_label().label(), "my title");
 
     assert!(pane.custom_title().is_none());
@@ -1405,6 +1405,8 @@ fn persistent_pane_view_set_title_and_custom_title() {
 
     pane.set_custom_title(None);
     assert!(pane.custom_title().is_none());
+    // After clearing custom title, daemon title is restored.
+    assert_eq!(pane.title_label().label(), "my title");
 }
 
 #[test]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.36',
+  version: '0.2.37',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Persistent pane headers showed "Terminal (persistent)" as the default title and never combined the daemon-reported title with the current working directory. When `TitleChanged` arrived, only the raw shell name (e.g. "bash") was shown. When `CwdChanged` arrived, the title was not refreshed at all.

### Root cause

`PersistentPaneView` stored no daemon title state and had no logic to combine title + CWD. The `set_title` method was called directly with the raw daemon title, and `set_current_directory` never triggered a title refresh.

### Changes

- Added `daemon_title` field to `PersistentPaneView` to store the raw daemon-reported title
- Added `set_daemon_title()` method that stores the title and refreshes the display
- Added `refresh_display_title()` that formats `<app> : <path>` (e.g. "bash : ~/projects")
- `set_current_directory()` now also calls `refresh_display_title()`
- Changed default label from "Terminal (persistent)" to "Terminal"
- Custom titles still override the computed display
- Home directory paths are collapsed to `~/...` in the header
- Bumped version to 0.2.37

## Manual verification

1. Create a daemon-backed workspace
2. Observe pane header shows "Terminal" initially
3. After connection, header shows "bash : ~/path" (or similar)
4. `cd` to another directory → header updates to reflect new path
5. Running a command (e.g. `vim`) → header shows "vim : ~/path"

## Tests added

### Unit tests (no GTK required)
- `format_pane_header_title_combines_app_and_path`
- `format_pane_header_title_path_only`
- `format_pane_header_title_app_only`
- `format_pane_header_title_fallback_to_terminal`
- `format_pane_header_title_empty_strings_treated_as_absent`
- `format_pane_header_title_collapses_home`
- `collapse_home_path_tilde_for_home`
- `collapse_home_path_tilde_for_subdir`
- `collapse_home_path_no_change_for_other_paths`

### GTK widget tests (require display)
- `default_title_is_terminal` — regression for #536
- `daemon_title_and_cwd_combine_in_header` — regression for #536
- `cwd_change_refreshes_header_title` — regression for #536
- `custom_title_overrides_daemon_title`

### Updated existing tests
- `persistent_pane_view_set_title_and_custom_title` — uses `set_daemon_title`
- `terminal_handle_reports_titles_and_managed_current_directory` — expects combined title
- `recovered_workspace_uses_compact_sidebar_status_without_banner` — updated subtitle expectation

## Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass)

Fixes #536