### PR TITLE
fix: strip user@host prefix from pane titles for consistency

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1095,4 +1095,16 @@ mod search_tests {
         let mixed = b"\x1b[<0;5;10M\x1b[1;6R";
         assert_eq!(strip_cpr_responses(mixed).unwrap(), b"\x1b[<0;5;10M");
     }
+
+    /// Regression for #655: `strip_user_host_prefix` must remove the
+    /// user@host prefix that shells set via OSC 0/2 so pane titles
+    /// do not show redundant host information.
+    #[test]
+    fn strip_user_host_prefix_removes_shell_title_prefix() {
+        use super::persistent_widget::strip_user_host_prefix;
+
+        assert_eq!(strip_user_host_prefix("user@host: ~/projects"), "~/projects");
+        assert_eq!(strip_user_host_prefix("bash"), "bash");
+        assert_eq!(strip_user_host_prefix(""), "");
+    }
 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -992,20 +992,45 @@ pub(crate) fn pastify_for_pane(pane: &PersistentPaneView, text: &[u8]) -> Vec<u8
     }
 }
 
+/// Strip `user@host: ` prefix that shells set via OSC 0/2.
+///
+/// Returns the remainder after the prefix, or the original string when
+/// no prefix is found.
+pub(crate) fn strip_user_host_prefix(title: &str) -> &str {
+    if let Some(at) = title.find('@')
+        && let Some(colon_space) = title[at..].find(": ")
+    {
+        let prefix_end = at + colon_space + 2;
+        let candidate = &title[..at];
+        if !candidate.is_empty() && !candidate.contains(' ') {
+            return title[prefix_end..].trim();
+        }
+    }
+    title
+}
+
 /// Format the pane header title from daemon-reported title and CWD.
 ///
-/// Returns `<app> : <path>` when both are available, just the path when
-/// the title is a generic shell name, or falls back to the title alone.
+/// Strips `user@host: path` prefixes so the pane header shows a clean
+/// `<app> : <path>` when both are available, just the path when the
+/// title is redundant, or falls back to the title alone.
 fn format_pane_header_title(daemon_title: Option<&str>, cwd: Option<&str>) -> String {
     let path = cwd.map(collapse_home_path);
-    let title = daemon_title.map(str::trim).filter(|t| !t.is_empty());
+    let title = daemon_title
+        .map(|t| strip_user_host_prefix(t.trim()))
+        .filter(|t| !t.is_empty());
 
     match (title, path.as_deref().filter(|p| !p.is_empty())) {
+        (Some(t), Some(p)) if looks_like_path(t) => p.to_string(),
         (Some(t), Some(p)) => format!("{t} : {p}"),
         (None, Some(p)) => p.to_string(),
         (Some(t), None) => t.to_string(),
         (None, None) => "Terminal".into(),
     }
+}
+
+fn looks_like_path(s: &str) -> bool {
+    s.starts_with('/') || s.starts_with('~')
 }
 
 /// Collapse `/home/<user>/…` to `~/…`.
