### PR TITLE
test: add session persistence end-to-end tests

### DIFF
--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -5539,3 +5539,188 @@ fn event_poll_batch_limit_is_bounded() {
     const { assert!(EVENT_POLL_BATCH_LIMIT > 0) };
     const { assert!(EVENT_POLL_BATCH_LIMIT <= 256) };
 }
+
+// ── Session persistence end-to-end (GUI round-trip) ─────────────
+
+/// Full GUI round-trip: create workspaces, split, rename, reorder →
+/// save_state → close → new Window (load_state) → verify widget tree.
+/// Covers the gap identified in #325.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn save_and_restart_full_session_persistence_roundtrip() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.persistence-e2e-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    // ── Phase 1: Build state through GUI actions ────────────────
+
+    let first_window = Window::new(&app);
+    first_window.set_default_size(1200, 800);
+    first_window.present();
+    pump_events(100);
+
+    // Add two more workspaces (3 total).
+    first_window.add_direct_session();
+    first_window.add_direct_session();
+    pump_events(100);
+
+    let (ws0_uuid, ws1_uuid, ws2_uuid) = {
+        let state = first_window.imp().state.borrow();
+        assert_eq!(state.sessions.len(), 3);
+        (
+            state.sessions[0].uuid.clone(),
+            state.sessions[1].uuid.clone(),
+            state.sessions[2].uuid.clone(),
+        )
+    };
+
+    // Rename workspace 0.
+    first_window.rename_session(&ws0_uuid, "Editor");
+
+    // Split workspace 0 horizontally.
+    let ws0_t1 = {
+        let state = first_window.imp().state.borrow();
+        state.sessions[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    first_window.split_terminal(&ws0_t1, SplitOrientation::Horizontal);
+    pump_events(100);
+
+    let ws0_t2 = {
+        let state = first_window.imp().state.borrow();
+        state.sessions[0].layout.terminal_uuids().into_iter().find(|u| u != &ws0_t1).unwrap()
+    };
+
+    // Rename workspace 1.
+    first_window.rename_session(&ws1_uuid, "Build");
+
+    // Reorder: move workspace 2 to position 0.
+    first_window.reorder_session(&ws2_uuid, &ws0_uuid);
+    pump_events(50);
+
+    // Select workspace 1 (now at index 1 after reorder).
+    let active_index = {
+        let state = first_window.imp().state.borrow();
+        state.sessions.iter().position(|s| s.uuid == ws0_uuid).unwrap()
+    };
+    if let Some(row) = first_window.imp().sidebar_list.row_at_index(active_index as i32) {
+        first_window.imp().sidebar_list.select_row(Some(&row));
+    }
+    pump_events(50);
+
+    // Capture expected state before save.
+    let expected_order: Vec<String> = {
+        let state = first_window.imp().state.borrow();
+        state.sessions.iter().map(|s| s.uuid.clone()).collect()
+    };
+    let expected_names: Vec<String> = {
+        let state = first_window.imp().state.borrow();
+        state.sessions.iter().map(|s| s.name.clone()).collect()
+    };
+
+    // ── Phase 2: Save and close ─────────────────────────────────
+
+    first_window.save_state();
+    first_window.close();
+
+    // Verify saved state on disk.
+    let saved = session::load_window_state();
+    assert_eq!(saved.sessions.len(), 3, "saved state should have 3 workspaces");
+    let saved_order: Vec<&str> = saved.sessions.iter().map(|s| s.uuid.as_str()).collect();
+    assert_eq!(
+        saved_order,
+        expected_order.iter().map(String::as_str).collect::<Vec<_>>(),
+        "saved workspace order must match"
+    );
+    let saved_names: Vec<&str> = saved.sessions.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        saved_names,
+        expected_names.iter().map(String::as_str).collect::<Vec<_>>(),
+        "saved workspace names must match"
+    );
+
+    // The "Editor" workspace should have 2 terminals (was split).
+    let editor_session = saved.sessions.iter().find(|s| s.uuid == ws0_uuid).unwrap();
+    assert_eq!(
+        editor_session.layout.terminal_count(),
+        2,
+        "Editor workspace should have 2 panes after split"
+    );
+    assert!(editor_session.layout.contains_terminal(&ws0_t1));
+    assert!(editor_session.layout.contains_terminal(&ws0_t2));
+
+    // ── Phase 3: Restore into a new window ──────────────────────
+
+    let second_window = Window::new(&app);
+    second_window.set_default_size(1200, 800);
+    second_window.present();
+    pump_events(200);
+
+    // Verify workspace count.
+    let restored_count = {
+        let state = second_window.imp().state.borrow();
+        state.sessions.len()
+    };
+    assert_eq!(restored_count, 3, "restored window should have 3 workspaces");
+
+    // Verify workspace order.
+    let restored_order: Vec<String> = {
+        let state = second_window.imp().state.borrow();
+        state.sessions.iter().map(|s| s.uuid.clone()).collect()
+    };
+    assert_eq!(restored_order, expected_order, "workspace order must survive restart");
+
+    // Verify workspace names.
+    let restored_names: Vec<String> = {
+        let state = second_window.imp().state.borrow();
+        state.sessions.iter().map(|s| s.name.clone()).collect()
+    };
+    assert_eq!(restored_names, expected_names, "workspace names must survive restart");
+
+    // Verify sidebar rows match.
+    for (i, expected_uuid) in expected_order.iter().enumerate() {
+        let row = session_row_at(&second_window, i as i32);
+        assert_eq!(row.uuid(), *expected_uuid, "sidebar row {i} UUID must match after restart");
+    }
+
+    // Verify the "Editor" workspace has 2 terminals in the widget tree.
+    let editor_content = second_window
+        .imp()
+        .session_stack
+        .child_by_name(&ws0_uuid)
+        .expect("Editor workspace content should exist");
+    let paned = editor_content
+        .downcast_ref::<gtk4::Paned>()
+        .expect("Editor workspace root should be a Paned (split)");
+    assert!(paned.start_child().is_some(), "split should have a start child");
+    assert!(paned.end_child().is_some(), "split should have an end child");
+
+    // Verify both terminals exist in the terminal map.
+    {
+        let terminals = second_window.imp().terminals.borrow();
+        assert!(terminals.contains_key(&ws0_t1), "first terminal should be restored");
+        assert!(terminals.contains_key(&ws0_t2), "second terminal (from split) should be restored");
+    }
+
+    // Verify the renamed sidebar labels.
+    let editor_row = session_row_for_uuid(&second_window, &ws0_uuid);
+    assert_eq!(
+        editor_row.session_name(),
+        "Editor",
+        "renamed workspace should keep its name after restart"
+    );
+    let build_row = session_row_for_uuid(&second_window, &ws1_uuid);
+    assert_eq!(
+        build_row.session_name(),
+        "Build",
+        "renamed workspace should keep its name after restart"
+    );
+
+    second_window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/session_persistence_e2e.rs
+++ b/clients/rttx/tests/session_persistence_e2e.rs
@@ -1,0 +1,482 @@
+//! End-to-end session persistence tests.
+//!
+//! These tests exercise the full save → load cycle through serde and
+//! file I/O, covering backward compatibility with older JSON formats,
+//! graceful recovery from corrupted state files, and correctness under
+//! large/complex layouts.
+
+use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy, WorkspaceRuntime};
+use rttx::session::*;
+use std::collections::BTreeMap;
+
+// ── Inline helpers (test_helpers is cfg(test)-gated) ────────────
+
+fn term(id: &str) -> LayoutNode {
+    LayoutNode::Terminal { uuid: id.to_string(), profile: None, cwd: None, custom_title: None }
+}
+
+fn term_full(id: &str, cwd: &str, title: &str) -> LayoutNode {
+    LayoutNode::Terminal {
+        uuid: id.to_string(),
+        profile: Some("default".into()),
+        cwd: Some(cwd.into()),
+        custom_title: Some(title.into()),
+    }
+}
+
+fn hsplit(first: LayoutNode, second: LayoutNode) -> LayoutNode {
+    LayoutNode::Split {
+        orientation: SplitOrientation::Horizontal,
+        ratio: 0.5,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+fn vsplit(first: LayoutNode, second: LayoutNode) -> LayoutNode {
+    LayoutNode::Split {
+        orientation: SplitOrientation::Vertical,
+        ratio: 0.5,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+fn split_ratio(
+    orientation: SplitOrientation,
+    ratio: f64,
+    first: LayoutNode,
+    second: LayoutNode,
+) -> LayoutNode {
+    LayoutNode::Split { orientation, ratio, first: Box::new(first), second: Box::new(second) }
+}
+
+/// Save state to a temp directory and load it back via direct file I/O,
+/// mirroring the real persistence path without depending on glib config
+/// dir caching.
+fn save_and_load(state: &WindowState) -> WindowState {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = tmp.path().join("sessions.json");
+    let json = serde_json::to_string_pretty(state).unwrap();
+    std::fs::write(&path, &json).unwrap();
+    let loaded_json = std::fs::read_to_string(&path).unwrap();
+    let mut loaded: WindowState = serde_json::from_str(&loaded_json).unwrap();
+    for session in &mut loaded.sessions {
+        session.normalize_runtime_metadata();
+        session.normalize_active_terminal();
+    }
+    loaded
+}
+
+// ── Backward compatibility ──────────────────────────────────────
+
+/// State saved before `left_sidebar_width` / `right_sidebar_width` existed
+/// must load with sensible defaults.
+#[test]
+fn older_format_without_sidebar_widths_loads_with_defaults() {
+    let json = r#"{
+        "sessions": [{
+            "uuid": "s1",
+            "name": "Legacy",
+            "layout": {"Terminal": {"uuid": "t1"}}
+        }],
+        "active_session_index": 0,
+        "width": 1024,
+        "height": 768,
+        "is_maximized": false
+    }"#;
+
+    let state: WindowState = serde_json::from_str(json).unwrap();
+    assert_eq!(state.sessions.len(), 1);
+    assert_eq!(state.sessions[0].name, "Legacy");
+    assert_eq!(state.left_sidebar_width, 220, "missing left_sidebar_width should default to 220");
+    assert_eq!(
+        state.right_sidebar_width, 320,
+        "missing right_sidebar_width should default to 320"
+    );
+}
+
+/// State saved before `runtime`, `color`, `zoomed_terminal_uuid`, and
+/// `user_renamed` fields existed must load with defaults for each.
+#[test]
+fn older_format_without_runtime_or_color_fields_loads_gracefully() {
+    let json = r#"{
+        "sessions": [{
+            "uuid": "s1",
+            "name": "Old Session",
+            "layout": {"Terminal": {"uuid": "t1"}},
+            "terminal_recovery": {},
+            "active_terminal_uuid": "t1",
+            "input_sync": false,
+            "mode": "direct"
+        }],
+        "active_session_index": 0,
+        "width": 800,
+        "height": 600,
+        "is_maximized": false
+    }"#;
+
+    let state: WindowState = serde_json::from_str(json).unwrap();
+    let session = &state.sessions[0];
+    assert_eq!(session.runtime, WorkspaceRuntime::default());
+    assert_eq!(session.color, SessionColor::Blue);
+    assert!(session.zoomed_terminal_uuid.is_none());
+    assert!(!session.user_renamed);
+}
+
+/// State saved before `dismissed_runtime_ids` existed must load with an
+/// empty set.
+#[test]
+fn older_format_without_dismissed_runtime_ids_loads_empty() {
+    let json = r#"{
+        "sessions": [{"uuid": "s1", "name": "W", "layout": {"Terminal": {"uuid": "t1"}}}],
+        "active_session_index": 0,
+        "width": 800,
+        "height": 600,
+        "is_maximized": false
+    }"#;
+
+    let state: WindowState = serde_json::from_str(json).unwrap();
+    assert!(state.dismissed_runtime_ids.is_empty());
+}
+
+/// A session saved with the legacy `Persistent` mode (before the `runtime`
+/// struct existed) must normalize into the modern runtime metadata.
+#[test]
+fn legacy_persistent_mode_normalizes_to_runtime_metadata() {
+    let json = r#"{
+        "uuid": "s1",
+        "name": "Legacy Persistent",
+        "layout": {"Terminal": {"uuid": "t1"}},
+        "terminal_recovery": {},
+        "active_terminal_uuid": "t1",
+        "input_sync": false,
+        "mode": {"persistent": {"daemon_session_id": "runtime-abc"}}
+    }"#;
+
+    let mut session: SessionState = serde_json::from_str(json).unwrap();
+    session.normalize_runtime_metadata();
+
+    assert!(session.runtime.is_managed());
+    assert_eq!(session.runtime.endpoint, RuntimeEndpoint::Local);
+    assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
+    assert_eq!(session.runtime.runtime_id.as_deref(), Some("runtime-abc"));
+}
+
+// ── Corrupted state ─────────────────────────────────────────────
+
+/// Completely invalid JSON must fall back to default state via
+/// `unwrap_or_default`.
+#[test]
+fn corrupted_json_falls_back_to_default() {
+    let result: WindowState =
+        serde_json::from_str("{{{{not json at all!!!!").unwrap_or_default();
+    assert_eq!(result.sessions.len(), 1, "corrupted JSON should produce default state");
+    assert_eq!(result.sessions[0].name, "Session 1");
+}
+
+/// Truncated JSON (e.g. from a crash during write) must fall back to
+/// default state.
+#[test]
+fn truncated_json_falls_back_to_default() {
+    let state = WindowState {
+        sessions: vec![
+            SessionState::new("First".into()),
+            SessionState::new("Second".into()),
+        ],
+        active_session_index: 1,
+        ..WindowState::default()
+    };
+    let full_json = serde_json::to_string_pretty(&state).unwrap();
+    let truncated = &full_json[..full_json.len() / 2];
+
+    let loaded: WindowState = serde_json::from_str(truncated).unwrap_or_default();
+    assert_eq!(loaded.sessions.len(), 1, "truncated JSON should produce default state");
+    assert_eq!(loaded.sessions[0].name, "Session 1");
+}
+
+/// An empty string must fall back to default state.
+#[test]
+fn empty_string_falls_back_to_default() {
+    let loaded: WindowState = serde_json::from_str("").unwrap_or_default();
+    assert_eq!(loaded.sessions.len(), 1);
+}
+
+/// JSON with unknown extra fields must still deserialize (forward compat).
+#[test]
+fn unknown_fields_are_ignored_gracefully() {
+    let json = r#"{
+        "sessions": [{
+            "uuid": "s1",
+            "name": "Future",
+            "layout": {"Terminal": {"uuid": "t1"}},
+            "some_future_field": true,
+            "another_new_thing": [1, 2, 3]
+        }],
+        "active_session_index": 0,
+        "width": 800,
+        "height": 600,
+        "is_maximized": false,
+        "future_window_field": "hello"
+    }"#;
+
+    let state: WindowState = serde_json::from_str(json).unwrap();
+    assert_eq!(state.sessions.len(), 1);
+    assert_eq!(state.sessions[0].name, "Future");
+}
+
+// ── Large state ─────────────────────────────────────────────────
+
+/// A workspace with 16 terminals must round-trip through file-based
+/// persistence without data loss.
+#[test]
+fn large_layout_persists_and_restores_through_file() {
+    let mut layout = term_full("t0", "/home/user/project-0", "vim");
+    for i in 1..16 {
+        layout = hsplit(
+            layout,
+            term_full(
+                &format!("t{i}"),
+                &format!("/home/user/project-{i}"),
+                &format!("shell-{i}"),
+            ),
+        );
+    }
+    assert_eq!(layout.terminal_count(), 16);
+
+    let state = WindowState {
+        sessions: vec![SessionState {
+            uuid: "large-session".into(),
+            name: "Large Workspace".into(),
+            layout,
+            terminal_recovery: BTreeMap::default(),
+            active_terminal_uuid: Some("t7".into()),
+            input_sync: true,
+            mode: SessionMode::default(),
+            runtime: WorkspaceRuntime::default(),
+            color: SessionColor::Teal,
+            zoomed_terminal_uuid: None,
+            user_renamed: true,
+        }],
+        active_session_index: 0,
+        width: 2560,
+        height: 1440,
+        is_maximized: true,
+        ..WindowState::default()
+    };
+
+    let loaded = save_and_load(&state);
+
+    assert_eq!(loaded.sessions.len(), 1);
+    assert_eq!(loaded.sessions[0].layout.terminal_count(), 16);
+    assert_eq!(loaded.sessions[0].name, "Large Workspace");
+    assert_eq!(loaded.sessions[0].active_terminal_uuid.as_deref(), Some("t7"));
+    assert!(loaded.sessions[0].input_sync);
+    assert_eq!(loaded.sessions[0].color, SessionColor::Teal);
+    assert!(loaded.sessions[0].user_renamed);
+    assert!(loaded.is_maximized);
+
+    for i in 0..16 {
+        let uuid = format!("t{i}");
+        assert_eq!(
+            loaded.sessions[0].layout.terminal_cwd(&uuid).as_deref(),
+            Some(format!("/home/user/project-{i}").as_str()),
+            "CWD for {uuid} must survive persistence"
+        );
+    }
+}
+
+/// Multiple workspaces with mixed configurations must all survive the
+/// file-based save/load cycle.
+#[test]
+fn multi_workspace_mixed_config_persists_through_file() {
+    let sessions = vec![
+        SessionState {
+            uuid: "ws-direct".into(),
+            name: "Editor".into(),
+            layout: hsplit(
+                term_full("t1", "/home/user/src", "nvim"),
+                vsplit(
+                    term_full("t2", "/home/user/src", "cargo watch"),
+                    term_full("t3", "/home/user/logs", "tail -f"),
+                ),
+            ),
+            terminal_recovery: BTreeMap::default(),
+            active_terminal_uuid: Some("t2".into()),
+            input_sync: false,
+            mode: SessionMode::default(),
+            runtime: WorkspaceRuntime::default(),
+            color: SessionColor::Green,
+            zoomed_terminal_uuid: None,
+            user_renamed: true,
+        },
+        {
+            let mut s = SessionState::new_managed_local(
+                "Build".into(),
+                WorkspacePolicy::Persistent,
+                Some("/home/user/build".into()),
+            );
+            s.uuid = "ws-managed".into();
+            s.color = SessionColor::Red;
+            s
+        },
+        SessionState {
+            uuid: "ws-simple".into(),
+            name: "Monitoring".into(),
+            layout: term("t-mon"),
+            terminal_recovery: BTreeMap::default(),
+            active_terminal_uuid: Some("t-mon".into()),
+            input_sync: false,
+            mode: SessionMode::default(),
+            runtime: WorkspaceRuntime::default(),
+            color: SessionColor::Purple,
+            zoomed_terminal_uuid: None,
+            user_renamed: false,
+        },
+    ];
+
+    let state = WindowState {
+        sessions,
+        active_session_index: 1,
+        width: 1920,
+        height: 1080,
+        is_maximized: false,
+        left_sidebar_width: 250,
+        right_sidebar_width: 400,
+        ..WindowState::default()
+    };
+
+    let loaded = save_and_load(&state);
+
+    assert_eq!(loaded.sessions.len(), 3);
+    assert_eq!(loaded.active_session_index, 1);
+    assert_eq!(loaded.left_sidebar_width, 250);
+    assert_eq!(loaded.right_sidebar_width, 400);
+
+    // Workspace order preserved.
+    assert_eq!(loaded.sessions[0].uuid, "ws-direct");
+    assert_eq!(loaded.sessions[1].uuid, "ws-managed");
+    assert_eq!(loaded.sessions[2].uuid, "ws-simple");
+
+    // Names preserved.
+    assert_eq!(loaded.sessions[0].name, "Editor");
+    assert_eq!(loaded.sessions[1].name, "Build");
+    assert_eq!(loaded.sessions[2].name, "Monitoring");
+
+    // Layout structure preserved.
+    assert_eq!(loaded.sessions[0].layout.terminal_count(), 3);
+    assert_eq!(loaded.sessions[2].layout.terminal_count(), 1);
+
+    // Colors preserved.
+    assert_eq!(loaded.sessions[0].color, SessionColor::Green);
+    assert_eq!(loaded.sessions[1].color, SessionColor::Red);
+    assert_eq!(loaded.sessions[2].color, SessionColor::Purple);
+
+    // Active terminal preserved.
+    assert_eq!(loaded.sessions[0].active_terminal_uuid.as_deref(), Some("t2"));
+
+    // Managed runtime metadata preserved.
+    assert!(loaded.sessions[1].runtime.is_managed());
+    assert_eq!(loaded.sessions[1].runtime.endpoint, RuntimeEndpoint::Local);
+    assert_eq!(loaded.sessions[1].runtime.policy, WorkspacePolicy::Persistent);
+}
+
+// ── Full round-trip through file persistence ────────────────────
+
+/// Build state programmatically → save to file → load from file → verify
+/// every field matches.
+#[test]
+fn full_roundtrip_through_file_persistence() {
+    let mut dismissed = std::collections::BTreeSet::new();
+    dismissed.insert("old-runtime-1".to_string());
+    dismissed.insert("old-runtime-2".to_string());
+
+    let state = WindowState {
+        sessions: vec![
+            SessionState {
+                uuid: "ws-1".into(),
+                name: "Development".into(),
+                layout: split_ratio(
+                    SplitOrientation::Horizontal,
+                    0.35,
+                    term_full("t1", "/home/user/rttx", "nvim"),
+                    term_full("t2", "/home/user/rttx", "cargo test"),
+                ),
+                terminal_recovery: BTreeMap::default(),
+                active_terminal_uuid: Some("t2".into()),
+                input_sync: true,
+                mode: SessionMode::default(),
+                runtime: WorkspaceRuntime::default(),
+                color: SessionColor::Orange,
+                zoomed_terminal_uuid: None,
+                user_renamed: true,
+            },
+            SessionState {
+                uuid: "ws-2".into(),
+                name: "Session 2".into(),
+                layout: term("t3"),
+                terminal_recovery: BTreeMap::default(),
+                active_terminal_uuid: Some("t3".into()),
+                input_sync: false,
+                mode: SessionMode::default(),
+                runtime: WorkspaceRuntime::default(),
+                color: SessionColor::Blue,
+                zoomed_terminal_uuid: None,
+                user_renamed: false,
+            },
+        ],
+        active_session_index: 0,
+        width: 1600,
+        height: 900,
+        is_maximized: false,
+        left_sidebar_width: 200,
+        right_sidebar_width: 350,
+        dismissed_runtime_ids: dismissed,
+    };
+
+    let loaded = save_and_load(&state);
+
+    // Window geometry.
+    assert_eq!(loaded.width, 1600);
+    assert_eq!(loaded.height, 900);
+    assert!(!loaded.is_maximized);
+    assert_eq!(loaded.left_sidebar_width, 200);
+    assert_eq!(loaded.right_sidebar_width, 350);
+    assert_eq!(loaded.active_session_index, 0);
+
+    // Dismissed runtime IDs.
+    assert!(loaded.dismissed_runtime_ids.contains("old-runtime-1"));
+    assert!(loaded.dismissed_runtime_ids.contains("old-runtime-2"));
+
+    // Session 1 details.
+    let s1 = &loaded.sessions[0];
+    assert_eq!(s1.uuid, "ws-1");
+    assert_eq!(s1.name, "Development");
+    assert_eq!(s1.active_terminal_uuid.as_deref(), Some("t2"));
+    assert!(s1.input_sync);
+    assert_eq!(s1.color, SessionColor::Orange);
+    assert!(s1.user_renamed);
+    assert_eq!(s1.layout.terminal_count(), 2);
+
+    // Split ratio preserved.
+    if let LayoutNode::Split { ratio, .. } = &s1.layout {
+        assert!(
+            (*ratio - 0.35).abs() < 0.001,
+            "split ratio should be preserved, got {ratio}"
+        );
+    } else {
+        panic!("expected split layout");
+    }
+
+    // CWDs and titles preserved.
+    assert_eq!(s1.layout.terminal_cwd("t1").as_deref(), Some("/home/user/rttx"));
+    assert_eq!(s1.layout.terminal_custom_title("t1").as_deref(), Some("nvim"));
+    assert_eq!(s1.layout.terminal_custom_title("t2").as_deref(), Some("cargo test"));
+
+    // Session 2 details.
+    let s2 = &loaded.sessions[1];
+    assert_eq!(s2.uuid, "ws-2");
+    assert_eq!(s2.name, "Session 2");
+    assert!(!s2.input_sync);
+    assert_eq!(s2.color, SessionColor::Blue);
+}

