### PR TITLE
fix: add cols/rows to CreatePane protocol message (#636)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.40"
+version = "0.2.41"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -296,12 +296,16 @@ impl DaemonConnection {
         session_id: Uuid,
         cwd: Option<String>,
         dark_background: Option<bool>,
+        cols: u32,
+        rows: u32,
     ) -> Result<Uuid, DaemonError> {
         let msg = proto::ClientMessage {
             msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
                 session_id: uuid_to_bytes(session_id),
                 cwd,
                 dark_background,
+                cols,
+                rows,
             })),
         };
         self.send(&msg).await?;

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -112,6 +112,8 @@ enum EndpointCommand {
         layout_terminal_uuid: String,
         cwd: Option<String>,
         dark_background: bool,
+        cols: u32,
+        rows: u32,
     },
     ClosePane {
         workspace_id: String,
@@ -249,6 +251,7 @@ impl EndpointConnectionManager {
     }
 
     /// Request a new pane inside an attached runtime.
+    #[allow(clippy::too_many_arguments)] // Protocol-level initial size added alongside existing pane params
     pub fn create_pane(
         &self,
         workspace_id: &str,
@@ -257,6 +260,7 @@ impl EndpointConnectionManager {
         layout_terminal_uuid: &str,
         cwd: Option<String>,
         dark_background: bool,
+        initial_size: (u32, u32),
     ) {
         let _ = self.endpoint_handle(endpoint).try_send(EndpointCommand::CreatePane {
             workspace_id: workspace_id.to_string(),
@@ -264,6 +268,8 @@ impl EndpointConnectionManager {
             layout_terminal_uuid: layout_terminal_uuid.to_string(),
             cwd,
             dark_background,
+            cols: initial_size.0,
+            rows: initial_size.1,
         });
     }
 
@@ -621,6 +627,8 @@ impl EndpointActor {
                             layout_terminal_uuid,
                             cwd,
                             dark_background: true,
+                            cols: 0,
+                            rows: 0,
                         });
                     } else {
                         self.emit_status(&workspace_id, ConnectionStatus::Connected);
@@ -635,6 +643,8 @@ impl EndpointActor {
                 layout_terminal_uuid,
                 cwd,
                 dark_background,
+                cols,
+                rows,
             } => {
                 if let Err(problem) = self.ensure_connected(&workspace_id).await {
                     self.emit_error(
@@ -659,6 +669,8 @@ impl EndpointActor {
                         session_id: rttx_proto::uuid_to_bytes(runtime_uuid),
                         cwd,
                         dark_background: Some(dark_background),
+                        cols,
+                        rows,
                     })),
                 };
                 if let Err(error) = self.send_message(&msg).await {

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -583,6 +583,7 @@ impl Window {
                     &request.layout_terminal_uuid,
                     request.cwd.clone(),
                     adw::StyleManager::default().is_dark(),
+                    (0, 0),
                 );
             }
         }

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -328,6 +328,7 @@ impl Window {
                         &new_terminal_uuid,
                         source_cwd,
                         adw::StyleManager::default().is_dark(),
+                        (0, 0),
                     );
                 }
             }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.40',
+  version: '0.2.41',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/proto/rttx.proto
+++ b/protocols/rttx-proto/proto/rttx.proto
@@ -46,6 +46,8 @@ message CreatePane {
     bytes session_id = 1;
     optional string cwd = 2;
     optional bool dark_background = 3;
+    uint32 cols = 4;
+    uint32 rows = 5;
 }
 
 message ClosePane {

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -409,4 +409,30 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn create_pane_cols_rows_roundtrip() {
+        let session_id = uuid_to_bytes(uuid::Uuid::new_v4());
+
+        for (cols, rows) in [(0, 0), (80, 24), (132, 43), (300, 100)] {
+            let msg = proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+                    session_id: session_id.clone(),
+                    cwd: None,
+                    dark_background: None,
+                    cols,
+                    rows,
+                })),
+            };
+            let mut buf = BytesMut::new();
+            encode_frame(&msg, &mut buf).unwrap();
+            let decoded: proto::ClientMessage = decode_frame(&mut buf).unwrap();
+            if let Some(proto::client_message::Msg::CreatePane(cp)) = decoded.msg {
+                assert_eq!(cp.cols, cols);
+                assert_eq!(cp.rows, rows);
+            } else {
+                panic!("expected CreatePane");
+            }
+        }
+    }
 }

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -170,6 +170,8 @@ mod tests {
                     session_id: session_id.clone(),
                     cwd: None,
                     dark_background: None,
+                    cols: 0,
+                    rows: 0,
                 })),
             },
             proto::ClientMessage {
@@ -393,6 +395,8 @@ mod tests {
                     session_id: session_id.clone(),
                     cwd: Some("/tmp".into()),
                     dark_background: dark,
+                    cols: 0,
+                    rows: 0,
                 })),
             };
             let mut buf = BytesMut::new();

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -575,7 +575,7 @@ impl Server {
                 };
 
                 let pane_id = Uuid::new_v4();
