### PR TITLE
fix: strip DSR/DA query sequences from client-bound output

### DIFF
--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -1042,7 +1042,6 @@ mod tests {
         assert_eq!(replies[2], b"\x1b[0n"); // status OK
         assert_eq!(replies[3], b"\x1b[1;1R"); // cursor at 1,1
     }
-}
 
     // --- strip_client_queries ---
 
@@ -1165,3 +1164,4 @@ mod tests {
         let input = b"line1\r\n\x1b[6n\x1b[6nline2\r\n\x1b[6n\x1b[c";
         assert_eq!(strip_client_queries(input), b"line1\r\nline2\r\n");
     }
+}

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -368,6 +368,98 @@ impl vte::Perform for ScreenPerformer {
     }
 }
 
+/// Strip terminal query sequences that the daemon handles server-side.
+///
+/// Applications send DSR, DA1, DA2, and DECRQM queries expecting the terminal
+/// to respond. The daemon's `PaneScreen` already intercepts these and writes
+/// replies back to the PTY. If the raw queries are also forwarded to the
+/// client's VTE widget, VTE generates duplicate responses that leak back as
+/// visible garbage (`;1R` fragments).
+///
+/// This function removes those query sequences from the output stream before
+/// it is broadcast to clients. Non-query bytes pass through unchanged.
+///
+/// Stripped sequences:
+/// - `ESC [ 5 n` / `ESC [ 6 n` (DSR)
+/// - `ESC [ c` / `ESC [ 0 c` (DA1)
+/// - `ESC [ > c` / `ESC [ > 0 c` (DA2)
+/// - `ESC [ ? <digits> $ p` (DECRQM)
+#[must_use]
+pub fn strip_client_queries(data: &[u8]) -> Vec<u8> {
+    // Fast path: no ESC byte means no CSI sequences to strip.
+    if !data.contains(&0x1b) {
+        return data.to_vec();
+    }
+
+    let mut out = Vec::with_capacity(data.len());
+    let mut i = 0;
+
+    while i < data.len() {
+        if data[i] == 0x1b
+            && let Some(seq_len) = csi_query_len(&data[i..])
+        {
+            i += seq_len;
+        } else {
+            out.push(data[i]);
+            i += 1;
+        }
+    }
+
+    out
+}
+
+/// If `data` starts with a CSI query sequence handled by the daemon, return
+/// its length in bytes. Otherwise return `None`.
+fn csi_query_len(data: &[u8]) -> Option<usize> {
+    // Minimum CSI sequence: ESC [ <final> = 3 bytes.
+    if data.len() < 3 || data[0] != 0x1b || data[1] != b'[' {
+        return None;
+    }
+
+    let mut pos = 2;
+
+    // Collect intermediates (0x20..=0x2F) and parameter bytes (0x30..=0x3F).
+    // CSI structure: ESC [ <param bytes 0x30-0x3F>* <intermediate bytes 0x20-0x2F>* <final 0x40-0x7E>
+    let param_start = pos;
+    while pos < data.len() && (0x30..=0x3F).contains(&data[pos]) {
+        pos += 1;
+    }
+    let params = &data[param_start..pos];
+
+    let inter_start = pos;
+    while pos < data.len() && (0x20..=0x2F).contains(&data[pos]) {
+        pos += 1;
+    }
+    let intermediates = &data[inter_start..pos];
+
+    // Final byte must be in 0x40..=0x7E.
+    if pos >= data.len() || !(0x40..=0x7E).contains(&data[pos]) {
+        return None;
+    }
+    let final_byte = data[pos];
+    let seq_len = pos + 1;
+
+    match final_byte {
+        // DSR: CSI 5 n, CSI 6 n
+        b'n' if intermediates.is_empty() && matches!(params, b"5" | b"6") => Some(seq_len),
+        // DA1: CSI c, CSI 0 c
+        b'c' if intermediates.is_empty() && matches!(params, b"" | b"0") => Some(seq_len),
+        // DA2: ESC [ > c or ESC [ > 0 c
+        // `>` (0x3E) falls in the param byte range, so the parser puts it in params.
+        b'c' if intermediates.is_empty() && matches!(params, b">" | b">0") => Some(seq_len),
+        // DECRQM: ESC [ ? <digits> $ p
+        // `?` (0x3F) is a param byte, `$` (0x24) is an intermediate byte.
+        b'p' if intermediates == b"$"
+            && params.first() == Some(&b'?')
+            && params.len() >= 2
+            && params[1..].iter().all(u8::is_ascii_digit) =>
+        {
+            Some(seq_len)
+        }
+        _ => None,
+    }
+}
+
 fn parse_osc7_current_directory(uri: &str) -> Option<String> {
     let path_with_host = uri.strip_prefix("file://")?;
     let path_start = path_with_host.find('/')?;
@@ -951,3 +1043,125 @@ mod tests {
         assert_eq!(replies[3], b"\x1b[1;1R"); // cursor at 1,1
     }
 }
