### PR TITLE
fix: swap right-click and Shift+right-click to match GNOME conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ modern GNOME desktop.
 ### Terminal
 
 - Ctrl+click to open URLs, OSC 8 hyperlinks, and detected file paths
-- Shift+right-click for context menu; plain mouse events pass through to terminal apps
+- Right-click for context menu; Shift+right-click passes mouse events to terminal apps
 - Optional smart clipboard: plain Ctrl+C copies selected text, Ctrl+V pastes
 - Built-in Nightfall and Daybreak themes, with Tilix color scheme compatibility
 - Background process notifications via toast (foreground) or desktop notification (background)

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -34,6 +34,15 @@ pub(crate) fn copy_to_clipboard(vte: &vte4::Terminal) {
 /// preventing immediate item activation on button release (#480).
 pub(crate) const CONTEXT_MENU_HALIGN: gtk4::Align = gtk4::Align::Start;
 
+/// Whether a right-click with the given modifiers should open the context menu.
+///
+/// Plain right-click opens the menu (matches GNOME Terminal, Ptyxis, Tilix).
+/// Shift+right-click passes through to VTE for mouse-aware apps.
+#[must_use]
+pub const fn should_open_context_menu(mods: gtk4::gdk::ModifierType) -> bool {
+    !mods.contains(gtk4::gdk::ModifierType::SHIFT_MASK)
+}
+
 /// Populate a `gio::Menu` with places visible on the given host key.
 ///
 /// Each item triggers `win.open-place` with the place path as parameter.
@@ -990,6 +999,48 @@ mod pane_passive_tests {
             super::CONTEXT_MENU_HALIGN,
             gtk4::Align::Start,
             "context menu must open adjacent to the pointer, not centered on it"
+        );
+    }
+
+    /// Plain right-click (no modifiers) must open the context menu.
+    /// Matches GNOME Terminal, Ptyxis, and Tilix conventions. Regression for #659.
+    #[test]
+    fn plain_right_click_opens_context_menu() {
+        assert!(
+            super::should_open_context_menu(gtk4::gdk::ModifierType::empty()),
+            "plain right-click must open context menu"
+        );
+    }
+
+    /// Shift+right-click must pass through to VTE for mouse-aware apps.
+    /// Regression for #659.
+    #[test]
+    fn shift_right_click_passes_through() {
+        assert!(
+            !super::should_open_context_menu(gtk4::gdk::ModifierType::SHIFT_MASK),
+            "Shift+right-click must not open context menu"
+        );
+    }
+
+    /// Ctrl+right-click (without Shift) must still open the context menu.
+    /// Only Shift suppresses the menu. Regression for #659.
+    #[test]
+    fn ctrl_right_click_opens_context_menu() {
+        assert!(
+            super::should_open_context_menu(gtk4::gdk::ModifierType::CONTROL_MASK),
+            "Ctrl+right-click (no Shift) must open context menu"
+        );
+    }
+
+    /// Ctrl+Shift+right-click must pass through (Shift is present).
+    /// Regression for #659.
+    #[test]
+    fn ctrl_shift_right_click_passes_through() {
+        let mods =
+            gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK;
+        assert!(
+            !super::should_open_context_menu(mods),
+            "Ctrl+Shift+right-click must not open context menu"
         );
     }
 }

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -972,7 +972,7 @@ mod pane_passive_tests {
     }
 
     /// Gesture modifier masks used by link and context menu handlers must be
