### PR TITLE
fix: preserve VTE scroll position across split, rebuild, and reparent

### DIFF
--- a/clients/rttx/src/terminal/handle.rs
+++ b/clients/rttx/src/terminal/handle.rs
@@ -36,7 +36,8 @@ impl TerminalHandle {
             if let Some(adj) = vte.vadjustment() {
                 // Clamp to valid range — the upper bound may have changed
                 // if the terminal was resized during the rebuild.
-                let clamped = value.clamp(adj.lower(), (adj.upper() - adj.page_size()).max(adj.lower()));
+                let clamped =
+                    value.clamp(adj.lower(), (adj.upper() - adj.page_size()).max(adj.lower()));
                 adj.set_value(clamped);
             }
         });

--- a/clients/rttx/src/terminal/handle.rs
+++ b/clients/rttx/src/terminal/handle.rs
@@ -1,3 +1,5 @@
+use gtk4::glib;
+
 use crate::terminal::persistent_widget::PersistentPaneView;
 use crate::terminal::widget::TerminalWidget;
 use vte4::prelude::*;
@@ -15,6 +17,29 @@ impl TerminalHandle {
             Self::Direct(terminal) => terminal.vte(),
             Self::Managed(pane) => pane.vte(),
         }
+    }
+
+    /// Capture the current VTE scroll position as a vadjustment value.
+    #[must_use]
+    pub fn scroll_position(&self) -> Option<f64> {
+        self.vte().vadjustment().map(|adj| adj.value())
+    }
+
+    /// Schedule restoration of a saved scroll position after the next layout
+    /// pass. Reparenting resets the vadjustment, so the value must be
+    /// reapplied once GTK has laid out the widget.
+    pub fn restore_scroll_position(&self, value: f64) {
+        let vte = self.vte().clone();
+        // Use idle to let GTK finish the current reparenting/layout pass
+        // before touching the adjustment.
+        glib::idle_add_local_once(move || {
+            if let Some(adj) = vte.vadjustment() {
+                // Clamp to valid range — the upper bound may have changed
+                // if the terminal was resized during the rebuild.
+                let clamped = value.clamp(adj.lower(), (adj.upper() - adj.page_size()).max(adj.lower()));
+                adj.set_value(clamped);
+            }
+        });
     }
 
     /// Human-readable title for notifications and UI actions.

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1157,4 +1157,21 @@ mod search_tests {
         assert_eq!(strip_user_host_prefix("bash"), "bash");
         assert_eq!(strip_user_host_prefix(""), "");
     }
+
+    /// `TerminalHandle::scroll_position` returns `None` when the VTE has
+    /// no vadjustment (widget not yet realized). Regression for #686.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn scroll_position_returns_none_before_realize() {
+        if !crate::test_helpers::ensure_gtk() {
+            eprintln!("SKIPPED: no display available");
+            return;
+        }
+
+        let pane = super::persistent_widget::PersistentPaneView::new("sp-1", "rt-1");
+        let handle = super::handle::TerminalHandle::Managed(pane);
+        // Before the widget is parented, vadjustment may or may not exist
+        // depending on VTE version, but scroll_position must not panic.
+        let _ = handle.scroll_position();
+    }
 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -2073,4 +2073,90 @@ mod tests {
         pane.set_custom_title(None);
         assert_eq!(pane.title_label().label(), "bash : /var");
     }
