### PR TITLE
feat: add option to trim trailing whitespace on copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.39"
+version = "0.2.40"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/preferences.rs
+++ b/clients/rttx/src/preferences.rs
@@ -73,6 +73,8 @@ pub struct Preferences {
     pub visual_bell: bool,
     #[serde(default)]
     pub smart_clipboard: bool,
+    #[serde(default)]
+    pub trim_trailing_whitespace_on_copy: bool,
     #[serde(default = "default_session_folder")]
     pub default_session_folder: DefaultSessionFolder,
     #[serde(default)]
@@ -130,6 +132,7 @@ impl Default for Preferences {
             audible_bell: true,
             visual_bell: true,
             smart_clipboard: false,
+            trim_trailing_whitespace_on_copy: false,
             default_session_folder: default_session_folder(),
             pane_navigation_keys: PaneNavigationKeys::default(),
             auto_start_daemon: true,
@@ -183,6 +186,8 @@ struct PreferencesDisk {
     visual_bell: bool,
     #[serde(default)]
     smart_clipboard: bool,
+    #[serde(default)]
+    trim_trailing_whitespace_on_copy: bool,
     #[serde(default = "default_session_folder")]
     default_session_folder: DefaultSessionFolder,
     #[serde(default)]
@@ -224,6 +229,7 @@ impl From<PreferencesDisk> for Preferences {
             audible_bell: raw.audible_bell,
             visual_bell: raw.visual_bell,
             smart_clipboard: raw.smart_clipboard,
+            trim_trailing_whitespace_on_copy: raw.trim_trailing_whitespace_on_copy,
             default_session_folder: raw.default_session_folder,
             pane_navigation_keys: raw.pane_navigation_keys,
             auto_start_daemon: raw.auto_start_daemon,
@@ -298,6 +304,7 @@ mod tests {
         assert!(prefs.scroll_on_keystroke);
         assert!(!prefs.scroll_on_output);
         assert!(!prefs.smart_clipboard);
+        assert!(!prefs.trim_trailing_whitespace_on_copy);
         assert!(prefs.auto_start_daemon);
         assert_eq!(prefs.reconnect_delay_secs, 10);
         assert!(prefs.paste_guard);

--- a/clients/rttx/src/preferences_window.rs
+++ b/clients/rttx/src/preferences_window.rs
@@ -105,6 +105,12 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
     paste_guard_row.set_active(prefs.paste_guard);
     terminal_group.add(&paste_guard_row);
 
+    let trim_whitespace_row = adw::SwitchRow::new();
+    trim_whitespace_row.set_title("Trim trailing whitespace on copy");
+    trim_whitespace_row.set_subtitle("Remove trailing spaces from each line when copying text");
+    trim_whitespace_row.set_active(prefs.trim_trailing_whitespace_on_copy);
+    terminal_group.add(&trim_whitespace_row);
+
     let session_group = adw::PreferencesGroup::new();
     session_group.set_title("Workspaces");
 
@@ -195,6 +201,7 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
             audible_bell: bell_row.is_active(),
             visual_bell: visual_bell_row.is_active(),
             smart_clipboard: smart_clipboard_row.is_active(),
+            trim_trailing_whitespace_on_copy: trim_whitespace_row.is_active(),
             default_session_folder: match folder_mode_row.selected() {
                 1 => DefaultSessionFolder::CurrentSession,
                 2 => DefaultSessionFolder::Custom(custom_folder_row.text().to_string()),

--- a/clients/rttx/src/terminal/handle.rs
+++ b/clients/rttx/src/terminal/handle.rs
@@ -62,7 +62,7 @@ impl TerminalHandle {
 
     /// Copy the current terminal selection to the clipboard.
     pub fn copy_clipboard(&self) {
-        self.vte().copy_clipboard_format(vte4::Format::Text);
+        crate::terminal::copy_to_clipboard(self.vte());
     }
 
     /// Mark the pane as active or inactive in the UI.

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -6,6 +6,29 @@ pub mod persistent_widget;
 pub mod widget;
 
 use gtk4::prelude::*;
+use vte4::prelude::*;
+
+/// Trim trailing whitespace from each line in `text`.
+fn trim_trailing_whitespace(text: &str) -> String {
+    text.lines().map(str::trim_end).collect::<Vec<_>>().join("\n")
+}
+
+/// Copy the terminal selection to the system clipboard, trimming trailing
+/// whitespace per line when the preference is enabled.
+pub(crate) fn copy_to_clipboard(vte: &vte4::Terminal) {
+    let prefs = crate::preferences::load();
+    if !prefs.trim_trailing_whitespace_on_copy {
+        vte.copy_clipboard_format(vte4::Format::Text);
+        return;
+    }
+    let Some(selected) = vte.text_selected(vte4::Format::Text) else {
+        return;
+    };
+    let trimmed = trim_trailing_whitespace(&selected);
+    if let Some(display) = gtk4::gdk::Display::default() {
+        display.clipboard().set_text(&trimmed);
+    }
+}
 
 /// Context menu alignment: Start so the left edge aligns with the pointer,
 /// preventing immediate item activation on button release (#480).
@@ -836,6 +859,56 @@ mod tests {
         let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
         assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::c, ctrl), Some(vec![0x03]),);
         assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::d, ctrl), Some(vec![0x04]),);
+    }
+}
+
+#[cfg(test)]
+mod trim_tests {
+    use super::trim_trailing_whitespace;
+
+    #[test]
+    fn no_trailing_whitespace_unchanged() {
+        assert_eq!(trim_trailing_whitespace("hello\nworld"), "hello\nworld");
+    }
+
+    #[test]
+    fn trailing_spaces_removed() {
+        assert_eq!(trim_trailing_whitespace("hello   \nworld  "), "hello\nworld");
+    }
+
+    #[test]
+    fn trailing_tabs_removed() {
+        assert_eq!(trim_trailing_whitespace("hello\t\t\nworld\t"), "hello\nworld");
+    }
+
+    #[test]
+    fn mixed_whitespace_removed() {
+        assert_eq!(trim_trailing_whitespace("hello \t \nworld\t "), "hello\nworld");
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(trim_trailing_whitespace(""), "");
+    }
+
+    #[test]
+    fn all_whitespace_lines_become_empty() {
+        assert_eq!(trim_trailing_whitespace("   \n\t\t\n  \t  "), "\n\n");
+    }
+
+    #[test]
+    fn single_line_no_newline() {
+        assert_eq!(trim_trailing_whitespace("hello   "), "hello");
+    }
+
+    #[test]
+    fn leading_whitespace_preserved() {
+        assert_eq!(trim_trailing_whitespace("  hello  \n  world  "), "  hello\n  world");
+    }
+
+    #[test]
+    fn preserves_internal_spaces() {
+        assert_eq!(trim_trailing_whitespace("hello  world   "), "hello  world");
     }
 }
 

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -807,7 +807,7 @@ impl PersistentPaneView {
                 pane.imp().smart_clipboard.get(),
             ) {
                 TerminalKeyAction::CopySelection => {
-                    pane.vte().copy_clipboard_format(vte4::Format::Text);
+                    crate::terminal::copy_to_clipboard(pane.vte());
                     pane.vte().unselect_all();
                     glib::Propagation::Stop
                 }

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -173,7 +173,7 @@ mod imp {
                     term.imp().smart_clipboard.get(),
                 ) {
                     TerminalKeyAction::CopySelection => {
-                        vte.copy_clipboard_format(vte4::Format::Text);
+                        crate::terminal::copy_to_clipboard(&vte);
                         vte.unselect_all();
                         glib::Propagation::Stop
                     }

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -29,6 +29,7 @@ fn preferences_roundtrip_all_fields() {
         audible_bell: false,
         visual_bell: true,
         smart_clipboard: true,
+        trim_trailing_whitespace_on_copy: true,
         default_session_folder: DefaultSessionFolder::Custom("/home/user/dev".into()),
         pane_navigation_keys: PaneNavigationKeys::AltArrow,
         auto_start_daemon: true,
@@ -239,4 +240,30 @@ fn paste_guard_backward_compat_missing_fields() {
     let loaded = preferences::load_from(&path);
     assert!(loaded.paste_guard);
     assert_eq!(loaded.paste_guard_threshold, 1024);
+}
+
+#[test]
+fn trim_trailing_whitespace_on_copy_defaults_to_false() {
+    let prefs = Preferences::default();
+    assert!(!prefs.trim_trailing_whitespace_on_copy);
+}
+
+#[test]
+fn trim_trailing_whitespace_on_copy_roundtrips() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+
+    let prefs = Preferences { trim_trailing_whitespace_on_copy: true, ..Default::default() };
+    preferences::save_to(&prefs, &path).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert!(loaded.trim_trailing_whitespace_on_copy);
+}
+
+#[test]
+fn trim_trailing_whitespace_on_copy_backward_compat_missing_field() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+    std::fs::write(&path, r#"{"font": "Mono 12"}"#).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert!(!loaded.trim_trailing_whitespace_on_copy);
 }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.39',
+  version: '0.2.40',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds a new user preference **"Trim trailing whitespace on copy"** (default: off) that strips trailing whitespace from each line when copying text from the terminal to the clipboard.

When copying terminal output, lines often include trailing spaces that pad to the terminal width. Pasting this into editors, chat apps, or YAML files introduces invisible trailing whitespace. This option eliminates that.

### Implementation

- New boolean preference `trim_trailing_whitespace_on_copy` in `preferences.rs` with `#[serde(default)]` for backward compatibility
- UI switch in Preferences > Terminal section (`preferences_window.rs`)
- Single `copy_to_clipboard(vte)` helper in `terminal/mod.rs` that reads the preference and either delegates to VTE's standard `copy_clipboard_format()` or reads selected text via `text_selected()`, trims trailing whitespace per line, and writes to the system clipboard
- All three clipboard copy paths now go through this helper:
  - `TerminalHandle::copy_clipboard()` (Ctrl+Shift+C / context menu)
  - Smart Ctrl+C in direct terminal widget
  - Smart Ctrl+C in persistent/managed pane widget
- Version bumped to 0.2.40 (6+ source files changed)

## How to verify manually

1. Open rttx, go to Preferences > Terminal
2. Enable "Trim trailing whitespace on copy"
3. Run `ls -la` or any command that produces output with trailing spaces
4. Select text in the terminal, copy with Ctrl+Shift+C (or Ctrl+C with smart clipboard)
5. Paste into a text editor — trailing spaces should be gone
6. Disable the option, copy again — trailing spaces should be preserved

## Tests added

### Unit tests (9) — `terminal::trim_tests`
- `no_trailing_whitespace_unchanged`
- `trailing_spaces_removed`
- `trailing_tabs_removed`
- `mixed_whitespace_removed`
- `empty_string`
- `all_whitespace_lines_become_empty`
- `single_line_no_newline`
- `leading_whitespace_preserved`
- `preserves_internal_spaces`

### Unit test (1) — `preferences::tests`
- `default_preferences_are_sensible` (updated to assert new field)

### Integration tests (3) — `preferences_integration`
- `trim_trailing_whitespace_on_copy_defaults_to_false`
- `trim_trailing_whitespace_on_copy_roundtrips`
- `trim_trailing_whitespace_on_copy_backward_compat_missing_field`

## Tests run

- `cargo build --workspace` (with VTE 0.76) ✅
- `cargo test -p rttx --lib` — 559 passed, 0 failed ✅
- `cargo test -p rttx-proto -p rttx-server` — all passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — 1416 tests, 0 failures ✅
- All 12 new tests confirmed passing in quality test output

Fixes #646