### PR TITLE
docs: update RFC template with guidance from established patterns

### DIFF
--- a/designs/RFC-000-template.md
+++ b/designs/RFC-000-template.md
@@ -1,33 +1,44 @@
-# RFC-000: [Short Title]
+# RFC-NNN: [Short Title]
 
-| Field         | Value                                                       |
-|---------------|-------------------------------------------------------------|
-| Status        | Draft / Review / Accepted / Implemented / Superseded        |
-| Author(s)     | [Name]                                                      |
-| Supersedes    | —                                                           |
-| Superseded by | —                                                           |
+<!--
+  Copy this file as RFC-NNN-<slug>.md, where NNN is the next number after the
+  last existing RFC.  Fill in every section; delete only the HTML comments.
+  See CONTRIBUTING.md § "Design process (RFCs)" for when an RFC is required.
+
+  Status lifecycle:  Draft → Review → Accepted → Implemented  (or Superseded)
+  Do not begin implementation until the RFC reaches Accepted.
+-->
+
+| Field         | Value         |
+|---------------|---------------|
+| Status        | Draft         |
+| Author(s)     | [Name]        |
+| Supersedes    | —             |
+| Superseded by | —             |
 
 ---
 
 ## Summary
 
-One paragraph. What is this change, and why does it matter right now?
+One paragraph: what is this change, and why does it matter right now?
 
 ---
 
 ## Goals
 
-- **G1** —
+- **G1** — …
+- **G2** — …
 
 ## Non-Goals
 
-- **NG1** —
+- **NG1** — …
 
 ---
 
 ## Background & Motivation
 
-Context a new contributor needs to understand the problem.
+Context a new contributor needs to understand the problem.  Reference existing
+code paths, issues, or user-visible symptoms that motivate the change.
 
 ---
 
@@ -65,7 +76,8 @@ Rationale: …
 
 ## Design
 
-Technical detail of the chosen approach.
+Technical detail of the chosen approach.  Use subsections, code blocks, and
+tables as needed.
 
 ---
 
@@ -74,22 +86,28 @@ Technical detail of the chosen approach.
 | Goal | How addressed |
 |------|---------------|
 | G1   |               |
+| G2   |               |
 
 ---
 
 ## Development Plan
 
-- [ ] **Step 1** — *(prerequisite: —)*
-- [ ] **Step 2** — *(prerequisite: Step 1)*
+- [ ] **Step 1** — … *(prerequisite: —)*
+- [ ] **Step 2** — … *(prerequisite: Step 1)*
+
+Mark steps `[x]` as they are completed.
 
 ---
 
 ## Open Questions
 
-- [ ] **Q1** —
+- [ ] **Q1** — …
+
+Mark questions `[x]` once resolved and record the answer inline.
 
 ---
 
 ## References
 
-- [Link text](url)
+- [Tracking issue](https://github.com/IllyaYalovyy/rttx/issues/NNN)
+- [Related RFC](./RFC-NNN-slug.md)


### PR DESCRIPTION
## What changed and why

The RFC template (`designs/RFC-000-template.md`) was written before any real RFCs existed. After 20+ RFCs have been written, the template can now reflect the conventions that emerged in practice.

Changes:
- Title uses `RFC-NNN` instead of `RFC-000` so it reads as a template to copy
- HTML comment block with usage instructions, status lifecycle, and CONTRIBUTING.md pointer
- Status field shows a single `Draft` value instead of listing all possible values inline
- Added a second goal placeholder and ellipsis markers throughout for better guidance
- Expanded Background & Motivation and Design section guidance
- Added notes about marking Development Plan steps and Open Questions as complete
- References section shows the two most common link types: tracking issue and related RFC

## Manual verification

- Compared the updated template against RFC-017, RFC-020, RFC-021, RFC-022, and RFC-023 to confirm alignment with established patterns
- Verified the HTML comment renders correctly (hidden in rendered markdown, visible in source)

## Tests added

None — documentation-only change.

## Tests run

- `cargo build --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #584