### PR TITLE
feat(commands): replace host tags text entry with checkbox list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.38"
+version = "0.2.39"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/commands_window.rs
+++ b/clients/rttx/src/commands_window.rs
@@ -4,7 +4,7 @@ use libadwaita::prelude::*;
 
 use crate::commands::{self, CommandRunMode, SavedCommand};
 use crate::form_dialog::FormDialog;
-use crate::host;
+use crate::host_tag_picker::HostTagPicker;
 use crate::window::Window;
 
 pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
@@ -26,26 +26,25 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
     run_mode_row.add_suffix(&run_mode);
     run_mode_row.set_activatable_widget(Some(&run_mode));
 
-    let host_tags_row =
-        adw::EntryRow::builder().title("Host tags (comma-separated, empty = global)").build();
+    let selected_tags = command.map_or_else(Vec::new, |c| c.host_tags.clone());
+    let host_picker = HostTagPicker::new(&selected_tags);
 
     let title_group = adw::PreferencesGroup::new();
     title_group.add(&title_row);
 
     let behavior_group = adw::PreferencesGroup::new();
     behavior_group.add(&run_mode_row);
-    behavior_group.add(&host_tags_row);
 
     form.content_box.append(&title_group);
     form.content_box.append(&body_scroll);
     form.content_box.append(&behavior_group);
+    form.content_box.append(&host_picker.group);
     form.finish_layout();
 
     if let Some(c) = command {
         title_row.set_text(&c.title);
         body_buffer.set_text(&c.body);
         run_mode.set_selected(run_mode_index(c.default_run_mode));
-        host_tags_row.set_text(&c.host_tags.join(", "));
     }
 
     let dialog = form.dialog.clone();
@@ -56,7 +55,7 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
             &title_row,
             &body_buffer,
             &run_mode,
