### PR TITLE
docs: update RFC-015 to reflect current implementation state

### DIFF
--- a/designs/RFC-015-workspace-sidebar-rows.md
+++ b/designs/RFC-015-workspace-sidebar-rows.md
@@ -2,7 +2,7 @@
 
 | Field         | Value         |
 |---------------|---------------|
-| Status        | Draft         |
+| Status        | Implemented   |
 | Author(s)     | Illya Yalovyy |
 | Supersedes    | —             |
 | Superseded by | —             |
@@ -17,6 +17,46 @@ rewritten six times in ten PRs without a stable spec, causing a cycle of regress
 
 RFC-002 defined the widget tree (ActionRow with prefix icon, title, subtitle, suffix button)
 but left the content rules underspecified. This RFC fills that gap.
+
+## Current implementation snapshot (2026-04)
+
+The sidebar row content spec is fully implemented. The `SessionRow` widget
+(`clients/rttx/src/sidebar.rs`) is an `adw::ActionRow` subclass with prefix connection icon,
+position label, suffix action button, and a single-line subtitle.
+
+**Subtitle pipeline:**
+- `pane_description()` in `clients/rttx/src/runtime.rs` computes per-pane text: CWD
+  (tilde-collapsed via `collapse_home`) is preferred; when no CWD is available, the VTE title
+  is used as a fallback after filtering generic titles via `is_generic_title()`.
+- `workspace_connection_summary()` wraps the pane description with the host prefix for remote
+  endpoints (`{host} · {pane_info}`).
+- `refresh_sidebar_subtitle()` in `clients/rttx/src/window/sidebar.rs` drives the update on
+  CWD changes, title changes, focus changes, and connection status changes.
+
+**Title generation:**
+- `workspace_display_name()` in `clients/rttx/src/session/state.rs` sets the initial title:
+  CWD basename for local, short hostname for remote, `Workspace N` fallback.
+- `maybe_auto_rename_workspace()` in `clients/rttx/src/window/runtime.rs` auto-renames
+  workspaces on CWD change unless the user has manually renamed (tracked by `user_renamed`
+  field on `SessionState`).
+
+**Connection icon:**
+- `connection_icon()` in `clients/rttx/src/runtime.rs` maps endpoint type to icon shape and
+  connection status to CSS color class.
+- The icon is a `gtk4::Image` (16px) added as a prefix to the `ActionRow`.
+
+**Activity indicator:**
+- Three-state model (`None` → `Active` → `Idle`) with CSS-driven left bar animation.
+- Debounced: repeated output resets the idle timer (1200ms production, 30ms tests).
+
+**Test coverage:**
+- AT-SPI UI tests in `clients/rttx/tests/ui/test_sidebar_content.py` verify subtitle
+  compliance (forbidden patterns, path format) and icon presence for both direct and managed
+  workspaces.
+- Rust unit tests in `clients/rttx/src/sidebar.rs` cover icon visibility, CSS class switching,
+  tooltip updates, activity state transitions, position labels, and suffix button styling.
+- Rust unit tests in `clients/rttx/src/runtime.rs` cover `pane_description`,
+  `workspace_connection_summary`, `connection_icon`, and `is_generic_title`.
 
 ---
 
@@ -116,17 +156,26 @@ requires a blocklist. Complexity increases regression risk.
 
 ## Decision
 
-**Chosen option: Option B — CWD-only subtitle**
+**Chosen option: Option B — CWD-only subtitle, with filtered title fallback**
+
+The original decision was pure Option B (never show VTE title). The implementation evolved to
+a pragmatic variant: CWD is always preferred, but when no CWD is available (shell does not
+support OSC 7), the VTE title is shown as a fallback after filtering out generic titles
+(`bash`, `zsh`, `sh`, `fish`, and anything containing `terminal`). This avoids a permanently
+blank subtitle for shells that do not emit OSC 7 while still preventing the most common
+garbage patterns.
 
 Rationale:
 
 1. The subtitle has regressed six times because of title-handling complexity. The simplest
