### PR TITLE
fix: let VTE handle non-text clipboard paste in direct terminals

### DIFF
--- a/clients/rttx/src/terminal/paste_guard.rs
+++ b/clients/rttx/src/terminal/paste_guard.rs
@@ -50,6 +50,47 @@ pub(crate) fn flatten_to_single_line(text: &str) -> String {
     out.trim().to_string()
 }
 
+/// What the paste guard should do after reading the clipboard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PasteGuardDecision {
+    /// Paste immediately — text is below the guard threshold.
+    Paste,
+    /// Show a confirmation dialog before pasting.
+    Confirm,
+    /// No text on clipboard — let VTE handle non-text content natively.
+    FallThroughToVte,
+    /// No text on clipboard and the terminal cannot handle non-text content.
+    Skip,
+}
+
+/// Decide what to do after reading clipboard text for the paste guard.
+///
+/// `is_direct` is true for direct (VTE-backed) terminals that can handle
+/// non-text clipboard content natively, false for managed (daemon-backed)
+/// terminals that only accept byte streams.
+pub(crate) fn decide(
+    clipboard_text: Option<&str>,
+    threshold_bytes: usize,
+    is_direct: bool,
+) -> PasteGuardDecision {
+    match clipboard_text {
+        Some(text) if !text.is_empty() => {
+            if needs_confirmation(text, threshold_bytes) {
+                PasteGuardDecision::Confirm
+            } else {
+                PasteGuardDecision::Paste
+            }
+        }
+        _ => {
+            if is_direct {
+                PasteGuardDecision::FallThroughToVte
+            } else {
+                PasteGuardDecision::Skip
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -136,5 +177,35 @@ mod tests {
     #[test]
     fn flatten_empty() {
         assert_eq!(flatten_to_single_line(""), "");
+    }
+
+    #[test]
+    fn decide_small_text_pastes_immediately() {
+        assert_eq!(decide(Some("hello"), 1024, true), PasteGuardDecision::Paste);
+        assert_eq!(decide(Some("hello"), 1024, false), PasteGuardDecision::Paste);
+    }
+
+    #[test]
+    fn decide_multiline_text_confirms() {
+        assert_eq!(decide(Some("a\nb"), 1024, true), PasteGuardDecision::Confirm);
+        assert_eq!(decide(Some("a\nb"), 1024, false), PasteGuardDecision::Confirm);
+    }
+
+    #[test]
+    fn decide_large_text_confirms() {
+        let big = "x".repeat(2000);
+        assert_eq!(decide(Some(&big), 1024, true), PasteGuardDecision::Confirm);
+    }
+
+    #[test]
+    fn decide_no_text_direct_falls_through_to_vte() {
+        assert_eq!(decide(None, 1024, true), PasteGuardDecision::FallThroughToVte);
+        assert_eq!(decide(Some(""), 1024, true), PasteGuardDecision::FallThroughToVte);
+    }
+
+    #[test]
+    fn decide_no_text_managed_skips() {
+        assert_eq!(decide(None, 1024, false), PasteGuardDecision::Skip);
+        assert_eq!(decide(Some(""), 1024, false), PasteGuardDecision::Skip);
     }
 }

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::terminal::paste_guard::{PasteGuardDecision, decide};
 
 impl Window {
     pub(super) fn setup_actions(&self, app: &adw::Application) {
@@ -318,23 +319,29 @@ impl Window {
             return;
         };
         let clipboard = display.clipboard();
+        let is_direct = matches!(terminal, TerminalHandle::Direct(_));
         let win = self.clone();
         let terminal_uuid = uuid;
         clipboard.read_text_async(None::<&gtk4::gio::Cancellable>, move |result| {
-            let text = match result {
-                Ok(Some(t)) if !t.is_empty() => t.to_string(),
-                _ => return,
+            let clipboard_text = match result {
+                Ok(Some(ref t)) if !t.is_empty() => Some(t.as_str()),
+                _ => None,
             };
 
             let threshold = crate::preferences::load().paste_guard_threshold;
-            if !crate::terminal::paste_guard::needs_confirmation(&text, threshold) {
-                if let Some(terminal) = win.terminal_handle(&terminal_uuid) {
-                    Self::execute_paste(&terminal, &win, &terminal_uuid);
+            match decide(clipboard_text, threshold, is_direct) {
+                PasteGuardDecision::Paste | PasteGuardDecision::FallThroughToVte => {
+                    if let Some(terminal) = win.terminal_handle(&terminal_uuid) {
+                        Self::execute_paste(&terminal, &win, &terminal_uuid);
+                    }
                 }
-                return;
+                PasteGuardDecision::Confirm => {
+                    if let Some(text) = clipboard_text {
+                        win.confirm_paste(&terminal_uuid, text);
+                    }
+                }
+                PasteGuardDecision::Skip => {}
             }
-
-            win.confirm_paste(&terminal_uuid, &text);
         });
     }
 


### PR DESCRIPTION
## What changed and why

The paste guard reads only text from the clipboard via `read_text_async`. When the clipboard contains non-text content (e.g., an image copied from a screenshot tool), the async callback received `None` and silently returned — dropping the paste entirely. This prevented applications running inside the terminal (like AI chat tools such as kiro) from receiving image paste that works in GNOME Terminal.

### Root cause

In `clipboard_paste()`, the paste guard path had:
```rust
let text = match result {
    Ok(Some(t)) if !t.is_empty() => t.to_string(),
    _ => return,  // silently drops non-text clipboard content
};
```

### Fix

Extracted a testable `decide()` function in `paste_guard` that determines the correct action based on clipboard content and terminal type:

- **Direct terminals** (VTE-backed): when clipboard has no text, fall through to VTE's native `paste_clipboard()` which handles non-text content types
- **Managed terminals** (daemon-backed): skip, since the daemon only accepts byte streams

## How to manually verify

1. Copy an image to the clipboard (e.g., take a screenshot with the GNOME screenshot tool)
2. Focus a direct terminal pane in rttx
3. Press Ctrl+Shift+V — VTE now receives the paste event
4. Verify that text paste (with and without paste guard confirmation) still works normally

## Tests added

5 new unit tests in `paste_guard`:
- `decide_small_text_pastes_immediately` — text below threshold pastes for both terminal types
- `decide_multiline_text_confirms` — multiline text triggers confirmation
- `decide_large_text_confirms` — large text triggers confirmation
- `decide_no_text_direct_falls_through_to_vte` — non-text clipboard falls through for direct terminals (the bug fix)
- `decide_no_text_managed_skips` — non-text clipboard is skipped for managed terminals

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (582 passed, 150 ignored, 0 failed)
- All 5 new `decide_*` tests confirmed passing in quality test output

Fixes #661