### PR TITLE
fix(server): resolve PTY CWD to home directory when unspecified

### DIFF
--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -85,7 +85,7 @@ fn start(foreground: bool) -> anyhow::Result<()> {
         };
 
     if !foreground {
-        let daemon = daemonize::Daemonize::new().pid_file(&pid_path).working_directory(".");
+        let daemon = daemonize::Daemonize::new().pid_file(&pid_path).working_directory("/");
 
         match daemon.start() {
             Ok(()) => {}

--- a/services/rttx-server/src/pty.rs
+++ b/services/rttx-server/src/pty.rs
@@ -58,7 +58,8 @@ impl Pty {
         if config.command.len() > 1 {
             cmd = cmd.args(&config.command[1..]);
         }
-        if let Some(ref cwd) = config.cwd {
+        let effective_cwd = config.cwd.clone().or_else(home_dir).filter(|p| p.is_dir());
+        if let Some(ref cwd) = effective_cwd {
             cmd = cmd.current_dir(cwd);
         }
         cmd = cmd.env("TERM", "xterm-256color").env("COLORTERM", "truecolor");
@@ -132,6 +133,11 @@ fn default_shell() -> String {
     std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
 }
 
+/// Resolve the user's home directory from the environment.
+fn home_dir() -> Option<PathBuf> {
+    std::env::var("HOME").ok().map(PathBuf::from)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,5 +164,58 @@ mod tests {
             );
             pty.kill().expect("kill must succeed");
         });
+    }
+
+    #[test]
+    fn none_cwd_resolves_to_home_directory() {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        rt.block_on(async {
+            let home = std::env::var("HOME").expect("HOME must be set");
+            let config = PtyConfig {
+                command: vec!["/bin/sh".into(), "-c".into(), "pwd".into()],
+                cwd: None,
+                ..PtyConfig::default()
+            };
+            let mut pty = Pty::spawn(Uuid::new_v4(), &config).expect("spawn must succeed");
+            let output = read_pty_output(&mut pty).await;
+            let cwd = output.trim();
+            assert_eq!(cwd, home, "PTY with cwd=None must start in $HOME, got {cwd}");
+        });
+    }
+
+    #[test]
+    fn explicit_cwd_is_used() {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        rt.block_on(async {
+            let config = PtyConfig {
+                command: vec!["/bin/sh".into(), "-c".into(), "pwd".into()],
+                cwd: Some(PathBuf::from("/tmp")),
+                ..PtyConfig::default()
+            };
+            let mut pty = Pty::spawn(Uuid::new_v4(), &config).expect("spawn must succeed");
+            let output = read_pty_output(&mut pty).await;
+            let cwd = output.trim();
+            assert_eq!(cwd, "/tmp", "PTY with cwd=Some(\"/tmp\") must start in /tmp, got {cwd}");
+        });
+    }
+
+    async fn read_pty_output(pty: &mut Pty) -> String {
+        let mut buf = [0u8; 4096];
+        let mut output = String::new();
+        loop {
+            match pty.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => output.push_str(&String::from_utf8_lossy(&buf[..n])),
+            }
+        }
+        let _ = pty.wait().await;
+        output
+    }
+
+    #[test]
+    fn home_dir_returns_value_from_env() {
+        let result = home_dir();
+        let expected = std::env::var("HOME").ok().map(PathBuf::from);
+        assert_eq!(result, expected);
     }
 }

--- a/services/rttx-server/tests/split_cwd.rs
+++ b/services/rttx-server/tests/split_cwd.rs
@@ -77,7 +77,32 @@ async fn create_pane_with_cwd_spawns_in_target_directory() {
     );
 }
 