-                let (pty_result, session_label) = {
+                let (pty_result, session_label, cols, rows) = {
                     let s = server.lock().await;
                     let Some(session) = s.sessions.get(&session_id) else {
                         return Some(protocol::error(
@@ -601,8 +601,10 @@ impl Server {
                         ("COLORFGBG".into(), colorfgbg.into()),
                     ];
                     let cwd = req.cwd;
-                    let config = PaneSpawnConfig { command: vec![], cwd, env, cols: 80, rows: 24 };
-                    (s.engine.spawn_pane(pane_id, &config), label)
+                    let cols = if req.cols > 0 { req.cols as u16 } else { 80 };
+                    let rows = if req.rows > 0 { req.rows as u16 } else { 24 };
+                    let config = PaneSpawnConfig { command: vec![], cwd, env, cols, rows };
+                    (s.engine.spawn_pane(pane_id, &config), label, cols, rows)
                 };
 
                 match pty_result {
@@ -619,7 +621,7 @@ impl Server {
                                     "session not found".into(),
                                 ));
                             };
-                            let mut pane = Pane::new(pane_id, 80, 24);
+                            let mut pane = Pane::new(pane_id, cols, rows);
                             pane.child_pid = child_pid;
                             session.add_pane(pane);
                             let revision = session.revision();

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -929,6 +929,8 @@ async fn create_pane_with_invalid_uuid_returns_invalid_parameter() {
             session_id: vec![0u8; 3],
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     let resp = Server::handle_message(&server, Uuid::new_v4(), msg).await.unwrap();
@@ -961,6 +963,8 @@ async fn create_pane_without_write_access_returns_ownership_error() {
             session_id: uuid_to_bytes(session_id),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     let resp = Server::handle_message(&server, reader, msg).await.unwrap();
@@ -982,6 +986,8 @@ async fn create_pane_nonexistent_session_returns_session_not_found() {
             session_id: uuid_to_bytes(Uuid::new_v4()),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     let resp = Server::handle_message(&server, Uuid::new_v4(), msg).await.unwrap();

--- a/services/rttx-server/tests/bounded_channels.rs
+++ b/services/rttx-server/tests/bounded_channels.rs
@@ -32,6 +32,8 @@ async fn slow_client_does_not_block_server() {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     })
     .await;

--- a/services/rttx-server/tests/client_lifecycle.rs
+++ b/services/rttx-server/tests/client_lifecycle.rs
@@ -44,6 +44,8 @@ async fn reconnect_restores_scrollback() {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;
@@ -218,6 +220,8 @@ async fn restart_preserves_session_count_and_scrollback() {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;

--- a/services/rttx-server/tests/colorfgbg.rs
+++ b/services/rttx-server/tests/colorfgbg.rs
@@ -16,6 +16,8 @@ async fn create_pane_with_appearance(
                 session_id: session_id.to_vec(),
                 cwd: None,
                 dark_background,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -244,6 +244,8 @@ pub async fn create_pane_with_cwd(
                 session_id: session_id.to_vec(),
                 cwd,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;

--- a/services/rttx-server/tests/create_pane_size.rs
+++ b/services/rttx-server/tests/create_pane_size.rs
@@ -1,0 +1,108 @@
+mod common;
+
+use common::{TestClient, start_test_server};
+use rttx_proto::proto;
+
+/// Helper: create a pane with explicit cols/rows and return its `pane_id`.
+async fn create_pane_with_size(
+    client: &mut TestClient,
+    session_id: &[u8],
+    cols: u32,
+    rows: u32,
+) -> Vec<u8> {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+                session_id: session_id.to_vec(),
+                cwd: None,
+                dark_background: None,
+                cols,
+                rows,
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::PaneCreated(pc)) => return pc.pane_id,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected PaneCreated, got {other:?}"),
+        }
+    }
+}
+
+/// Helper: create a session and return its id.
+async fn create_session(client: &mut TestClient, name: &str) -> Vec<u8> {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreateSession(proto::CreateSession {
+                name: name.into(),
+                policy: proto::RuntimePolicy::Persistent as i32,
+            })),
+        })
+        .await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::SessionCreated(sc)) => sc.session_id,
+        other => panic!("expected SessionCreated, got {other:?}"),
+    }
+}
+
+/// Helper: attach and return the snapshot.
+async fn attach_and_snapshot(client: &mut TestClient, session_id: &[u8]) -> proto::Snapshot {
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::AttachSession(proto::AttachSession {
+                session_id: session_id.to_vec(),
+                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+            })),
+        })
+        .await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(s)) => return s,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    }
+}
+
+/// `CreatePane` with explicit cols/rows creates PTY at that size. #636.
+#[tokio::test]
+async fn create_pane_uses_requested_dimensions() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let session_id = create_session(&mut client, "size-test").await;
+    let pane_id = create_pane_with_size(&mut client, &session_id, 132, 43).await;
+    let snapshot = attach_and_snapshot(&mut client, &session_id).await;
+
+    let pane = snapshot
+        .panes
+        .iter()
+        .find(|p| p.pane_id == pane_id)
+        .expect("pane should appear in snapshot");
+    assert_eq!(pane.cols, 132, "pane cols should match requested size");
+    assert_eq!(pane.rows, 43, "pane rows should match requested size");
+}
+
+/// `CreatePane` with zero cols/rows falls back to 80×24. #636.
+#[tokio::test]
+async fn create_pane_zero_size_falls_back_to_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let session_id = create_session(&mut client, "zero-size").await;
+    let pane_id = create_pane_with_size(&mut client, &session_id, 0, 0).await;
+    let snapshot = attach_and_snapshot(&mut client, &session_id).await;
+
+    let pane = snapshot
+        .panes
+        .iter()
+        .find(|p| p.pane_id == pane_id)
+        .expect("pane should appear in snapshot");
+    assert_eq!(pane.cols, 80, "zero cols should fall back to 80");
+    assert_eq!(pane.rows, 24, "zero rows should fall back to 24");
+}