+
+    /// Feeding a snapshot scrolls to the bottom of the scrollback.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn feed_snapshot_scrolls_to_bottom() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("scroll-1", "runtime-1");
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 480);
+        window.set_child(Some(&pane));
+        window.present();
+        pump_events(100);
+
+        // Feed enough lines to create scrollback.
+        let mut data = Vec::new();
+        for i in 0..200 {
+            data.extend_from_slice(format!("line {i}\r\n").as_bytes());
+        }
+        pane.feed_snapshot(&data);
+        pump_events(50);
+
+        let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+        let bottom = adj.upper() - adj.page_size();
+        assert!(
+            (adj.value() - bottom).abs() < 1.0,
+            "feed_snapshot should scroll to bottom, got {} expected ~{bottom}",
+            adj.value()
+        );
+
+        window.close();
+    }
+
+    /// Scroll position is accessible via vadjustment and can be saved/restored.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn scroll_position_save_restore_round_trip() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("scroll-rt", "runtime-1");
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 480);
+        window.set_child(Some(&pane));
+        window.present();
+        pump_events(100);
+
+        // Feed enough lines to create scrollback.
+        let mut data = Vec::new();
+        for i in 0..200 {
+            data.extend_from_slice(format!("line {i}\r\n").as_bytes());
+        }
+        pane.feed_snapshot(&data);
+        pump_events(50);
+
+        // Scroll up from the bottom.
+        let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+        let target = (adj.upper() - adj.page_size()) / 2.0;
+        adj.set_value(target);
+        pump_events(20);
+
+        let saved = adj.value();
+        assert!(
+            (saved - target).abs() < 1.0,
+            "scroll position should be near target {target}, got {saved}"
+        );
+
+        // Simulate reparenting: unparent and re-add.
+        window.set_child(None::<&gtk4::Widget>);
+        pump_events(20);
+        window.set_child(Some(&pane));
+        pump_events(20);
+
+        // Restore the saved position.
+        if let Some(adj) = pane.vte().vadjustment() {
+            adj.set_value(saved);
+        }
+        pump_events(20);
+
+        let restored = pane.vte().vadjustment().map_or(0.0, |a| a.value());
+        assert!(
+            (restored - saved).abs() < 1.0,
+            "restored scroll position should be near saved {saved}, got {restored}"
+        );
+
+        window.close();
+    }
 }

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -610,10 +610,7 @@ impl Window {
     }
 
     /// Save the VTE scroll position for every terminal in a session.
