### PR TITLE
fix: pass VTE terminal size in CreatePane instead of zeros

### DIFF
--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -576,6 +576,7 @@ impl Window {
 
         if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
             for request in &transition.pane_create_requests {
+                let size = self.persistent_terminal_size(&request.layout_terminal_uuid);
                 manager.create_pane(
                     &request.workspace_id,
                     &request.endpoint,
@@ -583,7 +584,7 @@ impl Window {
                     &request.layout_terminal_uuid,
                     request.cwd.clone(),
                     adw::StyleManager::default().is_dark(),
-                    (0, 0),
+                    size,
                 );
             }
         }
@@ -1040,5 +1041,18 @@ impl Window {
             }
             idx += 1;
         }
+    }
+
+    /// Return `(cols, rows)` from a persistent terminal's VTE widget.
+    ///
+    /// Returns `(0, 0)` when the terminal is not yet registered, letting the
+    /// daemon fall back to its default size.
+    pub(super) fn persistent_terminal_size(&self, layout_terminal_uuid: &str) -> (u32, u32) {
+        let panes = self.imp().persistent_terminals.borrow();
+        let Some(pane) = panes.get(layout_terminal_uuid) else {
+            return (0, 0);
+        };
+        let (cols, rows) = pane.terminal_size();
+        (u32::from(cols), u32::from(rows))
     }
 }

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -321,6 +321,7 @@ impl Window {
                     && let Some(runtime_id) = session_state.runtime.runtime_id.as_deref()
                     && let Some(manager) = self.imp().connection_manager.borrow().as_ref()
                 {
+                    let size = self.persistent_terminal_size(terminal_uuid);
                     manager.create_pane(
                         &session_uuid,
                         &session_state.runtime.endpoint,
@@ -328,7 +329,7 @@ impl Window {
                         &new_terminal_uuid,
                         source_cwd,
                         adw::StyleManager::default().is_dark(),
-                        (0, 0),
+                        size,
                     );
                 }
             }

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -5469,7 +5469,10 @@ fn persistent_terminal_size_returns_vte_dimensions() {
     window.build_session(&session_state, false);
 
     let (cols, rows) = window.persistent_terminal_size("pane-a");
-    assert!(cols > 0 && rows > 0, "registered terminal must report non-zero size, got {cols}x{rows}");
+    assert!(
+        cols > 0 && rows > 0,
+        "registered terminal must report non-zero size, got {cols}x{rows}"
+    );
 
     let (cols, rows) = window.persistent_terminal_size("no-such-pane");
     assert_eq!((cols, rows), (0, 0), "unregistered terminal must return (0, 0)");
@@ -5487,9 +5490,8 @@ fn split_managed_pane_passes_source_terminal_size() {
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.split-pane-size-test")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.split-pane-size-test").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -5444,3 +5444,87 @@ fn split_falls_back_to_layout_cwd_when_terminal_has_none() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn persistent_terminal_size_returns_vte_dimensions() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.persistent-terminal-size-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let session_state = crate::test_helpers::managed_session(
+        "ws-size",
+        "Size Workspace",
+        LayoutNode::new_terminal_with_uuid("pane-a"),
+    );
+    window.imp().state.borrow_mut().sessions.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    let (cols, rows) = window.persistent_terminal_size("pane-a");
+    assert!(cols > 0 && rows > 0, "registered terminal must report non-zero size, got {cols}x{rows}");
+
+    let (cols, rows) = window.persistent_terminal_size("no-such-pane");
+    assert_eq!((cols, rows), (0, 0), "unregistered terminal must return (0, 0)");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn split_managed_pane_passes_source_terminal_size() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.split-pane-size-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let session_state = crate::test_helpers::managed_session(
+        "ws-split-size",
+        "Split Size Workspace",
+        LayoutNode::new_terminal_with_uuid("source-pane"),
+    );
+    window.imp().state.borrow_mut().sessions.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    let source_size = window.persistent_terminal_size("source-pane");
+    assert!(
+        source_size.0 > 0 && source_size.1 > 0,
+        "source pane should report non-zero size before split"
+    );
+
+    // Trigger a horizontal split on the source pane.
+    window.split_terminal("source-pane", SplitOrientation::Horizontal);
+
+    let state = window.imp().state.borrow();
+    let session = state.sessions.iter().find(|s| s.uuid == "ws-split-size").unwrap();
+    let uuids = session.layout.terminal_uuids();
+    assert_eq!(uuids.len(), 2, "split should produce two panes");
+    let new_uuid = uuids.into_iter().find(|u| u != "source-pane").unwrap();
+    drop(state);
+
+    let new_size = window.persistent_terminal_size(&new_uuid);
+    assert!(
+        new_size.0 > 0 && new_size.1 > 0,
+        "new pane from split should report non-zero size, got {}x{}",
+        new_size.0,
+        new_size.1
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}


### PR DESCRIPTION
## What changed and why

Both `CreatePane` call sites (endpoint event transition and split pane) passed `(0, 0)` for cols/rows, causing the daemon to always create PTYs at 80×24 regardless of the client's actual terminal size. Programs that cache terminal dimensions at startup (e.g. LLM CLI streaming renderers) would see incorrect dimensions during the race window before the first `Resize` message arrived, causing word-per-line streaming output.

Added a `persistent_terminal_size` helper that looks up a `PersistentPaneView`'s VTE dimensions. Both call sites now pass this size to the daemon. For the split case, the source terminal's realized dimensions are used. For unrealized terminals, VTE reports its default size which matches the daemon's existing fallback — no regression for new-workspace creation.

## Root cause

`CreatePane` was always sent with `(0, 0)` dimensions. Even though #648 added `cols`/`rows` fields to the protocol, the client never populated them. The daemon fell back to 80×24, and by the time the client's VTE widget was realized and sent a `Resize`, programs had already started with incorrect dimensions.

## Manual verification

1. Build and run `rttx` with a daemon-backed workspace
2. Open a terminal and check `stty size` — should match the actual terminal dimensions immediately
3. Split a pane and verify the new pane also reports correct dimensions via `stty size`

## Tests added

- `persistent_terminal_size_returns_vte_dimensions`: GTK test verifying the helper returns non-zero VTE dimensions for registered terminals and (0, 0) for unregistered ones
- `split_managed_pane_passes_source_terminal_size`: GTK test verifying that splitting a managed pane produces a new pane with non-zero dimensions

## Tests run

- `cargo build --workspace --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ — both new tests ran and passed via Broadway

Fixes #637