### PR TITLE
docs: update RFC-013 to reflect current project state

### DIFF
--- a/designs/RFC-013-persistent-host-sessions.md
+++ b/designs/RFC-013-persistent-host-sessions.md
@@ -2,10 +2,10 @@
 
 | Field         | Value                   |
 |---------------|-------------------------|
-| Status        | Accepted / In Progress  |
+| Status        | Implemented             |
 | Author(s)     | Illya Yalovyy           |
 | Supersedes    | RFC-013 v1 (tmux-first) |
-| Superseded by | ---                       |
+| Superseded by | ---                     |
 
 ---
 
@@ -31,26 +31,40 @@ The core decisions:
 - workspace-level reconnect and remediation actions render once per workspace in the tab/sidebar
   row, not once per pane
 
-## Current implementation snapshot (2026-03)
+## Current implementation snapshot (2026-04)
 
-The core direction in this RFC is now live on `mainline`:
+The architecture defined in this RFC is fully implemented on `mainline`:
 
 - `rttx-server` and `rttx-proto` live in the same repository as the client
 - daemon inventory, runtime revisions, retention policy, and single-writer ownership are
   implemented in `services/rttx-server/`
 - the client has explicit `ephemeral` / `persistent` workspace policy, no implicit fallback,
   explicit connection-state UI, and shared terminal-handle behavior for managed panes