-            &host_tags_row,
+            &host_picker,
             existing_uuid.clone(),
         ) {
             Ok(c) => c,
@@ -87,7 +86,7 @@ fn build_command(
     title_row: &adw::EntryRow,
     body_buffer: &gtk4::TextBuffer,
     run_mode: &gtk4::DropDown,
-    host_tags_row: &adw::EntryRow,
+    host_picker: &HostTagPicker,
     existing_uuid: Option<String>,
 ) -> Result<SavedCommand, String> {
     let title = title_row.text().trim().to_string();
@@ -106,20 +105,8 @@ fn build_command(
         command.uuid = uuid;
     }
     command.default_run_mode = run_mode_from_index(run_mode.selected());
-    command.host_tags = parse_host_tags(&host_tags_row.text());
+    command.host_tags = host_picker.selected_tags();
     Ok(command)
-}
-
-/// Parse a comma-separated host tags string into a deduplicated list of host keys.
-pub(crate) fn parse_host_tags(input: &str) -> Vec<String> {
-    let mut tags: Vec<String> = input
-        .split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(host::normalize_ssh_key)
-        .collect();
-    tags.dedup();
-    tags
 }
 
 const fn run_mode_from_index(index: u32) -> CommandRunMode {
@@ -133,36 +120,5 @@ const fn run_mode_index(run_mode: CommandRunMode) -> u32 {
     match run_mode {
         CommandRunMode::Run => 0,
         CommandRunMode::Insert => 1,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_host_tags_splits_on_comma() {
-        assert_eq!(parse_host_tags("local, example.com"), vec!["local", "example.com"]);
-    }
-
-    #[test]
-    fn parse_host_tags_trims_whitespace() {
-        assert_eq!(parse_host_tags("  local ,  example.com  "), vec!["local", "example.com"]);
-    }
-
-    #[test]
-    fn parse_host_tags_empty_string_returns_empty_vec() {
-        assert!(parse_host_tags("").is_empty());
-        assert!(parse_host_tags("  ").is_empty());
-    }
-
-    #[test]
-    fn parse_host_tags_normalizes_ssh_keys() {
-        assert_eq!(parse_host_tags("deploy@Example.COM"), vec!["example.com"]);
-    }
-
-    #[test]
-    fn parse_host_tags_deduplicates() {
-        assert_eq!(parse_host_tags("local, local"), vec!["local"]);
     }
 }

--- a/clients/rttx/src/host_tag_picker.rs
+++ b/clients/rttx/src/host_tag_picker.rs
@@ -69,11 +69,8 @@ impl HostTagPicker {
 
     fn add_row(group: &adw::PreferencesGroup, key: &str, label: &str) -> gtk4::CheckButton {
         let check = gtk4::CheckButton::new();
-        let row = adw::ActionRow::builder()
-            .title(label)
-            .subtitle(key)
-            .activatable_widget(&check)
-            .build();
+        let row =
+            adw::ActionRow::builder().title(label).subtitle(key).activatable_widget(&check).build();
         row.add_prefix(&check);
         group.add(&row);
         check

--- a/clients/rttx/src/host_tag_picker.rs
+++ b/clients/rttx/src/host_tag_picker.rs
@@ -1,0 +1,121 @@
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use crate::host;
+
+/// A checkbox-based host selector for command and place editors.
+///
+/// Shows one row per known host (local + saved remotes) with a checkbox.
+/// When no hosts are checked the item is global (visible everywhere).
+pub struct HostTagPicker {
+    pub group: adw::PreferencesGroup,
+    checks: Vec<(String, gtk4::CheckButton)>,
+}
+
+impl std::fmt::Debug for HostTagPicker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let keys: Vec<&str> = self.checks.iter().map(|(k, _)| k.as_str()).collect();
+        f.debug_struct("HostTagPicker")
+            .field("group", &"<PreferencesGroup>")
+            .field("keys", &keys)
+            .finish()
+    }
+}
+
+impl HostTagPicker {
+    /// Build a picker from saved hosts, pre-checking `selected_tags`.
+    #[must_use]
+    pub fn new(selected_tags: &[String]) -> Self {
+        Self::with_hosts(&host::load(), selected_tags)
+    }
+
+    /// Build a picker from an explicit host list, pre-checking `selected_tags`.
+    #[must_use]
+    pub fn with_hosts(saved_hosts: &[host::Host], selected_tags: &[String]) -> Self {
+        let group = adw::PreferencesGroup::builder()
+            .title("Hosts")
+            .description("No selection means global (visible on all hosts)")
+            .build();
+
+        let mut checks: Vec<(String, gtk4::CheckButton)> = Vec::new();
+
+        // Local host — always first
+        let local_check = Self::add_row(&group, host::LOCAL_KEY, "Local");
+        local_check.set_active(selected_tags.contains(&host::LOCAL_KEY.to_string()));
+        checks.push((host::LOCAL_KEY.into(), local_check));
+
+        for h in saved_hosts {
+            if h.key == host::LOCAL_KEY {
+                continue;
+            }
+            let check = Self::add_row(&group, &h.key, &h.name);
+            check.set_active(selected_tags.contains(&h.key));
+            checks.push((h.key.clone(), check));
+        }
+
+        Self { group, checks }
+    }
+
+    /// Collect the host keys whose checkboxes are active.
+    #[must_use]
+    pub fn selected_tags(&self) -> Vec<String> {
+        self.checks
+            .iter()
+            .filter(|(_, check)| check.is_active())
+            .map(|(key, _)| key.clone())
+            .collect()
+    }
+
+    fn add_row(group: &adw::PreferencesGroup, key: &str, label: &str) -> gtk4::CheckButton {
+        let check = gtk4::CheckButton::new();
+        let row = adw::ActionRow::builder()
+            .title(label)
+            .subtitle(key)
+            .activatable_widget(&check)
+            .build();
+        row.add_prefix(&check);
+        group.add(&row);
+        check
+    }
+}
+
+/// Extract selected host tags from a list of `(key, is_active)` pairs.
+///
+/// Pure logic helper for testing without GTK.
+#[must_use]
+pub fn collect_selected(pairs: &[(String, bool)]) -> Vec<String> {
+    pairs.iter().filter(|(_, active)| *active).map(|(key, _)| key.clone()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_selected_returns_active_keys() {
+        let pairs = vec![
+            ("local".to_string(), true),
+            ("example.com".to_string(), false),
+            ("other.com".to_string(), true),
+        ];
+        assert_eq!(collect_selected(&pairs), vec!["local", "other.com"]);
+    }
+
+    #[test]
+    fn collect_selected_empty_when_none_active() {
+        let pairs = vec![("local".to_string(), false), ("example.com".to_string(), false)];
+        assert!(collect_selected(&pairs).is_empty());
+    }
+
+    #[test]
+    fn collect_selected_all_when_all_active() {
+        let pairs = vec![("local".to_string(), true), ("example.com".to_string(), true)];
+        assert_eq!(collect_selected(&pairs), vec!["local", "example.com"]);
+    }
+
+    #[test]
+    fn collect_selected_empty_input() {
+        assert!(collect_selected(&[]).is_empty());
+    }
+}

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -7,6 +7,7 @@ pub mod daemon;
 pub mod daemon_bridge;
 pub mod form_dialog;
 pub mod host;
+pub mod host_tag_picker;
 pub mod new_workspace_dialog;
 pub mod places;
 pub mod places_window;

--- a/clients/rttx/src/places_window.rs
+++ b/clients/rttx/src/places_window.rs
@@ -3,6 +3,7 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 
 use crate::form_dialog::FormDialog;
+use crate::host_tag_picker::HostTagPicker;
 use crate::places::{self, Place};
 use crate::window::Window;
 
@@ -13,34 +14,35 @@ pub fn show_form(parent: &Window, place: Option<&Place>) {
 
     let name_row = adw::EntryRow::builder().title("Name").build();
     let path_row = adw::EntryRow::builder().title("Path").build();
-    let host_tags_row =
-        adw::EntryRow::builder().title("Host tags (comma-separated, empty = global)").build();
+
+    let selected_tags = place.map_or_else(Vec::new, |p| p.host_tags.clone());
+    let host_picker = HostTagPicker::new(&selected_tags);
 
     let group = adw::PreferencesGroup::new();
     group.add(&name_row);
     group.add(&path_row);
-    group.add(&host_tags_row);
 
     form.content_box.append(&group);
+    form.content_box.append(&host_picker.group);
     form.finish_layout();
 
     if let Some(p) = place {
         name_row.set_text(&p.name);
         path_row.set_text(&p.path);
-        host_tags_row.set_text(&p.host_tags.join(", "));
     }
 
     let dialog = form.dialog.clone();
     let status_label = form.status_label.clone();
     let parent_for_save = parent.clone();
     form.save_button.connect_clicked(move |_| {
-        let place = match build_place(&name_row, &path_row, &host_tags_row, existing_uuid.clone()) {
-            Ok(p) => p,
-            Err(msg) => {
-                status_label.set_text(&msg);
-                return;
-            }
-        };
+        let place =
+            match build_place(&name_row, &path_row, &host_picker, existing_uuid.clone()) {
+                Ok(p) => p,
+                Err(msg) => {
+                    status_label.set_text(&msg);
+                    return;
+                }
+            };
 
         let mut items = places::load();
         if let Some(existing) = items.iter_mut().find(|i| i.uuid == place.uuid) {
@@ -62,7 +64,7 @@ pub fn show_form(parent: &Window, place: Option<&Place>) {
 fn build_place(
     name_row: &adw::EntryRow,
     path_row: &adw::EntryRow,
-    host_tags_row: &adw::EntryRow,
+    host_picker: &HostTagPicker,
     existing_uuid: Option<String>,
 ) -> Result<Place, String> {
     let name = name_row.text().trim().to_string();
@@ -79,6 +81,6 @@ fn build_place(
     if let Some(uuid) = existing_uuid {
         place.uuid = uuid;
     }
-    place.host_tags = crate::commands_window::parse_host_tags(&host_tags_row.text());
+    place.host_tags = host_picker.selected_tags();
     Ok(place)
 }

--- a/clients/rttx/src/places_window.rs
+++ b/clients/rttx/src/places_window.rs
@@ -35,14 +35,13 @@ pub fn show_form(parent: &Window, place: Option<&Place>) {
     let status_label = form.status_label.clone();
     let parent_for_save = parent.clone();
     form.save_button.connect_clicked(move |_| {
-        let place =
-            match build_place(&name_row, &path_row, &host_picker, existing_uuid.clone()) {
-                Ok(p) => p,
-                Err(msg) => {
-                    status_label.set_text(&msg);
-                    return;
-                }
-            };
+        let place = match build_place(&name_row, &path_row, &host_picker, existing_uuid.clone()) {
+            Ok(p) => p,
+            Err(msg) => {
+                status_label.set_text(&msg);
+                return;
+            }
+        };
 
         let mut items = places::load();
         if let Some(existing) = items.iter_mut().find(|i| i.uuid == place.uuid) {

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2451,10 +2451,8 @@ fn host_tag_picker_unrecognized_tag_not_checked() {
     require_display!();
 
     // If selected_tags contains a host not in the saved list, it won't appear
-    let picker = rttx::host_tag_picker::HostTagPicker::with_hosts(
-        &[],
-        &["unknown.example.com".to_string()],
-    );
+    let picker =
+        rttx::host_tag_picker::HostTagPicker::with_hosts(&[], &["unknown.example.com".to_string()]);
 
     // Only local is in the picker, and it's not selected
     assert!(picker.selected_tags().is_empty());

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2364,3 +2364,98 @@ fn utility_switcher_has_bottom_margin() {
     remove_env("RTTX_DISABLE_SHELL_SPAWN");
     remove_env("XDG_CONFIG_HOME");
 }
+
+// ── HostTagPicker widget tests ──────────────────────────────────
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_tag_picker_shows_local_checkbox() {
+    require_display!();
+
+    let picker = rttx::host_tag_picker::HostTagPicker::with_hosts(&[], &[]);
+
+    // No hosts checked → empty selection (global)
+    assert!(picker.selected_tags().is_empty());
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_tag_picker_prechecks_selected_tags() {
+    require_display!();
+
+    let picker = rttx::host_tag_picker::HostTagPicker::with_hosts(&[], &["local".to_string()]);
+
+    let tags = picker.selected_tags();
+    assert_eq!(tags, vec!["local"]);
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_tag_picker_shows_saved_remote_hosts() {
+    require_display!();
+
+    let host = rttx::host::Host::remote("deploy@example.com");
+    let picker =
+        rttx::host_tag_picker::HostTagPicker::with_hosts(&[host], &["example.com".to_string()]);
+
+    let tags = picker.selected_tags();
+    assert_eq!(tags, vec!["example.com"]);
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_tag_picker_no_selection_means_global() {
+    require_display!();
+
+    let host = rttx::host::Host::remote("deploy@example.com");
+    let picker = rttx::host_tag_picker::HostTagPicker::with_hosts(&[host], &[]);
+
+    assert!(picker.selected_tags().is_empty(), "no selection should mean global");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_tag_picker_multiple_hosts_selected() {
+    require_display!();
+
+    let host = rttx::host::Host::remote("deploy@example.com");
+    let picker = rttx::host_tag_picker::HostTagPicker::with_hosts(
+        &[host],
+        &["local".to_string(), "example.com".to_string()],
+    );
+
+    let tags = picker.selected_tags();
+    assert_eq!(tags, vec!["local", "example.com"]);
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_tag_picker_skips_duplicate_local_in_saved_hosts() {
+    require_display!();
+
+    // If saved hosts somehow contain a "local" entry, it should not duplicate
+    let local_host = rttx::host::Host::local();
+    let remote = rttx::host::Host::remote("example.com");
+    let picker = rttx::host_tag_picker::HostTagPicker::with_hosts(
+        &[local_host, remote],
+        &["local".to_string()],
+    );
+
+    let tags = picker.selected_tags();
+    assert_eq!(tags, vec!["local"], "local should appear only once");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn host_tag_picker_unrecognized_tag_not_checked() {
+    require_display!();
+
+    // If selected_tags contains a host not in the saved list, it won't appear
+    let picker = rttx::host_tag_picker::HostTagPicker::with_hosts(
+        &[],
+        &["unknown.example.com".to_string()],
+    );
+
+    // Only local is in the picker, and it's not selected
+    assert!(picker.selected_tags().is_empty());
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.38',
+  version: '0.2.39',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Replace the comma-separated host tags text entry in both the command and place editors with a checkbox-based host selector. Each known host (local + saved remote hosts) gets its own checkbox row using `adw::ActionRow` with a `CheckButton` prefix.

This makes host selection discoverable and consistent — users no longer need to remember exact host key strings or type them manually.

**No selection means global** (visible on all hosts), matching the previous behavior of an empty text field.

Fixes #580

## Changes

- New `host_tag_picker` module with `HostTagPicker` widget that builds a `PreferencesGroup` with checkbox rows
- `with_hosts()` constructor accepts an explicit host list for testability
- `commands_window.rs`: replaced `host_tags_row` (EntryRow) with `HostTagPicker`
- `places_window.rs`: replaced `host_tags_row` (EntryRow) with `HostTagPicker`
- Removed `parse_host_tags()` function and its tests (no longer needed)
- Version bump to 0.2.39

## Manual verification

1. Open rttx, go to Commands tab, click + to add a new command
2. Verify the Hosts section shows checkboxes for Local and any saved remote hosts
3. Check Local, save, verify the command appears only under Local host section
4. Edit the command, verify Local is pre-checked
5. Uncheck all hosts, save, verify the command appears as global
6. Repeat for Places tab

## Tests added

**Unit tests** (4):
- `collect_selected_returns_active_keys`
- `collect_selected_empty_when_none_active`
- `collect_selected_all_when_all_active`
- `collect_selected_empty_input`

**GTK widget tests** (7):
- `host_tag_picker_shows_local_checkbox`
- `host_tag_picker_prechecks_selected_tags`
- `host_tag_picker_shows_saved_remote_hosts`
- `host_tag_picker_no_selection_means_global`
- `host_tag_picker_multiple_hosts_selected`
- `host_tag_picker_skips_duplicate_local_in_saved_hosts`
- `host_tag_picker_unrecognized_tag_not_checked`

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (532 passed)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 11 host_tag_picker tests pass)
- `./run_ui_tests.sh` — 7 pre-existing failures (same on mainline), no new failures