### PR TITLE
fix: strip DSR queries from scrollback before writing to disk

### DIFF
--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -3,7 +3,7 @@
 //! Each pane represents a single terminal within a session, backed by a PTY
 //! process and an in-memory screen state.
 
-use crate::screen::PaneScreen;
+use crate::screen::{PaneScreen, strip_client_queries};
 use crate::serialization::scrollback_log_path;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -131,7 +131,8 @@ impl Pane {
         }
 
         let mut file = std::fs::OpenOptions::new().create(true).append(true).open(&path)?;
-        file.write_all(&self.pending_flush)?;
+        let clean = strip_client_queries(&self.pending_flush);
+        file.write_all(&clean)?;
         self.pending_flush = Vec::new();
         self.scrollback_log_path = Some(path.clone());
 
@@ -503,5 +504,21 @@ mod tests {
         pane.release_scrollback();
         pane.release_scrollback();
         assert!(pane.screen.raw_bytes().is_empty());
+    }
+
+    #[test]
+    fn flush_scrollback_strips_dsr_queries() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let session_id = Uuid::new_v4();
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+
+        // Feed output containing DSR queries mixed with real content.
+        pane.feed_output(b"line1\r\n\x1b[6nline2\r\n\x1b[c\x1b[>c");
+        pane.flush_scrollback(tmp.path(), session_id).unwrap();
+
+        let log_path = pane.scrollback_log_path.as_ref().unwrap();
+        let content = std::fs::read(log_path).unwrap();
+        // Scrollback log should not contain DSR/DA1/DA2 query sequences.
+        assert_eq!(content, b"line1\r\nline2\r\n");
     }
 }

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -1164,4 +1164,34 @@ mod tests {
         let input = b"line1\r\n\x1b[6n\x1b[6nline2\r\n\x1b[6n\x1b[c";
         assert_eq!(strip_client_queries(input), b"line1\r\nline2\r\n");
     }