@@ -1932,6 +1957,69 @@ mod tests {
     #[test]
     fn collapse_home_path_no_change_for_other_paths() {
         assert_eq!(collapse_home_path("/tmp/test"), "/tmp/test");
+    }
+
+    #[test]
+    fn strip_user_host_prefix_removes_standard_prefix() {
+        assert_eq!(strip_user_host_prefix("user@host: ~/projects"), "~/projects");
+    }
+
+    #[test]
+    fn strip_user_host_prefix_preserves_plain_app_name() {
+        assert_eq!(strip_user_host_prefix("vim"), "vim");
+        assert_eq!(strip_user_host_prefix("bash"), "bash");
+    }
+
+    #[test]
+    fn strip_user_host_prefix_preserves_app_with_args() {
+        assert_eq!(strip_user_host_prefix("vim /tmp/file.txt"), "vim /tmp/file.txt");
+    }
+
+    #[test]
+    fn strip_user_host_prefix_handles_fqdn_host() {
+        assert_eq!(strip_user_host_prefix("user@host.example.com: /tmp"), "/tmp");
+    }
+
+    #[test]
+    fn strip_user_host_prefix_preserves_email_like_without_colon_space() {
+        assert_eq!(strip_user_host_prefix("user@host"), "user@host");
+    }
+
+    #[test]
+    fn strip_user_host_prefix_empty_string() {
+        assert_eq!(strip_user_host_prefix(""), "");
+    }
+
+    /// Regression for #655: shell title with user@host + CWD must not
+    /// produce a double path in the pane header.
+    #[test]
+    fn format_pane_header_title_strips_user_host_and_deduplicates_path() {
+        let home = std::env::var("HOME").unwrap();
+        let cwd = format!("{home}/projects");
+        assert_eq!(
+            format_pane_header_title(Some(&format!("user@host: {home}/projects")), Some(&cwd)),
+            "~/projects"
+        );
+    }
+
+    /// Regression for #655: when the stripped title is a path and CWD is
+    /// available, only the CWD should appear.
+    #[test]
+    fn format_pane_header_title_path_title_with_cwd_shows_cwd_only() {
+        assert_eq!(
+            format_pane_header_title(Some("user@host: /tmp"), Some("/tmp")),
+            "/tmp"
+        );
+    }
+
+    /// Regression for #655: app name after stripping user@host must still
+    /// combine with CWD.
+    #[test]
+    fn format_pane_header_title_app_after_strip_combines_with_path() {
+        assert_eq!(
+            format_pane_header_title(Some("user@host: vim"), Some("/tmp")),
+            "vim : /tmp"
+        );
     }
 
     /// Regression for #536: default title must not show "(persistent)".

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -1016,9 +1016,7 @@ pub(crate) fn strip_user_host_prefix(title: &str) -> &str {
 /// title is redundant, or falls back to the title alone.
 fn format_pane_header_title(daemon_title: Option<&str>, cwd: Option<&str>) -> String {
     let path = cwd.map(collapse_home_path);
-    let title = daemon_title
-        .map(|t| strip_user_host_prefix(t.trim()))
-        .filter(|t| !t.is_empty());
+    let title = daemon_title.map(|t| strip_user_host_prefix(t.trim())).filter(|t| !t.is_empty());
 
     match (title, path.as_deref().filter(|p| !p.is_empty())) {
         (Some(t), Some(p)) if looks_like_path(t) => p.to_string(),
@@ -2006,20 +2004,14 @@ mod tests {
     /// available, only the CWD should appear.
     #[test]
     fn format_pane_header_title_path_title_with_cwd_shows_cwd_only() {
-        assert_eq!(
-            format_pane_header_title(Some("user@host: /tmp"), Some("/tmp")),
-            "/tmp"
-        );
+        assert_eq!(format_pane_header_title(Some("user@host: /tmp"), Some("/tmp")), "/tmp");
     }
 
     /// Regression for #655: app name after stripping user@host must still
     /// combine with CWD.
     #[test]
     fn format_pane_header_title_app_after_strip_combines_with_path() {
-        assert_eq!(
-            format_pane_header_title(Some("user@host: vim"), Some("/tmp")),
-            "vim : /tmp"
-        );
+        assert_eq!(format_pane_header_title(Some("user@host: vim"), Some("/tmp")), "vim : /tmp");
     }
 
     /// Regression for #536: default title must not show "(persistent)".

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -563,7 +563,8 @@ impl TerminalWidget {
             if custom_title.borrow().is_none()
                 && let Some(title) = vte.window_title()
             {
-                title_label.set_label(&title);
+                let cleaned = crate::terminal::persistent_widget::strip_user_host_prefix(&title);
+                title_label.set_label(cleaned);
             }
         });
 

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2472,9 +2472,6 @@ fn persistent_pane_title_strips_user_host_prefix() {
     pane.set_current_directory(Some(&format!("{home}/projects")));
 
     let label = pane.title_label().label().to_string();
-    assert!(
-        !label.contains('@'),
-        "pane title must not contain user@host, got: {label}"
-    );
+    assert!(!label.contains('@'), "pane title must not contain user@host, got: {label}");
     assert_eq!(label, "~/projects");
 }

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2457,3 +2457,24 @@ fn host_tag_picker_unrecognized_tag_not_checked() {
     // Only local is in the picker, and it's not selected
     assert!(picker.selected_tags().is_empty());
 }
+
+/// Regression for #655: managed pane title must strip user@host prefix
+/// and avoid duplicating the path when CWD is available.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn persistent_pane_title_strips_user_host_prefix() {
+    require_display!();
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("pane-title", "rt-1");
+    let home = std::env::var("HOME").unwrap();
+
+    pane.set_daemon_title(&format!("user@host: {home}/projects"));
+    pane.set_current_directory(Some(&format!("{home}/projects")));
+
+    let label = pane.title_label().label().to_string();
+    assert!(
+        !label.contains('@'),
+        "pane title must not contain user@host, got: {label}"
+    );
+    assert_eq!(label, "~/projects");
+}


### PR DESCRIPTION
## What changed and why

Pane title bars were inconsistent between direct and managed panes:

- **Managed panes** showed `user@host: ~/path : ~/path` — the shell's OSC 0/2 title (which includes user@host and path) was concatenated with the OSC 7 CWD, producing a duplicate path
- **Direct panes** showed the raw VTE title `user@host: ~/path` with no CWD-based formatting
- **Remote managed panes** showed just `app : ~/path` because the remote shell's title is typically just the app name

The user@host prefix is redundant (the endpoint is shown at the workspace level) and misleading (it doesn't update when SSH-ing to another host from within the pane).

### Changes

1. Added `strip_user_host_prefix()` that removes `user@host: ` from shell titles
2. Modified `format_pane_header_title()` to strip the prefix and avoid duplicating the path when the stripped title is itself a path
3. Applied the same stripping to direct pane titles in `widget.rs`

## Manual verification steps

1. Open a managed workspace on the local daemon
2. Verify pane title shows `bash : ~/path` (not `user@host: ~/path : ~/path`)
3. `cd` to another directory — title updates to new path
4. Run `vim` — title shows `vim : ~/path`
5. Open a direct workspace — verify same clean title format
6. Open a remote workspace — verify consistent format

## Tests added

- `strip_user_host_prefix_removes_standard_prefix`
- `strip_user_host_prefix_preserves_plain_app_name`
- `strip_user_host_prefix_preserves_app_with_args`
- `strip_user_host_prefix_handles_fqdn_host`
- `strip_user_host_prefix_preserves_email_like_without_colon_space`
- `strip_user_host_prefix_empty_string`
- `format_pane_header_title_strips_user_host_and_deduplicates_path` (regression for #655)
- `format_pane_header_title_path_title_with_cwd_shows_cwd_only` (regression for #655)
- `format_pane_header_title_app_after_strip_combines_with_path` (regression for #655)

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 572 passed, 150 ignored ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (GTK title tests confirmed passing)

Fixes #655