### PR TITLE
fix: remove session and dismiss runtime when closing last workspace

### DIFF
--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1015,6 +1015,14 @@ impl Window {
                     s.uses_managed_runtime()
                         .then(|| (s.runtime.endpoint.clone(), s.runtime.runtime_id.clone()))
                 });
+                // Remove the session and dismiss the runtime so save_state()
+                // (triggered by close_request) writes clean state to disk.
+                state.sessions.retain(|s| s.uuid != session_uuid);
+                if let Some((_, ref runtime_id)) = managed_runtime
+                    && let Some(runtime_id) = runtime_id
+                {
+                    state.dismissed_runtime_ids.insert(runtime_id.clone());
+                }
                 drop(state);
                 if let Some((endpoint, runtime_id)) = managed_runtime
                     && let Some(manager) = imp.connection_manager.borrow().as_ref()

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -5264,3 +5264,111 @@ fn rebuild_session_content_preserves_terminals_from_other_workspaces() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+/// Closing the last managed workspace must remove the session from state
+/// and add the runtime_id to dismissed_runtime_ids so the daemon session
+/// is not resurrected on next launch. Regression test for #578.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn close_last_managed_workspace_dismisses_runtime() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.close-last-managed-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    // Replace the default session with a managed one that has a runtime_id.
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let managed = crate::test_helpers::managed_session_with_runtime(
+        "managed-ws",
+        "Managed",
+        crate::test_helpers::term("t1"),
+        crate::runtime::RuntimeEndpoint::Local,
+        crate::runtime::WorkspacePolicy::Persistent,
+        Some(runtime_id),
+    );
+    let session_uuid = managed.uuid.clone();
+    {
+        let mut state = window.imp().state.borrow_mut();
+        state.sessions.clear();
+        state.sessions.push(managed.clone());
+    }
+    window.build_session(&managed, false);
+
+    assert_eq!(window.imp().state.borrow().sessions.len(), 1);
+
+    window.close_session(&session_uuid);
+    pump_events(50);
+
+    let state = window.imp().state.borrow();
+    assert!(
+        !state.sessions.iter().any(|s| s.uuid == session_uuid),
+        "closed managed workspace must be removed from state"
+    );
+    assert!(
+        state.dismissed_runtime_ids.contains(runtime_id),
+        "runtime_id must be added to dismissed_runtime_ids"
+    );
+
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+/// After closing the last managed workspace, the persisted state must not
+/// contain the closed session. This prevents resurrection on next launch.
+/// Regression test for #578.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn close_last_managed_workspace_persists_clean_state() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.close-last-managed-persist-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    let runtime_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    let managed = crate::test_helpers::managed_session_with_runtime(
+        "managed-ws",
+        "Managed",
+        crate::test_helpers::term("t1"),
+        crate::runtime::RuntimeEndpoint::Local,
+        crate::runtime::WorkspacePolicy::Persistent,
+        Some(runtime_id),
+    );
+    let session_uuid = managed.uuid.clone();
+    {
+        let mut state = window.imp().state.borrow_mut();
+        state.sessions.clear();
+        state.sessions.push(managed.clone());
+    }
+    window.build_session(&managed, false);
+
+    window.close_session(&session_uuid);
+    pump_events(50);
+
+    // Reload persisted state and verify the closed session is gone.
+    let saved = crate::session::load_window_state();
+    assert!(
+        !saved.sessions.iter().any(|s| s.uuid == session_uuid),
+        "persisted state must not contain the closed managed workspace"
+    );
+    assert!(
+        saved.dismissed_runtime_ids.contains(runtime_id),
+        "persisted state must contain the dismissed runtime_id"
+    );
+
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}


### PR DESCRIPTION
## What changed and why

When closing the last workspace in a window (`close_session()` with `sessions.len() <= 1`), the session was not removed from state and the `runtime_id` was not added to `dismissed_runtime_ids` before the window closed. This meant:

1. `save_state()` (triggered by `close_request`) wrote the session back to disk
2. On next launch, the session was loaded from disk with its `runtime_id` intact
3. If the daemon was still running, inventory reconciliation resurrected the workspace

The multi-workspace close path already handled this correctly. This fix aligns the last-workspace path to match.

### Root cause

The last-workspace branch in `close_session()` called `self.close()` without first removing the session from state or dismissing the runtime_id. The `close_request` handler calls `save_state()` which persisted the stale session.

## Manual verification steps

1. Start rttx with a daemon-backed workspace
2. Close the workspace (Ctrl+Shift+W or context menu → Close)
3. Relaunch rttx
4. Verify the workspace is not resurrected from the daemon

## Tests added

- `close_last_managed_workspace_dismisses_runtime` — GTK test verifying the session is removed from state and runtime_id is dismissed
- `close_last_managed_workspace_persists_clean_state` — GTK test verifying persisted state does not contain the closed session

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` — clean
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 533 passed, 146 ignored
- `cargo test -p rttx-proto -p rttx-server` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass (GTK tests skip in this environment due to no display, same as all other GTK tests)

Fixes #578