### PR TITLE
feat(sidebar): group commands by host section in command tab

### DIFF
--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -255,11 +255,8 @@ impl Window {
                 let mut shown = false;
                 if !host_specific.is_empty() {
                     let resolved = host::resolve(key, &saved_hosts);
-                    shown |= self.append_command_section(
-                        &resolved.name,
-                        &host_specific,
-                        query.as_str(),
-                    );
+                    shown |=
+                        self.append_command_section(&resolved.name, &host_specific, query.as_str());
                 }
                 shown |= self.append_command_section("Global", &global, query.as_str());
                 shown

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -216,17 +216,84 @@ impl Window {
         }
 
         let query = imp.sidebar_search_entry.text();
-
         let all_commands = commands::load();
+        let saved_hosts = host::load();
         let selected_key = self.selected_host_key();
 
-        let filtered: Vec<_> = match &selected_key {
-            Some(key) => commands::visible_for_host(&all_commands, key),
-            None => all_commands,
+        let any_shown = selected_key.as_ref().map_or_else(
+            || {
+                // All Hosts view: group by host key
+                let mut shown = false;
+                let all_keys = self.collect_all_host_keys(&saved_hosts);
+                for key in &all_keys {
+                    let resolved = host::resolve(key, &saved_hosts);
+                    let visible: Vec<_> = all_commands
+                        .iter()
+                        .filter(|c| c.host_tags.iter().any(|t| t == key))
+                        .cloned()
+                        .collect();
+                    if !visible.is_empty() {
+                        let is_orphaned = !self.is_known_host_key(key, &saved_hosts);
+                        let label = if is_orphaned {
+                            format!("{} (orphaned)", resolved.name)
+                        } else {
+                            resolved.name.clone()
+                        };
+                        shown |= self.append_command_section(&label, &visible, query.as_str());
+                    }
+                }
+                let global: Vec<_> =
+                    all_commands.iter().filter(|c| c.host_tags.is_empty()).cloned().collect();
+                shown |= self.append_command_section("Global", &global, query.as_str());
+                shown
+            },
+            |key| {
+                let visible = commands::visible_for_host(&all_commands, key);
+                let (host_specific, global): (Vec<_>, Vec<_>) =
+                    visible.into_iter().partition(|c| !c.host_tags.is_empty());
+
+                let mut shown = false;
+                if !host_specific.is_empty() {
+                    let resolved = host::resolve(key, &saved_hosts);
+                    shown |= self.append_command_section(
+                        &resolved.name,
+                        &host_specific,
+                        query.as_str(),
+                    );
+                }
+                shown |= self.append_command_section("Global", &global, query.as_str());
+                shown
+            },
+        );
+
+        imp.command_scroll.set_visible(any_shown);
+        imp.command_empty.set_visible(!any_shown);
+    }
+
+    fn append_command_section(
+        &self,
+        section_label: &str,
+        items: &[SavedCommand],
+        query: &str,
+    ) -> bool {
+        let imp = self.imp();
+        let filtered: Vec<_> = items.iter().filter(|c| commands::matches_query(c, query)).collect();
+        if filtered.is_empty() {
+            return false;
         }
-        .into_iter()
-        .filter(|command| commands::matches_query(command, &query))
-        .collect();
+
+        let label = gtk4::Label::new(Some(section_label));
+        label.set_xalign(0.0);
+        label.add_css_class("dim-label");
+        label.add_css_class("caption");
+        label.set_margin_start(6);
+        label.set_margin_top(8);
+        label.set_margin_bottom(2);
+        let label_row = gtk4::ListBoxRow::new();
+        label_row.set_child(Some(&label));
+        label_row.set_selectable(false);
+        label_row.set_activatable(false);
+        imp.command_list.append(&label_row);
 
         for command in &filtered {
             let action_row = adw::ActionRow::new();
@@ -288,21 +355,18 @@ impl Window {
             imp.command_list.append(&action_row);
 
             let win = self.clone();
-            let command_for_run = command.clone();
+            let command_for_run = (*command).clone();
             action_row.connect_activated(move |_| {
                 win.execute_saved_command(&command_for_run, CommandRunMode::Run);
             });
 
             let win = self.clone();
-            let command_clone = command.clone();
+            let command_clone = (*command).clone();
             insert_button.connect_clicked(move |_| {
                 win.execute_saved_command(&command_clone, CommandRunMode::Insert);
             });
         }
-
-        let is_empty = imp.command_list.row_at_index(0).is_none();
-        imp.command_scroll.set_visible(!is_empty);
-        imp.command_empty.set_visible(is_empty);
+        true
     }
 
     /// Collect all host keys referenced by places and commands.

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3835,10 +3835,7 @@ fn command_sidebar_filters_by_selected_host() {
     // Default is local host — should show local + global commands with section headers
     // 2 sections (Local header + cmd, Global header + cmd) = 4 rows
     let count = window.imp().command_list.observe_children().n_items();
-    assert_eq!(
-        count, 4,
-        "local host should show 2 section headers + 2 commands, got {count}"
-    );
+    assert_eq!(count, 4, "local host should show 2 section headers + 2 commands, got {count}");
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
@@ -3882,10 +3879,7 @@ fn command_sidebar_groups_by_host_in_all_hosts_view() {
 
     // All Hosts view: 3 sections (Local header + cmd, example header + cmd, Global header + cmd)
     let count = window.imp().command_list.observe_children().n_items();
-    assert_eq!(
-        count, 6,
-        "All Hosts should show 3 section headers + 3 commands, got {count}"
-    );
+    assert_eq!(count, 6, "All Hosts should show 3 section headers + 3 commands, got {count}");
 
     // Verify section headers are present by checking first row is non-activatable (header)
     let first_row = window.imp().command_list.row_at_index(0).unwrap();

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3832,9 +3832,132 @@ fn command_sidebar_filters_by_selected_host() {
     window.present();
     pump_events(50);
 
-    // Default is local host — should show local + global commands
+    // Default is local host — should show local + global commands with section headers
+    // 2 sections (Local header + cmd, Global header + cmd) = 4 rows
     let count = window.imp().command_list.observe_children().n_items();
-    assert_eq!(count, 2, "local host should show local + global commands, got {count}");
+    assert_eq!(
+        count, 4,
+        "local host should show 2 section headers + 2 commands, got {count}"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn command_sidebar_groups_by_host_in_all_hosts_view() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let config_dir = tmp.path().join("rttx-devel");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let hosts = vec![crate::host::Host::remote("deploy@example.com")];
+    crate::host::save_to(&hosts, &config_dir.join("hosts.json")).unwrap();
+
+    let mut local_cmd = crate::commands::SavedCommand::new("Local cmd", "echo local");
+    local_cmd.host_tags = vec!["local".into()];
+    let mut remote_cmd = crate::commands::SavedCommand::new("Remote cmd", "echo remote");
+    remote_cmd.host_tags = vec!["example.com".into()];
+    let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
+    crate::commands::save(&[local_cmd, remote_cmd, global_cmd]).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.command-all-hosts-sections-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Select "All Hosts" (last entry in the dropdown)
+    let dd = &window.imp().host_selector;
+    let all_hosts_idx = dd.model().unwrap().n_items() - 1;
+    dd.set_selected(all_hosts_idx);
+    pump_events(50);
+
+    // All Hosts view: 3 sections (Local header + cmd, example header + cmd, Global header + cmd)
+    let count = window.imp().command_list.observe_children().n_items();
+    assert_eq!(
+        count, 6,
+        "All Hosts should show 3 section headers + 3 commands, got {count}"
+    );
+
+    // Verify section headers are present by checking first row is non-activatable (header)
+    let first_row = window.imp().command_list.row_at_index(0).unwrap();
+    assert!(!first_row.is_activatable(), "first row should be a non-activatable section header");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn command_sidebar_shows_sections_for_specific_host() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let mut local_cmd = crate::commands::SavedCommand::new("Local cmd", "echo local");
+    local_cmd.host_tags = vec!["local".into()];
+    let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
+    crate::commands::save(&[local_cmd, global_cmd]).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.command-host-sections-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Default is local host — should show "Local" section + "Global" section
+    // Local header + local_cmd + Global header + global_cmd = 4
+    let count = window.imp().command_list.observe_children().n_items();
+    assert_eq!(
+        count, 4,
+        "specific host should show host section + global section with headers, got {count}"
+    );
+
+    // First row should be a section header (non-activatable)
+    let first_row = window.imp().command_list.row_at_index(0).unwrap();
+    assert!(!first_row.is_activatable(), "first row should be a section header");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn command_sidebar_only_global_section_when_no_host_commands() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
+    crate::commands::save(&[global_cmd]).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.command-global-only-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    // Only global commands — should show just Global section header + command
+    let count = window.imp().command_list.observe_children().n_items();
+    assert_eq!(count, 2, "should show Global header + 1 command, got {count}");
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");


### PR DESCRIPTION
## What changed and why

The Commands tab in the right tools sidebar previously showed all commands in a flat list regardless of host selection. The Places tab already grouped items by host with section headers — this PR makes the Commands tab consistent.

**When a specific host is selected:** commands are split into a host-specific section and a Global section, each with a header label.

**When All Hosts is selected:** commands are grouped by each host key with section headers, plus a Global section for untagged commands. Orphaned host tags show an `(orphaned)` suffix.

Extracted `append_command_section` helper to build section headers and command rows, mirroring the existing `append_place_section` pattern for Places.

## Manual verification

1. Add commands with different host tags (local, remote, global)
2. Select a specific host → see host-specific + Global sections with headers
3. Select All Hosts → see commands grouped by host key with section headers
4. Verify orphaned host tags show `(orphaned)` suffix
5. Verify search filtering works within sections
6. Verify drag-and-drop reorder still works
7. Verify empty state still shows when no commands match

## Tests added

- `command_sidebar_groups_by_host_in_all_hosts_view` — verifies All Hosts view shows 3 sections (local, remote, global) with correct row count
- `command_sidebar_shows_sections_for_specific_host` — verifies specific host view shows host + global sections
- `command_sidebar_only_global_section_when_no_host_commands` — verifies only Global section appears when no host-tagged commands exist
- Updated `command_sidebar_filters_by_selected_host` — adjusted expected row count to include section headers

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 5 command_sidebar tests pass)

Fixes #572