### PR TITLE
fix: limit event poller batch size to prevent UI hang during output bursts

### DIFF
--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+/// Maximum events the poller processes per GTK timer callback.
+/// Keeps the main loop responsive during output bursts.
+pub(super) const EVENT_POLL_BATCH_LIMIT: usize = 64;
+
 impl Window {
     pub fn add_session(&self) {
         crate::new_workspace_dialog::show(self, &crate::host::Host::local());
@@ -501,8 +505,11 @@ impl Window {
             let Some(win) = win.upgrade() else {
                 return glib::ControlFlow::Break;
             };
-            while let Ok(event) = rx.try_recv() {
-                win.handle_endpoint_event(event);
+            for _ in 0..EVENT_POLL_BATCH_LIMIT {
+                match rx.try_recv() {
+                    Ok(event) => win.handle_endpoint_event(event),
+                    Err(_) => break,
+                }
             }
             glib::ControlFlow::Continue
         });

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -5530,3 +5530,12 @@ fn split_managed_pane_passes_source_terminal_size() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+/// The event poller batch limit must be positive and bounded to prevent
+/// the main loop from starving during output bursts. Regression for #653.
+#[test]
+fn event_poll_batch_limit_is_bounded() {
+    use super::runtime::EVENT_POLL_BATCH_LIMIT;
+    const { assert!(EVENT_POLL_BATCH_LIMIT > 0) };
+    const { assert!(EVENT_POLL_BATCH_LIMIT <= 256) };
+}


### PR DESCRIPTION
## What changed and why

The endpoint event poller in `window/runtime.rs` drained the entire event channel in a single GTK timer callback:

```rust
while let Ok(event) = rx.try_recv() {
    win.handle_endpoint_event(event);
}
```

The channel capacity is 4096 events. When a command produces heavy output and the user presses Ctrl+C, the daemon may have already buffered many Delta messages. Processing all of them in one callback iteration blocks the GTK main thread, freezing the UI and — on Wayland — potentially the desktop (since clipboard requests from other apps cannot be served while the main loop is blocked).

The fix caps each callback iteration at `EVENT_POLL_BATCH_LIMIT` (64) events, so the main loop can service rendering, clipboard requests, and input between batches. The 8ms timer interval means the poller still processes up to 8000 events/second, which is more than sufficient for interactive use.

## Manual verification steps

1. Open a managed (daemon-backed) workspace
2. Run a command that produces heavy output (e.g. `yes` or `cat /dev/urandom | base64`)
3. Press Ctrl+C to interrupt it
4. Verify the UI remains responsive during the output burst

## Tests added

- `event_poll_batch_limit_is_bounded` — verifies the batch limit constant is positive and bounded

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 563 passed, 150 ignored ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #653