### PR TITLE
docs: update RFC-021 to reflect current protocol implementation state

### DIFF
--- a/designs/RFC-021-client-server-protocol-v3.md
+++ b/designs/RFC-021-client-server-protocol-v3.md
@@ -14,11 +14,16 @@
 Define the next daemon protocol direction so daemon-backed workspaces can grow around stable
 runtime, endpoint, terminal, and recovery semantics instead of one-off wire fields.
 
-The current protocol is sufficient for basic persistent panes, but it is not forward-looking
-enough for the product direction in RFC-016 and the compatibility work raised by recent terminal
-input issues. Protocol v3 should keep protobuf framing and SSH/stdin transport flexibility, but add
-capability negotiation, structured command/event envelopes, authoritative terminal interaction
-state, resumable snapshots, typed errors, and explicit ownership/discovery semantics.
+The current v2 protocol has grown significantly since this RFC was drafted. Several of the
+motivating issues have been resolved within the v2 wire format, and the referenced RFCs (RFC-016,
+RFC-018, RFC-020) have reached Implemented status. The remaining protocol gaps — capability
+negotiation, request/response correlation, typed errors, structured terminal input events, and
+resumable snapshots — still justify a v3 evolution, but the urgency has shifted from terminal
+correctness (largely addressed) to protocol structure and evolution mechanics.
+
+Protocol v3 should keep protobuf framing and SSH/stdin transport flexibility, but add capability
+negotiation, structured command/event envelopes, resumable snapshots, typed errors, and explicit
+ownership/discovery semantics.
 
 ---
 
@@ -46,6 +51,76 @@ state, resumable snapshots, typed errors, and explicit ownership/discovery seman
 
 ---
 
+## Implementation Snapshot
+
+This section documents what has been built within the v2 protocol since this RFC was drafted,
+which motivating issues have been resolved, and what protocol gaps remain.
+
+### Terminal mode state in PaneSnapshot (partial)
+
+The v2 `PaneSnapshot` message now carries five terminal interaction modes:
+
+| Field | Proto type | Tracked in ScreenPerformer |
+|-------|-----------|---------------------------|
+| `bracketed_paste_mode` | `bool` | ✅ |
+| `application_cursor_keys` | `bool` | ✅ |
+| `application_keypad` | `bool` | ✅ |
+| `mouse_tracking_mode` | `uint32` | ✅ |
+| `sgr_mouse_mode` | `bool` | ✅ |
+
+The daemon's `ScreenPerformer` also tracks `focus_event_mode` and `cursor_visible`, but these
+are not yet included in the `PaneSnapshot` protobuf message. A future protocol revision should
+add these fields so newly-attached clients can restore the correct mode state on reconnection.
+
+`alternate_screen` and `keyboard_protocol` (Kitty progressive enhancement) are not tracked.
+
+### Terminal response ownership (RFC-020 — Implemented)
+
+The daemon now answers DA1, DA2, DSR, and DECRQM queries directly in `ScreenPerformer`. The
+`strip_client_queries` function removes these sequences from client-bound output to prevent
+duplicate responses. Detached persistent sessions no longer hang waiting for a client VTE to
+generate terminal responses.
+
+### Bounded push channels (partial #362)
+
+Client push channels are now bounded (`PUSH_CHANNEL_BOUND = 4096`) with `try_send`. When a
+client falls behind, messages are dropped with a warning log. This addresses the memory growth
+concern from #362 but does not yet implement the protocol-level `StreamOverflow` resync path
+described in this RFC's Section 11.
+
+### Multi-client ownership semantics
+
+The v2 protocol includes `RuntimeAttachMode` (read-write, read-only, take-over) and
+`RuntimeClientRole` enums. `AttachBlocked` reports when a runtime cannot be attached. `SessionInfo`
+carries `has_write_owner`, `read_only_client_count`, and `current_client_role`. This partially
+addresses Section 9 (Ownership and Multi-Client Semantics) but without the explicit lease model
+or typed ownership events described there.
+
+### Input sync for daemon-backed panes (#463 — closed)
+
+Input sync now works for managed panes. The client resolves `input_sync_targets` through
+`WorkspaceState` and sends input to sibling daemon panes via the connection manager, not just
+through local VTE `feed_child`.
+
+### Diagnostics
+
+The v2 protocol includes `GetDiagnostics`/`DiagnosticsReport` messages for runtime health
+inspection, which were not anticipated in the original RFC.
+
+### Remaining v2 protocol gaps
+
+The following structural issues from the Background section remain unaddressed in v2:
+
+1. **No compatibility window** — exact `PROTOCOL_VERSION` equality is still enforced
+2. **Terminal input is untyped raw bytes** — `Input { data }` remains the only input path
+3. **Request/response correlation is implicit** — no request IDs or envelopes
+4. **Errors are ad hoc** — `Error { code, message }` lacks typed variants
+5. **Runtime/session terminology mismatch** — wire messages still use `Session*` names
+6. **Snapshots lack revisions for resync** — no `ResyncRuntime` or chunked scrollback
+7. **Endpoint inventory is basic** — `ListSessions` lacks busy/disabled/takeover metadata
+
+---
+
 ## Background & Motivation
 
 The current daemon protocol is a length-prefixed protobuf stream with a flat `ClientMessage` and