-    fn save_session_scroll_positions(
-        &self,
-        session_state: &SessionState,
-    ) -> Vec<(String, f64)> {
+    fn save_session_scroll_positions(&self, session_state: &SessionState) -> Vec<(String, f64)> {
         let mut positions = Vec::new();
         for uuid in session_state.layout.terminal_uuids() {
             if let Some(handle) = self.terminal_handle(&uuid)

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -438,6 +438,8 @@ impl Window {
             return false;
         };
 
+        let saved_scroll = target.vte().vadjustment().map(|adj| adj.value());
+
         let pre_split_position = match orientation {
             SplitOrientation::Horizontal => target.width() / 2,
             SplitOrientation::Vertical => target.height() / 2,
@@ -493,6 +495,19 @@ impl Window {
             }
         };
 
+        let restore_target_scroll = |target_uuid: &str, imp: &imp::Window| {
+            if let Some(value) = saved_scroll
+                && let Some(term) = imp.terminals.borrow().get(target_uuid)
+            {
+                let vte = term.vte().clone();
+                glib::idle_add_local_once(move || {
+                    if let Some(adj) = vte.vadjustment() {
+                        adj.set_value(value);
+                    }
+                });
+            }
+        };
+
         if let Ok(stack) = parent.clone().downcast::<gtk4::Stack>() {
             stack.remove(&target);
             let branch = build_branch();
@@ -509,6 +524,7 @@ impl Window {
             if let Some(term) = imp.terminals.borrow().get(new_terminal_uuid) {
                 term.ensure_shell_spawned_when_ready();
             }
+            restore_target_scroll(target_uuid, imp);
             return true;
         }
 
@@ -551,11 +567,15 @@ impl Window {
         if let Some(term) = imp.terminals.borrow().get(new_terminal_uuid) {
             term.ensure_shell_spawned_when_ready();
         }
+        restore_target_scroll(target_uuid, imp);
         true
     }
 
     pub(super) fn rebuild_session_content(&self, session_uuid: &str, session_state: &SessionState) {
         let imp = self.imp();
+
+        let saved_positions = self.save_session_scroll_positions(session_state);
+
         let previously_visible =
             imp.session_stack.visible_child_name().map(|name| name.to_string());
 
@@ -582,9 +602,36 @@ impl Window {
             session::schedule_initial_paned_ratios(&content, &session_state.layout);
         }
 
+        self.restore_scroll_positions(&saved_positions);
+
         self.remove_stale_terminal_map_entries(imp);
         self.refresh_sidebar_subtitle(session_uuid);
         self.sync_sidebar_to_visible_session();
+    }
+
+    /// Save the VTE scroll position for every terminal in a session.
+    fn save_session_scroll_positions(
+        &self,
+        session_state: &SessionState,
+    ) -> Vec<(String, f64)> {
+        let mut positions = Vec::new();
+        for uuid in session_state.layout.terminal_uuids() {
+            if let Some(handle) = self.terminal_handle(&uuid)
+                && let Some(value) = handle.scroll_position()
+            {
+                positions.push((uuid, value));
+            }
+        }
+        positions
+    }
+
+    /// Schedule restoration of saved scroll positions after widgets are realized.
+    fn restore_scroll_positions(&self, positions: &[(String, f64)]) {
+        for (uuid, value) in positions {
+            if let Some(handle) = self.terminal_handle(uuid) {
+                handle.restore_scroll_position(*value);
+            }
+        }
     }
 
     /// Remove terminal map entries that no longer belong to any workspace layout.

--- a/clients/rttx/tests/scroll_position_tests.rs
+++ b/clients/rttx/tests/scroll_position_tests.rs
@@ -1,0 +1,146 @@
+//! Integration tests for VTE scroll position preservation across
+//! reparenting operations (split, rebuild, close). Regression for #686.
+
+use gtk4::prelude::*;
+use rttx::terminal::handle::TerminalHandle;
+use rttx::terminal::persistent_widget::PersistentPaneView;
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+static GTK_INIT: Once = Once::new();
+static GTK_AVAILABLE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+fn ensure_gtk_init() -> bool {
+    GTK_INIT.call_once(|| {
+        // SAFETY: GTK init runs once before any threads spawn; no concurrent env readers.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("GTK_A11Y", "none");
+        };
+        let ok = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| gtk4::init().is_ok()))
+            .unwrap_or(false);
+        if ok && let Some(display) = gtk4::gdk::Display::default() {
+            std::mem::forget(display);
+        }
+        GTK_AVAILABLE.store(ok, std::sync::atomic::Ordering::Relaxed);
+    });
+    GTK_AVAILABLE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+macro_rules! require_display {
+    () => {
+        if !ensure_gtk_init() {
+            eprintln!("SKIPPED: no display available");
+            return;
+        }
+    };
+}
+
+fn pump_events(max_ms: u64) {
+    let ctx = gtk4::glib::MainContext::default();
+    let deadline = Instant::now() + Duration::from_millis(max_ms);
+    while Instant::now() < deadline {
+        if !ctx.iteration(false) {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+}
+
+fn feed_scrollback(pane: &PersistentPaneView, line_count: usize) {
+    let mut data = Vec::new();
+    for i in 0..line_count {
+        data.extend_from_slice(format!("line {i}\r\n").as_bytes());
+    }
+    pane.feed_snapshot(&data);
+}
+
+/// Scroll position is preserved when a persistent pane is reparented
+/// (unparent + re-add), simulating what happens during split or rebuild.
+/// Regression for #686.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn scroll_position_preserved_across_reparent() {
+    require_display!();
+
+    let pane = PersistentPaneView::new("reparent-1", "runtime-1");
+    let handle = TerminalHandle::Managed(pane.clone());
+
+    let window = gtk4::Window::new();
+    window.set_default_size(640, 480);
+    window.set_child(Some(&pane));
+    window.present();
+    pump_events(100);
+
+    feed_scrollback(&pane, 200);
+    pump_events(50);
+
+    // Scroll to a mid-point.
+    let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+    let mid = (adj.upper() - adj.page_size()) / 2.0;
+    adj.set_value(mid);
+    pump_events(20);
+
+    let saved = handle.scroll_position().expect("scroll position should be available");
+    assert!(
+        (saved - mid).abs() < 1.0,
+        "saved position should be near mid-point {mid}, got {saved}"
+    );
+
+    // Reparent: remove from window, re-add.
+    window.set_child(None::<&gtk4::Widget>);
+    pump_events(20);
+    window.set_child(Some(&pane));
+    pump_events(20);
+
+    // Restore via TerminalHandle.
+    handle.restore_scroll_position(saved);
+    pump_events(50);
+
+    let restored = handle.scroll_position().expect("scroll position should be available");
+    assert!(
+        (restored - saved).abs() < 1.0,
+        "restored position {restored} should be near saved {saved}"
+    );
+
+    window.close();
+}
+
+/// Scroll position restore clamps to valid range when the scrollback
+/// shrinks (e.g., terminal resized to show more rows). Regression for #686.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn scroll_position_restore_clamps_to_valid_range() {
+    require_display!();
+
+    let pane = PersistentPaneView::new("clamp-1", "runtime-1");
+    let handle = TerminalHandle::Managed(pane.clone());
+
+    let window = gtk4::Window::new();
+    window.set_default_size(640, 480);
+    window.set_child(Some(&pane));
+    window.present();
+    pump_events(100);
+
+    feed_scrollback(&pane, 200);
+    pump_events(50);
+
+    // Save a position near the bottom.
+    let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+    let near_bottom = adj.upper() - adj.page_size() - 5.0;
+    adj.set_value(near_bottom);
+    pump_events(20);
+
+    // Attempt to restore an out-of-range value (larger than upper - page_size).
+    // The restore should clamp without panicking.
+    handle.restore_scroll_position(999_999.0);
+    pump_events(50);
+
+    let restored = handle.scroll_position().expect("scroll position should be available");
+    let max_valid = adj.upper() - adj.page_size();
+    assert!(
+        restored <= max_valid + 1.0,
+        "restored position {restored} should be clamped to max {max_valid}"
+    );
+
+    window.close();
+}


### PR DESCRIPTION
## What changed and why

When a pane is split, the layout is rebuilt (close, rotate, drag-rearrange), or a daemon-driven workspace rebuild occurs, the VTE viewport jumps to the beginning of the scrollback log. This happens because reparenting a VTE widget resets its scroll adjustment.

This PR saves the vadjustment value before any reparenting or widget tree rebuild and restores it via `glib::idle_add_local_once` after GTK finishes the layout pass.

### Changes

- **`terminal/handle.rs`**: Added `scroll_position()` and `restore_scroll_position()` to `TerminalHandle`. The restore uses an idle callback with clamping to handle cases where the terminal was resized during rebuild.
- **`window/terminal.rs`**: `rebuild_session_content()` now saves all terminal scroll positions before teardown and restores them after rebuild. `split_terminal_in_place()` saves the target terminal's scroll position before reparenting and restores it after.
- **`terminal/persistent_widget.rs`**: Added tests only (no behavioral changes to `feed_snapshot` — scroll-to-bottom on snapshot restore is intentional).

### What is NOT changed

`feed_snapshot()` still scrolls to bottom after feeding scrollback data. This is the correct behavior for initial snapshot restore on reconnect — the user expects to see the most recent output.

## Manual verification

1. Open rttx, create a workspace, run a command that produces lots of output
2. Scroll up to review earlier output
3. Split the pane (Ctrl+Shift+E) — the original pane should preserve its scroll position
4. Close the new pane — the remaining pane should preserve its scroll position
5. With multiple panes, rotate layout (Ctrl+Shift+R) — all panes should preserve scroll positions
6. Drag-rearrange panes — scroll positions should be preserved

## Tests added

- `feed_snapshot_scrolls_to_bottom` — verifies snapshot restore scrolls to bottom (regression guard)
- `scroll_position_save_restore_round_trip` — verifies vadjustment can be saved, survives reparenting, and is restorable

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 598 tests pass, 0 failures)
- Both new GTK tests confirmed running and passing in quality test output

Fixes #686