--- a/services/rttx-server/tests/cwd_propagation.rs
+++ b/services/rttx-server/tests/cwd_propagation.rs
@@ -27,6 +27,8 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/device_attributes.rs
+++ b/services/rttx-server/tests/device_attributes.rs
@@ -26,6 +26,8 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/dsr_response.rs
+++ b/services/rttx-server/tests/dsr_response.rs
@@ -27,6 +27,8 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/dsr_stripped_from_client.rs
+++ b/services/rttx-server/tests/dsr_stripped_from_client.rs
@@ -29,6 +29,8 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/gui_restore_flow.rs
+++ b/services/rttx-server/tests/gui_restore_flow.rs
@@ -44,6 +44,8 @@ async fn gui_restore_flow_no_duplicates() {
                     session_id: sid.clone(),
                     cwd: None,
                     dark_background: None,
+                    cols: 0,
+                    rows: 0,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/heartbeat.rs
+++ b/services/rttx-server/tests/heartbeat.rs
@@ -134,6 +134,8 @@ fn ping_answered_during_pty_output() {
                     session_id: session_id.clone(),
                     cwd: None,
                     dark_background: Some(true),
+                    cols: 0,
+                    rows: 0,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/inventory.rs
+++ b/services/rttx-server/tests/inventory.rs
@@ -33,6 +33,8 @@ async fn list_sessions_includes_runtime_inventory_metadata() {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;
@@ -186,6 +188,8 @@ async fn list_sessions_marks_restored_runtime_and_panes_as_reconstructed() {
                     session_id: session_id.clone(),
                     cwd: None,
                     dark_background: None,
+                    cols: 0,
+                    rows: 0,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/make_pane_persistent.rs
+++ b/services/rttx-server/tests/make_pane_persistent.rs
@@ -53,6 +53,8 @@ async fn make_pane_persistent_flow() {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     })
     .await;

--- a/services/rttx-server/tests/managed_input_parity.rs
+++ b/services/rttx-server/tests/managed_input_parity.rs
@@ -92,6 +92,8 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;

--- a/services/rttx-server/tests/negative_protocol.rs
+++ b/services/rttx-server/tests/negative_protocol.rs
@@ -149,6 +149,8 @@ async fn create_pane_in_nonexistent_session_returns_error() {
             session_id: bogus_uuid(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&msg).await;
@@ -418,6 +420,8 @@ async fn attach_and_create_pane(client: &mut TestClient, session_id: &[u8]) -> V
             session_id: session_id.to_vec(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&msg).await;

--- a/services/rttx-server/tests/ownership.rs
+++ b/services/rttx-server/tests/ownership.rs
@@ -129,6 +129,8 @@ async fn read_only_attach_cannot_mutate_runtime() {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;

--- a/services/rttx-server/tests/ownership_races.rs
+++ b/services/rttx-server/tests/ownership_races.rs
@@ -68,6 +68,8 @@ async fn readers_observe_pane_created_push() {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;

--- a/services/rttx-server/tests/pty_io.rs
+++ b/services/rttx-server/tests/pty_io.rs
@@ -29,6 +29,8 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/reconstruction.rs
+++ b/services/rttx-server/tests/reconstruction.rs
@@ -40,6 +40,8 @@ async fn reconstruct_session_after_restart() {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         };
         client.send(&create_pane).await;
@@ -164,6 +166,8 @@ async fn reconstruct_session_respawns_shell_in_last_reported_cwd() {
                     session_id: session_id.clone(),
                     cwd: None,
                     dark_background: None,
+                    cols: 0,
+                    rows: 0,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/revisions.rs
+++ b/services/rttx-server/tests/revisions.rs
@@ -50,6 +50,8 @@ async fn mutation_acks_return_monotonic_runtime_revisions() {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;
@@ -177,6 +179,8 @@ async fn runtime_revision_survives_restart_and_attach_advances_it() {
                     session_id: session_id.clone(),
                     cwd: None,
                     dark_background: None,
+                    cols: 0,
+                    rows: 0,
                 })),
             })
             .await;
@@ -269,6 +273,8 @@ async fn failed_close_pane_returns_error_without_revision_change() {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;

--- a/services/rttx-server/tests/runtime_policy.rs
+++ b/services/rttx-server/tests/runtime_policy.rs
@@ -156,6 +156,8 @@ async fn ephemeral_runtime_is_not_restored_after_restart() {
                     session_id,
                     cwd: None,
                     dark_background: None,
+                    cols: 0,
+                    rows: 0,
                 })),
             })
             .await;

--- a/services/rttx-server/tests/scrollback.rs
+++ b/services/rttx-server/tests/scrollback.rs
@@ -32,6 +32,8 @@ async fn scrollback_flushed_to_disk_after_serialization_tick() {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;
@@ -124,6 +126,8 @@ async fn scrollback_log_capped_at_max_size() {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;
@@ -208,6 +212,8 @@ async fn scrollback_log_does_not_contain_dsr_queries() {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/session_lifecycle.rs
+++ b/services/rttx-server/tests/session_lifecycle.rs
@@ -143,6 +143,8 @@ async fn create_and_close_pane() {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;

--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -89,6 +89,8 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
                 session_id: session_id.clone(),
                 cwd: None,
                 dark_background: None,
+                cols: 0,
+                rows: 0,
             })),
         })
         .await;