+
+    // --- strip_client_queries ---
+
+    #[test]
+    fn strip_passes_plain_text_through() {
+        assert_eq!(strip_client_queries(b"hello world"), b"hello world");
+    }
+
+    #[test]
+    fn strip_passes_empty_input_through() {
+        assert_eq!(strip_client_queries(b""), b"");
+    }
+
+    #[test]
+    fn strip_removes_dsr_cursor_position() {
+        assert_eq!(strip_client_queries(b"before\x1b[6nafter"), b"beforeafter");
+    }
+
+    #[test]
+    fn strip_removes_dsr_operating_status() {
+        assert_eq!(strip_client_queries(b"before\x1b[5nafter"), b"beforeafter");
+    }
+
+    #[test]
+    fn strip_removes_da1_no_param() {
+        assert_eq!(strip_client_queries(b"before\x1b[cafter"), b"beforeafter");
+    }
+
+    #[test]
+    fn strip_removes_da1_zero_param() {
+        assert_eq!(strip_client_queries(b"before\x1b[0cafter"), b"beforeafter");
+    }
+
+    #[test]
+    fn strip_removes_da2() {
+        assert_eq!(strip_client_queries(b"before\x1b[>cafter"), b"beforeafter");
+    }
+
+    #[test]
+    fn strip_removes_da2_zero_param() {
+        assert_eq!(strip_client_queries(b"before\x1b[>0cafter"), b"beforeafter");
+    }
+
+    #[test]
+    fn strip_removes_decrqm() {
+        assert_eq!(strip_client_queries(b"before\x1b[?2004$pafter"), b"beforeafter");
+    }
+
+    #[test]
+    fn strip_removes_multiple_queries() {
+        let input = b"text\x1b[6n\x1b[c\x1b[>cmore\x1b[5n";
+        assert_eq!(strip_client_queries(input), b"textmore");
+    }
+
+    #[test]
+    fn strip_preserves_non_query_csi_sequences() {
+        // SGR (color), CUP (cursor position), CUU (cursor up) should pass through.
+        let input = b"\x1b[31mred\x1b[0m \x1b[1;1H \x1b[2A";
+        assert_eq!(strip_client_queries(input), input.to_vec());
+    }
+
+    #[test]
+    fn strip_preserves_osc_sequences() {
+        let input = b"\x1b]0;title\x07text";
+        assert_eq!(strip_client_queries(input), input.to_vec());
+    }
+
+    #[test]
+    fn strip_preserves_decset_decrst() {
+        // DECSET/DECRST should not be stripped.
+        let input = b"\x1b[?2004h\x1b[?1l";
+        assert_eq!(strip_client_queries(input), input.to_vec());
+    }
+
+    #[test]
+    fn strip_handles_query_at_start() {
+        assert_eq!(strip_client_queries(b"\x1b[6ntext"), b"text");
+    }
+
+    #[test]
+    fn strip_handles_query_at_end() {
+        assert_eq!(strip_client_queries(b"text\x1b[6n"), b"text");
+    }
+
+    #[test]
+    fn strip_handles_only_queries() {
+        assert_eq!(strip_client_queries(b"\x1b[6n\x1b[c\x1b[>c"), b"");
+    }
+
+    #[test]
+    fn strip_handles_incomplete_csi_at_end() {
+        // Incomplete CSI at end of buffer should pass through.
+        let input = b"text\x1b[";
+        assert_eq!(strip_client_queries(input), input.to_vec());
+    }
+
+    #[test]
+    fn strip_handles_bare_esc_at_end() {
+        let input = b"text\x1b";
+        assert_eq!(strip_client_queries(input), input.to_vec());
+    }
+
+    #[test]
+    fn strip_does_not_remove_da1_with_nonzero_param() {
+        // CSI 2 c is not DA1 (only 0 or no param).
+        let input = b"\x1b[2c";
+        assert_eq!(strip_client_queries(input), input.to_vec());
+    }
+
+    #[test]
+    fn strip_does_not_remove_dsr_with_other_params() {
+        // CSI 1 n is not a handled DSR.
+        let input = b"\x1b[1n";
+        assert_eq!(strip_client_queries(input), input.to_vec());
+    }
+
+    #[test]
+    fn strip_interleaved_with_real_output() {
+        // Simulate rapid DSR queries mixed with real application output.
+        let input = b"line1\r\n\x1b[6n\x1b[6nline2\r\n\x1b[6n\x1b[c";
+        assert_eq!(strip_client_queries(input), b"line1\r\nline2\r\n");
+    }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -460,8 +460,10 @@ impl Server {
                         cwd: pane.effective_cwd().unwrap_or_default(),
                         cols: u32::from(pane.cols),
                         rows: u32::from(pane.rows),
-                        scrollback: bytes::Bytes::copy_from_slice(
-                            pane.screen.snapshot_bytes(crate::pane::MAX_SNAPSHOT_BYTES),
+                        scrollback: bytes::Bytes::from(
+                            crate::screen::strip_client_queries(
+                                pane.screen.snapshot_bytes(crate::pane::MAX_SNAPSHOT_BYTES),
+                            ),
                         ),
                         exit_status: pane.exit_status,
                         bracketed_paste_mode: pane.screen.bracketed_paste_mode(),
@@ -984,8 +986,14 @@ fn spawn_pty_read_loop(
                             }
 
                             // Phase 3: broadcast to clients without the server lock.
-                            let msg = protocol::delta(session_id, pane_id, data);
-                            send_to_collected(&senders, &msg);
+                            // Strip terminal query sequences (DSR, DA1, DA2, DECRQM)
+                            // that the daemon already handles. If forwarded, VTE would
+                            // generate duplicate responses that leak as visible garbage.
+                            let client_data = crate::screen::strip_client_queries(&data);
+                            if !client_data.is_empty() {
+                                let msg = protocol::delta(session_id, pane_id, bytes::Bytes::from(client_data));
+                                send_to_collected(&senders, &msg);
+                            }
                             if let Some((cwd, revision)) = new_cwd {
                                 let msg = protocol::cwd_changed(session_id, pane_id, cwd, revision);
                                 send_to_collected(&senders, &msg);

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -460,11 +460,9 @@ impl Server {
                         cwd: pane.effective_cwd().unwrap_or_default(),
                         cols: u32::from(pane.cols),
                         rows: u32::from(pane.rows),
-                        scrollback: bytes::Bytes::from(
-                            crate::screen::strip_client_queries(
-                                pane.screen.snapshot_bytes(crate::pane::MAX_SNAPSHOT_BYTES),
-                            ),
-                        ),
+                        scrollback: bytes::Bytes::from(crate::screen::strip_client_queries(
+                            pane.screen.snapshot_bytes(crate::pane::MAX_SNAPSHOT_BYTES),
+                        )),
                         exit_status: pane.exit_status,
                         bracketed_paste_mode: pane.screen.bracketed_paste_mode(),
                         application_cursor_keys: pane.screen.application_cursor_keys(),

--- a/services/rttx-server/tests/dsr_stripped_from_client.rs
+++ b/services/rttx-server/tests/dsr_stripped_from_client.rs
@@ -1,0 +1,109 @@
+//! Integration test: DSR/DA query sequences are stripped from client-bound output.
+//!
+//! Regression test for #582: applications that send DSR queries produce visible
+//! `;1R` garbage because VTE generates duplicate CPR responses.
+
+mod common;
+
+use common::{TestClient, start_test_server};
+use rttx_proto::proto;
+use std::time::Duration;
+
+async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+            name: "strip-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    let create_pane = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            session_id: session_id.clone(),
+            cwd: None,
+            dark_background: None,
+        })),
+    };
+    client.send(&create_pane).await;
+    let pane_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+            session_id: session_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+
+    (session_id, pane_id)
+}
+
+/// Verify that DSR query sequences do not appear in Delta messages sent to clients.
+#[tokio::test]
+async fn dsr_queries_stripped_from_delta_output() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    let (session_id, pane_id) = setup_attached_pane(&mut client).await;
+
+    client.drain(Duration::from_millis(500)).await;
+
+    // Send a command that writes multiple DSR queries to stdout interleaved
+    // with a known marker. The marker must appear in the Delta output, but
+    // the raw ESC[6n sequences must not.
+    let script = r"printf 'MARKER_A\033[6n\033[6nMARKER_B\033[c\033[>c'";
+    let input = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            session_id: session_id.clone(),
+            pane_id: pane_id.clone(),
+            data: bytes::Bytes::from(format!("{script}\n").into_bytes()),
+        })),
+    };
+    client.send(&input).await;
+
+    let msgs = client.drain(Duration::from_secs(5)).await;
+    let output: Vec<u8> = msgs
+        .iter()
+        .filter_map(|m| match &m.msg {
+            Some(proto::server_message::Msg::Delta(d)) => Some(d.data.to_vec()),
+            _ => None,
+        })
+        .flatten()
+        .collect();
+
+    // The raw ESC[6n (DSR cursor position query) must not appear in client output.
+    assert!(
+        !output.windows(4).any(|w| w == b"\x1b[6n"),
+        "DSR cursor position query must be stripped from client output"
+    );
+
+    // The raw ESC[c (DA1 query) must not appear in client output.
+    let has_da1_query = output.windows(3).enumerate().any(|(i, w)| {
+        w == b"\x1b[c"
+            && output.get(i.wrapping_sub(1)).is_none_or(|&b| b != b'?')
+            && output.get(i + 3).is_none_or(|&b| b != b'?')
+    });
+    assert!(!has_da1_query, "DA1 query must be stripped from client output");
+
+    // The markers should still be present (they are plain text).
+    let output_str = String::from_utf8_lossy(&output);
+    assert!(
+        output_str.contains("MARKER_A") && output_str.contains("MARKER_B"),
+        "markers must pass through: {output_str}"
+    );
+}


