### PR TITLE
fix(sidebar): add visual gap between tool selector and content list

### DIFF
--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -290,6 +290,7 @@ mod imp {
             utility_switcher.set_margin_start(12);
             utility_switcher.set_margin_end(12);
             utility_switcher.set_margin_top(8);
+            utility_switcher.set_margin_bottom(4);
 
             self.utility_sidebar_box.set_orientation(gtk4::Orientation::Vertical);
             self.utility_sidebar_box.append(&self.sidebar_search_entry);

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2321,3 +2321,46 @@ fn persistent_pane_header_title_combines_daemon_title_and_cwd() {
     pane.set_daemon_title("vim");
     assert_eq!(pane.title_label().label(), "vim : /var/log");
 }
+
+/// Regression for #574: the StackSwitcher (Places/Commands tab selector)
+/// must have a bottom margin so there is a visual gap between the tool
+/// selector and the content list below it.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn utility_switcher_has_bottom_margin() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    set_env("XDG_CONFIG_HOME", tmp.path());
+    set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.utility-switcher-gap-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = rttx::window::Window::new(&app);
+    window.set_default_size(1200, 800);
+    window.present();
+    pump_events(100);
+
+    let sidebar_box = &window.imp().utility_sidebar_box;
+    let mut found_switcher = false;
+    let mut child = sidebar_box.first_child();
+    while let Some(widget) = child {
+        if widget.is::<gtk4::StackSwitcher>() {
+            assert!(
+                widget.margin_bottom() > 0,
+                "StackSwitcher must have a bottom margin for visual separation from content"
+            );
+            found_switcher = true;
+            break;
+        }
+        child = widget.next_sibling();
+    }
+    assert!(found_switcher, "utility sidebar must contain a StackSwitcher");
+
+    window.close();
+    remove_env("RTTX_DISABLE_SHELL_SPAWN");
+    remove_env("XDG_CONFIG_HOME");
+}


### PR DESCRIPTION
## What changed and why

The StackSwitcher (Places/Commands tab selector) in the right tools sidebar had no bottom margin, so the tab selector and the content list below it appeared visually merged. Added `margin_bottom(4)` to the StackSwitcher to create a clear visual gap.

Fixes #574

## How to manually verify

1. Open rttx
2. Toggle the right tools sidebar (Ctrl+Shift+B)
3. Observe the gap between the Places/Commands tab selector and the content list below it
4. The gap should be visually distinct — the selector and list should not appear merged

## Tests added

- `utility_switcher_has_bottom_margin` — GTK widget test that verifies the StackSwitcher in the utility sidebar has a non-zero bottom margin

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (GTK tests skipped in headless env — no display available)

## Limitations

- GTK widget test `utility_switcher_has_bottom_margin` cannot run in the current headless environment (no Broadway display available to Rust GTK). The test is structurally correct and will run in CI or on a machine with a display.