--- a/services/rttx-server/tests/title_propagation.rs
+++ b/services/rttx-server/tests/title_propagation.rs
@@ -27,6 +27,8 @@ async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
             session_id: session_id.clone(),
             cwd: None,
             dark_background: None,
+            cols: 0,
+            rows: 0,
         })),
     };
     client.send(&create_pane).await;


### PR DESCRIPTION
## What changed and why

The `CreatePane` protobuf message had no `cols`/`rows` fields, causing the daemon to always create PTYs at 80×24 regardless of the client's actual terminal size. The client sends a `Resize` after connection, but there's a race window where programs see wrong dimensions.

This PR adds `cols` and `rows` fields to the `CreatePane` message. The server uses them when non-zero, falling back to 80×24 for backward compatibility with older clients.

### Protocol change

- Added `uint32 cols = 4` and `uint32 rows = 5` to the `CreatePane` message in `rttx.proto`
- Zero values trigger the 80×24 default (backward compatible — proto3 uint32 defaults to 0)
- Bumped version to 0.2.41

### Server change

- `CreatePane` handler in `server.rs` reads `req.cols`/`req.rows`, using them when non-zero
- Both the PTY spawn and the `Pane` struct use the resolved dimensions (previously hardcoded 80×24)

### Client change

- `daemon.rs`: `create_pane()` accepts `cols`/`rows` parameters
- `daemon_bridge.rs`: `EndpointCommand::CreatePane` and public API carry `initial_size: (u32, u32)`
- Both client call sites (split in `terminal.rs`, reconciled panes in `runtime.rs`) pass `(0, 0)` because the terminal widget is not yet realized at creation time. This preserves the existing behavior while establishing the protocol pathway for future size hints.

## How to manually verify

1. Build and run with `RTTX_DEV_MODE=1`
2. Create a workspace — PTY starts at 80×24 (unchanged behavior since client sends 0,0)
3. Split a pane — new pane also starts at 80×24, then gets resized by the widget
4. The key improvement: the protocol now supports sending actual dimensions, closing the race window for any future client that can determine the size before creating the pane

## Tests added

- `create_pane_uses_requested_dimensions` — verifies that `CreatePane` with explicit cols/rows (132×43) creates a PTY and `Pane` at that exact size, confirmed via snapshot
- `create_pane_zero_size_falls_back_to_default` — verifies that zero cols/rows fall back to 80×24

## Tests run

- `cargo test -p rttx-proto` — 8 passed
- `cargo test -p rttx-server --lib` — 247 passed
- `cargo test -p rttx-server --tests` — all integration tests passed (including new `create_pane_size` tests)
- `cargo test -p rttx --no-default-features --features vte-0_76` — 27 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests passed, new tests confirmed in output

Fixes #636