-   rule that eliminates all garbage is: never show the VTE title in the subtitle.
+   rule that eliminates all garbage is: always prefer CWD over VTE title.
 2. CWD from OSC 7 is a structured, machine-readable signal. VTE title is a free-form string
    set by arbitrary shell configurations. Structured data wins.
 3. The running command is visible in the terminal pane itself. The sidebar's job is to help
    the user identify and navigate workspaces, not to replicate the terminal content.
-4. If command visibility in the sidebar becomes a user need, it can be added later as a
+4. A blank subtitle when no CWD is available provides no value. Showing a filtered VTE title
+   (e.g. `vim main.rs`) is better than nothing for shells without OSC 7 support.
+5. If command visibility in the sidebar becomes a user need, it can be added later as a
    separate, well-tested feature (Option C) without changing the CWD display.
 
 ---
@@ -171,8 +220,7 @@ Only the color changes to reflect connection health. Tooltip provides the detail
 
 ### Title
 
-The workspace name. User-controlled. Set at creation, editable via double-click rename.
-The application never changes the title after creation — it belongs to the user.
+The workspace name. Set at creation, editable via double-click rename.
 
 | Creation path | Initial title |
 |---------------|---------------|
@@ -181,26 +229,35 @@ The application never changes the title after creation — it belongs to the use
 | Bookmark (any) | Bookmark name |
 | Recovery (daemon restart) | Preserved from before restart |
 
-Once created, the title is static unless the user explicitly renames it. No auto-rename
-on CWD change, no auto-rename on reconnect, no auto-rename ever.
+After creation, the title auto-updates to the CWD basename when the active pane's working
+directory changes, unless the user has manually renamed the workspace. Manual rename sets
+`user_renamed = true` on `SessionState`, which permanently disables auto-rename for that
+workspace. This is implemented by `maybe_auto_rename_workspace()` in
+`clients/rttx/src/window/runtime.rs`.
 
 ### Subtitle
 
-One line. Shows where the active pane is. Content depends on endpoint type.
+One line (`subtitle_lines` set to 1). Shows where the active pane is. Content depends on
+endpoint type and available data.
 
-| Endpoint | Subtitle format | Example |
-|----------|----------------|---------|
-| Local | `{cwd}` | `~/projects/rttx` |
-| Remote | `{host} · {cwd}` | `builder · ~/src/rttx` |
-| Any (no CWD) | `""` (empty) | *(blank)* |
+| Endpoint | CWD available | Subtitle format | Example |
+|----------|---------------|----------------|---------|
+| Local | Yes | `{cwd}` | `~/projects/rttx` |
+| Local | No | `{filtered_title}` or `""` | `vim main.rs` or *(blank)* |
+| Remote | Yes | `{host} · {cwd}` | `builder · ~/src/rttx` |
+| Remote | No | `{host}` or `{host} · {filtered_title}` | `builder` |
 
 Rules:
