### PR TITLE
fix(server): log probe connections at debug level, not info

### DIFF
--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -1197,7 +1197,6 @@ where
 {
     let client_id = Uuid::new_v4();
     let client_short = short_id(client_id);
-    tracing::info!("Client {client_short} connected");
 
     let (tx, rx) = mpsc::channel(PUSH_CHANNEL_BOUND);
     // Channel for responses that the reader task needs to send back to the
@@ -1214,14 +1213,17 @@ where
     let write_short = client_short.clone();
     let writer_task = tokio::spawn(client_writer(writer, rx, resp_rx, write_short));
 
-    let result = client_reader(server.clone(), client_id, &client_short, reader, resp_tx).await;
+    let (result, handshake_completed) =
+        client_reader(server.clone(), client_id, &client_short, reader, resp_tx).await;
 
     // Cleanup: remove sender and detach from all sessions.
     {
         let mut s = server.lock().await;
         s.client_senders.remove(&client_id);
-        for session in s.sessions.values_mut() {
-            let _ = session.detach_client(client_id, DetachReason::Disconnect);
+        if handshake_completed {
+            for session in s.sessions.values_mut() {
+                let _ = session.detach_client(client_id, DetachReason::Disconnect);
+            }
         }
     }
 
@@ -1237,31 +1239,47 @@ where
 
 /// Read client messages and dispatch responses via `resp_tx`.
 ///
-/// Runs until the client disconnects or an error occurs.
+/// Runs until the client disconnects or an error occurs. Returns `true`
+/// if the client completed the handshake (sent at least one message),
+/// `false` if it disconnected before sending anything (probe connection).
 async fn client_reader(
     server: Arc<Mutex<Server>>,
     client_id: Uuid,
     client_short: &str,
     mut reader: ClientConnectionReader,
     resp_tx: mpsc::Sender<proto::ServerMessage>,
-) -> anyhow::Result<()> {
+) -> (anyhow::Result<()>, bool) {
+    let mut handshake_completed = false;
     loop {
-        let Some(msg) = reader.read_message().await? else {
-            tracing::info!("Client {client_short} disconnected");
-            return Ok(());
+        let msg = match reader.read_message().await {
+            Ok(Some(msg)) => msg,
+            Ok(None) => {
+                if handshake_completed {
+                    tracing::info!("Client {client_short} disconnected");
+                } else {
+                    tracing::debug!("Client probe from {client_short} (disconnected without handshake)");
+                }
+                return (Ok(()), handshake_completed);
+            }
+            Err(e) => return (Err(e.into()), handshake_completed),
         };
+
+        if !handshake_completed {
+            handshake_completed = true;
+            tracing::info!("Client {client_short} connected");
+        }
 
         if matches!(msg.msg, Some(proto::client_message::Msg::Shutdown(_))) {
             tracing::info!("Shutdown requested by client {client_short}");
             server.lock().await.request_shutdown();
-            return Ok(());
+            return (Ok(()), handshake_completed);
         }
 
         // Fast-path: respond to Ping without acquiring the server mutex.
         // The heartbeat must never stall behind PTY I/O or session work.
         if let Some(proto::client_message::Msg::Ping(ping)) = &msg.msg {
             if resp_tx.send(protocol::pong(ping.nonce)).await.is_err() {
-                return Ok(());
+                return (Ok(()), handshake_completed);
             }
             continue;
         }
@@ -1269,7 +1287,7 @@ async fn client_reader(
         if let Some(response) = Server::handle_message(&server, client_id, msg).await
             && resp_tx.send(response).await.is_err()
         {
-            return Ok(());
+            return (Ok(()), handshake_completed);
         }
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -1257,7 +1257,9 @@ async fn client_reader(
                 if handshake_completed {
                     tracing::info!("Client {client_short} disconnected");
                 } else {
-                    tracing::debug!("Client probe from {client_short} (disconnected without handshake)");
+                    tracing::debug!(
+                        "Client probe from {client_short} (disconnected without handshake)"
+                    );
                 }
                 return (Ok(()), handshake_completed);
             }

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1506,3 +1506,63 @@ fn mutex_hold_warn_threshold_is_reasonable() {
     assert!(threshold_ms >= 5, "threshold too aggressive: {threshold_ms}ms");
     assert!(threshold_ms <= 100, "threshold too lenient: {threshold_ms}ms");
 }
+
+// ── Probe connection logging (#641) ─────────────────────────────
+
+#[tokio::test]
+#[traced_test]
+async fn probe_connection_logs_at_debug_not_info() {
+    let server = new_server();
+
+    // Create a duplex stream and immediately drop the client half so the
+    // server sees EOF on its first read.  A bare `_` drops immediately;
+    // `_client_half` would keep the value alive until end of scope.
+    let (server_half, _) = tokio::io::duplex(1024);
+    let conn = crate::ipc::ClientConnection::new(server_half);
+
+    // handle_client will see EOF immediately (no Hello sent).
+    let _ = super::handle_client(server, conn).await;
+
+    // Probe should be logged at debug level, not info.
+    assert!(logs_contain("Client probe from"));
+    assert!(logs_contain("disconnected without handshake"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn real_client_logs_connected_and_disconnected_at_info() {
+    let server = new_server();
+
+    let (server_half, mut client_half) = tokio::io::duplex(64 * 1024);
+    let conn = crate::ipc::ClientConnection::new(server_half);
+
+    // Spawn handle_client in background.
+    let handle = tokio::spawn(async move {
+        let _ = super::handle_client(server, conn).await;
+    });
+
+    // Send a Hello message from the client side.
+    let hello = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Hello(proto::Hello {
+            protocol_version: rttx_proto::PROTOCOL_VERSION,
+            client_id: uuid_to_bytes(Uuid::new_v4()),
+        })),
+    };
+    let mut buf = bytes::BytesMut::new();
+    rttx_proto::encode_frame(&hello, &mut buf).unwrap();
+    tokio::io::AsyncWriteExt::write_all(&mut client_half, &buf).await.unwrap();
+
+    // Read the HelloAck response.
+    let mut resp_buf = [0u8; 4096];
+    let _ = tokio::io::AsyncReadExt::read(&mut client_half, &mut resp_buf).await.unwrap();
+
+    // Close the client half to trigger disconnect.
+    drop(client_half);
+
+    handle.await.unwrap();
+
+    assert!(logs_contain("connected"));
+    assert!(logs_contain("disconnected"));
+    // Must NOT contain probe message.
+    assert!(!logs_contain("Client probe from"));
+}

--- a/services/rttx-server/tests/probe_connection.rs
+++ b/services/rttx-server/tests/probe_connection.rs
@@ -1,0 +1,58 @@
+//! Regression test for #641: `is_server_running()` probe connections
+//! must not pollute the daemon log with INFO-level connect/disconnect
+//! messages.
+
+mod common;
+
+use common::start_test_server;
+use tokio::net::UnixStream;
+
+/// A bare connect-and-drop (the pattern used by `is_server_running`)
+/// must not crash the server or prevent subsequent real clients from
+/// connecting.
+#[tokio::test]
+async fn probe_connection_does_not_break_server() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+
+    // Simulate is_server_running(): connect and immediately drop.
+    {
+        let _stream = UnixStream::connect(&socket_path).await.unwrap();
+    }
+
+    // Small delay so the server processes the disconnect.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // A real client should still be able to connect and handshake.
+    let mut client = common::TestClient::connect(&socket_path).await;
+    let ack = client.handshake().await;
+    assert!(!ack.server_id.is_empty());
+}
+
+/// Multiple rapid probe connections (simulating repeated status checks)
+/// must not leak resources or prevent real clients.
+#[tokio::test]
+async fn repeated_probes_do_not_leak_resources() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+
+    // Simulate 10 rapid is_server_running() calls.
+    for _ in 0..10 {
+        let _stream = UnixStream::connect(&socket_path).await.unwrap();
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Real client should work fine.
+    let mut client = common::TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    // Create a session to verify full functionality.
+    let sid = common::create_session(
+        &mut client,
+        "after-probes",
+        rttx_proto::proto::RuntimePolicy::Persistent,
+    )
+    .await;
+    assert!(!sid.is_empty());
+}


### PR DESCRIPTION
## What changed and why

`is_server_running()` health-check connections (connect + immediate disconnect) were logged at INFO level, polluting the daemon log. This PR:

1. **Defers the "connected" log** until the first message arrives
2. **Logs probe connections at DEBUG** instead of INFO
3. **Skips session detach cleanup** for connections that never completed handshake
4. **Fixes a deadlock** in the `probe_connection_logs_at_debug_not_info` unit test where `_client_half` kept the duplex alive (should have been bare `_` for immediate drop)

## Root cause

The test bound the client half of a `tokio::io::duplex` to `_client_half`. The `_` prefix suppresses the unused-variable warning but does **not** drop the value — it lives until end of scope. Since `handle_client` was awaited synchronously and blocks on `reader.read_message()`, the test deadlocked because EOF never arrived.

## How to verify

```bash
cargo test -p rttx-server --lib probe_connection_logs_at_debug_not_info
cargo test -p rttx-server --lib real_client_logs_connected_and_disconnected_at_info
cargo test -p rttx-server --test probe_connection
```

## Tests added

- `probe_connection_logs_at_debug_not_info` — unit test: probe logs at debug, not info
- `real_client_logs_connected_and_disconnected_at_info` — unit test: real client logs at info
- `probe_connection_does_not_break_server` — integration test: probe does not break subsequent clients
- `repeated_probes_do_not_leak_resources` — integration test: rapid probes do not leak

## Tests run

- `cargo test -p rttx-proto -p rttx-server` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass

Fixes #641