-    /// distinct so Ctrl+click and Shift+right-click do not interfere with
+    /// distinct so Ctrl+click and plain right-click do not interfere with
     /// each other. Regression for #459.
     #[test]
     fn gesture_modifier_masks_are_distinct() {

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1036,8 +1036,7 @@ mod pane_passive_tests {
     /// Regression for #659.
     #[test]
     fn ctrl_shift_right_click_passes_through() {
-        let mods =
-            gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK;
+        let mods = gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK;
         assert!(
             !super::should_open_context_menu(mods),
             "Ctrl+Shift+right-click must not open context menu"

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -251,7 +251,7 @@ mod imp {
                 // Plain right-click opens the context menu. Shift+right-click
                 // is denied so VTE can forward it to mouse-aware apps.
                 let mods = gesture.current_event_state();
-                if mods.contains(gtk4::gdk::ModifierType::SHIFT_MASK) {
+                if !crate::terminal::should_open_context_menu(mods) {
                     gesture.set_state(gtk4::EventSequenceState::Denied);
                     return;
                 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -248,10 +248,10 @@ mod imp {
             let open_link_ref = open_link_action;
             let obj_weak = obj.downgrade();
             right_click.connect_pressed(move |gesture, _, x, y| {
-                // Shift+right-click opens the context menu. Plain right-click
+                // Plain right-click opens the context menu. Shift+right-click
                 // is denied so VTE can forward it to mouse-aware apps.
                 let mods = gesture.current_event_state();
-                if !mods.contains(gtk4::gdk::ModifierType::SHIFT_MASK) {
+                if mods.contains(gtk4::gdk::ModifierType::SHIFT_MASK) {
                     gesture.set_state(gtk4::EventSequenceState::Denied);
                     return;
                 }

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -270,7 +270,7 @@ mod imp {
                 // Plain right-click opens the context menu. Shift+right-click
                 // is denied so VTE can forward it to mouse-aware apps.
                 let mods = gesture.current_event_state();
-                if mods.contains(gtk4::gdk::ModifierType::SHIFT_MASK) {
+                if !crate::terminal::should_open_context_menu(mods) {
                     gesture.set_state(gtk4::EventSequenceState::Denied);
                     return;
                 }

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -267,10 +267,10 @@ mod imp {
             let open_link_ref = open_link_action;
             let obj_weak = obj.downgrade();
             right_click.connect_pressed(move |gesture, _, x, y| {
-                // Shift+right-click opens the context menu. Plain right-click
+                // Plain right-click opens the context menu. Shift+right-click
                 // is denied so VTE can forward it to mouse-aware apps.
                 let mods = gesture.current_event_state();
-                if !mods.contains(gtk4::gdk::ModifierType::SHIFT_MASK) {
+                if mods.contains(gtk4::gdk::ModifierType::SHIFT_MASK) {
                     gesture.set_state(gtk4::EventSequenceState::Denied);
                     return;
                 }

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2475,3 +2475,48 @@ fn persistent_pane_title_strips_user_host_prefix() {
     assert!(!label.contains('@'), "pane title must not contain user@host, got: {label}");
     assert_eq!(label, "~/projects");
 }
+
+/// Regression for #659: the shared `should_open_context_menu` helper must
+/// return true for plain right-click (no modifiers) and false when Shift is
+/// held, matching GNOME Terminal / Ptyxis / Tilix conventions. Both
+/// `TerminalWidget` and `PersistentPaneView` delegate to this helper.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn context_menu_modifier_convention_matches_gnome() {
+    require_display!();
+
+    // Verify the helper function implements the GNOME convention.
+    assert!(
+        rttx::terminal::should_open_context_menu(gtk4::gdk::ModifierType::empty()),
+        "plain right-click must open context menu"
+    );
+    assert!(
+        !rttx::terminal::should_open_context_menu(gtk4::gdk::ModifierType::SHIFT_MASK),
+        "Shift+right-click must pass through to VTE"
+    );
+
+    // Verify both widget types have a button-3 capture gesture that can
+    // invoke the context menu (structural prerequisite for the helper).
+    for (label, controllers) in [
+        (
+            "TerminalWidget",
+            rttx::terminal::widget::TerminalWidget::new("t-mod", None)
+                .vte()
+                .observe_controllers(),
+        ),
+        (
+            "PersistentPaneView",
+            rttx::terminal::persistent_widget::PersistentPaneView::new("p-mod", "s1")
+                .vte()
+                .observe_controllers(),
+        ),
+    ] {
+        let has_btn3 = (0..controllers.n_items()).any(|i| {
+            controllers
+                .item(i)
+                .and_then(|c| c.downcast::<gtk4::GestureClick>().ok())
+                .is_some_and(|g| g.button() == 3)
+        });
+        assert!(has_btn3, "{label} must have a button-3 gesture for context menu");
+    }
+}

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2500,9 +2500,7 @@ fn context_menu_modifier_convention_matches_gnome() {
     for (label, controllers) in [
         (
             "TerminalWidget",
-            rttx::terminal::widget::TerminalWidget::new("t-mod", None)
-                .vte()
-                .observe_controllers(),
+            rttx::terminal::widget::TerminalWidget::new("t-mod", None).vte().observe_controllers(),
         ),
         (
             "PersistentPaneView",

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2046,7 +2046,7 @@ fn direct_terminal_link_gesture_is_capture_phase() {
 }
 
 /// The right-click context menu gesture on a persistent pane must use
-/// capture phase. When Shift is not held, the gesture denies so VTE
+/// capture phase. When Shift is held, the gesture denies so VTE
 /// receives the right-click for mouse-aware apps. Regression for #459.
 #[test]
 #[ignore = "requires isolated GTK harness"]

--- a/designs/RFC-008-terminal-links.md
+++ b/designs/RFC-008-terminal-links.md
@@ -19,7 +19,7 @@ turning rttx into a general-purpose terminal hyperlink engine.
 The implementation lives in a shared `terminal/links.rs` module used by both `TerminalWidget`
 (direct panes) and `PersistentPaneView` (daemon-backed panes). Activation requires Ctrl+click,
 which was added post-RFC to avoid intercepting mouse events from terminal apps (vim, htop, mc).
-A Shift+right-click context menu with "Open Link" and "Copy Link" actions was also added
+A right-click context menu with "Open Link" and "Copy Link" actions was also added
 post-RFC.
 
 ---
@@ -32,7 +32,7 @@ post-RFC.
 
 ## Non-Goals
 
-- **NG1** — No hover popover in this RFC. A Shift+right-click context menu with "Open Link" and
+- **NG1** — No hover popover in this RFC. A right-click context menu with "Open Link" and
   "Copy Link" was added post-RFC as a natural extension, but no hover tooltip is shown.
 - **NG2** — No line/column handoff to editors; `:42:7` suffixes only resolve the file path
 - **NG3** — No remote path opening or SSH-aware path translation
@@ -54,7 +54,7 @@ and sysadmin workflows and open them with one click.
 
 | Audience | Impact |
 | --- | --- |
-| End users | Links and local paths in terminal output become Ctrl+clickable; Shift+right-click context menu offers "Open Link" and "Copy Link" |
+| End users | Links and local paths in terminal output become Ctrl+clickable; right-click context menu offers "Open Link" and "Copy Link" |
 | Contributors | Behavior is isolated to `terminal/links.rs`; no `window.rs` involvement |
 | Packagers | No new dependencies |
 
@@ -125,8 +125,8 @@ so that plain mouse events pass through to VTE for mouse-aware terminal apps (vi
 
 **Status: implemented** in `widget.rs` and `persistent_widget.rs` (post-RFC addition).
 
-Shift+right-click opens a context menu with "Open Link" and "Copy Link" actions. Plain
-right-click is denied so VTE receives the event for mouse-aware apps. The menu resolves the
+Plain right-click opens a context menu with "Open Link" and "Copy Link" actions.
+Shift+right-click is denied so VTE receives the event for mouse-aware apps. The menu resolves the
 link at the click position and enables/disables the link actions accordingly. "Copy Link"
 converts file URIs to filesystem paths via `display_text_for_uri()` for clipboard friendliness.
 
@@ -179,7 +179,7 @@ without spawning external applications.
 - [x] Register VTE regex matches for URLs and paths — `configure_openable_matches()` in
   `links.rs`
 - [x] Add click handling that opens matches via Gio — Ctrl+click via
-  `install_openable_link_controllers()`; Shift+right-click context menu in both widget types
+  `install_openable_link_controllers()`; right-click context menu in both widget types
 - [x] Update user-facing docs and `META/todo.md`
 - [x] Add GTK widget tests for link activation in both direct and daemon-backed panes
   (post-RFC) — `direct_terminal_plain_click_does_not_launch_url`,


### PR DESCRIPTION
## What changed and why

Plain right-click now opens the context menu. Shift+right-click passes the event through to VTE for mouse-aware terminal apps (vim, htop, mc, etc.).

The current behavior is backwards from what users expect — GNOME Terminal, Ptyxis, and Tilix all use right-click for the context menu and Shift+right-click for pass-through.

The fix inverts the Shift modifier check in both `TerminalWidget` (ephemeral panes) and `PersistentPaneView` (daemon-backed panes) right-click gesture handlers.

## Changes

- `clients/rttx/src/terminal/widget.rs`: Invert `!mods.contains(SHIFT_MASK)` → `mods.contains(SHIFT_MASK)`
- `clients/rttx/src/terminal/persistent_widget.rs`: Same inversion
- `clients/rttx/src/terminal/mod.rs`: Update test comment
- `clients/rttx/tests/gtk_widget_tests.rs`: Update test comment
- `README.md`: Update feature description
- `designs/RFC-008-terminal-links.md`: Update all references to match new behavior

## Manual verification

1. Launch rttx
2. Right-click in a terminal pane → context menu opens
3. Shift+right-click in a terminal pane → event passes through to VTE (no context menu)
4. In a mouse-aware app (e.g. `vim`, `htop`), Shift+right-click passes through correctly

## Tests

All existing context menu and gesture tests pass unchanged — the tests verify structural properties (capture phase, parent widget, halign, action model) that are unaffected by the modifier swap.

### Tests run locally (all pass)

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass)

Fixes #659