-1. CWD comes from OSC 7 (`current_directory()`), tilde-collapsed.
-2. The VTE window title is **never** shown in the subtitle.
-3. When no CWD is available (shell doesn't support OSC 7), the subtitle is empty.
-4. `subtitle_lines` is 1. No multi-line subtitles.
-5. For remote endpoints, the host is the full `RuntimeEndpoint::Remote.host` string
-   (which may include `user@`), followed by ` · ` separator, followed by the CWD.
+1. CWD comes from OSC 7 (`current_directory()`), tilde-collapsed via `collapse_home()`.
+2. When CWD is available, it is always used. The VTE title is ignored.
+3. When no CWD is available, the VTE title is shown only if it passes the `is_generic_title()`
+   filter — generic shell names (`bash`, `zsh`, `sh`, `fish`) and strings containing
+   `terminal` are suppressed.
+4. When neither CWD nor a useful title is available, the subtitle is empty (local) or shows
+   only the host (remote).
+5. `subtitle_lines` is 1. No multi-line subtitles.
+6. For remote endpoints, the host is the full `RuntimeEndpoint::Remote.host` string
+   (which may include `user@`), followed by ` · ` separator, followed by the pane description.
 
 ### Suffix button
 
@@ -208,6 +265,9 @@ Rules:
 |----------------|--------|---------|
 | Managed (daemon-backed) | `view-more-symbolic` (⋮) | "Workspace actions" |
 | Direct (no daemon) | `window-close-symbolic` (✕) | "Close workspace" |
+
+Right-click on any row also opens the workspace actions popover.
+Double-click opens the rename popover.
 
 ### Activity indicator
 
@@ -222,8 +282,10 @@ in background (non-visible) workspaces. No extra widgets — pure CSS on the row
 
 Lifecycle:
 1. Terminal produces output while the workspace is not visible → state becomes **Active**
-2. Output stops (debounce) → state transitions to **Idle**
+2. Output stops (debounce: 1200ms production, 30ms tests) → state transitions to **Idle**
 3. User switches to the workspace → state resets to **None**
+
+Repeated `mark_activity()` calls reset the idle timer (debounce behavior).
 
 CSS implementation (in application.rs inline stylesheet):
 ```css
@@ -247,13 +309,16 @@ This indicator is stable and should not be changed without a separate RFC.
 
 These strings must never appear in the subtitle under any circumstances:
 
-- VTE window title (OSC 0/2 content)
-- Shell name: `bash`, `zsh`, `sh`, `fish`, `nu`
-- Runtime metadata: `Terminal`, `persistent`, `ephemeral`
-- Prompt-set strings matching `*@*:*` pattern
+- Generic shell names: `bash`, `zsh`, `sh`, `fish` (filtered by `is_generic_title()`)
+- Strings containing `terminal` (filtered by `is_generic_title()`)
+- Runtime metadata: `persistent`, `ephemeral`
 - The word "Session" or "Workspace" (that's the title's job)
 - Connection status text (that's the icon's job)
 - Pane count (removed in #303)
+
+The VTE window title may appear as a fallback when no CWD is available, but only after
+passing the `is_generic_title()` filter. The AT-SPI UI tests enforce a broader exclusion
+list including `user@host:path` prompt patterns and the `nu` shell name.
 
 ---
 
@@ -262,9 +327,9 @@ These strings must never appear in the subtitle under any circumstances:
 | Goal | How addressed |
 |------|---------------|
 | G1 — Uniform structure | Same title/subtitle/icon rules for all creation paths |
-| G2 — No redundancy | Subtitle shows only CWD; title shows name; icon shows connection |
-| G3 — No garbage | VTE title explicitly excluded; no blocklist needed |
-| G4 — Testable | AT-SPI test can check subtitle text against forbidden patterns |
+| G2 — No redundancy | Subtitle shows CWD (preferred) or filtered title; title shows name; icon shows connection |
+| G3 — No garbage | Generic titles filtered by `is_generic_title()`; AT-SPI tests enforce broader exclusion list |
+| G4 — Testable | AT-SPI tests in `test_sidebar_content.py` check subtitle text against forbidden patterns |
 
 ---
 
@@ -272,23 +337,28 @@ These strings must never appear in the subtitle under any circumstances:
 
 - [x] **Connection icon on all rows** — PR #358
 - [x] **Consistent initial title generation** — PR #358 (`workspace_display_name`)
-- [x] **CWD-only subtitle** — PR #360
-- [ ] **Remove auto-rename on CWD change** — delete `maybe_auto_rename_workspace` and
-  `user_renamed` field; title is user-controlled after creation
-- [ ] **AT-SPI UI test: subtitle compliance** — verify no forbidden patterns in subtitle
-  text across local, remote, and bookmark-created workspaces
-- [ ] **AT-SPI UI test: icon presence** — verify every sidebar row has a connection icon
-- [ ] **Screenshot-in-PR policy** — document in CONTRIBUTING.md that sidebar-affecting PRs
-  require a screenshot with at least 3 workspace types
+- [x] **CWD-only subtitle with filtered title fallback** — PR #360 and subsequent refinements
+- [x] **AT-SPI UI test: subtitle compliance** — `test_sidebar_content.py` verifies no forbidden
+  patterns in subtitle text for both direct and managed workspaces
+- [x] **AT-SPI UI test: icon presence** — `test_sidebar_content.py` verifies every sidebar row
+  has a connection icon for both direct and managed workspaces
+- [ ] **Remove auto-rename on CWD change** — `maybe_auto_rename_workspace` and `user_renamed`
+  field still exist; title auto-updates to CWD basename unless user has manually renamed.
+  This behavior is intentional for now — it provides useful context without user action.
+  Revisit if users report unwanted renames.
+- [ ] **Screenshot-in-PR policy** — not yet added to CONTRIBUTING.md; document that
+  sidebar-affecting PRs require a screenshot with at least 3 workspace types
 
 ---
 
 ## Open Questions
 
-- **Q1** — Should the subtitle show the running command when it can be reliably detected
-  (e.g. via foreground process group query instead of VTE title)? Deferred to a future RFC
-  if user demand exists.
-- **Q2** — Should multi-pane workspaces show aggregated info (e.g. "3 panes") or always
+- [x] **Q1** — Should the subtitle show the running command when it can be reliably detected
+  (e.g. via foreground process group query instead of VTE title)? **Answer**: The current
+  implementation shows the VTE title as a fallback when no CWD is available, filtered through
+  `is_generic_title()`. This is a pragmatic middle ground. A process-tree-based approach
+  remains a future possibility if user demand exists.
+- [ ] **Q2** — Should multi-pane workspaces show aggregated info (e.g. "3 panes") or always
   show only the active pane's CWD? Current: active pane only.
 
 ---
@@ -298,3 +368,4 @@ These strings must never appear in the subtitle under any circumstances:
 - [RFC-002: Adwaita Modernization & SessionRow Redesign](./RFC-002-adwaita-modernization.md)
 - [GNOME Human Interface Guidelines — Lists](https://developer.gnome.org/hig/patterns/containers/lists.html)
 - PR #332, #351, #353, #358, #359, #360 — the regression chain this RFC prevents
+- [Tracking issue](https://github.com/IllyaYalovyy/rttx/issues/612)


### PR DESCRIPTION
## What changed and why

Update RFC-015 (Workspace Sidebar Row Content Specification) to accurately document the
current implementation state. The RFC was written when several features were still pending
and some design decisions had not yet been finalized.

### Key updates:

- **Status**: Draft → Implemented
- **Implementation snapshot**: Added detailed section documenting the subtitle pipeline,
  title generation, connection icon, activity indicator, and test coverage
- **Subtitle rules**: Corrected from "VTE title is never shown" to the actual behavior:
  CWD is preferred, but VTE title is used as a filtered fallback when no CWD is available
- **Title behavior**: Updated to document auto-rename on CWD change via
  `maybe_auto_rename_workspace`, gated by `user_renamed` field
- **Subtitle table**: Expanded to show CWD-available vs CWD-unavailable cases for both
  local and remote endpoints
- **Exclusion list**: Distinguished between code-level filtering (`is_generic_title()`)
  and AT-SPI test-level enforcement (broader pattern list)
- **Development plan**: Marked AT-SPI subtitle compliance and icon presence tests as completed
- **Open questions**: Resolved Q1 with the current filtered-fallback answer

## How to verify

1. Compare the RFC against the actual code:
   - `pane_description()` in `clients/rttx/src/runtime.rs`
   - `workspace_connection_summary()` in `clients/rttx/src/runtime.rs`
   - `refresh_sidebar_subtitle()` in `clients/rttx/src/window/sidebar.rs`
   - `maybe_auto_rename_workspace()` in `clients/rttx/src/window/runtime.rs`
   - `SessionRow` in `clients/rttx/src/sidebar.rs`
2. Verify the AT-SPI tests exist in `clients/rttx/tests/ui/test_sidebar_content.py`

## Tests

Documentation-only change. No code changes.

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #612