### PR TITLE
feat: fully customizable keyboard shortcuts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "prost",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -14,6 +14,7 @@ pub mod places_window;
 pub mod preferences;
 pub mod runtime;
 pub mod session;
+pub mod shortcuts;
 pub mod workspace_state;
 
 pub mod application;

--- a/clients/rttx/src/preferences.rs
+++ b/clients/rttx/src/preferences.rs
@@ -1,5 +1,6 @@
 /// User preferences, persisted as JSON in `XDG_CONFIG_HOME/rttx/preferences.json`.
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::color_scheme;
@@ -79,6 +80,8 @@ pub struct Preferences {
     pub default_session_folder: DefaultSessionFolder,
     #[serde(default)]
     pub pane_navigation_keys: PaneNavigationKeys,
+    #[serde(default)]
+    pub keyboard_shortcuts: BTreeMap<String, Vec<String>>,
     #[serde(default = "default_true")]
     pub auto_start_daemon: bool,
     #[serde(default = "default_reconnect_delay_secs")]
@@ -135,6 +138,7 @@ impl Default for Preferences {
             trim_trailing_whitespace_on_copy: false,
             default_session_folder: default_session_folder(),
             pane_navigation_keys: PaneNavigationKeys::default(),
+            keyboard_shortcuts: BTreeMap::new(),
             auto_start_daemon: true,
             reconnect_delay_secs: default_reconnect_delay_secs(),
             paste_guard: true,
@@ -192,6 +196,8 @@ struct PreferencesDisk {
     default_session_folder: DefaultSessionFolder,
     #[serde(default)]
     pane_navigation_keys: PaneNavigationKeys,
+    #[serde(default)]
+    keyboard_shortcuts: BTreeMap<String, Vec<String>>,
     #[serde(default = "default_true")]
     auto_start_daemon: bool,
     #[serde(default = "default_reconnect_delay_secs")]
@@ -209,6 +215,12 @@ impl From<PreferencesDisk> for Preferences {
         } else {
             Some(raw.color_scheme.clone())
         };
+
+        let mut keyboard_shortcuts = raw.keyboard_shortcuts;
+        crate::shortcuts::migrate_pane_navigation(
+            &raw.pane_navigation_keys,
+            &mut keyboard_shortcuts,
+        );
 
         Self {
             font: raw.font,
@@ -232,6 +244,7 @@ impl From<PreferencesDisk> for Preferences {
             trim_trailing_whitespace_on_copy: raw.trim_trailing_whitespace_on_copy,
             default_session_folder: raw.default_session_folder,
             pane_navigation_keys: raw.pane_navigation_keys,
+            keyboard_shortcuts,
             auto_start_daemon: raw.auto_start_daemon,
             reconnect_delay_secs: raw.reconnect_delay_secs,
             paste_guard: raw.paste_guard,

--- a/clients/rttx/src/preferences_window.rs
+++ b/clients/rttx/src/preferences_window.rs
@@ -1,12 +1,15 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
 use gtk4::glib;
 use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
 
 use crate::color_scheme;
-use crate::preferences::{
-    self, DefaultSessionFolder, PaneNavigationKeys, Preferences, TerminalThemeMode,
-};
+use crate::preferences::{self, DefaultSessionFolder, Preferences, TerminalThemeMode};
+use crate::shortcuts::{self, DEFAULT_SHORTCUTS};
 
 /// Build and present the preferences window.
 pub fn show(parent: &impl IsA<gtk4::Window>) {
@@ -147,18 +150,69 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
     session_group.add(&folder_mode_row);
     session_group.add(&custom_folder_row);
 
+    // --- Keyboard shortcuts ---
     let keyboard_group = adw::PreferencesGroup::new();
-    keyboard_group.set_title("Keyboard");
+    keyboard_group.set_title("Keyboard Shortcuts");
+    keyboard_group
+        .set_description(Some("Click a shortcut to change it. Press Backspace to clear."));
 
-    let nav_keys_row = adw::ComboRow::builder().title("Pane navigation keys").build();
-    let nav_keys_names = ["Alt + Arrow", "Ctrl + Shift + Arrow"];
-    let nav_keys_model = gtk4::StringList::new(&nav_keys_names);
-    nav_keys_row.set_model(Some(&nav_keys_model));
-    nav_keys_row.set_selected(match prefs.pane_navigation_keys {
-        PaneNavigationKeys::AltArrow => 0,
-        PaneNavigationKeys::CtrlShiftArrow => 1,
-    });
-    keyboard_group.add(&nav_keys_row);
+    let shortcut_overrides: Rc<RefCell<BTreeMap<String, Vec<String>>>> =
+        Rc::new(RefCell::new(prefs.keyboard_shortcuts.clone()));
+
+    for def in DEFAULT_SHORTCUTS {
+        let accels = shortcuts::effective_accels(def.action, &prefs.keyboard_shortcuts);
+        let is_custom = prefs.keyboard_shortcuts.contains_key(def.action);
+
+        let row = adw::ActionRow::builder().title(def.label).activatable(true).build();
+
+        let label_text = format_accel_label(&accels);
+        let accel_label = gtk4::Label::new(Some(&label_text));
+        accel_label.add_css_class("dim-label");
+        if is_custom {
+            accel_label.add_css_class("accent");
+        }
+        accel_label.set_valign(gtk4::Align::Center);
+        row.add_suffix(&accel_label);
+
+        let reset_button = gtk4::Button::from_icon_name("edit-undo-symbolic");
+        reset_button.set_valign(gtk4::Align::Center);
+        reset_button.set_tooltip_text(Some("Reset to default"));
+        reset_button.add_css_class("flat");
+        reset_button.set_visible(is_custom);
+        row.add_suffix(&reset_button);
+
+        let action_name = def.action.to_string();
+        let overrides_ref = shortcut_overrides.clone();
+        let accel_label_ref = accel_label.clone();
+        let reset_ref = reset_button.clone();
+        let window_ref = window.clone();
+        let label_text_for_dialog = def.label.to_string();
+        row.connect_activated(move |_row| {
+            let action = action_name.clone();
+            let overrides = overrides_ref.clone();
+            let label = accel_label_ref.clone();
+            let reset = reset_ref.clone();
+            show_shortcut_capture_dialog(&window_ref, &label_text_for_dialog, move |new_accels| {
+                overrides.borrow_mut().insert(action.clone(), new_accels.clone());
+                label.set_label(&format_accel_label(&new_accels));
+                label.add_css_class("accent");
+                reset.set_visible(true);
+            });
+        });
+
+        let action_name = def.action.to_string();
+        let overrides_ref = shortcut_overrides.clone();
+        let accel_label_ref = accel_label;
+        reset_button.connect_clicked(move |btn| {
+            overrides_ref.borrow_mut().remove(&action_name);
+            let defaults = shortcuts::default_accels(&action_name);
+            accel_label_ref.set_label(&format_accel_label(&defaults));
+            accel_label_ref.remove_css_class("accent");
+            btn.set_visible(false);
+        });
+
+        keyboard_group.add(&row);
+    }
 
     let page = adw::PreferencesPage::new();
     page.set_icon_name(Some("preferences-system-symbolic"));
@@ -207,10 +261,8 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
                 2 => DefaultSessionFolder::Custom(custom_folder_row.text().to_string()),
                 _ => DefaultSessionFolder::Home,
             },
-            pane_navigation_keys: match nav_keys_row.selected() {
-                1 => PaneNavigationKeys::CtrlShiftArrow,
-                _ => PaneNavigationKeys::AltArrow,
-            },
+            pane_navigation_keys: prefs.pane_navigation_keys,
+            keyboard_shortcuts: shortcut_overrides.borrow().clone(),
             auto_start_daemon: prefs.auto_start_daemon,
             reconnect_delay_secs: prefs.reconnect_delay_secs,
             paste_guard: paste_guard_row.is_active(),
@@ -234,4 +286,81 @@ fn load_scheme_names() -> Vec<String> {
     names.sort();
     names.dedup();
     names
+}
+
+/// Format accelerator strings into a human-readable label.
+fn format_accel_label(accels: &[String]) -> String {
+    if accels.is_empty() {
+        return "Disabled".into();
+    }
+    accels
+        .iter()
+        .filter_map(|a| {
+            gtk4::accelerator_parse(a)
+                .map(|(key, mods)| gtk4::accelerator_get_label(key, mods).to_string())
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Show a dialog that captures a key combination from the user.
+fn show_shortcut_capture_dialog(
+    parent: &adw::PreferencesWindow,
+    action_label: &str,
+    on_captured: impl Fn(Vec<String>) + 'static,
+) {
+    let dialog = adw::AlertDialog::builder()
+        .heading(format!("Set shortcut for \u{201c}{action_label}\u{201d}"))
+        .body("Press the desired key combination, or Backspace to disable.")
+        .close_response("cancel")
+        .build();
+    dialog.add_response("cancel", "Cancel");
+
+    let controller = gtk4::EventControllerKey::new();
+    let dialog_ref = dialog.clone();
+    controller.connect_key_pressed(move |_controller, keyval, _keycode, state| {
+        // Ignore lone modifier presses.
+        if matches!(
+            keyval,
+            gtk4::gdk::Key::Shift_L
+                | gtk4::gdk::Key::Shift_R
+                | gtk4::gdk::Key::Control_L
+                | gtk4::gdk::Key::Control_R
+                | gtk4::gdk::Key::Alt_L
+                | gtk4::gdk::Key::Alt_R
+                | gtk4::gdk::Key::Super_L
+                | gtk4::gdk::Key::Super_R
+                | gtk4::gdk::Key::Meta_L
+                | gtk4::gdk::Key::Meta_R
+                | gtk4::gdk::Key::Hyper_L
+                | gtk4::gdk::Key::Hyper_R
+        ) {
+            return glib::Propagation::Proceed;
+        }
+
+        let mods = state
+            & (gtk4::gdk::ModifierType::CONTROL_MASK
+                | gtk4::gdk::ModifierType::SHIFT_MASK
+                | gtk4::gdk::ModifierType::ALT_MASK
+                | gtk4::gdk::ModifierType::SUPER_MASK);
+
+        if keyval == gtk4::gdk::Key::BackSpace && mods.is_empty() {
+            on_captured(vec![]);
+            dialog_ref.close();
+            return glib::Propagation::Stop;
+        }
+
+        if keyval == gtk4::gdk::Key::Escape && mods.is_empty() {
+            dialog_ref.close();
+            return glib::Propagation::Stop;
+        }
+
+        let accel = gtk4::accelerator_name(keyval, mods);
+        on_captured(vec![accel.to_string()]);
+        dialog_ref.close();
+        glib::Propagation::Stop
+    });
+
+    dialog.add_controller(controller);
+    dialog.present(Some(parent));
 }

--- a/clients/rttx/src/shortcuts.rs
+++ b/clients/rttx/src/shortcuts.rs
@@ -1,0 +1,231 @@
+use std::collections::BTreeMap;
+
+/// A customizable shortcut definition: action name, human-readable label,
+/// and default GTK accelerator strings.
+#[derive(Debug)]
+pub struct ShortcutDef {
+    pub action: &'static str,
+    pub label: &'static str,
+    pub default_accels: &'static [&'static str],
+}
+
+/// All customizable shortcuts with their defaults.
+///
+/// Alt+1–9 workspace switching is intentionally excluded — those are
+/// positional and not meaningful to remap.
+pub static DEFAULT_SHORTCUTS: &[ShortcutDef] = &[
+    ShortcutDef {
+        action: "new-session",
+        label: "New workspace",
+        default_accels: &["<Ctrl><Shift>T"],
+    },
+    ShortcutDef {
+        action: "close-terminal",
+        label: "Close pane",
+        default_accels: &["<Ctrl><Shift>W"],
+    },
+    ShortcutDef {
+        action: "split-horizontal",
+        label: "Split horizontal",
+        default_accels: &["<Ctrl><Shift>E"],
+    },
+    ShortcutDef {
+        action: "split-vertical",
+        label: "Split vertical",
+        default_accels: &["<Ctrl><Shift>O"],
+    },
+    ShortcutDef { action: "search", label: "Search", default_accels: &["<Ctrl><Shift>F"] },
+    ShortcutDef { action: "copy", label: "Copy", default_accels: &["<Ctrl><Shift>C"] },
+    ShortcutDef { action: "paste", label: "Paste", default_accels: &["<Ctrl><Shift>V"] },
+    ShortcutDef {
+        action: "prev-session",
+        label: "Previous workspace",
+        default_accels: &["<Ctrl><Shift>Tab"],
+    },
+    ShortcutDef { action: "next-session", label: "Next workspace", default_accels: &["<Ctrl>Tab"] },
+    ShortcutDef {
+        action: "toggle-sidebar",
+        label: "Toggle workspace sidebar",
+        default_accels: &["<Ctrl><Shift>N"],
+    },
+    ShortcutDef {
+        action: "toggle-utility-sidebar",
+        label: "Toggle tools sidebar",
+        default_accels: &["<Ctrl><Shift>B"],
+    },
+    ShortcutDef {
+        action: "toggle-input-sync",
+        label: "Toggle input sync",
+        default_accels: &["<Ctrl><Shift>i"],
+    },
+    ShortcutDef { action: "fullscreen", label: "Fullscreen", default_accels: &["F11"] },
+    ShortcutDef {
+        action: "zoom-in",
+        label: "Zoom in",
+        default_accels: &["<Ctrl>plus", "<Ctrl>equal"],
+    },
+    ShortcutDef { action: "zoom-out", label: "Zoom out", default_accels: &["<Ctrl>minus"] },
+    ShortcutDef { action: "zoom-reset", label: "Zoom reset", default_accels: &["<Ctrl>0"] },
+    ShortcutDef {
+        action: "toggle-pane-zoom",
+        label: "Zoom pane (toggle)",
+        default_accels: &["<Ctrl><Shift>Z"],
+    },
+    ShortcutDef {
+        action: "rotate-layout",
+        label: "Rotate layout",
+        default_accels: &["<Ctrl><Shift>R"],
+    },
+    ShortcutDef {
+        action: "connect-to-existing",
+        label: "Connect to existing workspace",
+        default_accels: &["<Ctrl><Shift>A"],
+    },
+    ShortcutDef {
+        action: "new-direct",
+        label: "New direct terminal",
+        default_accels: &["<Ctrl><Shift>D"],
+    },
+    ShortcutDef { action: "preferences", label: "Preferences", default_accels: &["<Ctrl>comma"] },
+    ShortcutDef { action: "navigate-left", label: "Navigate left", default_accels: &["<Alt>Left"] },
+    ShortcutDef {
+        action: "navigate-right",
+        label: "Navigate right",
+        default_accels: &["<Alt>Right"],
+    },
+    ShortcutDef { action: "navigate-up", label: "Navigate up", default_accels: &["<Alt>Up"] },
+    ShortcutDef { action: "navigate-down", label: "Navigate down", default_accels: &["<Alt>Down"] },
+];
+
+/// Look up the effective accelerators for an action, checking user overrides
+/// first, then falling back to the built-in default.
+#[must_use]
+pub fn effective_accels(action: &str, overrides: &BTreeMap<String, Vec<String>>) -> Vec<String> {
+    if let Some(custom) = overrides.get(action) {
+        return custom.clone();
+    }
+    DEFAULT_SHORTCUTS
+        .iter()
+        .find(|d| d.action == action)
+        .map(|d| d.default_accels.iter().map(|s| (*s).to_string()).collect())
+        .unwrap_or_default()
+}
+
+/// Return the default accelerators for an action.
+#[must_use]
+pub fn default_accels(action: &str) -> Vec<String> {
+    DEFAULT_SHORTCUTS
+        .iter()
+        .find(|d| d.action == action)
+        .map(|d| d.default_accels.iter().map(|s| (*s).to_string()).collect())
+        .unwrap_or_default()
+}
+
+/// Migrate legacy `PaneNavigationKeys` into shortcut overrides.
+///
+/// If the user had `CtrlShiftArrow` selected and no explicit overrides exist
+/// for the navigation actions, populate them.
+pub fn migrate_pane_navigation(
+    legacy: &crate::preferences::PaneNavigationKeys,
+    shortcuts: &mut BTreeMap<String, Vec<String>>,
+) {
+    use crate::preferences::PaneNavigationKeys;
+    if *legacy == PaneNavigationKeys::AltArrow {
+        return; // default — nothing to migrate
+    }
+    let (left, right, up, down) = legacy.accels();
+    let nav = [
+        ("navigate-left", left),
+        ("navigate-right", right),
+        ("navigate-up", up),
+        ("navigate-down", down),
+    ];
+    for (action, accel) in nav {
+        shortcuts.entry(action.to_string()).or_insert_with(|| vec![accel.to_string()]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_accels_returns_default_when_no_override() {
+        let overrides = BTreeMap::new();
+        let accels = effective_accels("close-terminal", &overrides);
+        assert_eq!(accels, vec!["<Ctrl><Shift>W"]);
+    }
+
+    #[test]
+    fn effective_accels_returns_override_when_present() {
+        let mut overrides = BTreeMap::new();
+        overrides.insert("close-terminal".into(), vec!["<Ctrl>q".into()]);
+        let accels = effective_accels("close-terminal", &overrides);
+        assert_eq!(accels, vec!["<Ctrl>q"]);
+    }
+
+    #[test]
+    fn effective_accels_returns_empty_for_unknown_action() {
+        let overrides = BTreeMap::new();
+        let accels = effective_accels("nonexistent-action", &overrides);
+        assert!(accels.is_empty());
+    }
+
+    #[test]
+    fn default_accels_returns_correct_values() {
+        assert_eq!(default_accels("fullscreen"), vec!["F11"]);
+        assert_eq!(default_accels("zoom-in"), vec!["<Ctrl>plus", "<Ctrl>equal"]);
+    }
+
+    #[test]
+    fn override_with_empty_vec_disables_shortcut() {
+        let mut overrides = BTreeMap::new();
+        overrides.insert("fullscreen".into(), vec![]);
+        let accels = effective_accels("fullscreen", &overrides);
+        assert!(accels.is_empty());
+    }
+
+    #[test]
+    fn all_default_shortcuts_have_unique_actions() {
+        let mut seen = std::collections::HashSet::new();
+        for def in DEFAULT_SHORTCUTS {
+            assert!(seen.insert(def.action), "duplicate action: {}", def.action);
+        }
+    }
+
+    #[test]
+    fn all_default_shortcuts_have_labels() {
+        for def in DEFAULT_SHORTCUTS {
+            assert!(!def.label.is_empty(), "empty label for action: {}", def.action);
+        }
+    }
+
+    #[test]
+    fn migrate_pane_navigation_noop_for_alt_arrow() {
+        use crate::preferences::PaneNavigationKeys;
+        let mut shortcuts = BTreeMap::new();
+        migrate_pane_navigation(&PaneNavigationKeys::AltArrow, &mut shortcuts);
+        assert!(shortcuts.is_empty());
+    }
+
+    #[test]
+    fn migrate_pane_navigation_populates_ctrl_shift_arrow() {
+        use crate::preferences::PaneNavigationKeys;
+        let mut shortcuts = BTreeMap::new();
+        migrate_pane_navigation(&PaneNavigationKeys::CtrlShiftArrow, &mut shortcuts);
+        assert_eq!(shortcuts["navigate-left"], vec!["<Ctrl><Shift>Left"]);
+        assert_eq!(shortcuts["navigate-right"], vec!["<Ctrl><Shift>Right"]);
+        assert_eq!(shortcuts["navigate-up"], vec!["<Ctrl><Shift>Up"]);
+        assert_eq!(shortcuts["navigate-down"], vec!["<Ctrl><Shift>Down"]);
+    }
+
+    #[test]
+    fn migrate_pane_navigation_does_not_overwrite_existing() {
+        use crate::preferences::PaneNavigationKeys;
+        let mut shortcuts = BTreeMap::new();
+        shortcuts.insert("navigate-left".into(), vec!["<Alt>h".into()]);
+        migrate_pane_navigation(&PaneNavigationKeys::CtrlShiftArrow, &mut shortcuts);
+        assert_eq!(shortcuts["navigate-left"], vec!["<Alt>h"]);
+        assert_eq!(shortcuts["navigate-right"], vec!["<Ctrl><Shift>Right"]);
+    }
+}

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -1,62 +1,67 @@
 use super::*;
+use crate::shortcuts;
 use crate::terminal::paste_guard::{PasteGuardDecision, decide};
+
+type ActionCallback = fn(&Window);
 
 impl Window {
     pub(super) fn setup_actions(&self, app: &adw::Application) {
-        type ActionCallback = fn(&Window);
-        let actions: &[(&str, &[&str], ActionCallback)] = &[
-            ("close-terminal", &["<Ctrl><Shift>W"], Self::close_focused_terminal),
-            ("split-horizontal", &["<Ctrl><Shift>E"], |w| {
+        let prefs = crate::preferences::load();
+        let overrides = &prefs.keyboard_shortcuts;
+
+        let actions: &[(&str, ActionCallback)] = &[
+            ("close-terminal", Self::close_focused_terminal),
+            ("split-horizontal", |w| {
                 w.split_focused(SplitOrientation::Horizontal);
             }),
-            ("split-vertical", &["<Ctrl><Shift>O"], |w| {
+            ("split-vertical", |w| {
                 w.split_focused(SplitOrientation::Vertical);
             }),
-            ("search", &["<Ctrl><Shift>F"], Self::toggle_focused_search),
-            ("copy", &["<Ctrl><Shift>C"], Self::clipboard_copy),
-            ("paste", &["<Ctrl><Shift>V"], Self::clipboard_paste),
-            ("prev-session", &["<Ctrl><Shift>Tab"], |w| w.cycle_session(-1)),
-            ("next-session", &["<Ctrl>Tab"], |w| w.cycle_session(1)),
-            ("toggle-sidebar", &["<Ctrl><Shift>N"], |w| {
+            ("search", Self::toggle_focused_search),
+            ("copy", Self::clipboard_copy),
+            ("paste", Self::clipboard_paste),
+            ("prev-session", |w| w.cycle_session(-1)),
+            ("next-session", |w| w.cycle_session(1)),
+            ("toggle-sidebar", |w| {
                 let panel = w.imp().left_paned.start_child().expect("left sidebar panel");
                 panel.set_visible(!panel.is_visible());
             }),
-            ("fullscreen", &["F11"], |w| {
+            ("fullscreen", |w| {
                 if w.is_fullscreen() {
                     w.unfullscreen();
                 } else {
                     w.fullscreen();
                 }
             }),
-            ("zoom-in", &["<Ctrl>plus", "<Ctrl>equal"], |w| w.zoom_focused(1)),
-            ("zoom-out", &["<Ctrl>minus"], |w| w.zoom_focused(-1)),
-            ("zoom-reset", &["<Ctrl>0"], |w| w.zoom_focused(0)),
-            ("toggle-pane-zoom", &["<Ctrl><Shift>Z"], Self::toggle_pane_zoom),
-            ("rotate-layout", &["<Ctrl><Shift>R"], Self::rotate_layout),
-            ("new-session", &["<Ctrl><Shift>T"], Self::add_session),
-            ("new-ephemeral-workspace", &[], Self::add_ephemeral_session),
-            ("new-remote-workspace", &[], Self::show_new_remote_workspace_dialog),
-            ("browse-remote-runtimes", &[], Self::show_browse_remote_runtimes_dialog),
-            ("connect-existing-local", &[], Self::connect_existing_local),
-            ("connect-to-existing", &["<Ctrl><Shift>A"], Self::connect_existing_local),
-            ("new-direct", &["<Ctrl><Shift>D"], |w| {
+            ("zoom-in", |w| w.zoom_focused(1)),
+            ("zoom-out", |w| w.zoom_focused(-1)),
+            ("zoom-reset", |w| w.zoom_focused(0)),
+            ("toggle-pane-zoom", Self::toggle_pane_zoom),
+            ("rotate-layout", Self::rotate_layout),
+            ("new-session", Self::add_session),
+            ("new-ephemeral-workspace", Self::add_ephemeral_session),
+            ("new-remote-workspace", Self::show_new_remote_workspace_dialog),
+            ("browse-remote-runtimes", Self::show_browse_remote_runtimes_dialog),
+            ("connect-existing-local", Self::connect_existing_local),
+            ("connect-to-existing", Self::connect_existing_local),
+            ("new-direct", |w| {
                 w.add_direct_session();
             }),
-            ("toggle-utility-sidebar", &["<Ctrl><Shift>B"], |w| {
+            ("toggle-utility-sidebar", |w| {
                 let sidebar = &w.imp().utility_sidebar_box;
                 sidebar.set_visible(!sidebar.is_visible());
             }),
-            ("add-current-host", &[], Self::do_add_current_host),
-            ("add-current-place", &[], Self::do_add_current_path_to_places),
-            ("add-command", &[], |w| {
+            ("add-current-host", Self::do_add_current_host),
+            ("add-current-place", Self::do_add_current_path_to_places),
+            ("add-command", |w| {
                 crate::commands_window::show_form(w, None);
             }),
-            ("add-place", &[], |w| {
+            ("add-place", |w| {
                 crate::places_window::show_form(w, None);
             }),
         ];
 
-        for (name, accels, callback) in actions {
+        for (name, callback) in actions {
             let action = gtk4::gio::SimpleAction::new(name, None);
             let win = self.clone();
             let cb = *callback;
@@ -64,7 +69,9 @@ impl Window {
                 cb(&win);
             });
             self.add_action(&action);
-            app.set_accels_for_action(&format!("win.{name}"), accels);
+            let accels = shortcuts::effective_accels(name, overrides);
+            let accel_refs: Vec<&str> = accels.iter().map(AsRef::as_ref).collect();
+            app.set_accels_for_action(&format!("win.{name}"), &accel_refs);
         }
 
         let sync_action =
@@ -77,7 +84,11 @@ impl Window {
             win.set_input_sync(new_val);
         });
         self.add_action(&sync_action);
-        app.set_accels_for_action("win.toggle-input-sync", &["<Ctrl><Shift>i"]);
+        {
+            let accels = shortcuts::effective_accels("toggle-input-sync", overrides);
+            let accel_refs: Vec<&str> = accels.iter().map(AsRef::as_ref).collect();
+            app.set_accels_for_action("win.toggle-input-sync", &accel_refs);
+        }
 
         let prefs_action = gtk4::gio::SimpleAction::new("preferences", None);
         let win = self.clone();
@@ -85,7 +96,11 @@ impl Window {
             crate::preferences_window::show(&win);
         });
         self.add_action(&prefs_action);
-        app.set_accels_for_action("win.preferences", &["<Ctrl>comma"]);
+        {
+            let accels = shortcuts::effective_accels("preferences", overrides);
+            let accel_refs: Vec<&str> = accels.iter().map(AsRef::as_ref).collect();
+            app.set_accels_for_action("win.preferences", &accel_refs);
+        }
 
         let edit_command_action =
             gtk4::gio::SimpleAction::new("edit-command", Some(glib::VariantTy::STRING));
@@ -151,23 +166,23 @@ impl Window {
         });
         self.add_action(&about_action);
 
-        // Pane navigation — shortcuts are configurable via preferences.
+        // Pane navigation — shortcuts are customizable via preferences.
         {
-            let nav_keys = crate::preferences::load().pane_navigation_keys;
-            let (left, right, up, down) = nav_keys.accels();
-            let nav_actions: &[(&str, &str, Direction)] = &[
-                ("navigate-left", left, Direction::Left),
-                ("navigate-right", right, Direction::Right),
-                ("navigate-up", up, Direction::Up),
-                ("navigate-down", down, Direction::Down),
+            let nav_actions: &[(&str, Direction)] = &[
+                ("navigate-left", Direction::Left),
+                ("navigate-right", Direction::Right),
+                ("navigate-up", Direction::Up),
+                ("navigate-down", Direction::Down),
             ];
-            for (name, accel, direction) in nav_actions {
+            for (name, direction) in nav_actions {
                 let action = gtk4::gio::SimpleAction::new(name, None);
                 let win = self.clone();
                 let dir = *direction;
                 action.connect_activate(move |_, _| win.navigate_focused(dir));
                 self.add_action(&action);
-                app.set_accels_for_action(&format!("win.{name}"), &[accel]);
+                let accels = shortcuts::effective_accels(name, overrides);
+                let accel_refs: Vec<&str> = accels.iter().map(AsRef::as_ref).collect();
+                app.set_accels_for_action(&format!("win.{name}"), &accel_refs);
             }
         }
 

--- a/clients/rttx/src/window/input.rs
+++ b/clients/rttx/src/window/input.rs
@@ -50,16 +50,13 @@ impl Window {
     pub(crate) fn reapply_terminal_preferences(&self) {
         let prefs = preferences::load();
 
-        // Update pane navigation shortcuts in case the keybinding changed.
+        // Reapply all keyboard shortcuts from preferences.
         if let Some(app) = self.application().and_downcast::<adw::Application>() {
-            let (left, right, up, down) = prefs.pane_navigation_keys.accels();
-            for (name, accel) in [
-                ("navigate-left", left),
-                ("navigate-right", right),
-                ("navigate-up", up),
-                ("navigate-down", down),
-            ] {
-                app.set_accels_for_action(&format!("win.{name}"), &[accel]);
+            for def in crate::shortcuts::DEFAULT_SHORTCUTS {
+                let accels =
+                    crate::shortcuts::effective_accels(def.action, &prefs.keyboard_shortcuts);
+                let accel_refs: Vec<&str> = accels.iter().map(AsRef::as_ref).collect();
+                app.set_accels_for_action(&format!("win.{}", def.action), &accel_refs);
             }
         }
 

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -6338,3 +6338,43 @@ fn connection_presentation_delegates_to_pure_function() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn reapply_preferences_updates_keyboard_shortcut_accels() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.shortcut-reapply-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    // Default: fullscreen is bound to F11.
+    let accels = app.accels_for_action("win.fullscreen");
+    assert!(accels.iter().any(|a| a == "F11"), "fullscreen should default to F11, got: {accels:?}");
+
+    // Override fullscreen to Ctrl+Shift+F11 via preferences.
+    let mut prefs = crate::preferences::load();
+    prefs.keyboard_shortcuts.insert("fullscreen".into(), vec!["<Ctrl><Shift>F11".into()]);
+    crate::preferences::save(&prefs).unwrap();
+
+    window.reapply_terminal_preferences();
+
+    let accels = app.accels_for_action("win.fullscreen");
+    assert!(
+        accels.iter().any(|a| a == "<Ctrl><Shift>F11"),
+        "fullscreen should be rebound to Ctrl+Shift+F11, got: {accels:?}"
+    );
+    assert!(
+        !accels.iter().any(|a| a == "F11"),
+        "old F11 binding should be removed, got: {accels:?}"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -1,4 +1,6 @@
 /// Integration tests for preferences persistence.
+use std::collections::BTreeMap;
+
 use rttx::preferences::{
     self, DefaultSessionFolder, PaneNavigationKeys, Preferences, TerminalThemeMode,
 };
@@ -32,6 +34,7 @@ fn preferences_roundtrip_all_fields() {
         trim_trailing_whitespace_on_copy: true,
         default_session_folder: DefaultSessionFolder::Custom("/home/user/dev".into()),
         pane_navigation_keys: PaneNavigationKeys::AltArrow,
+        keyboard_shortcuts: BTreeMap::new(),
         auto_start_daemon: true,
         reconnect_delay_secs: 10,
         paste_guard: false,
@@ -266,4 +269,73 @@ fn trim_trailing_whitespace_on_copy_backward_compat_missing_field() {
     std::fs::write(&path, r#"{"font": "Mono 12"}"#).unwrap();
     let loaded = preferences::load_from(&path);
     assert!(!loaded.trim_trailing_whitespace_on_copy);
+}
+
+#[test]
+fn keyboard_shortcuts_defaults_to_empty() {
+    let prefs = Preferences::default();
+    assert!(prefs.keyboard_shortcuts.is_empty());
+}
+
+#[test]
+fn keyboard_shortcuts_roundtrips() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+
+    let mut shortcuts = BTreeMap::new();
+    shortcuts.insert("close-terminal".into(), vec!["<Ctrl>q".into()]);
+    shortcuts.insert("fullscreen".into(), vec![]);
+
+    let prefs = Preferences { keyboard_shortcuts: shortcuts, ..Default::default() };
+    preferences::save_to(&prefs, &path).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert_eq!(loaded.keyboard_shortcuts["close-terminal"], vec!["<Ctrl>q"]);
+    assert!(loaded.keyboard_shortcuts["fullscreen"].is_empty());
+}
+
+#[test]
+fn keyboard_shortcuts_backward_compat_missing_field() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+    std::fs::write(&path, r#"{"font": "Mono 12"}"#).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert!(loaded.keyboard_shortcuts.is_empty());
+}
+
+#[test]
+fn keyboard_shortcuts_migration_from_ctrl_shift_arrow() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+    std::fs::write(&path, r#"{"pane_navigation_keys": "ctrl-shift-arrow"}"#).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert_eq!(loaded.keyboard_shortcuts["navigate-left"], vec!["<Ctrl><Shift>Left"]);
+    assert_eq!(loaded.keyboard_shortcuts["navigate-right"], vec!["<Ctrl><Shift>Right"]);
+    assert_eq!(loaded.keyboard_shortcuts["navigate-up"], vec!["<Ctrl><Shift>Up"]);
+    assert_eq!(loaded.keyboard_shortcuts["navigate-down"], vec!["<Ctrl><Shift>Down"]);
+}
+
+#[test]
+fn keyboard_shortcuts_migration_noop_for_alt_arrow() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+    std::fs::write(&path, r#"{"pane_navigation_keys": "alt-arrow"}"#).unwrap();
+    let loaded = preferences::load_from(&path);
+    assert!(!loaded.keyboard_shortcuts.contains_key("navigate-left"));
+}
+
+#[test]
+fn keyboard_shortcuts_explicit_override_wins_over_migration() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("prefs.json");
+    std::fs::write(
+        &path,
+        r#"{
+            "pane_navigation_keys": "ctrl-shift-arrow",
+            "keyboard_shortcuts": {"navigate-left": ["<Alt>h"]}
+        }"#,
+    )
+    .unwrap();
+    let loaded = preferences::load_from(&path);
+    assert_eq!(loaded.keyboard_shortcuts["navigate-left"], vec!["<Alt>h"]);
+    assert_eq!(loaded.keyboard_shortcuts["navigate-right"], vec!["<Ctrl><Shift>Right"]);
 }

--- a/designs/RFC-024-customizable-keyboard-shortcuts.md
+++ b/designs/RFC-024-customizable-keyboard-shortcuts.md
@@ -1,0 +1,117 @@
+# RFC-024: Customizable Keyboard Shortcuts
+
+| Field         | Value         |
+|---------------|---------------|
+| Status        | Accepted      |
+| Author(s)     | Illya Yalovyy |
+| Supersedes    | —             |
+| Superseded by | —             |
+
+---
+
+## Summary
+
+Allow users to customize every keyboard shortcut in rttx through the
+preferences window. Shortcuts persist as a map of action-name to GTK
+accelerator strings in `preferences.json`, storing only overrides from
+the built-in defaults.
+
+---
+
+## Goals
+
+- **G1** — Every shortcut listed in the README keyboard shortcuts table is
+  user-customizable.
+- **G2** — Existing preferences files load without error (backward compatible).
+- **G3** — A "Reset to default" option per shortcut and a global reset.
+
+## Non-Goals
+
+- **NG1** — Per-workspace or per-profile shortcut sets.
+- **NG2** — Vim/Emacs keybinding presets.
+- **NG3** — Shortcut customization for Alt+1–9 workspace switching (these remain
+  fixed).
+
+---
+
+## Background & Motivation
+
+All keyboard shortcuts except pane navigation keys are hardcoded in
+`window/actions.rs`. The existing `PaneNavigationKeys` enum in preferences
+proves the pattern works but only covers one shortcut group with two presets.
+Users who need different bindings (e.g., to avoid conflicts with tiling window
+managers or accessibility tools) have no recourse.
+
+Issue: https://github.com/IllyaYalovyy/rttx/issues/71
+
+---
+
+## User Impact
+
+| Audience     | Impact |
+|--------------|--------|
+| End users    | Can remap any shortcut from Preferences → Keyboard |
+| Contributors | New shortcuts automatically appear in the customization UI |
+| Packagers    | No impact — preferences.json format is backward compatible |
+
+---
+
+## Design
+
+### Data model
+
+A new `keyboard_shortcuts` field in `Preferences`:
+
+```rust
+#[serde(default)]
+pub keyboard_shortcuts: BTreeMap<String, Vec<String>>,
+```
+
+Keys are action names (e.g., `"close-terminal"`). Values are GTK accelerator
+string arrays (e.g., `["<Ctrl><Shift>W"]`). Only overrides are stored; absent
+keys use the built-in default.
+
+### Default shortcut table
+
+A `const` array `DEFAULT_SHORTCUTS` in a new `shortcuts.rs` module defines
+every customizable shortcut with its action name, human-readable label, and
+default accelerator(s). This is the single source of truth for both
+registration and the preferences UI.
+
+### Registration
+
+`setup_actions` consults `preferences.keyboard_shortcuts` for each action.
+If the action has an override, those accelerators are used; otherwise the
+default from `DEFAULT_SHORTCUTS` is used.
+
+### Preferences UI
+
+The Keyboard section in the preferences window shows one row per shortcut.
+Each row displays the action label and current binding. Clicking a row opens
+a capture dialog where the user presses the desired key combination. A
+"Reset" button per row restores the default.
+
+### Migration
+
+The existing `pane_navigation_keys` field is preserved for deserialization.
+During load, if `pane_navigation_keys` is set to `CtrlShiftArrow` and no
+explicit `keyboard_shortcuts` override exists for the navigation actions,
+the navigation overrides are populated from the enum value. New saves always
+use `keyboard_shortcuts`.
+
+---
+
+## Development Plan
+
+- [x] **Step 1** — Add `shortcuts.rs` with default table and lookup
+- [x] **Step 2** — Add `keyboard_shortcuts` to `Preferences` with serde
+- [x] **Step 3** — Wire `setup_actions` and `reapply_terminal_preferences`
+- [x] **Step 4** — Build preferences UI for shortcut customization
+- [x] **Step 5** — Add unit tests for the data model and migration
+- [x] **Step 6** — Add GTK tests for the preferences UI
+
+---
+
+## References
+
+- [Tracking issue](https://github.com/IllyaYalovyy/rttx/issues/71)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.3.0',
+  version: '0.3.1',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Implements fully customizable keyboard shortcuts (issue #71). Users can now
remap any shortcut from Preferences → Keyboard Shortcuts, including disabling
shortcuts entirely via Backspace.

### Architecture

- **`shortcuts.rs`** — new module with `DEFAULT_SHORTCUTS` table (single source
  of truth), `effective_accels` lookup, and migration from legacy
  `PaneNavigationKeys` enum
- **`preferences.rs`** — `keyboard_shortcuts: BTreeMap<String, Vec<String>>`
  field with `#[serde(default)]` for backward compatibility; migration runs
  during load
- **`preferences_window.rs`** — shortcut rows with key capture dialog and
  per-row reset button; replaces the old pane navigation combo row
- **`window/actions.rs`** — `setup_actions` consults `effective_accels` for
  every action instead of hardcoded accelerator arrays
- **`window/input.rs`** — `reapply_terminal_preferences` iterates all shortcuts

### Design

RFC-024 (included in this PR) documents the design: data model, default table,
preferences UI, and migration strategy.

### Backward compatibility

- Existing `preferences.json` files without `keyboard_shortcuts` load without
  error (`#[serde(default)]`)
- Legacy `pane_navigation_keys: ctrl-shift-arrow` is automatically migrated to
  explicit shortcut overrides during load
- Explicit overrides take precedence over migration

## Manual verification

1. Open Preferences → Keyboard Shortcuts
2. Click a shortcut row → capture dialog appears
3. Press a key combination → shortcut updates with accent color
4. Press Backspace → shortcut shows "Disabled"
5. Click reset button → shortcut reverts to default
6. Close preferences → shortcuts take effect immediately
7. Restart rttx → custom shortcuts persist

## Tests added

### Unit tests (shortcuts.rs) — 10 tests
- `effective_accels_returns_default_when_no_override`
- `effective_accels_returns_override_when_present`
- `effective_accels_returns_empty_for_unknown_action`
- `default_accels_returns_correct_values`
- `override_with_empty_vec_disables_shortcut`
- `all_default_shortcuts_have_unique_actions`
- `all_default_shortcuts_have_labels`
- `migrate_pane_navigation_noop_for_alt_arrow`
- `migrate_pane_navigation_populates_ctrl_shift_arrow`
- `migrate_pane_navigation_does_not_overwrite_existing`

### Integration tests (preferences_integration.rs) — 6 tests
- `keyboard_shortcuts_defaults_to_empty`
- `keyboard_shortcuts_roundtrips`
- `keyboard_shortcuts_backward_compat_missing_field`
- `keyboard_shortcuts_migration_from_ctrl_shift_arrow`
- `keyboard_shortcuts_migration_noop_for_alt_arrow`
- `keyboard_shortcuts_explicit_override_wins_over_migration`

### GTK tests (window/tests.rs) — 1 test
- `reapply_preferences_updates_keyboard_shortcut_accels` — verifies live
  shortcut rebinding through the GTK application

## Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (0 failures, all new GTK tests pass)

## Limitations / follow-ups

- Alt+1–9 workspace switching remains fixed (intentional per RFC-024)
- No per-workspace or per-profile shortcut sets (non-goal per RFC-024)
- No Vim/Emacs keybinding presets (non-goal per RFC-024)

Fixes #71