@@ -66,16 +141,20 @@ That simple shape was a good starting point, but recent work shows several struc
    focus changes, IME commits, compose output, or a terminal-generated response. The daemon sees
    only bytes after the client has already made terminal-semantics decisions.
 
-3. **Terminal output is untyped raw bytes.**
+3. **Terminal output is untyped raw bytes.** *(partially addressed)*
    `Delta { data }` is a useful low-level stream, but it carries no revision and does not identify
-   the semantic state changes implied by the bytes. The daemon currently parses a small subset for
-   title, cwd, DSR replies, and bracketed paste mode. That is already enough to prove that protocol
-   state must become explicit.
+   the semantic state changes implied by the bytes. The daemon now parses output for title, cwd,
+   DSR replies, DA1, DA2, DECRQM, bracketed paste mode, cursor keys, keypad, mouse modes, focus
+   event mode, and cursor visibility. Query sequences are stripped from client-bound output via
+   `strip_client_queries`. The remaining gap is that parsed state changes are not emitted as
+   separate typed events — the client must infer mode changes from the snapshot on attach.
 
-4. **Snapshots are replay-oriented, not state-oriented.**
-   `PaneSnapshot` sends scrollback bytes and a small amount of pane metadata. `bracketed_paste_mode`
-   was added because replaying scrollback is not enough to reconstruct live terminal interaction
-   state. More modes will have the same problem unless they share one terminal state model.
+4. **Snapshots are partially state-oriented.** *(partially addressed)*
+   `PaneSnapshot` now carries five terminal mode fields (bracketed paste, cursor keys, keypad,
+   mouse tracking, SGR mouse) in addition to scrollback bytes and pane metadata. However,
+   `focus_event_mode` and `cursor_visible` are tracked by the daemon but not yet in the proto
+   message. Snapshots still lack revisions for delta catch-up and are not chunked for large
+   scrollback.
 
 5. **Request and response correlation is implicit.**
    Some operations expect the next non-push message to be their response while asynchronous pushes
@@ -93,38 +172,43 @@ That simple shape was a good starting point, but recent work shows several struc
    boundary.
 
 8. **Discovery is not endpoint-aware enough.**
-   RFC-016 needs explicit host selection, explicit "connect to existing" inventory, disabled busy
-   runtimes, and eventually takeover. Current `ListSessions` is a daemon-local session list without
-   a richer discovery contract.
+   RFC-016 (now Implemented) needed explicit host selection and "connect to existing" inventory.
+   Current `SessionInfo` carries `has_write_owner`, `read_only_client_count`, and
+   `current_client_role`, which partially supports busy-session visibility. However, the protocol
+   lacks disabled reasons, takeover eligibility metadata, and endpoint-level identity.
 
