### PR TITLE
docs: update RFC-001 manifesto to reflect current project state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ process. Read it fully before opening a pull request.
 
 ## Project philosophy
 
-rttx has five core principles (see `designs/RFC-001-manifesto.md` for the full rationale):
+rttx has six core principles (see `designs/RFC-001-manifesto.md` for the full rationale):
 
 1. **Native GNOME integration over cross-platform portability** — Libadwaita widgets, GNOME HIG,
    system light/dark mode. No portability shims.
@@ -32,11 +32,10 @@ rttx has five core principles (see `designs/RFC-001-manifesto.md` for the full r
    Every critical path has tests.
 3. **Workflow context over layout geometry** — Per-pane recovery recipes reconstruct what the user
    was doing, not just the shape of the window.
-4. **Composable building blocks over monolithic workflows** — Bookmarks, commands, and templates
-   are distinct but composable concepts.
+4. **Composable building blocks over monolithic workflows** — Places, commands, and hosts are
+   distinct but composable concepts.
 5. **Practical tools over impressive features** — Every feature must answer: does this help a
    developer or sysadmin get real work done faster?
-
 6. **Infrastructure serves the application, never the reverse** — Do not downgrade dependencies,
    remove features, or lower version requirements to satisfy CI runners, old distributions, or
    test environments. If CI fails because a runner lacks a library, fix the runner. If a

--- a/designs/RFC-001-manifesto.md
+++ b/designs/RFC-001-manifesto.md
@@ -16,6 +16,11 @@ Tilix. Where Tilix is stuck on GTK3 and D, rttx starts from scratch with GTK4, L
 VTE4. The defining features — sidebar workspaces and split-screen panes — are preserved and deepened.
 Everything else is reconsidered from first principles.
 
+A daemon (`rttx-server`) owns all PTYs, scrollback, and runtime state. The GUI owns workspace
+layout and presentation. This separation means workspaces attach and detach freely while terminal
+processes continue running, and recovery reconstructs what the user was doing rather than just the
+shape of the window.
+
 ---
 
 ## Core Principles
@@ -30,26 +35,38 @@ no portability shims, no cross-platform UI toolkits.
 
 A terminal emulator that crashes is worse than no terminal at all. Every critical code path is
 covered by tests. Crashes at the Rust/C boundary — the place most GTK-Rust apps silently fail —
-are caught by a dedicated contract-testing layer before they reach users.
+are caught by a dedicated contract-testing layer before they reach users. A crash-taxonomy-driven
+testing strategy (RFC-003) ensures every test answers: which specific failure does this test
+prevent?
 
 ### 3. Workflow context over layout geometry
 
 Saving a grid of terminal panes is not workspace recovery. rttx persists per-pane recovery
 recipes and daemon-backed runtime state so it can reconstruct what the user was doing, not just
 the shape of the window they were doing it in. This includes working directories, startup
-provenance, SSH targets, reconnect state, and tmux sessions where applicable.
+provenance, SSH targets, and reconnect state. Connection state is explicit and user-visible — the
+GUI shows workspace connection status and offers in-pane retry rather than hiding failures behind
+modal dialogs.
 
 ### 4. Composable building blocks over monolithic workflows
 
-Bookmarks, commands, and workspace templates are distinct but composable. A bookmark sets context
-(where you are). A command executes work (what you do). A template composes both into a
-ready-to-use working environment. These remain separate concepts in the data model and the UI.
+Places, commands, and hosts are distinct but composable. A place sets context (where you are). A
+command executes work (what you do). A host defines an endpoint (where it runs). These remain
+separate concepts in the data model and the UI, connected through host tags rather than rigid
+hierarchies.
 
 ### 5. Practical tools over impressive features
 
 Every feature must answer the question: does this help a developer or sysadmin get real work done
 faster? URL detection, smart clipboard, searchable command launcher — yes. Custom scripting
 languages, remote GUI, Quake mode — no.
+
+### 6. Infrastructure serves the application, never the reverse
+
+Do not downgrade dependencies, remove features, or lower version requirements to satisfy CI
+runners, old distributions, or test environments. If CI fails because a runner lacks a library,
+fix the runner. If a distribution ships an outdated package, use a different distribution or build
+from source. The application's requirements are ground truth. Everything else adapts.
 
 ---
 
@@ -59,7 +76,7 @@ rttx is built for **developers and sysadmins** who:
 
 - Live in the terminal for most of their workday
 - Use GNOME as their primary desktop
-- Work across multiple contexts simultaneously (local projects, SSH hosts, tmux sessions)
+- Work across multiple contexts simultaneously (local projects, SSH hosts)
 - Value a tool that stays out of the way until they need it
 
 rttx is **not** for:
@@ -80,6 +97,9 @@ These are permanent, not just deferred:
 - **No product-level direct-terminal architecture** — managed local and remote execution goes
   through the daemon-backed runtime model rather than maintaining a separate first-class direct
   path
+- **No implicit fallback to a separate execution model** — when the daemon is unavailable, the GUI
+  shows explicit connection state and retries rather than silently degrading to a different
+  terminal model
 - **No custom scripting or macro language** — shell variables and shell functions already exist;
   rttx does not invent a second scripting layer
 - **No cross-platform support** — Windows and macOS are explicitly out of scope; GNOME-specific
@@ -93,7 +113,8 @@ These are permanent, not just deferred:
 | Principle                      | Capability already present or on roadmap                                            |
 |--------------------------------|-------------------------------------------------------------------------------------|
 | Native GNOME integration       | `adw::ToolbarView`, `adw::ActionRow`, `adw::Toast`, system light/dark mode, `gio::Notification`, GNOME HIG-compliant layout |
-| Rock-solid stability           | Unit, proptest, integration, GTK contract, GTK widget, and behavioral UI tests; crash taxonomy with dedicated test categories |
-| Workflow context over geometry | Per-pane recovery recipes, daemon-backed runtimes, CWD persistence, pane origin tracking, startup replay, SSH/tmux reconnect roadmap |
-| Composable building blocks     | Bookmarks (context), commands (actions), workspace templates (roadmap); right utility sidebar separates them from workspace nav |
-| Practical tools                | Smart clipboard, searchable command launcher, searchable bookmark sidebar, workspace renaming, input sync |
+| Rock-solid stability           | Unit, proptest, integration, GTK contract, GTK widget, and behavioral UI tests; crash taxonomy with dedicated test categories (RFC-003); runtime behavior gate in CI (RFC-012) |
+| Workflow context over geometry | Per-pane recovery recipes, daemon-backed runtimes with terminal response ownership (RFC-020), CWD persistence, pane origin tracking, explicit connection state machine (RFC-018), SSH reconnect |
+| Composable building blocks     | Places (context), commands (actions), hosts (endpoints); host-aware right sidebar with tag-based scoping (RFC-006, RFC-016) |
+| Practical tools                | Smart clipboard, searchable command launcher, searchable places sidebar, workspace renaming, input sync, Ctrl+click URL/path detection |
+| Infrastructure serves the app  | Minimum GTK4 4.14, Libadwaita 1.5, VTE 0.76+; CI adapts to the application, not the reverse |


### PR DESCRIPTION
## What changed and why

RFC-001 (Project Manifesto) was out of date with the current state of the project. This PR brings it in line with the implemented architecture and terminology.

### Changes to RFC-001:
- **Added Principle 6** (Infrastructure serves the application) — already in CONTRIBUTING.md but missing from the manifesto
- **Updated terminology**: bookmarks/templates → places/commands/hosts (per RFC-016)
- **Removed tmux references** — tmux integration was dropped per RFC-016
- **Added crash-taxonomy testing** reference to Principle 2 (per RFC-003)
- **Added explicit connection state** and in-pane retry to Principle 3 (per RFC-018)
- **Added daemon architecture summary** to 'What rttx Is' section
- **Added 'No implicit fallback'** scope boundary (per RFC-013)
- **Updated Goals Alignment table** with current capabilities and RFC cross-references

### Changes to CONTRIBUTING.md:
- Fixed principle count from "five" to "six" (was already listing six)
- Updated Principle 4 terminology to match RFC-001 (bookmarks/templates → places/commands/hosts)

## Manual verification
- Reviewed all 23 RFCs to identify gaps between RFC-001 and current project state
- Cross-referenced CONTRIBUTING.md, README.md, and RFC-016 for terminology consistency
- Verified no code changes — documentation only

## Tests run
- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test --workspace` (same VTE note) ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

No new tests needed — this is a documentation-only change.

Fixes #592