### PR TITLE
fix: increase heartbeat miss limit to tolerate socket backpressure

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -405,8 +405,9 @@ struct HeartbeatMonitor {
 
 /// Number of consecutive heartbeat ticks with an outstanding ping before
 /// the connection is declared lost. With a 2-second interval this gives
-/// the server 6 seconds to respond.
-const HEARTBEAT_MISS_LIMIT: u8 = 3;
+/// the server 16 seconds to respond — generous enough to survive transient
+/// socket backpressure from large Delta writes or a busy GTK main thread.
+const HEARTBEAT_MISS_LIMIT: u8 = 8;
 
 impl HeartbeatMonitor {
     const fn on_tick(&mut self) -> HeartbeatAction {
@@ -2556,5 +2557,68 @@ mod tests {
             HEARTBEAT_INTERVAL <= Duration::from_secs(10),
             "heartbeat should fire at least every 10s to detect stale connections"
         );
+    }
+
+    /// The effective heartbeat timeout must be generous enough to survive
+    /// transient backpressure on local Unix sockets (large Delta writes
+    /// blocking Pong delivery) without spurious disconnections.
+    #[test]
+    fn heartbeat_miss_limit_provides_adequate_tolerance() {
+        const {
+            assert!(
+                HEARTBEAT_MISS_LIMIT >= 5,
+                "miss limit must be >= 5 to tolerate transient socket backpressure",
+            );
+            assert!(
+                HEARTBEAT_MISS_LIMIT <= 15,
+                "miss limit must be <= 15 to detect actual daemon failures promptly",
+            );
+        }
+    }
+
+    /// A late Pong arriving after several missed ticks must reset the
+    /// monitor and prevent a spurious disconnect declaration.
+    #[test]
+    fn heartbeat_monitor_recovers_from_late_pong() {
+        let mut heartbeat = HeartbeatMonitor::default();
+        // First tick sends nonce 0.
+        assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 0 });
+        // Simulate several missed ticks (but fewer than the limit).
+        for _ in 1..HEARTBEAT_MISS_LIMIT.saturating_sub(1) {
+            assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 0 });
+        }
+        // Late Pong arrives just before the limit.
+        assert!(heartbeat.observe_inbound(&proto::ServerMessage {
+            msg: Some(proto::server_message::Msg::Pong(proto::Pong { nonce: 0 })),
+        }));
+        // Next tick should issue a fresh nonce, not declare lost.
+        assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 1 });
+    }
+
+    /// Multiple consecutive missed ticks below the limit must not trigger
+    /// a false disconnect when interspersed with inbound traffic.
+    #[test]
+    fn heartbeat_monitor_survives_intermittent_traffic() {
+        let mut heartbeat = HeartbeatMonitor::default();
+        assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 0 });
+        // Miss half the limit.
+        let half = HEARTBEAT_MISS_LIMIT / 2;
+        for _ in 0..half {
+            assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 0 });
+        }
+        // Inbound Delta resets the monitor.
+        assert!(!heartbeat.observe_inbound(&proto::ServerMessage {
+            msg: Some(proto::server_message::Msg::Delta(proto::Delta {
+                session_id: vec![],
+                pane_id: vec![],
+                data: bytes::Bytes::from_static(b"output"),
+            })),
+        }));
+        // Miss another half — should still be fine because we reset.
+        for _ in 0..half {
+            assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 1 });
+        }
+        // Should NOT be declared lost.
+        assert_ne!(heartbeat.on_tick(), HeartbeatAction::DeclareLost);
     }
 }

--- a/services/rttx-server/tests/heartbeat.rs
+++ b/services/rttx-server/tests/heartbeat.rs
@@ -203,12 +203,9 @@ fn sustained_pings_answered_during_continuous_output() {
         let mut client = TestClient::connect(&sock).await;
         client.handshake().await;
 
-        let session_id = create_session(
-            &mut client,
-            "sustained-heartbeat",
-            proto::RuntimePolicy::Persistent,
-        )
-        .await;
+        let session_id =
+            create_session(&mut client, "sustained-heartbeat", proto::RuntimePolicy::Persistent)
+                .await;
         let _snapshot = attach_rw(&mut client, &session_id).await;
         let pane_id = common::create_pane(&mut client, &session_id).await;
 

--- a/services/rttx-server/tests/heartbeat.rs
+++ b/services/rttx-server/tests/heartbeat.rs
@@ -189,3 +189,71 @@ fn ping_answered_during_pty_output() {
         assert!(got_pong, "pong should arrive even during PTY output");
     });
 }