-9. **Backpressure and stream lifecycle are under-specified.**
-   The daemon uses unbounded client push channels today. The protocol does not describe flow
-   control, dropped-client behavior, resumable deltas, or how a client should resynchronize after
-   backpressure, transport loss, or daemon restart.
+9. **Backpressure recovery is implementation-only.** *(partially addressed)*
+   Push channels are now bounded with drop-on-full semantics. However, the protocol does not
+   describe how a client should detect dropped messages or resynchronize. There is no
+   `StreamOverflow` event or `ResyncRuntime` command.
 
-10. **Terminal response ownership is split.**
-    The daemon already synthesizes some DSR responses by parsing PTY output, while the attached
-    client VTE may still generate or depend on other terminal responses. Detached sessions and
-    reattached sessions need one authoritative model.
+10. **Terminal response ownership is split.** *(largely addressed)*
+    The daemon now answers DA1, DA2, DSR, and DECRQM queries directly and strips these from
+    client-bound output (RFC-020, Implemented). The remaining gap is that focus in/out sequences
+    are still generated by the client, and OSC color/clipboard queries depend on client attachment.
 
 ### Issue Pressure
 
 The open issue list and recent terminal regression history point at the same protocol gap from
-multiple directions:
+multiple directions. Since this RFC was drafted, most of the motivating issues have been resolved
+within the v2 protocol:
 
 - #457 (closed): managed terminals used stateless key encoding instead of VTE keyboard semantics
 - #458 (closed): managed paste needed bracketed paste semantics
 - #459 (closed): managed mouse reporting could be preempted by client gestures
-- #460 (open): reattached clients do not restore terminal interaction modes explicitly
-- #461 (open): daemon does not own full terminal response semantics
-- #462 (open): managed terminal input lacks explicit IME and compose coverage
-- #463 (open): input sync does not include daemon-backed panes
-- #464 (closed): the VTE parity harness prevents shortcut and mouse regressions from returning
-- #478 (open): missing daemon sessions need a protocol-supported reconciliation path
-- #362 (open): unbounded daemon push channels need a bounded/backpressure-aware protocol contract
+- #460 (closed): reattached clients now restore terminal interaction modes from PaneSnapshot
+- #461 (closed): daemon now owns terminal response semantics (RFC-020 Implemented)
+- #462 (closed): managed terminal input now covers IME and compose
+- #463 (closed): input sync now includes daemon-backed panes
+- #464 (closed): VTE parity harness added for managed terminal input and mouse behavior
+- #478 (closed): missing daemon sessions handled gracefully (RFC-019)
+- #362 (open): push channels are now bounded, but protocol-level resync is not yet defined
+- #493 (open): RFC tracking issue for protocol v3
 