-- pure state extraction has started in `clients/rttx/src/runtime.rs` and
-  `clients/rttx/src/workspace_state.rs`
+- pure state extraction is complete in `clients/rttx/src/runtime.rs` (connection state machine,
+  failure classification, binding reconciliation) and `clients/rttx/src/workspace_state.rs`
+  (managed workspace open/restore, endpoint event processing, inventory recovery)
+- the endpoint connection manager lives in `clients/rttx/src/daemon_bridge.rs` with one async
+  actor per endpoint, multiplexing workspaces and runtimes on a shared transport
+- recovered-workspace synthesis from daemon inventory is implemented and tested
+- `window.rs` has been decomposed into `window/mod.rs`, `window/runtime.rs`, `window/actions.rs`,
+  `window/sidebar.rs`, `window/terminal.rs`, `window/dialogs.rs`, and `window/input.rs`
+- managed workspace lifecycle UX matches the intended contract: `Close Workspace` is authoritative
+  and destructive (#192), attach is explicit (#194), terminate/detach removed from normal close
+  flow (#195), reconnect actions render per workspace not per pane (#196)
+- `SessionMissing` state (RFC-019) handles workspaces whose daemon-side runtime has disappeared
+- RFC-016 workspace management v2 provides the action-oriented creation model: `New`, `Connect to
+  Existing`, `New Direct`
+- RFC-018 connection state machine is implemented as `advance_connection_status` in `runtime.rs`
+- RFC-020 terminal response ownership ensures the daemon answers terminal queries independently of
+  client attachment
 
-The remaining gaps are implementation follow-through, not architecture choice:
+Remaining forward-looking work is tracked in separate RFCs:
 
-- event delivery from the endpoint manager still has cleanup work
-- recovered-workspace synthesis from daemon inventory is still incomplete
-- higher-level workflow extraction out of `window.rs` is still in progress
-- managed workspace lifecycle UX still violates the intended contract: `Close Workspace` is not
-  authoritative, `Terminate Runtime` leaves disconnected placeholders behind, and reconnect
-  actions are duplicated per pane
+- RFC-021 defines the protocol v3 direction (capability negotiation, structured envelopes, typed
+  errors)
+- RFC-022 proposes a v2 daemon state storage layout (per-session directories, schema versioning,
+  dirty-flag writes)
+- #319 tracks integration test coverage for `window/runtime.rs` orchestration logic
 
 ---
 
@@ -75,7 +89,7 @@ The remaining gaps are implementation follow-through, not architecture choice:
 - **R9** — Multiple windows may connect to the same endpoint. A specific runtime has one writer by
   default; any multi-attach mode must be explicit.
 - **R10** — Users must always know the current runtime state: `Starting`, `Connecting`,
-  `Connected`, `Reconnecting`, `Blocked`, `Disconnected`, or `Recovered`.
+  `Connected`, `Reconnecting`, `Blocked`, `Disconnected`, `Recovered`, or `SessionMissing`.
 - **R11** — `New Workspace` must never implicitly attach to or surface unrelated existing runtimes.
   Attaching to an existing runtime is a separate explicit action.
 - **R12** — Workspace connection state and actions render once per workspace, using the tab/sidebar
@@ -149,6 +163,8 @@ rttx (GTK GUI)                         rttx-server (daemon)
 - runtime existence and policy
 - PTYs, scrollback, cwd, runtime titles, process lifetime
 - runtime reconstruction after daemon restart
+- terminal response semantics (RFC-020): the daemon answers terminal queries independently of
+  client attachment
 - endpoint-scoped transport serving one or more clients
 
 **Bindings**
@@ -177,13 +193,13 @@ Both policies are daemon-backed:
 
 ### Connection management
 
-The GUI keeps one connection manager per endpoint. It:
+The GUI keeps one connection manager per endpoint (`daemon_bridge.rs`). It:
 
 - establishes the transport (Unix socket locally, SSH stdio remotely)
 - multiplexes workspaces and runtimes on that endpoint
 - routes protocol messages onto the GTK main loop
 - owns reconnect backoff for transient failures
-- classifies failures into `transient` or `needs user action`
+- classifies failures into `transient` or `needs user action` via `ConnectionProblem`
 
 ---
 
@@ -191,15 +207,24 @@ The GUI keeps one connection manager per endpoint. It:
 
 ### Workspace state machine
 
-The application layer should expose a pure state machine:
+The connection state machine is implemented as a pure function (`advance_connection_status` in
+`runtime.rs`) that maps `ConnectionEvent` values to `ConnectionStatus` states. See RFC-018 for the
+full specification.
+
+States:
 
 - `Starting`
 - `Connecting`
 - `Connected`
-- `Reconnecting { attempt, next_retry_at }`
-- `Blocked { reason }`
+- `Reconnecting { attempt, retry_in_secs }`
+- `Blocked(ConnectionProblem)`
 - `Disconnected`
 - `Recovered`
+- `SessionMissing` — the daemon has no record of this workspace's runtime (RFC-019)
+
+`ConnectionProblem` classifies errors into: `DaemonUnavailable` (transient, auto-retryable),
+`VersionMismatch`, `OwnershipConflict`, `PermissionDenied`, `SessionMissing`, `Protocol`, and
+`UserActionRequired`.
 
 GTK renders these states in the workspace tab/sidebar row. Panes may disable input and show
 minimal passive status, but workspace-level actions such as `Retry now`, `Close Workspace`, or
@@ -207,15 +232,15 @@ minimal passive status, but workspace-level actions such as `Retry now`, `Close 
 
 ### User-facing workspace lifecycle
 
-These operations must match normal user expectations:
+These operations match normal user expectations (RFC-016 defines the creation model):
 
 - **New Workspace** — always creates exactly one new workspace and one new runtime according to the
   chosen endpoint/policy. It must not implicitly surface unrelated existing runtimes.
 - **Close Workspace** — authoritative destructive action. It removes the workspace from the UI and
   saved state, stops any attached runtime and its processes, and must not auto-resurrect later.
-- **Attach to Existing Runtime...** — explicit user action exposed from the new-workspace
-  affordance. This is the only ordinary way to surface a runtime that already exists on a daemon
-  but has no visible workspace in the GUI.
+- **Connect to Existing Runtime...** — explicit user action exposed from the new-workspace dialog.
+  This is the only ordinary way to surface a runtime that already exists on a daemon but has no
+  visible workspace in the GUI.
 - **Detach Runtime** — advanced keep-running operation only if retained. It must not appear as part
   of the ordinary close path, and detached runtimes should require explicit later attach rather
   than silently reappearing.
@@ -225,7 +250,7 @@ These operations must match normal user expectations:
 
 ### Failure classification
 
-**Transient**
+**Transient** (`ConnectionProblem::DaemonUnavailable`)
 - local daemon still starting
 - local socket temporarily unavailable
 - SSH timeout or broken pipe
@@ -234,12 +259,13 @@ These operations must match normal user expectations:
 
 These auto-retry with backoff.
 
-**Needs user action**
-- bad credentials
-- host key verification failure
-- protocol version mismatch
-- missing daemon binary
-- unsupported server version
+**Needs user action** (all other `ConnectionProblem` variants)
+- bad credentials (`PermissionDenied`)
+- host key verification failure (`UserActionRequired`)
+- protocol version mismatch (`VersionMismatch`)
+- runtime already owned by another client (`OwnershipConflict`)
+- runtime no longer exists on daemon (`SessionMissing`)
+- protocol-level errors (`Protocol`)
 
 These stop in `Blocked` with a clear explanation and a user action.
 
@@ -259,7 +285,7 @@ Rules:
    automatically in the normal workspace list; it is eligible only for explicit attach.
 3. If a workspace was explicitly closed by the user, inventory refresh must not recreate it.
 4. If a workspace is bound to a missing runtime during restore or reconnect, keep the workspace
-   and mark it disconnected or orphaned unless the user explicitly closed it.
+   and mark it `SessionMissing` (RFC-019) unless the user explicitly closed it.
 5. If a runtime has extra panes not present in the layout, add recovered panes.
 6. If the layout references missing runtime panes, keep explicit placeholders.
 7. Reconciliation may create recovered objects automatically for known workspaces, but it may
@@ -268,49 +294,54 @@ Rules:
 ### Terminal model
 
 There is one product-level terminal model for managed execution. Any user-facing action such as
-search, zoom, copy, paste, title updates, or cwd reporting should target a shared terminal
-abstraction rather than splitting behavior across "direct" and "persistent" paths.
+search, zoom, copy, paste, title updates, or cwd reporting targets a shared terminal abstraction
+(`terminal/handle.rs`) rather than splitting behavior across "direct" and "persistent" paths.
+
+The daemon owns terminal response semantics (RFC-020) so that applications behave identically
+whether or not a GUI client is attached.
 
 ### Relationship to recipe recovery (RFC-007)
 
-RFC-007 still matters for workspace-owned recovery metadata: bookmarks, SSH/tmux targets, retry
-UX, and honest replay of what the user asked the pane to do. It is no longer the primary managed
-execution architecture. The daemon-backed runtime model is primary, and recipe recovery augments it
-where replayable context is useful.
+RFC-007 still matters for workspace-owned recovery metadata: bookmarks, SSH targets, retry UX, and
+honest replay of what the user asked the pane to do. It is no longer the primary managed execution
+architecture. The daemon-backed runtime model is primary, and recipe recovery augments it where
+replayable context is useful.
 
 ---
 
 ## Development Plan
 
+All planned items are implemented:
+
 1. **Terminology and doc cleanup** ✅
    Product docs aligned on `Workspace`, `Runtime`, `Endpoint`, `Policy`, and the no-fallback rule.
-2. **Endpoint connection manager** — partially done
+2. **Endpoint connection manager** ✅
    `runtime.rs` holds pure connection-state logic; `workspace_state.rs` owns managed-workspace
-   transitions. Full async manager extraction remains.
+   transitions; `daemon_bridge.rs` provides the async endpoint-scoped actor with one connection per
+   endpoint, multiplexing workspaces and runtimes.
 3. **Workspace/runtime binding model** ✅
    Stable ids and binding map persist; restore and reconcile do not depend on layout position.
 4. **Homogeneous workspace policy** ✅
    One endpoint and one runtime policy per workspace enforced.
 5. **Explicit connection UX** ✅
-   `Connecting`, `Reconnecting`, `Blocked`, and `Recovered` UI states with connection icon in
-   sidebar prefix and state-specific icons/colors.
+   `Connecting`, `Reconnecting`, `Blocked`, `Recovered`, and `SessionMissing` UI states with
+   connection icon in sidebar prefix and state-specific icons/colors.
 6. **Shared terminal abstraction** ✅
    `terminal/handle.rs` provides unified search, zoom, copy, paste, cwd/title tracking for both
    direct and managed terminals.
 7. **Authoritative workspace lifecycle** ✅
    `Close Workspace` is destructive and final (#192). Attach is explicit (#194). Advanced daemon
    lifecycle actions removed from normal close flow (#195).
-8. **Test strategy** — partially done
-   Pure state tests in `runtime.rs` and `workspace_state.rs`. Runtime behavior gate enforces
-   coverage on every PR. GTK integration tests cover wiring and widget contracts. Deeper
-   client+daemon end-to-end coverage remains a gap.
+8. **Test strategy** ✅
+   Pure state tests in `runtime.rs` (64 tests) and `workspace_state.rs` (40 tests). Runtime
+   behavior gate enforces coverage on every PR. GTK integration tests cover wiring and widget
+   contracts. Daemon bridge reconnection and error recovery tests in place (#318).
 
 ---
 
 ## Rejected Behaviors
 
-The following behaviors are rejected by this RFC revision even if they exist temporarily in the
-implementation:
+The following behaviors are rejected by this RFC and are not present in the implementation:
 
 - `Close Workspace` deleting only local GUI metadata while the runtime continues running and later
   reappears through inventory recovery
@@ -333,20 +364,32 @@ All original backlog items have been completed:
 5. ~~`#196` — Move managed reconnect/connection actions from panes to workspace tabs~~ ✅
 6. ~~`#193` — Add regression coverage for managed workspace close, attach, and reconnect UX~~ ✅
 
-Remaining work tracked in RFC-010 (Steps 1, 2, 4) and test issues #318, #319.
+Test coverage tracked in RFC-010:
+
+- ~~`#318` — Integration tests for daemon bridge reconnection and error recovery~~ ✅
+- `#319` — Integration tests for `window/runtime.rs` managed workspace orchestration (open)
 
 ---
 
 ## Open Questions
 
 - **Q1** — Should multi-attach to the same runtime eventually support `share`, `read-only mirror`,
-  or `take over`, and how explicit should that handoff be?
-- **Q2** — What default scrollback retention and disk cap should each pane use?
-- **Q3** — Should local daemon auto-start happen only on demand, or also at login when the user
-  opts in?
+  or `take over`, and how explicit should that handoff be? Single-writer ownership is enforced;
+  `OwnershipConflict` blocks concurrent attach.
+- **Q2** — ~~What default scrollback retention and disk cap should each pane use?~~
+  *Resolved*: 10 MB per pane for both in-memory scrollback and on-disk scrollback log
+  (`services/rttx-server/src/pane.rs`).
+- **Q3** — ~~Should local daemon auto-start happen only on demand, or also at login when the user
+  opts in?~~
+  *Resolved*: On-demand by default. The `auto_start_daemon` preference (default `true`) controls
+  whether the GUI auto-starts the local daemon when a managed workspace is created.
 - **Q4** — How should the GUI surface endpoint version skew when different hosts run different
-  daemon versions?
+  daemon versions? Version mismatch is detected during handshake and surfaced as
+  `Blocked(VersionMismatch)`. Cross-host version skew awareness is deferred to protocol v3
+  (RFC-021).
 - **Q5** — Should daemon reconstruction be surfaced as terminal output, a GUI overlay, or both?
+  The `reconstructed` flag is propagated from daemon to client via the protocol; surfacing
+  strategy is not yet decided.
 
 ---
 
@@ -371,6 +414,12 @@ Key differences from rttx:
 ## References
 
 - [RFC-007: Per-Pane Recovery Recipes & Smart Session Restoration](./RFC-007-session-recovery.md)
+- [RFC-016: Workspace Management v2](./RFC-016-workspace-management-v2.md)
+- [RFC-018: Workspace Connection State Machine](./RFC-018-workspace-connection-state-machine.md)
+- [RFC-019: Missing Daemon Session Handling](./RFC-019-missing-session-handling.md)
+- [RFC-020: Terminal Response Ownership](./RFC-020-terminal-response-ownership.md)
+- [RFC-021: Client/Server Protocol v3](./RFC-021-client-server-protocol-v3.md)
+- [RFC-022: Daemon State Storage](./RFC-022-daemon-state-storage.md)
 - [`services/rttx-server/README.md`](../services/rttx-server/README.md)
 - [Zellij terminal workspace](https://github.com/zellij-org/zellij)
 - [Zellij session resurrection docs](https://zellij.dev/documentation/session-resurrection)


### PR DESCRIPTION
## What changed and why

RFC-013 (Daemon-Backed Workspaces and Runtimes) was out of date with the current state of the project. This PR brings it in line with the implemented architecture.

### Changes:
- **Status**: Updated from `Accepted / In Progress` to `Implemented`
- **Implementation snapshot**: Updated to 2026-04; all previously listed gaps (event delivery cleanup, recovered-workspace synthesis, window.rs extraction, lifecycle UX violations) are now resolved
- **State machine**: Updated to match actual code — added `SessionMissing` (RFC-019), `Blocked(ConnectionProblem)` with 7 variants, `Reconnecting { attempt, retry_in_secs }`
- **Failure classification**: Updated to list actual `ConnectionProblem` variants with their meanings
- **Development plan**: All 8 items marked complete (endpoint connection manager and test strategy were previously partial)
- **Backlog**: #318 marked closed, #319 noted as still open
- **Open questions**: Q2 (scrollback: 10 MB) and Q3 (auto-start: on-demand) resolved; Q1, Q4, Q5 updated with progress notes
- **Terminology**: Renamed `Attach to Existing Runtime` to `Connect to Existing Runtime` per RFC-016
- **Ownership boundaries**: Added terminal response ownership (RFC-020)
- **Cross-references**: Added RFC-016, RFC-018, RFC-019, RFC-020, RFC-021, RFC-022
- **Recipe recovery**: Removed tmux references (removed per RFC-016)

## Manual verification
- Reviewed actual code in `runtime.rs`, `workspace_state.rs`, `daemon_bridge.rs`, `window/runtime.rs`, `pane.rs`, `preferences.rs` to verify accuracy of all claims
- Cross-referenced RFC-016, RFC-018, RFC-019, RFC-020, RFC-021, RFC-022 for consistency
- Verified all backlog issues (#191–#196, #318) are closed on GitHub
- Verified #319 is still open
- No code changes — documentation only

## Tests run
- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

No new tests needed — this is a documentation-only change.

Fixes #596