+
+/// Regression test for #640: sustained heartbeat pings must all receive
+/// matching pongs even when the server is under continuous PTY output
+/// pressure. With the old 3-miss limit (6s timeout), transient socket
+/// backpressure could cause the client to declare the connection lost.
+/// The raised limit (8 misses, 16s) gives the server enough headroom.
+#[test]
+fn sustained_pings_answered_during_continuous_output() {
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (sock, _handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&sock).await;
+        client.handshake().await;
+
+        let session_id = create_session(
+            &mut client,
+            "sustained-heartbeat",
+            proto::RuntimePolicy::Persistent,
+        )
+        .await;
+        let _snapshot = attach_rw(&mut client, &session_id).await;
+        let pane_id = common::create_pane(&mut client, &session_id).await;
+
+        // Generate continuous output to create backpressure.
+        client
+            .send(&proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::Input(proto::Input {
+                    session_id: session_id.clone(),
+                    pane_id,
+                    data: bytes::Bytes::from_static(
+                        b"for i in $(seq 1 2000); do echo backpressure_line_$i; done\n",
+                    ),
+                })),
+            })
+            .await;
+
+        // Simulate the client heartbeat pattern: send 8 pings at short
+        // intervals (matching the new HEARTBEAT_MISS_LIMIT of 8).
+        let ping_count = 8u64;
+        for nonce in 0..ping_count {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            client
+                .send(&proto::ClientMessage {
+                    msg: Some(proto::client_message::Msg::Ping(proto::Ping { nonce })),
+                })
+                .await;
+        }
+
+        // All pongs must arrive within a generous deadline.
+        let mut pong_nonces = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        while (pong_nonces.len() as u64) < ping_count && tokio::time::Instant::now() < deadline {
+            match client.try_recv(std::time::Duration::from_secs(3)).await {
+                Some(msg) => {
+                    if let Some(proto::server_message::Msg::Pong(pong)) = msg.msg {
+                        pong_nonces.push(pong.nonce);
+                    }
+                }
+                None => break,
+            }
+        }
+        let expected: Vec<u64> = (0..ping_count).collect();
+        assert_eq!(
+            pong_nonces, expected,
+            "all {ping_count} pongs must arrive during sustained output"
+        );
+    });
+}


### PR DESCRIPTION
## What changed

Increased `HEARTBEAT_MISS_LIMIT` from 3 to 8 in the client's heartbeat monitor. This raises the effective heartbeat timeout from 6 seconds (3 × 2s) to 16 seconds (8 × 2s).

## Why

The 6-second timeout was too aggressive for local Unix socket connections. Transient backpressure — from large Delta writes blocking the server's socket writer, or a busy GTK main thread slowing client reads — could delay Pong delivery beyond 6 seconds, causing spurious disconnections. 33 heartbeat timeouts per day were observed in production, each causing a brief UI disruption (snapshot re-feed, scrollback position reset).

The daemon was always healthy and immediately reachable on reconnect. The problem was purely a timing tolerance issue.

## How to verify

1. Run rttx with a local daemon and multiple workspaces
2. Generate sustained PTY output (e.g. `find / -type f` in several panes)
3. Observe that heartbeat timeouts no longer occur during normal operation
4. Kill the daemon process — the client should still detect the loss within ~16 seconds

## Tests added

- `heartbeat_miss_limit_provides_adequate_tolerance` — compile-time assertion that the miss limit stays within [5, 15]
- `heartbeat_monitor_recovers_from_late_pong` — verifies a late Pong arriving after several missed ticks resets the monitor
- `heartbeat_monitor_survives_intermittent_traffic` — verifies intermittent inbound traffic prevents false disconnect declarations

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo build -p rttx-server -p rttx-proto` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76 -p rttx-proto -p rttx-server` ✅ (all pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 9 heartbeat tests pass, 0 failures)

Fixes #640