--- a/clients/rttx/tests/session_persistence_e2e.rs
+++ b/clients/rttx/tests/session_persistence_e2e.rs
@@ -90,10 +90,7 @@ fn older_format_without_sidebar_widths_loads_with_defaults() {
     assert_eq!(state.sessions.len(), 1);
     assert_eq!(state.sessions[0].name, "Legacy");
     assert_eq!(state.left_sidebar_width, 220, "missing left_sidebar_width should default to 220");
-    assert_eq!(
-        state.right_sidebar_width, 320,
-        "missing right_sidebar_width should default to 320"
-    );
+    assert_eq!(state.right_sidebar_width, 320, "missing right_sidebar_width should default to 320");
 }
 
 /// State saved before `runtime`, `color`, `zoomed_terminal_uuid`, and
@@ -169,8 +166,7 @@ fn legacy_persistent_mode_normalizes_to_runtime_metadata() {
 /// `unwrap_or_default`.
 #[test]
 fn corrupted_json_falls_back_to_default() {
-    let result: WindowState =
-        serde_json::from_str("{{{{not json at all!!!!").unwrap_or_default();
+    let result: WindowState = serde_json::from_str("{{{{not json at all!!!!").unwrap_or_default();
     assert_eq!(result.sessions.len(), 1, "corrupted JSON should produce default state");
     assert_eq!(result.sessions[0].name, "Session 1");
 }
@@ -180,10 +176,7 @@ fn corrupted_json_falls_back_to_default() {
 #[test]
 fn truncated_json_falls_back_to_default() {
     let state = WindowState {
-        sessions: vec![
-            SessionState::new("First".into()),
-            SessionState::new("Second".into()),
-        ],
+        sessions: vec![SessionState::new("First".into()), SessionState::new("Second".into())],
         active_session_index: 1,
         ..WindowState::default()
     };
@@ -235,11 +228,7 @@ fn large_layout_persists_and_restores_through_file() {
     for i in 1..16 {
         layout = hsplit(
             layout,
-            term_full(
-                &format!("t{i}"),
-                &format!("/home/user/project-{i}"),
-                &format!("shell-{i}"),
-            ),
+            term_full(&format!("t{i}"), &format!("/home/user/project-{i}"), &format!("shell-{i}")),
         );
     }
     assert_eq!(layout.terminal_count(), 16);
@@ -460,10 +449,7 @@ fn full_roundtrip_through_file_persistence() {
 
     // Split ratio preserved.
     if let LayoutNode::Split { ratio, .. } = &s1.layout {
-        assert!(
-            (*ratio - 0.35).abs() < 0.001,
-            "split ratio should be preserved, got {ratio}"
-        );
+        assert!((*ratio - 0.35).abs() < 0.001, "split ratio should be preserved, got {ratio}");
     } else {
         panic!("expected split layout");
     }


### PR DESCRIPTION
## What changed and why

Closes #325 — adds end-to-end tests for the full session persistence save/restore cycle.

The existing test suite had good coverage of the data model (24 unit tests in `state.rs`, 28 integration tests in `session_lifecycle.rs`) and individual GUI save/restore aspects (ratios, active terminal, CWDs, custom titles). However, there was no test exercising the complete user workflow: create workspaces → configure them → save → close → reopen → verify everything is restored.

## Tests added

### Integration tests (`session_persistence_e2e.rs` — 11 tests, no GTK required)

**Backward compatibility (4 tests):**
- `older_format_without_sidebar_widths_loads_with_defaults` — pre-sidebar-width JSON loads with defaults
- `older_format_without_runtime_or_color_fields_loads_gracefully` — pre-runtime/color JSON loads with defaults
- `older_format_without_dismissed_runtime_ids_loads_empty` — pre-dismissed-IDs JSON loads empty
- `legacy_persistent_mode_normalizes_to_runtime_metadata` — legacy Persistent mode migrates to runtime struct

**Corrupted state (4 tests):**
- `corrupted_json_falls_back_to_default` — garbage JSON → default state
- `truncated_json_falls_back_to_default` — half-written JSON → default state
- `empty_string_falls_back_to_default` — empty file → default state
- `unknown_fields_are_ignored_gracefully` — future fields silently ignored

**Large/complex state (3 tests):**
- `large_layout_persists_and_restores_through_file` — 16-terminal layout round-trip
- `multi_workspace_mixed_config_persists_through_file` — 3 workspaces with mixed direct/managed configs
- `full_roundtrip_through_file_persistence` — every WindowState field verified after file I/O

### GTK widget test (`window/tests.rs` — 1 test, requires Broadway)

- `save_and_restart_full_session_persistence_roundtrip` — full GUI round-trip:
  1. Create 3 workspaces, rename 2, split 1, reorder
  2. `save_state()` → close window
  3. New window (`load_state()`) → verify workspace count, order, names, sidebar rows, split widget tree, terminal map

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (VTE 0.76)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
  - `save_and_restart_full_session_persistence_roundtrip ... ok`
  - `session_persistence_e2e: 11 passed; 0 failed`

## Manual verification

Ran all 12 new tests individually and in batch. Confirmed the GTK test runs via Broadway in the quality test script (not skipped).

## Limitations

- The GTK round-trip test uses `add_direct_session()` (non-managed) because managed workspace creation requires a dialog interaction. Managed workspace persistence is covered by the integration tests.
- CWD verification in the GTK test is not included because `RTTX_DISABLE_SHELL_SPAWN=1` prevents shells from reporting CWDs. CWD persistence is covered by existing tests (`save_state_updates_nested_terminal_cwds`) and the new integration tests.