-/// Pane created without CWD should start in the user's home directory. #644.
+/// Pane created without CWD should still work (spawns in default directory). #297.
+#[tokio::test]
+async fn create_pane_without_cwd_uses_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+            name: "no-cwd-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let session_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    };
+
+    // Should not panic — None CWD is valid.
+    let _pane_id = create_pane_with_cwd(&mut client, &session_id, None).await;
+}
+
+/// Pane created without CWD starts in the user's home directory, not the
+/// daemon's working directory. Regression test for #644.
 #[tokio::test]
 async fn create_pane_without_cwd_starts_in_home_directory() {
     let tmp = tempfile::tempdir().unwrap();
@@ -87,7 +112,7 @@ async fn create_pane_without_cwd_starts_in_home_directory() {
 
     let create = proto::ClientMessage {
         msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
-            name: "no-cwd-test".into(),
+            name: "home-cwd-test".into(),
             policy: proto::RuntimePolicy::Persistent as i32,
         })),
     };

--- a/services/rttx-server/tests/split_cwd.rs
+++ b/services/rttx-server/tests/split_cwd.rs
@@ -77,9 +77,9 @@ async fn create_pane_with_cwd_spawns_in_target_directory() {
     );
 }
 
-/// Pane created without CWD should still work (spawns in default directory). #297.
+/// Pane created without CWD should start in the user's home directory. #644.
 #[tokio::test]
-async fn create_pane_without_cwd_uses_default() {
+async fn create_pane_without_cwd_starts_in_home_directory() {
     let tmp = tempfile::tempdir().unwrap();
     let (socket_path, _handle) = start_test_server(tmp.path()).await;
     let mut client = TestClient::connect(&socket_path).await;
@@ -97,6 +97,44 @@ async fn create_pane_without_cwd_uses_default() {
         other => panic!("expected SessionCreated, got {other:?}"),
     };
 
-    // Should not panic — None CWD is valid.
-    let _pane_id = create_pane_with_cwd(&mut client, &session_id, None).await;
+    let pane_id = create_pane_with_cwd(&mut client, &session_id, None).await;
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+            session_id: session_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(_)) => break,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    }
+
+    let input = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            session_id: session_id.clone(),
+            pane_id: pane_id.clone(),
+            data: bytes::Bytes::from_static(b"pwd\n"),
+        })),
+    };
+    client.send(&input).await;
+
+    let home = std::env::var("HOME").expect("HOME must be set");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut output = String::new();
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(delta)) = msg.msg
+        {
+            output.push_str(&String::from_utf8_lossy(&delta.data));
+            if output.contains(&home) {
+                return;
+            }
+        }
+    }
+    panic!("pwd output did not contain home directory {home:?} within timeout.\nOutput: {output}");
 }


### PR DESCRIPTION
## What changed and why

When creating a new workspace via the New Workspace dialog and selecting Home folder, the pane starts in the daemon's working directory instead of the user's home directory. This happens because `cwd=None` in `CreatePane` causes the PTY to inherit the daemon process's CWD.

### Root cause

1. `Pty::spawn` skipped `cmd.current_dir()` when `cwd` was `None`, causing the child process to inherit the daemon's working directory
2. The daemon's `Daemonize` call used `.working_directory(".")` which locked the daemon to whatever directory it was started from

### Changes

- **`services/rttx-server/src/pty.rs`**: When `cwd` is `None`, resolve to `$HOME` before spawning the PTY. Falls back gracefully if `HOME` is unset or the directory doesn't exist.
- **`services/rttx-server/src/main.rs`**: Changed daemon working directory from `.` to `/` so the daemon doesn't hold a reference to the caller's CWD.

## Manual verification

1. Start `rttx-server` from a non-home directory (e.g. `~/projects/rttx`)
2. Create a new workspace, select Home
3. Verify the pane starts in `~` (home directory), not the daemon's CWD

## Tests added

- `none_cwd_resolves_to_home_directory` — regression test: spawns a PTY with `cwd=None`, verifies it starts in `$HOME`
- `explicit_cwd_is_used` — explicit CWD still works correctly (`/tmp`)
- `home_dir_returns_value_from_env` — unit test for the `home_dir()` helper

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx-server` ✅ (all 56 tests pass)
- `cargo test -p rttx-proto` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #644