### PR TITLE
fix: fall back to layout node CWD when splitting panes

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -104,6 +104,7 @@ enum EndpointCommand {
         policy: WorkspacePolicy,
         runtime_id: Option<String>,
         placeholder_terminal_uuid: Option<String>,
+        cwd: Option<String>,
     },
     CreatePane {
         workspace_id: String,
@@ -221,6 +222,7 @@ impl EndpointConnectionManager {
     }
 
     /// Create or attach a managed workspace runtime asynchronously.
+    #[allow(clippy::too_many_arguments)] // CWD must travel alongside the placeholder UUID
     pub fn open_workspace(
         &self,
         workspace_id: &str,
@@ -229,6 +231,7 @@ impl EndpointConnectionManager {
         policy: WorkspacePolicy,
         runtime_id: Option<&str>,
         placeholder_terminal_uuid: Option<&str>,
+        cwd: Option<&str>,
     ) {
         let _ = self.endpoint_handle(endpoint).try_send(EndpointCommand::OpenWorkspace {
             workspace_id: workspace_id.to_string(),
@@ -236,6 +239,7 @@ impl EndpointConnectionManager {
             policy,
             runtime_id: runtime_id.map(str::to_string),
             placeholder_terminal_uuid: placeholder_terminal_uuid.map(str::to_string),
+            cwd: cwd.map(str::to_string),
         });
     }
 
@@ -581,6 +585,7 @@ impl EndpointActor {
                 policy,
                 runtime_id,
                 placeholder_terminal_uuid,
+                cwd,
             } => {
                 self.emit_status(&workspace_id, ConnectionStatus::Connecting);
                 if let Err(problem) = self.ensure_connected(&workspace_id).await {
@@ -614,7 +619,7 @@ impl EndpointActor {
                             workspace_id,
                             runtime_id,
                             layout_terminal_uuid,
-                            cwd: None,
+                            cwd,
                             dark_background: true,
                         });
                     } else {

--- a/clients/rttx/src/session/layout.rs
+++ b/clients/rttx/src/session/layout.rs
@@ -980,6 +980,29 @@ mod tests {
     }
 
     #[test]
+    fn split_preserves_source_terminal_cwd_in_layout() {
+        let layout = LayoutNode::Terminal {
+            uuid: "t1".into(),
+            profile: None,
+            cwd: Some("/srv/project".into()),
+            custom_title: None,
+        };
+        let (new_layout, new_uuid) =
+            layout.split_terminal_with_new_uuid("t1", SplitOrientation::Horizontal).unwrap();
+
+        assert_eq!(
+            new_layout.terminal_cwd("t1").as_deref(),
+            Some("/srv/project"),
+            "source terminal CWD must survive the split"
+        );
+        assert_eq!(
+            new_layout.terminal_cwd(&new_uuid),
+            None,
+            "new terminal should have no CWD until explicitly set"
+        );
+    }
+
+    #[test]
     fn split_then_set_cwd_on_new_terminal() {
         let layout = LayoutNode::Terminal {
             uuid: "t1".into(),

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -264,6 +264,9 @@ impl Window {
         }
 
         let placeholder_terminal_uuid = session_state.layout.terminal_uuids().into_iter().next();
+        let cwd = placeholder_terminal_uuid
+            .as_deref()
+            .and_then(|uuid| session_state.layout.terminal_cwd(uuid));
         if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
             manager.open_workspace(
                 &session_state.uuid,
@@ -272,6 +275,7 @@ impl Window {
                 session_state.runtime.policy,
                 session_state.runtime.runtime_id.as_deref(),
                 placeholder_terminal_uuid.as_deref(),
+                cwd.as_deref(),
             );
         }
     }

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -267,7 +267,7 @@ impl Window {
 
         let imp = self.imp();
 
-        let source_cwd =
+        let terminal_cwd =
             self.terminal_handle(terminal_uuid).and_then(|terminal| terminal.current_directory());
 
         let mut state = imp.state.borrow_mut();
@@ -287,10 +287,13 @@ impl Window {
                 return;
             }
 
+            // Fall back to the layout node's CWD when the terminal widget has none.
+            let source_cwd =
+                terminal_cwd.or_else(|| state.sessions[idx].layout.terminal_cwd(terminal_uuid));
+
             if let Some((mut new_layout, new_terminal_uuid)) =
                 state.sessions[idx].layout.split_terminal_with_new_uuid(terminal_uuid, orientation)
             {
-                // Propagate the source terminal's CWD to the new terminal node.
                 if let Some(cwd) = &source_cwd {
                     new_layout.set_terminal_cwd(&new_terminal_uuid, Some(cwd.clone()));
                 }
@@ -307,6 +310,7 @@ impl Window {
                     terminal_uuid,
                     &new_terminal_uuid,
                     orientation,
+                    source_cwd.as_deref(),
                 ) {
                     self.refresh_sidebar_subtitle(&session_uuid);
                 } else {
@@ -416,6 +420,7 @@ impl Window {
         target_uuid: &str,
         new_terminal_uuid: &str,
         orientation: SplitOrientation,
+        source_cwd: Option<&str>,
     ) -> bool {
         let imp = self.imp();
         let target = {
@@ -436,7 +441,7 @@ impl Window {
             SplitOrientation::Vertical => target.height() / 2,
         };
 
-        let inherited_cwd = target.current_directory();
+        let inherited_cwd = target.current_directory().or_else(|| source_cwd.map(str::to_string));
         let new_term = TerminalWidget::new(new_terminal_uuid, inherited_cwd.as_deref());
         self.connect_terminal_signals(&new_term);
         imp.terminals.borrow_mut().insert(new_terminal_uuid.to_string(), new_term.clone());

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -5372,3 +5372,75 @@ fn close_last_managed_workspace_persists_clean_state() {
 
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+/// When the terminal widget has no CWD (e.g. managed pane before OSC 7),
+/// `split_terminal` should fall back to the layout node's CWD.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn split_falls_back_to_layout_cwd_when_terminal_has_none() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.split-layout-cwd-fallback")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.set_default_size(1200, 800);
+    window.present();
+    pump_events(100);
+
+    let t1_uuid = {
+        let state = window.imp().state.borrow();
+        state.sessions[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+
+    // Set CWD on the layout node only — the terminal widget has no CWD.
+    {
+        let mut state = window.imp().state.borrow_mut();
+        state.sessions[0].layout.set_terminal_cwd(&t1_uuid, Some("/srv/project".into()));
+    }
+
+    // Confirm the terminal widget itself has no CWD.
+    {
+        let terminals = window.imp().terminals.borrow();
+        let t1 = terminals.get(&t1_uuid).unwrap();
+        assert!(
+            t1.current_directory().is_none(),
+            "precondition: terminal widget should have no CWD"
+        );
+    }
+
+    window.split_terminal(&t1_uuid, SplitOrientation::Horizontal);
+
+    let (t2_uuid, t2_cwd) = {
+        let state = window.imp().state.borrow();
+        let uuids = state.sessions[0].layout.terminal_uuids();
+        let t2 = uuids.into_iter().find(|u| u != &t1_uuid).unwrap();
+        let cwd = state.sessions[0].layout.terminal_cwd(&t2);
+        (t2, cwd)
+    };
+
+    assert_eq!(
+        t2_cwd.as_deref(),
+        Some("/srv/project"),
+        "new pane should inherit CWD from layout node when terminal widget has none"
+    );
+
+    {
+        let terminals = window.imp().terminals.borrow();
+        let t2 = terminals.get(&t2_uuid).unwrap();
+        assert_eq!(
+            t2.initial_cwd_for_test(),
+            Some("/srv/project".to_string()),
+            "new TerminalWidget should receive layout-fallback CWD"
+        );
+    }
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/layout_widget_tests.rs
+++ b/clients/rttx/tests/layout_widget_tests.rs
@@ -1,5 +1,7 @@
 use gtk4::prelude::*;
 use rttx::session::{self, *};
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::Once;
 use std::time::{Duration, Instant};
 
@@ -459,5 +461,52 @@ fn build_layout_widget_does_not_set_magic_paned_position() {
         0,
         "build_layout_widget must not set a hardcoded paned position; \
          position application is deferred to schedule_initial_paned_ratios"
+    );
+}
+
+/// After splitting a terminal whose layout node carries a CWD, the source
+/// terminal's CWD must remain accessible and the new terminal's widget
+/// builder receives the propagated CWD.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn split_layout_propagates_source_cwd_to_new_terminal_widget() {
+    require_display!();
+
+    let layout = LayoutNode::Terminal {
+        uuid: "src".into(),
+        profile: None,
+        cwd: Some("/srv/project".into()),
+        custom_title: None,
+    };
+
+    let (mut new_layout, new_uuid) =
+        layout.split_terminal_with_new_uuid("src", SplitOrientation::Horizontal).unwrap();
+
+    // Propagate source CWD to the new terminal (mirrors what split_terminal does).
+    if let Some(cwd) = new_layout.terminal_cwd("src") {
+        new_layout.set_terminal_cwd(&new_uuid, Some(cwd));
+    }
+
+    let received_cwds: Rc<RefCell<Vec<_>>> = Rc::default();
+    let captured = received_cwds.clone();
+
+    let _widget = session::build_layout_widget(&new_layout, &|spec| {
+        captured.borrow_mut().push((spec.uuid.to_string(), spec.cwd.map(str::to_string)));
+        gtk4::Label::new(Some(spec.uuid)).upcast()
+    });
+
+    let cwds = received_cwds.borrow();
+    let src_entry = cwds.iter().find(|(u, _)| u == "src").unwrap();
+    let new_entry = cwds.iter().find(|(u, _)| u == &new_uuid).unwrap();
+
+    assert_eq!(
+        src_entry.1.as_deref(),
+        Some("/srv/project"),
+        "source terminal builder spec should carry its CWD"
+    );
+    assert_eq!(
+        new_entry.1.as_deref(),
+        Some("/srv/project"),
+        "new terminal builder spec should inherit propagated CWD"
     );
 }

--- a/clients/rttx/tests/retry_connection.rs
+++ b/clients/rttx/tests/retry_connection.rs
@@ -12,12 +12,12 @@ fn reset_endpoint_creates_fresh_actor_on_next_access() {
     let endpoint = RuntimeEndpoint::Local;
 
     // First access creates an actor.
-    manager.open_workspace("ws-1", &endpoint, "Test", WorkspacePolicy::default(), None, None);
+    manager.open_workspace("ws-1", &endpoint, "Test", WorkspacePolicy::default(), None, None, None);
 
     // Reset kills the old actor.
     manager.reset_endpoint(&endpoint);
 
     // Next access should create a fresh actor (not reuse the old one).
     // If the old actor were reused, it would be shut down and unable to process.
-    manager.open_workspace("ws-1", &endpoint, "Test", WorkspacePolicy::default(), None, None);
+    manager.open_workspace("ws-1", &endpoint, "Test", WorkspacePolicy::default(), None, None, None);
 }


### PR DESCRIPTION
## What changed and why

Fixes #642 — split panes used the workspace creation path instead of the current directory.

**Root cause:** `split_terminal` read the source CWD only from the terminal widget's `current_directory()`. For managed panes where the daemon reports CWD via `CwdChanged` messages (updating the layout node), the terminal widget itself could return `None` before the shell sends OSC 7. The new pane then fell back to the home directory.

A second related issue: `connect_managed_workspace` sent `cwd: None` when creating the first pane of a new workspace, even though the layout node carried the correct CWD.

**Fix:**
1. `split_terminal` now falls back to the layout node's CWD when the terminal widget has none
2. `split_terminal_in_place` receives the resolved CWD so the new `TerminalWidget` is created with the correct initial CWD
3. `connect_managed_workspace` forwards the layout node's CWD to the daemon when opening a workspace

## Manual verification

1. Open a workspace → `cd /tmp`
2. Split horizontally or vertically
3. The new pane opens in `/tmp` (not `~`)

## Tests added

- `split_falls_back_to_layout_cwd_when_terminal_has_none` — GTK widget test that sets CWD only on the layout node (not the terminal widget), splits, and verifies both the new layout node and the new TerminalWidget inherit the CWD

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass, including the new test)
- Existing `split_inherits_cwd_from_source_terminal` continues to pass