+
+    // --- Scrollback replay: DSR queries must not generate stale replies ---
+
+    #[test]
+    fn replay_stripped_scrollback_produces_no_pending_replies() {
+        // Simulate scrollback data that was stored with DSR queries.
+        let scrollback = b"line1\r\n\x1b[6nline2\r\n\x1b[c\x1b[>c\x1b[5n";
+        let cleaned = strip_client_queries(scrollback);
+
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(&cleaned);
+
+        // No stale replies should be generated from cleaned scrollback.
+        assert!(screen.take_pending_replies().is_empty());
+        // Real content should be preserved.
+        assert_eq!(screen.raw_bytes(), b"line1\r\nline2\r\n");
+    }
+
+    #[test]
+    fn raw_scrollback_replay_generates_stale_replies() {
+        // Demonstrates the bug: replaying raw scrollback with DSR queries
+        // generates stale pending_replies that would be written to the PTY.
+        let scrollback = b"line1\r\n\x1b[6nline2\r\n";
+
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(scrollback);
+
+        let replies = screen.take_pending_replies();
+        assert!(!replies.is_empty(), "raw replay should generate stale replies (the bug)");
+    }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -10,7 +10,7 @@ use crate::ipc::{ClientConnection, ClientConnectionReader, ClientConnectionWrite
 use crate::os::OsInterface;
 use crate::pane::Pane;
 use crate::protocol;
-use crate::screen::restart_safe_scrollback;
+use crate::screen::{restart_safe_scrollback, strip_client_queries};
 use crate::serialization::{self, ServerState, default_state_path, load_state, write_state_atomic};
 use crate::session::{
     AttachError, AttachMode, AttachOutcome, DetachOutcome, DetachReason, RuntimePolicy, Session,
@@ -167,13 +167,14 @@ impl Server {
                         match std::fs::read(log_path) {
                             Ok(data) => {
                                 let restart_safe = restart_safe_scrollback(&data);
+                                let clean = strip_client_queries(restart_safe);
                                 tracing::info!(
                                     "Replaying {} bytes of scrollback for pane {pane_short} in session {label}",
-                                    restart_safe.len(),
+                                    clean.len(),
                                 );
-                                pane.screen.feed(restart_safe);
-                                if restart_safe.len() != data.len()
-                                    && let Err(e) = std::fs::write(log_path, restart_safe)
+                                pane.screen.feed(&clean);
+                                if clean.len() != data.len()
+                                    && let Err(e) = std::fs::write(log_path, &clean)
                                 {
                                     tracing::error!(
                                         "Failed to rewrite restart-safe scrollback for pane {pane_short} in session {label}: {e}",

--- a/services/rttx-server/tests/scrollback.rs
+++ b/services/rttx-server/tests/scrollback.rs
@@ -236,20 +236,14 @@ async fn scrollback_log_does_not_contain_dsr_queries() {
         msg: Some(proto::client_message::Msg::Input(proto::Input {
             session_id: session_id.clone(),
             pane_id: pane_id.clone(),
-            data: bytes::Bytes::from_static(
-                b"printf '\\033[6n' && echo DSR_STRIP_MARKER\n",
-            ),
+            data: bytes::Bytes::from_static(b"printf '\\033[6n' && echo DSR_STRIP_MARKER\n"),
         })),
     };
     client.send(&input).await;
 
     // Wait for serialization tick to flush scrollback.
-    wait_for_state_containing(
-        &tmp.path().join("cache"),
-        "dsr-strip-test",
-        Duration::from_secs(10),
-    )
-    .await;
+    wait_for_state_containing(&tmp.path().join("cache"), "dsr-strip-test", Duration::from_secs(10))
+        .await;
     // Extra wait for the scrollback flush after the DSR-producing command.
     tokio::time::sleep(Duration::from_secs(2)).await;
 
@@ -273,10 +267,7 @@ async fn scrollback_log_does_not_contain_dsr_queries() {
 
     // The log must contain our marker.
     let text = String::from_utf8_lossy(&content);
-    assert!(
-        text.contains("DSR_STRIP_MARKER"),
-        "scrollback should contain marker, got: {text}"
-    );
+    assert!(text.contains("DSR_STRIP_MARKER"), "scrollback should contain marker, got: {text}");
 
     // The log must NOT contain DSR query sequences (ESC[6n, ESC[5n, ESC[c, ESC[>c).
     let dsr_patterns: &[&[u8]] = &[

--- a/services/rttx-server/tests/scrollback.rs
+++ b/services/rttx-server/tests/scrollback.rs
@@ -179,3 +179,119 @@ async fn scrollback_log_capped_at_max_size() {
     let max = 10 * 1024 * 1024_u64; // 10 MB
     assert!(size <= max, "scrollback log is {size} bytes, exceeds {max} byte cap");
 }
+
+/// Scrollback logs must not contain DSR/DA1/DA2 query sequences.
+/// If they did, replaying them after daemon restart would generate stale
+/// CPR responses that appear as visible garbage (`;1R` fragments).
+#[tokio::test]
+async fn scrollback_log_does_not_contain_dsr_queries() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+            name: "dsr-strip-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    let create_pane = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            session_id: session_id.clone(),
+            cwd: None,
+            dark_background: None,
+        })),
+    };
+    client.send(&create_pane).await;
+    let pane_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+            session_id: session_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+    client.drain(Duration::from_millis(500)).await;
+
+    // Send a command that triggers DSR queries from the shell/readline.
+    // Most shells send DSR 6 (cursor position query) during prompt setup.
+    // We also explicitly emit one via printf to guarantee it appears.
+    let input = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            session_id: session_id.clone(),
+            pane_id: pane_id.clone(),
+            data: bytes::Bytes::from_static(
+                b"printf '\\033[6n' && echo DSR_STRIP_MARKER\n",
+            ),
+        })),
+    };
+    client.send(&input).await;
+
+    // Wait for serialization tick to flush scrollback.
+    wait_for_state_containing(
+        &tmp.path().join("cache"),
+        "dsr-strip-test",
+        Duration::from_secs(10),
+    )
+    .await;
+    // Extra wait for the scrollback flush after the DSR-producing command.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Find the scrollback log file.
+    let scrollback_dir = tmp.path().join("cache").join("scrollback");
+    let mut log_files = Vec::new();
+    for session_dir in std::fs::read_dir(&scrollback_dir).unwrap() {
+        let session_dir = session_dir.unwrap().path();
+        if session_dir.is_dir() {
+            for entry in std::fs::read_dir(&session_dir).unwrap() {
+                let entry = entry.unwrap().path();
+                if entry.extension().is_some_and(|ext| ext == "log") {
+                    log_files.push(entry);
+                }
+            }
+        }
+    }
+    assert!(!log_files.is_empty(), "expected at least one scrollback log");
+
+    let content = std::fs::read(&log_files[0]).unwrap();
+
+    // The log must contain our marker.
+    let text = String::from_utf8_lossy(&content);
+    assert!(
+        text.contains("DSR_STRIP_MARKER"),
+        "scrollback should contain marker, got: {text}"
+    );
+
+    // The log must NOT contain DSR query sequences (ESC[6n, ESC[5n, ESC[c, ESC[>c).
+    let dsr_patterns: &[&[u8]] = &[
+        b"\x1b[6n", // DSR cursor position
+        b"\x1b[5n", // DSR operating status
+    ];
+    for pattern in dsr_patterns {
+        assert!(
+            !contains_bytes(&content, pattern),
+            "scrollback log should not contain DSR query {:?}",
+            String::from_utf8_lossy(pattern),
+        );
+    }
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}


### PR DESCRIPTION
## What changed and why

Scrollback logs stored raw terminal query sequences (DSR, DA1, DA2, DECRQM). When the daemon restarted and replayed these logs into `PaneScreen`, the queries generated stale `pending_replies` (CPR responses like `ESC[1;1R`) that were written to the new PTY. The shell interpreted these as keyboard input, producing visible garbage (`;1R` fragments).

### Root cause

`flush_scrollback()` wrote `pending_flush` bytes to disk without filtering. The existing `strip_client_queries()` function only stripped queries from the live output stream sent to clients, not from the scrollback persistence path.

### Fix

Two-layer defense:

1. **`flush_scrollback()`** now applies `strip_client_queries()` before writing to disk, so new scrollback logs are clean from the start.
2. **`reconstruct_sessions()`** applies `strip_client_queries()` to scrollback data read from existing logs during replay, cleaning up pre-fix files on first restart. The cleaned data is also rewritten to disk.

## Manual verification

1. Start daemon, open a workspace, run commands that trigger DSR (most shells do this during prompt setup)
2. Kill daemon, restart it
3. Reconnect — no `;1R` garbage visible in the restored scrollback

## Tests added

### Unit tests (screen.rs)
- `replay_stripped_scrollback_produces_no_pending_replies` — stripped scrollback generates no stale replies
- `raw_scrollback_replay_generates_stale_replies` — documents the bug: raw replay generates stale replies

### Unit tests (pane.rs)
- `flush_scrollback_strips_dsr_queries` — scrollback log on disk does not contain DSR sequences

### Integration tests (scrollback.rs)
- `scrollback_log_does_not_contain_dsr_queries` — end-to-end: DSR queries emitted by a real shell are stripped from the persisted log

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #632