### PR TITLE
fix: remove separate search entry from Commands tab

### DIFF
--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -56,7 +56,6 @@ mod imp {
         pub place_list: gtk4::ListBox,
         pub place_scroll: gtk4::ScrolledWindow,
         pub place_empty: adw::StatusPage,
-        pub command_search_entry: gtk4::SearchEntry,
         pub command_list: gtk4::ListBox,
         pub command_scroll: gtk4::ScrolledWindow,
         pub command_empty: adw::StatusPage,
@@ -262,12 +261,6 @@ mod imp {
             commands_header.append(&commands_title);
             commands_header.append(&add_command_button);
 
-            self.command_search_entry.set_placeholder_text(Some("Search commands"));
-            self.command_search_entry.set_margin_start(12);
-            self.command_search_entry.set_margin_end(12);
-            self.command_search_entry.set_margin_top(12);
-            self.command_search_entry.set_margin_bottom(12);
-
             self.command_scroll.set_hscrollbar_policy(gtk4::PolicyType::Never);
             self.command_scroll.set_vexpand(true);
             self.command_scroll.set_margin_start(12);
@@ -285,7 +278,6 @@ mod imp {
 
             let commands_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
             commands_page.append(&commands_header);
-            commands_page.append(&self.command_search_entry);
             commands_page.append(&self.command_scroll);
             commands_page.append(&self.command_empty);
 
@@ -504,11 +496,6 @@ impl Window {
         let win = self.clone();
         self.imp().sidebar_search_entry.connect_changed(move |_| {
             win.refresh_place_sidebar();
-            win.refresh_command_sidebar();
-        });
-
-        let win = self.clone();
-        self.imp().command_search_entry.connect_changed(move |_| {
             win.refresh_command_sidebar();
         });
 

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -215,15 +215,7 @@ impl Window {
             imp.command_list.remove(&row);
         }
 
-        let query = imp.command_search_entry.text();
-        let sidebar_query = imp.sidebar_search_entry.text();
-        let combined_query = if sidebar_query.is_empty() {
-            query.to_string()
-        } else if query.is_empty() {
-            sidebar_query.to_string()
-        } else {
-            format!("{sidebar_query} {query}")
-        };
+        let query = imp.sidebar_search_entry.text();
 
         let all_commands = commands::load();
         let selected_key = self.selected_host_key();
@@ -233,7 +225,7 @@ impl Window {
             None => all_commands,
         }
         .into_iter()
-        .filter(|command| commands::matches_query(command, &combined_query))
+        .filter(|command| commands::matches_query(command, &query))
         .collect();
 
         for command in &filtered {

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -428,13 +428,54 @@ fn utility_sidebar_shows_and_filters_commands() {
         "utility sidebar should show saved commands"
     );
 
-    window.imp().command_search_entry.set_text("deploy");
+    window.imp().sidebar_search_entry.set_text("deploy");
     pump_events(50);
     assert_eq!(
         window.imp().command_list.observe_children().n_items(),
         1,
         "search should filter the utility sidebar command list"
     );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn commands_page_has_no_separate_search_entry() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.commands-no-search-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    let commands_page = window
+        .imp()
+        .utility_stack
+        .child_by_name("commands")
+        .expect("commands page must exist")
+        .downcast::<gtk4::Box>()
+        .expect("commands page must be a Box");
+
+    let mut has_search = false;
+    let mut child = commands_page.first_child();
+    while let Some(widget) = child {
+        if widget.downcast_ref::<gtk4::SearchEntry>().is_some() {
+            has_search = true;
+            break;
+        }
+        child = widget.next_sibling();
+    }
+    assert!(!has_search, "commands page should not contain a separate SearchEntry");
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");


### PR DESCRIPTION
## What changed and why

The Commands tab in the right tools sidebar had its own `SearchEntry` (`command_search_entry`) in addition to the shared sidebar search entry (`sidebar_search_entry`). The Places tab uses only the shared sidebar search. This inconsistency was confusing — the Commands tab should behave the same way.

Removed the separate `command_search_entry` so both tabs filter through the single shared `sidebar_search_entry`.

## Changes

- Removed `command_search_entry` field from the `Window` struct
- Removed its construction, layout inclusion, and `connect_changed` signal handler
- Simplified `refresh_command_sidebar()` to use only `sidebar_search_entry` instead of combining two queries

## How to manually verify

1. Open rttx, add some commands in the right sidebar
2. Switch to the Commands tab — there should be no search entry inside the tab itself
3. Type in the shared search bar at the top of the right sidebar — commands should filter correctly
4. Switch to Places tab — places should also filter from the same search bar

## Tests added

- `commands_page_has_no_separate_search_entry` — regression test verifying the commands page widget tree contains no `SearchEntry`

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
  - `commands_page_has_no_separate_search_entry` — ok
  - `utility_sidebar_shows_and_filters_commands` — ok
  - `command_sidebar_shows_empty_state_when_no_commands` — ok
  - `command_sidebar_filters_by_selected_host` — ok

Fixes #570