### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.2.41"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.2.41"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.2.41"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.41"
+version = "0.3.0"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.2.41',
+  version: '0.3.0',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Bumps the project version from 0.2.41 to 0.3.0 for both the GUI client and daemon.

Files changed:
- `Cargo.toml` — workspace version
- `Cargo.lock` — auto-updated by Cargo
- `meson.build` — Meson project version

## Manual verification

```bash
cargo build -p rttx --no-default-features --features vte-0_76
cargo build -p rttx-server
# Both report version 0.3.0 in compilation output
```

## Tests added

No new tests — this is a version string change with no behavioral impact. Existing tests that reference `CARGO_PKG_VERSION` (e.g. `persistence_compat::round_trip_current_version`) automatically validate the new version.

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76` — 27 passed, 0 failed
- `cargo test -p rttx-proto -p rttx-server` — all passed, 0 failed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — 327 test suites, all ok, 0 failed

Fixes #657