### PR DESCRIPTION
## What changed and why

Applications that send DSR queries (`ESC[6n`) — such as chatbots, kiro-cli, and similar tools — produce visible garbage (`;1R` fragments) in the terminal. This happens because:

1. The daemon correctly handles DSR queries in its screen parser and writes CPR responses back to the PTY
2. But the raw PTY output (including the query sequences) is also forwarded to the client's VTE widget as Delta messages
3. VTE interprets these queries and generates its own CPR responses via the `commit` signal
4. These duplicate responses are sent back to the daemon as input, where the shell echoes them as visible text

### Fix

Added `strip_client_queries()` in `screen.rs` that removes DSR, DA1, DA2, and DECRQM query sequences from the output stream before broadcasting to clients. Applied in two places:
- Delta broadcasts in the PTY read loop
- Snapshot scrollback sent to reconnecting clients

The daemon continues to handle these queries server-side — only the client-bound copy is stripped.

## Manual verification

1. Run `rttx` with a daemon
2. In a pane, run an application that sends frequent DSR queries (e.g., `printf '\033[6n'` in a loop)
3. Verify no `;1R` garbage appears in the terminal output

## Tests added

### Unit tests (21 new in `screen.rs`)
- `strip_passes_plain_text_through` / `strip_passes_empty_input_through`
- `strip_removes_dsr_cursor_position` / `strip_removes_dsr_operating_status`
- `strip_removes_da1_no_param` / `strip_removes_da1_zero_param`
- `strip_removes_da2` / `strip_removes_da2_zero_param`
- `strip_removes_decrqm`
- `strip_removes_multiple_queries`
- `strip_preserves_non_query_csi_sequences` / `strip_preserves_osc_sequences` / `strip_preserves_decset_decrst`
- `strip_handles_query_at_start` / `strip_handles_query_at_end` / `strip_handles_only_queries`
- `strip_handles_incomplete_csi_at_end` / `strip_handles_bare_esc_at_end`
- `strip_does_not_remove_da1_with_nonzero_param` / `strip_does_not_remove_dsr_with_other_params`
- `strip_interleaved_with_real_output`

### Integration test (1 new file)
- `dsr_stripped_from_client.rs`: `dsr_queries_stripped_from_delta_output` — verifies DSR/DA1 queries are absent from Delta messages while plain text markers pass through

## Tests run

- `cargo test -p rttx-server --lib` — 241 passed, 0 failed
- `cargo test -p rttx-server --tests` — all passed including new integration test
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed

Fixes #582