-These should not be treated as isolated bugs. They are symptoms of a protocol where terminal
-semantics, inventory, recovery, and stream control do not have enough structure.
+The terminal correctness issues (#457–#464) were resolved by improving the v2 protocol and client
+implementation rather than waiting for v3. The remaining protocol gaps — version negotiation,
+request correlation, typed errors, structured input events, and resync semantics — are structural
+improvements that would make future evolution safer but are not blocking current functionality.
 
 ---
 
@@ -359,7 +443,9 @@ important architectural change is that the wire format can distinguish intent fr
 ### 5. Terminal Interaction State
 
 The daemon must own the terminal interaction state needed to preserve behavior across detach,
-reattach, reconnect, and multiple clients.
+reattach, reconnect, and multiple clients. The v2 protocol already carries five mode fields in
+`PaneSnapshot`; v3 should consolidate these into a single `TerminalModeState` message and add
+the modes that the daemon tracks but does not yet expose over the wire.
 
 Conceptual state:
 
@@ -376,16 +462,22 @@ message TerminalModeState {
 }
 ```
 
-Minimum tracked state:
+Current tracking status in the daemon's `ScreenPerformer`:
 
-- bracketed paste mode
-- focus reporting
-- mouse reporting modes: X10, normal, button-event, any-event, SGR, URXVT, pixel coordinates
-- application cursor keys
-- application keypad
-- alternate screen
-- cursor visibility
-- modified-key/keyboard protocol mode needed for modern terminal apps
+| Mode | Tracked | In PaneSnapshot |
+|------|---------|-----------------|
+| bracketed paste | ✅ | ✅ |
+| application cursor keys | ✅ | ✅ |
+| application keypad | ✅ | ✅ |
+| mouse tracking mode | ✅ | ✅ |
+| SGR mouse mode | ✅ | ✅ |
+| focus event mode | ✅ | ❌ (not in proto) |
+| cursor visible | ✅ | ❌ (not in proto) |
+| alternate screen | ❌ | ❌ |
+| keyboard protocol | ❌ | ❌ |
+
+The immediate next step is adding `focus_event_mode` and `cursor_visible` to the v2 `PaneSnapshot`
+message. The full `TerminalModeState` consolidation can happen as part of v3.
 
 `PaneSnapshot` should carry the full `TerminalModeState`. Live changes should be emitted as a
 `TerminalModeChanged` event with runtime ID, pane ID, revision, and the updated mode state.
@@ -396,8 +488,9 @@ mode bug is found.
 ### 6. Terminal Output And Responses
 
 Raw PTY bytes remain the primary output stream because VTE should continue to render the terminal.
-However, the daemon must parse enough output to maintain authoritative interaction state and
-synthesize daemon-owned replies when no attached VTE can safely do so.
+The daemon now parses enough output to maintain authoritative interaction state and synthesizes
+daemon-owned replies for DA1, DA2, DSR, and DECRQM queries (RFC-020, Implemented). Query sequences
+are stripped from client-bound output via `strip_client_queries` to prevent duplicate responses.
 
 Rules:
 
@@ -407,7 +500,9 @@ Rules:
   input.
 - Detached runtimes must not depend on an attached client VTE to keep terminal modes coherent.
 
-This supports #461 without requiring the daemon to become a full renderer.
+The daemon already satisfies the last rule for DA1, DA2, DSR, and DECRQM. Focus in/out sequences
+remain client-generated since only the GUI knows focus state. OSC color and clipboard queries
+remain client-dependent and are rare enough that the current behavior is acceptable.
 
 ### 7. Snapshot, Revision, And Resync
 
@@ -446,8 +541,10 @@ Resync rules:
 
 ### 8. Endpoint Inventory And Busy Runtime Discovery
 
-RFC-016 requires an explicit "connect to existing" dialog for a selected host. Protocol v3 should
-model that directly.
+RFC-016 (now Implemented) required an explicit "connect to existing" dialog for a selected host.
+The v2 protocol partially supports this through `SessionInfo` fields: `has_write_owner`,
+`read_only_client_count`, `current_client_role`, and `attached_client_count`. Protocol v3 should
+extend this into a richer inventory model.
 
 Inventory entries should include:
 
@@ -469,7 +566,14 @@ data for the client to explain why a runtime cannot be selected.
 
 ### 9. Ownership And Multi-Client Semantics
 
-The protocol should define ownership as a first-class runtime lease model:
+The v2 protocol already defines ownership as a partial model:
+
+- `RuntimeAttachMode` supports read-write, read-only, and take-over attach requests
+- `RuntimeClientRole` reports unattached, writer, or reader status
+- `AttachBlocked` signals when a runtime cannot be attached
+- `SessionInfo` carries `has_write_owner` and `read_only_client_count`
+
+Protocol v3 should formalize this into a first-class runtime lease model:
 
 - one writer lease per runtime
 - zero or more readers
@@ -514,11 +618,13 @@ The client should map typed errors to `ConnectionProblem` and UI policy without 
 
 ### 11. Backpressure And Bounded Streams
 
-Protocol v3 should pair bounded daemon push queues with an explicit recovery path.
+The daemon now uses bounded push channels (`PUSH_CHANNEL_BOUND = 4096`) with `try_send`
+drop-on-full semantics. This prevents unbounded memory growth but does not give the client a way
+to detect or recover from dropped messages.
 
-Rules:
+Protocol v3 should pair the existing bounded channels with an explicit recovery path:
 
-- Server push channels are bounded.
+- Server push channels remain bounded (already implemented).
 - If a client falls behind and lossy dropping is unsafe, the server marks the client out of sync.
 - The client receives `StreamOverflow` or detects a missing sequence and requests resync.
 - The server sends a full snapshot if it cannot provide safe delta catch-up.
@@ -570,21 +676,28 @@ Persisted state changes caused by v3 implementation must still use the existing
 
 ## Development Plan
 
-- [ ] **Step 1** - Land this RFC and review the protocol domains *(prerequisite: -)*
-- [ ] **Step 2** - Add a VTE parity harness for managed terminal input and mouse behavior
-  *(prerequisite: Step 1; tracks #464)*
+- [x] **Step 1** - Land this RFC and review the protocol domains *(prerequisite: -)*
+- [x] **Step 2** - Add a VTE parity harness for managed terminal input and mouse behavior
+  *(prerequisite: Step 1; closed #464)*
 - [ ] **Step 3** - Add v3 handshake, capability negotiation, envelopes, and typed errors while
   preserving v2 compatibility *(prerequisite: Step 1)*
 - [ ] **Step 4** - Add revisioned runtime/pane snapshots and resync commands
-  *(prerequisite: Step 3; supports #478)*
-- [ ] **Step 5** - Add `TerminalModeState` to snapshots and mode-change events
-  *(prerequisite: Step 4; supports #458 and #460)*
-- [ ] **Step 6** - Add terminal input intent commands for paste, key, mouse, focus, IME/compose,
-  and terminal responses *(prerequisite: Step 5; supports #457, #459, #461, and #462)*
+  *(prerequisite: Step 3; supports #362 resync path)*
+- [x] **Step 5** - Add `TerminalModeState` to snapshots and mode-change events
+  *(prerequisite: Step 4; closed #458 and #460)* — partially done: five modes are in
+  `PaneSnapshot`; `focus_event_mode` and `cursor_visible` are tracked but not yet in the proto
+  message; full `TerminalModeState` consolidation deferred to v3
+- [x] **Step 6** - Add terminal input intent commands for paste, key, mouse, focus, IME/compose,
+  and terminal responses *(prerequisite: Step 5; closed #457, #459, #461, and #462)* — resolved
+  within v2 by improving client-side VTE integration and daemon response ownership (RFC-020)
+  rather than adding structured input commands; the v3 `TerminalInput` design remains valid for
+  future structured input
 - [ ] **Step 7** - Add endpoint inventory v2 for host-aware "connect to existing" flows
-  *(prerequisite: Step 3; supports RFC-016)*
+  *(prerequisite: Step 3; supports RFC-016)* — RFC-016 is Implemented with v2 `SessionInfo`
+  fields; richer inventory metadata deferred to v3
 - [ ] **Step 8** - Define bounded push-channel behavior and stream overflow resync
-  *(prerequisite: Step 4; supports #362)*
+  *(prerequisite: Step 4; supports #362)* — bounded channels implemented; protocol-level resync
+  not yet defined
 - [ ] **Step 9** - Remove v2 compatibility after the v3 client/server path is stable
   *(prerequisite: Steps 3-8)*
 
@@ -593,12 +706,21 @@ Persisted state changes caused by v3 implementation must still use the existing
 ## Open Questions
 
 - [ ] **Q1** - How much keyboard encoding should live in the daemon versus a shared
-  client/server terminal-input crate?
+  client/server terminal-input crate? The current implementation keeps keyboard encoding in the
+  client (VTE commit path). The v3 `TerminalInput` design would move structured key events to the
+  wire, but the practical need is reduced now that VTE parity issues (#457) are resolved.
 - [ ] **Q2** - Should terminal mode tracking remain a minimal state parser, or should we adopt
-  more of VTE's parser behavior through shared tests before adding features?
-- [ ] **Q3** - Should read-only clients receive all terminal state deltas immediately, or only
-  after attach snapshot plus output stream subscription?
-- [ ] **Q4** - What is the exact v2 removal point for a pre-production project?
+  more of VTE's parser behavior through shared tests before adding features? The daemon's
+  `ScreenPerformer` has grown to handle DA1, DA2, DSR, DECRQM, and seven tracked modes. This
+  is already beyond "minimal" but well short of a full terminal emulator.
+- [x] **Q3** - Should read-only clients receive all terminal state deltas immediately, or only
+  after attach snapshot plus output stream subscription? **Resolved**: read-only clients receive
+  a full snapshot on attach followed by live deltas, same as write clients. The v2 implementation
+  does not distinguish delta delivery by client role.
+- [x] **Q4** - What is the exact v2 removal point for a pre-production project? **Resolved**:
+  v2 removal happens after v3 client and server are both stable (Step 9). Since rttx is
+  pre-production, there is no persisted protocol migration requirement — all active builds move
+  to v3 together.
 - [ ] **Q5** - Should remote endpoint metadata remain entirely client-owned, or should remote
   daemons expose stable host identity for inventory and troubleshooting?
 
@@ -606,18 +728,20 @@ Persisted state changes caused by v3 implementation must still use the existing
 
 ## References
 
-- [RFC-013: Persistent Host Sessions](RFC-013-persistent-host-sessions.md)
-- [RFC-016: Workspace Management v2](RFC-016-workspace-management-v2.md)
-- [RFC-018: Workspace Connection State Machine](RFC-018-workspace-connection-state-machine.md)
-- [RFC-019: Missing Session Handling](RFC-019-missing-session-handling.md)
-- [Issue #362: replace unbounded push channel with bounded channel](https://github.com/IllyaYalovyy/rttx/issues/362)
-- [Issue #457: managed terminals use stateless key encoding](https://github.com/IllyaYalovyy/rttx/issues/457)
-- [Issue #458: managed paste ignores bracketed paste mode](https://github.com/IllyaYalovyy/rttx/issues/458)
-- [Issue #459: managed mouse reporting is preempted by client gestures](https://github.com/IllyaYalovyy/rttx/issues/459)
-- [Issue #460: reattached clients do not restore terminal interaction modes explicitly](https://github.com/IllyaYalovyy/rttx/issues/460)
-- [Issue #461: daemon does not own full terminal response semantics](https://github.com/IllyaYalovyy/rttx/issues/461)
-- [Issue #462: managed terminal input lacks explicit IME and compose coverage](https://github.com/IllyaYalovyy/rttx/issues/462)
-- [Issue #463: input sync does not include daemon-backed panes](https://github.com/IllyaYalovyy/rttx/issues/463)
-- [Issue #464: add VTE parity harness](https://github.com/IllyaYalovyy/rttx/issues/464)
-- [Issue #478: handle missing daemon sessions gracefully](https://github.com/IllyaYalovyy/rttx/issues/478)
+- [RFC-013: Persistent Host Sessions](RFC-013-persistent-host-sessions.md) *(Implemented)*
+- [RFC-016: Workspace Management v2](RFC-016-workspace-management-v2.md) *(Implemented)*
+- [RFC-018: Workspace Connection State Machine](RFC-018-workspace-connection-state-machine.md) *(Implemented)*
+- [RFC-019: Missing Session Handling](RFC-019-missing-session-handling.md) *(Accepted, partially implemented)*
+- [RFC-020: Terminal Response Ownership](RFC-020-terminal-response-ownership.md) *(Implemented)*
+- [Issue #362: replace unbounded push channel with bounded channel](https://github.com/IllyaYalovyy/rttx/issues/362) *(open — bounded channels implemented, protocol-level resync not yet defined)*
+- [Issue #457: managed terminals use stateless key encoding](https://github.com/IllyaYalovyy/rttx/issues/457) *(closed)*
+- [Issue #458: managed paste ignores bracketed paste mode](https://github.com/IllyaYalovyy/rttx/issues/458) *(closed)*
+- [Issue #459: managed mouse reporting is preempted by client gestures](https://github.com/IllyaYalovyy/rttx/issues/459) *(closed)*
+- [Issue #460: reattached clients do not restore terminal interaction modes explicitly](https://github.com/IllyaYalovyy/rttx/issues/460) *(closed)*
+- [Issue #461: daemon does not own full terminal response semantics](https://github.com/IllyaYalovyy/rttx/issues/461) *(closed)*
+- [Issue #462: managed terminal input lacks explicit IME and compose coverage](https://github.com/IllyaYalovyy/rttx/issues/462) *(closed)*
+- [Issue #463: input sync does not include daemon-backed panes](https://github.com/IllyaYalovyy/rttx/issues/463) *(closed)*
+- [Issue #464: add VTE parity harness](https://github.com/IllyaYalovyy/rttx/issues/464) *(closed)*
+- [Issue #478: handle missing daemon sessions gracefully](https://github.com/IllyaYalovyy/rttx/issues/478) *(closed)*
 - [Issue #493: RFC tracking issue for client/server protocol v3](https://github.com/IllyaYalovyy/rttx/issues/493)
+- [Issue #614: review and update RFC-021](https://github.com/IllyaYalovyy/rttx/issues/614)


### PR DESCRIPTION
## What changed and why

Update RFC-021 (Client/Server Protocol v3) to accurately document the current implementation
state. The RFC was written when most motivating issues were open and several referenced RFCs
were still in progress. Since then, significant protocol work has landed within v2.

### Key updates:

- **Implementation snapshot**: Added new section documenting terminal mode state in PaneSnapshot,
  terminal response ownership (RFC-020 Implemented), bounded push channels, multi-client ownership
  semantics, input sync for daemon-backed panes, and diagnostics
- **Issue status**: Updated all 11 referenced issues — 9 of 11 are now closed (#457–#464, #478);
  only #362 (bounded channels — partially addressed) and #493 (RFC tracking) remain open
- **Background section**: Annotated protocol limits 3, 4, 9, 10 as partially or largely addressed
  with specific implementation details
- **Section 5 (Terminal Interaction State)**: Added ScreenPerformer tracking status table showing
  which modes are in PaneSnapshot (5) vs tracked-only (2: focus_event_mode, cursor_visible)
- **Section 6 (Terminal Output)**: Updated to reflect RFC-020 Implemented status
- **Section 8 (Endpoint Inventory)**: Updated to reflect RFC-016 Implemented status
- **Section 9 (Ownership)**: Documented current RuntimeAttachMode/RuntimeClientRole implementation
- **Section 11 (Backpressure)**: Documented PUSH_CHANNEL_BOUND=4096 with try_send drop-on-full
- **Development plan**: Marked Steps 1, 2, 5, 6 as done with notes on how issues were resolved
  within v2 rather than waiting for v3
- **Open questions**: Resolved Q3 (read-only client deltas) and Q4 (v2 removal point); added
  implementation context to Q1 and Q2
- **References**: Added RFC-020, status annotations for all RFCs, state markers for all issues

## How to manually verify

Review the RFC against the current codebase:
- `protocols/rttx-proto/proto/rttx.proto` — PaneSnapshot fields, RuntimeAttachMode, etc.
- `services/rttx-server/src/screen.rs` — ScreenPerformer tracked modes
- `services/rttx-server/src/server.rs` — PUSH_CHANNEL_BOUND, try_send
- `designs/RFC-020-terminal-response-ownership.md` — Implemented status

## Tests

Documentation-only change. No code modified.

## Tests run

- `cargo build -p rttx-proto -p rttx-server` ✅
- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #614