### PR TITLE
feat(proto): define complete v3 .proto file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytes",
  "prost",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.3.3',
+  version: '0.3.4',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/build.rs
+++ b/protocols/rttx-proto/build.rs
@@ -1,6 +1,19 @@
 fn main() -> std::io::Result<()> {
-    let mut config = prost_build::Config::new();
-    config.bytes(["Delta.data", "Input.data", "PaneSnapshot.scrollback"]);
-    config.compile_protos(&["proto/rttx.proto"], &["proto/"])?;
+    // v2 protocol (current)
+    let mut v2 = prost_build::Config::new();
+    v2.bytes(["Delta.data", "Input.data", "PaneSnapshot.scrollback"]);
+    v2.compile_protos(&["proto/rttx.proto"], &["proto/"])?;
+
+    // v3 protocol (RFC-021)
+    let mut v3 = prost_build::Config::new();
+    v3.bytes([
+        "rttx.v3.OutputDelta.data",
+        "rttx.v3.RawInput.data",
+        "rttx.v3.PasteInput.text",
+        "rttx.v3.PaneSnapshot.scrollback_tail",
+        "rttx.v3.ScrollbackChunk.data",
+    ]);
+    v3.compile_protos(&["proto/rttx-v3.proto"], &["proto/"])?;
+
     Ok(())
 }

--- a/protocols/rttx-proto/proto/rttx-v3.proto
+++ b/protocols/rttx-proto/proto/rttx-v3.proto
@@ -1,0 +1,491 @@
+syntax = "proto3";
+package rttx.v3;
+
+// ─── Enums ───────────────────────────────────────────────────────────
+
+enum Capability {
+  CAPABILITY_UNSPECIFIED = 0;
+  // Core (required) — values 1–99
+  CORE_RUNTIME_LIFECYCLE = 1;
+  CORE_PANE_LIFECYCLE = 2;
+  CORE_TERMINAL_IO = 3;
+  CORE_TERMINAL_MODES = 4;
+  CORE_PASTE_INTENT = 5;
+  CORE_FOCUS_EVENTS = 6;
+  // Optional — values 100+
+  OPT_RUNTIME_INVENTORY_V2 = 100;
+  OPT_RUNTIME_TAKEOVER = 101;
+  OPT_RESYNC = 102;
+  OPT_CHUNKED_SCROLLBACK = 103;
+  OPT_DIAGNOSTICS = 104;
+}
+
+enum RuntimePolicy {
+  RUNTIME_POLICY_UNSPECIFIED = 0;
+  RUNTIME_POLICY_PERSISTENT = 1;
+  RUNTIME_POLICY_EPHEMERAL = 2;
+}
+
+enum RuntimeAttachMode {
+  RUNTIME_ATTACH_MODE_UNSPECIFIED = 0;
+  RUNTIME_ATTACH_MODE_READ_WRITE = 1;
+  RUNTIME_ATTACH_MODE_READ_ONLY = 2;
+}
+
+enum RuntimeClientRole {
+  RUNTIME_CLIENT_ROLE_UNSPECIFIED = 0;
+  RUNTIME_CLIENT_ROLE_UNATTACHED = 1;
+  RUNTIME_CLIENT_ROLE_WRITER = 2;
+  RUNTIME_CLIENT_ROLE_READER = 3;
+}
+
+enum RuntimeTerminationReason {
+  RUNTIME_TERMINATION_REASON_UNSPECIFIED = 0;
+  RUNTIME_TERMINATION_REASON_EXPLICIT = 1;
+  RUNTIME_TERMINATION_REASON_EPHEMERAL_DETACH = 2;
+}
+
+enum MouseMode {
+  MOUSE_MODE_NONE = 0;
+  MOUSE_MODE_X10 = 1;
+  MOUSE_MODE_NORMAL = 2;
+  MOUSE_MODE_BUTTON = 3;
+  MOUSE_MODE_ANY = 4;
+}
+
+enum ErrorKind {
+  ERROR_KIND_UNSPECIFIED = 0;
+  ERROR_KIND_PROTOCOL_MISMATCH = 1;
+  ERROR_KIND_UNSUPPORTED_CAPABILITY = 2;
+  ERROR_KIND_INVALID_ARGUMENT = 3;
+  ERROR_KIND_RUNTIME_NOT_FOUND = 4;
+  ERROR_KIND_PANE_NOT_FOUND = 5;
+  ERROR_KIND_OWNERSHIP_CONFLICT = 6;
+  ERROR_KIND_TAKEOVER_REQUIRED = 7;
+  ERROR_KIND_STREAM_OVERFLOW = 8;
+  ERROR_KIND_INTERNAL = 9;
+}
+
+// ─── Handshake (bare messages, exchanged before envelopes) ───────────
+
+message ClientHello {
+  uint32 min_protocol_version = 1;
+  uint32 max_protocol_version = 2;
+  bytes client_id = 3;
+  string client_name = 4;
+  string client_version = 5;
+  repeated Capability capabilities = 6;
+}
+
+message ServerHello {
+  uint32 negotiated_protocol_version = 1;
+  bytes server_id = 2;
+  string server_version = 3;
+  repeated Capability capabilities = 4;
+}
+
+// ─── Terminal mode state ─────────────────────────────────────────────
+
+message TerminalModeState {
+  bool bracketed_paste = 1;
+  bool focus_reporting = 2;
+  bool application_cursor_keys = 3;
+  bool application_keypad = 4;
+  bool alternate_screen = 5;
+  bool cursor_hidden = 6;
+  MouseMode mouse_mode = 7;
+  bool sgr_mouse = 8;
+}
+
+// ─── Terminal I/O ────────────────────────────────────────────────────
+
+message TerminalInput {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  oneof kind {
+    RawInput raw = 3;
+    PasteInput paste = 4;
+    FocusInput focus = 5;
+  }
+}
+
+message RawInput {
+  bytes data = 1;
+}
+
+message PasteInput {
+  bytes text = 1;
+}
+
+message FocusInput {
+  bool focused = 1;
+}
+
+message OutputDelta {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  bytes data = 3;
+  uint64 pane_output_seq = 4;
+}
+
+message TerminalModeChanged {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  uint64 runtime_revision = 3;
+  TerminalModeState modes = 4;
+}
+
+// ─── Control ─────────────────────────────────────────────────────────
+
+message Ping {
+  uint64 nonce = 1;
+}
+
+message Pong {
+  uint64 nonce = 1;
+}
+
+message Shutdown {}
+
+// ─── Runtime lifecycle — commands ────────────────────────────────────
+
+message CreateRuntime {
+  string name = 1;
+  RuntimePolicy policy = 2;
+}
+
+message AttachRuntime {
+  bytes runtime_id = 1;
+  RuntimeAttachMode attach_mode = 2;
+}
+
+message DetachRuntime {
+  bytes runtime_id = 1;
+}
+
+message TerminateRuntime {
+  bytes runtime_id = 1;
+}
+
+message RenameRuntime {
+  bytes runtime_id = 1;
+  string name = 2;
+}
+
+message ListRuntimes {}
+
+// ─── Runtime lifecycle — events ──────────────────────────────────────
+
+message RuntimeCreated {
+  bytes runtime_id = 1;
+  uint64 runtime_revision = 2;
+}
+
+message RuntimeDetached {
+  bytes runtime_id = 1;
+  uint64 runtime_revision = 2;
+}
+
+message RuntimeTerminated {
+  bytes runtime_id = 1;
+  uint64 final_revision = 2;
+  RuntimeTerminationReason reason = 3;
+}
+
+message RuntimeRenamed {
+  bytes runtime_id = 1;
+  string name = 2;
+  uint64 runtime_revision = 3;
+}
+
+message AttachBlocked {
+  bytes runtime_id = 1;
+  RuntimeClientRole current_client_role = 2;
+  uint32 attached_client_count = 3;
+  uint32 read_only_client_count = 4;
+}
+
+// ─── Runtime inventory ───────────────────────────────────────────────
+
+message RuntimeList {
+  repeated RuntimeInfo runtimes = 1;
+}
+
+message RuntimeInfo {
+  bytes id = 1;
+  string name = 2;
+  RuntimePolicy policy = 3;
+  uint32 pane_count = 4;
+  bool has_write_owner = 5;
+  uint32 read_only_client_count = 6;
+  RuntimeClientRole current_client_role = 7;
+  uint64 runtime_revision = 8;
+  bool reconstructed = 9;
+  // OPT_RUNTIME_INVENTORY_V2 fields
+  string active_pane_summary = 10;
+  bool takeover_eligible = 11;
+  string disabled_reason = 12;
+  repeated PaneInfo panes = 13;
+}
+
+message PaneInfo {
+  bytes id = 1;
+  string title = 2;
+  string cwd = 3;
+  uint32 cols = 4;
+  uint32 rows = 5;
+  optional int32 exit_status = 6;
+  bool reconstructed = 7;
+}
+
+// ─── Snapshots ───────────────────────────────────────────────────────
+
+message RuntimeSnapshot {
+  bytes runtime_id = 1;
+  uint64 runtime_revision = 2;
+  RuntimeClientRole client_role = 3;
+  repeated PaneSnapshot panes = 4;
+}
+
+message PaneSnapshot {
+  bytes pane_id = 1;
+  uint64 pane_output_seq = 2;
+  string title = 3;
+  string cwd = 4;
+  uint32 cols = 5;
+  uint32 rows = 6;
+  optional int32 exit_status = 7;
+  TerminalModeState terminal_modes = 8;
+  bytes scrollback_tail = 9;
+  uint64 total_scrollback_bytes = 10;
+  bool scrollback_complete = 11;
+}
+
+// ─── Pane lifecycle — commands ───────────────────────────────────────
+
+message CreatePane {
+  bytes runtime_id = 1;
+  optional string cwd = 2;
+  optional bool dark_background = 3;
+  uint32 cols = 4;
+  uint32 rows = 5;
+}
+
+message ClosePane {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+}
+
+message ResizePane {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  uint32 cols = 3;
+  uint32 rows = 4;
+}
+
+message SetPaneTitle {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  string title = 3;
+}
+
+// ─── Pane lifecycle — events ─────────────────────────────────────────
+
+message PaneCreated {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  uint64 runtime_revision = 3;
+}
+
+message PaneClosed {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  uint64 runtime_revision = 3;
+}
+
+message PaneResized {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  uint32 cols = 3;
+  uint32 rows = 4;
+  uint64 runtime_revision = 5;
+}
+
+message PaneExited {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  int32 status = 3;
+  uint64 runtime_revision = 4;
+}
+
+message TitleChanged {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  string title = 3;
+  uint64 runtime_revision = 4;
+}
+
+message CwdChanged {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  string cwd = 3;
+  uint64 runtime_revision = 4;
+}
+
+message Bell {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+}
+
+// ─── Recovery (OPT_RESYNC) ──────────────────────────────────────────
+
+message ResyncRuntime {
+  bytes runtime_id = 1;
+}
+
+message StreamOverflow {
+  bytes runtime_id = 1;
+  optional bytes pane_id = 2;
+  uint64 dropped_count = 3;
+}
+
+// ─── Scrollback (OPT_CHUNKED_SCROLLBACK) ─────────────────────────────
+
+message GetScrollback {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  uint64 offset = 3;
+  uint32 limit = 4;
+}
+
+message ScrollbackChunk {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  uint64 offset = 3;
+  bytes data = 4;
+  bool is_last = 5;
+}
+
+// ─── Diagnostics (OPT_DIAGNOSTICS) ──────────────────────────────────
+
+message GetDiagnostics {}
+
+message PaneDiagnosticsInfo {
+  bytes id = 1;
+  uint64 raw_bytes_len = 2;
+  uint64 pending_flush_len = 3;
+  bool is_exited = 4;
+}
+
+message RuntimeDiagnosticsInfo {
+  bytes id = 1;
+  string name = 2;
+  uint32 active_pane_count = 3;
+  uint32 exited_pane_count = 4;
+  uint32 command_history_len = 5;
+  uint32 attached_client_count = 6;
+  repeated PaneDiagnosticsInfo panes = 7;
+}
+
+message DiagnosticsReport {
+  uint32 runtime_count = 1;
+  uint32 total_pane_count = 2;
+  uint32 total_active_panes = 3;
+  uint32 total_exited_panes = 4;
+  uint32 client_count = 5;
+  uint32 pty_writer_count = 6;
+  uint64 total_raw_bytes = 7;
+  uint64 total_pending_flush = 8;
+  uint32 total_command_history = 9;
+  repeated RuntimeDiagnosticsInfo runtimes = 10;
+}
+
+// ─── Errors ──────────────────────────────────────────────────────────
+
+message ProtocolError {
+  ErrorKind kind = 1;
+  string message = 2;
+  string operation = 3;
+  bool retryable = 4;
+  bool user_action_required = 5;
+  uint32 retry_after_seconds = 6;
+}
+
+// ─── Envelopes ───────────────────────────────────────────────────────
+
+message ClientEnvelope {
+  uint64 request_id = 1;
+  oneof command {
+    // Terminal I/O (field 2: single-byte tag for highest-frequency path)
+    TerminalInput terminal_input = 2;
+
+    // Control
+    Ping ping = 10;
+    Shutdown shutdown = 11;
+
+    // Runtime lifecycle
+    CreateRuntime create_runtime = 20;
+    AttachRuntime attach_runtime = 21;
+    DetachRuntime detach_runtime = 22;
+    TerminateRuntime terminate_runtime = 23;
+    RenameRuntime rename_runtime = 24;
+    ListRuntimes list_runtimes = 25;
+
+    // Pane lifecycle
+    CreatePane create_pane = 30;
+    ClosePane close_pane = 31;
+    ResizePane resize_pane = 32;
+    SetPaneTitle set_pane_title = 33;
+
+    // Recovery (OPT_RESYNC)
+    ResyncRuntime resync_runtime = 50;
+
+    // Scrollback (OPT_CHUNKED_SCROLLBACK)
+    GetScrollback get_scrollback = 51;
+
+    // Diagnostics (OPT_DIAGNOSTICS)
+    GetDiagnostics get_diagnostics = 60;
+  }
+}
+
+message ServerEnvelope {
+  uint64 request_id = 1;
+  oneof payload {
+    // Terminal I/O (fields 2–3: single-byte tags for highest-frequency paths)
+    OutputDelta output_delta = 2;
+    TerminalModeChanged terminal_mode_changed = 3;
+
+    // Control
+    Pong pong = 10;
+
+    // Runtime lifecycle events
+    RuntimeCreated runtime_created = 20;
+    RuntimeSnapshot runtime_snapshot = 21;
+    RuntimeDetached runtime_detached = 22;
+    RuntimeTerminated runtime_terminated = 23;
+    RuntimeRenamed runtime_renamed = 24;
+    RuntimeList runtime_list = 25;
+    AttachBlocked attach_blocked = 26;
+
+    // Pane lifecycle events
+    PaneCreated pane_created = 30;
+    PaneClosed pane_closed = 31;
+    PaneResized pane_resized = 32;
+    PaneExited pane_exited = 33;
+    TitleChanged title_changed = 34;
+    CwdChanged cwd_changed = 35;
+    Bell bell = 36;
+
+    // Recovery events (OPT_RESYNC)
+    StreamOverflow stream_overflow = 50;
+
+    // Scrollback response (OPT_CHUNKED_SCROLLBACK)
+    ScrollbackChunk scrollback_chunk = 51;
+
+    // Diagnostics response (OPT_DIAGNOSTICS)
+    DiagnosticsReport diagnostics_report = 60;
+
+    // Errors
+    ProtocolError error = 100;
+  }
+}

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -599,9 +599,7 @@ mod v3_tests {
         let msg = v3::TerminalInput {
             runtime_id: rid(),
             pane_id: pid(),
-            kind: Some(v3::terminal_input::Kind::Focus(v3::FocusInput {
-                focused: true,
-            })),
+            kind: Some(v3::terminal_input::Kind::Focus(v3::FocusInput { focused: true })),
         };
         let mut buf = BytesMut::new();
         encode_frame(&msg, &mut buf).unwrap();
@@ -699,11 +697,7 @@ mod v3_tests {
     #[test]
     fn v3_stream_overflow_roundtrip() {
         for pane_id in [Some(pid()), None] {
-            let msg = v3::StreamOverflow {
-                runtime_id: rid(),
-                pane_id,
-                dropped_count: 42,
-            };
+            let msg = v3::StreamOverflow { runtime_id: rid(), pane_id, dropped_count: 42 };
             let mut buf = BytesMut::new();
             encode_frame(&msg, &mut buf).unwrap();
             let decoded: v3::StreamOverflow = decode_frame(&mut buf).unwrap();
@@ -733,15 +727,13 @@ mod v3_envelope_tests {
             // Terminal I/O
             v3::ClientEnvelope {
                 request_id: 0,
-                command: Some(v3::client_envelope::Command::TerminalInput(
-                    v3::TerminalInput {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
-                            data: bytes::Bytes::from_static(b"x"),
-                        })),
-                    },
-                )),
+                command: Some(v3::client_envelope::Command::TerminalInput(v3::TerminalInput {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                        data: bytes::Bytes::from_static(b"x"),
+                    })),
+                })),
             },
             // Control
             v3::ClientEnvelope {
@@ -755,52 +747,40 @@ mod v3_envelope_tests {
             // Runtime lifecycle
             v3::ClientEnvelope {
                 request_id: 2,
-                command: Some(v3::client_envelope::Command::CreateRuntime(
-                    v3::CreateRuntime {
-                        name: "dev".into(),
-                        policy: v3::RuntimePolicy::Persistent as i32,
-                    },
-                )),
+                command: Some(v3::client_envelope::Command::CreateRuntime(v3::CreateRuntime {
+                    name: "dev".into(),
+                    policy: v3::RuntimePolicy::Persistent as i32,
+                })),
             },
             v3::ClientEnvelope {
                 request_id: 3,
-                command: Some(v3::client_envelope::Command::AttachRuntime(
-                    v3::AttachRuntime {
-                        runtime_id: rt.clone(),
-                        attach_mode: v3::RuntimeAttachMode::ReadWrite as i32,
-                    },
-                )),
+                command: Some(v3::client_envelope::Command::AttachRuntime(v3::AttachRuntime {
+                    runtime_id: rt.clone(),
+                    attach_mode: v3::RuntimeAttachMode::ReadWrite as i32,
+                })),
             },
             v3::ClientEnvelope {
                 request_id: 4,
-                command: Some(v3::client_envelope::Command::DetachRuntime(
-                    v3::DetachRuntime {
-                        runtime_id: rt.clone(),
-                    },
-                )),
+                command: Some(v3::client_envelope::Command::DetachRuntime(v3::DetachRuntime {
+                    runtime_id: rt.clone(),
+                })),
             },
             v3::ClientEnvelope {
                 request_id: 5,
                 command: Some(v3::client_envelope::Command::TerminateRuntime(
-                    v3::TerminateRuntime {
-                        runtime_id: rt.clone(),
-                    },
+                    v3::TerminateRuntime { runtime_id: rt.clone() },
                 )),
             },
             v3::ClientEnvelope {
                 request_id: 6,
-                command: Some(v3::client_envelope::Command::RenameRuntime(
-                    v3::RenameRuntime {
-                        runtime_id: rt.clone(),
-                        name: "prod".into(),
-                    },
-                )),
+                command: Some(v3::client_envelope::Command::RenameRuntime(v3::RenameRuntime {
+                    runtime_id: rt.clone(),
+                    name: "prod".into(),
+                })),
             },
             v3::ClientEnvelope {
                 request_id: 7,
-                command: Some(v3::client_envelope::Command::ListRuntimes(
-                    v3::ListRuntimes {},
-                )),
+                command: Some(v3::client_envelope::Command::ListRuntimes(v3::ListRuntimes {})),
             },
             // Pane lifecycle
             v3::ClientEnvelope {
@@ -831,41 +811,33 @@ mod v3_envelope_tests {
             },
             v3::ClientEnvelope {
                 request_id: 0,
-                command: Some(v3::client_envelope::Command::SetPaneTitle(
-                    v3::SetPaneTitle {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        title: "my pane".into(),
-                    },
-                )),
+                command: Some(v3::client_envelope::Command::SetPaneTitle(v3::SetPaneTitle {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    title: "my pane".into(),
+                })),
             },
             // Recovery
             v3::ClientEnvelope {
                 request_id: 10,
-                command: Some(v3::client_envelope::Command::ResyncRuntime(
-                    v3::ResyncRuntime {
-                        runtime_id: rt.clone(),
-                    },
-                )),
+                command: Some(v3::client_envelope::Command::ResyncRuntime(v3::ResyncRuntime {
+                    runtime_id: rt.clone(),
+                })),
             },
             // Scrollback
             v3::ClientEnvelope {
                 request_id: 11,
-                command: Some(v3::client_envelope::Command::GetScrollback(
-                    v3::GetScrollback {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        offset: 0,
-                        limit: 262_144,
-                    },
-                )),
+                command: Some(v3::client_envelope::Command::GetScrollback(v3::GetScrollback {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    offset: 0,
+                    limit: 262_144,
+                })),
             },
             // Diagnostics
             v3::ClientEnvelope {
                 request_id: 12,
-                command: Some(v3::client_envelope::Command::GetDiagnostics(
-                    v3::GetDiagnostics {},
-                )),
+                command: Some(v3::client_envelope::Command::GetDiagnostics(v3::GetDiagnostics {})),
             },
         ];
 
@@ -886,14 +858,12 @@ mod v3_envelope_tests {
             // Terminal I/O
             v3::ServerEnvelope {
                 request_id: 0,
-                payload: Some(v3::server_envelope::Payload::OutputDelta(
-                    v3::OutputDelta {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        data: bytes::Bytes::from_static(b"output"),
-                        pane_output_seq: 1,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::OutputDelta(v3::OutputDelta {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    data: bytes::Bytes::from_static(b"output"),
+                    pane_output_seq: 1,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 0,
@@ -917,32 +887,26 @@ mod v3_envelope_tests {
             // Runtime lifecycle
             v3::ServerEnvelope {
                 request_id: 2,
-                payload: Some(v3::server_envelope::Payload::RuntimeCreated(
-                    v3::RuntimeCreated {
-                        runtime_id: rt.clone(),
-                        runtime_revision: 1,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::RuntimeCreated(v3::RuntimeCreated {
+                    runtime_id: rt.clone(),
+                    runtime_revision: 1,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 3,
-                payload: Some(v3::server_envelope::Payload::RuntimeSnapshot(
-                    v3::RuntimeSnapshot {
-                        runtime_id: rt.clone(),
-                        runtime_revision: 10,
-                        client_role: v3::RuntimeClientRole::Writer as i32,
-                        panes: vec![],
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::RuntimeSnapshot(v3::RuntimeSnapshot {
+                    runtime_id: rt.clone(),
+                    runtime_revision: 10,
+                    client_role: v3::RuntimeClientRole::Writer as i32,
+                    panes: vec![],
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 4,
-                payload: Some(v3::server_envelope::Payload::RuntimeDetached(
-                    v3::RuntimeDetached {
-                        runtime_id: rt.clone(),
-                        runtime_revision: 11,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::RuntimeDetached(v3::RuntimeDetached {
+                    runtime_id: rt.clone(),
+                    runtime_revision: 11,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 5,
@@ -956,96 +920,80 @@ mod v3_envelope_tests {
             },
             v3::ServerEnvelope {
                 request_id: 6,
-                payload: Some(v3::server_envelope::Payload::RuntimeRenamed(
-                    v3::RuntimeRenamed {
-                        runtime_id: rt.clone(),
-                        name: "renamed".into(),
-                        runtime_revision: 13,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::RuntimeRenamed(v3::RuntimeRenamed {
+                    runtime_id: rt.clone(),
+                    name: "renamed".into(),
+                    runtime_revision: 13,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 7,
-                payload: Some(v3::server_envelope::Payload::RuntimeList(
-                    v3::RuntimeList { runtimes: vec![] },
-                )),
+                payload: Some(v3::server_envelope::Payload::RuntimeList(v3::RuntimeList {
+                    runtimes: vec![],
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 0,
-                payload: Some(v3::server_envelope::Payload::AttachBlocked(
-                    v3::AttachBlocked {
-                        runtime_id: rt.clone(),
-                        current_client_role: v3::RuntimeClientRole::Unattached as i32,
-                        attached_client_count: 1,
-                        read_only_client_count: 0,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::AttachBlocked(v3::AttachBlocked {
+                    runtime_id: rt.clone(),
+                    current_client_role: v3::RuntimeClientRole::Unattached as i32,
+                    attached_client_count: 1,
+                    read_only_client_count: 0,
+                })),
             },
             // Pane lifecycle
             v3::ServerEnvelope {
                 request_id: 8,
-                payload: Some(v3::server_envelope::Payload::PaneCreated(
-                    v3::PaneCreated {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        runtime_revision: 14,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::PaneCreated(v3::PaneCreated {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    runtime_revision: 14,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 9,
-                payload: Some(v3::server_envelope::Payload::PaneClosed(
-                    v3::PaneClosed {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        runtime_revision: 15,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::PaneClosed(v3::PaneClosed {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    runtime_revision: 15,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 0,
-                payload: Some(v3::server_envelope::Payload::PaneResized(
-                    v3::PaneResized {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        cols: 100,
-                        rows: 30,
-                        runtime_revision: 16,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::PaneResized(v3::PaneResized {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    cols: 100,
+                    rows: 30,
+                    runtime_revision: 16,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 0,
-                payload: Some(v3::server_envelope::Payload::PaneExited(
-                    v3::PaneExited {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        status: 0,
-                        runtime_revision: 17,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::PaneExited(v3::PaneExited {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    status: 0,
+                    runtime_revision: 17,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 0,
-                payload: Some(v3::server_envelope::Payload::TitleChanged(
-                    v3::TitleChanged {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        title: "new title".into(),
-                        runtime_revision: 18,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::TitleChanged(v3::TitleChanged {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    title: "new title".into(),
+                    runtime_revision: 18,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 0,
-                payload: Some(v3::server_envelope::Payload::CwdChanged(
-                    v3::CwdChanged {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        cwd: "/home".into(),
-                        runtime_revision: 19,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::CwdChanged(v3::CwdChanged {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    cwd: "/home".into(),
+                    runtime_revision: 19,
+                })),
             },
             v3::ServerEnvelope {
                 request_id: 0,
@@ -1057,26 +1005,22 @@ mod v3_envelope_tests {
             // Recovery
             v3::ServerEnvelope {
                 request_id: 0,
-                payload: Some(v3::server_envelope::Payload::StreamOverflow(
-                    v3::StreamOverflow {
-                        runtime_id: rt.clone(),
-                        pane_id: Some(pn.clone()),
-                        dropped_count: 5,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::StreamOverflow(v3::StreamOverflow {
+                    runtime_id: rt.clone(),
+                    pane_id: Some(pn.clone()),
+                    dropped_count: 5,
+                })),
             },
             // Scrollback
             v3::ServerEnvelope {
                 request_id: 11,
-                payload: Some(v3::server_envelope::Payload::ScrollbackChunk(
-                    v3::ScrollbackChunk {
-                        runtime_id: rt.clone(),
-                        pane_id: pn.clone(),
-                        offset: 0,
-                        data: bytes::Bytes::from_static(b"chunk"),
-                        is_last: true,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::ScrollbackChunk(v3::ScrollbackChunk {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    offset: 0,
+                    data: bytes::Bytes::from_static(b"chunk"),
+                    is_last: true,
+                })),
             },
             // Diagnostics
             v3::ServerEnvelope {
@@ -1099,16 +1043,14 @@ mod v3_envelope_tests {
             // Error
             v3::ServerEnvelope {
                 request_id: 99,
-                payload: Some(v3::server_envelope::Payload::Error(
-                    v3::ProtocolError {
-                        kind: v3::ErrorKind::RuntimeNotFound as i32,
-                        message: "not found".into(),
-                        operation: "AttachRuntime".into(),
-                        retryable: false,
-                        user_action_required: false,
-                        retry_after_seconds: 0,
-                    },
-                )),
+                payload: Some(v3::server_envelope::Payload::Error(v3::ProtocolError {
+                    kind: v3::ErrorKind::RuntimeNotFound as i32,
+                    message: "not found".into(),
+                    operation: "AttachRuntime".into(),
+                    retryable: false,
+                    user_action_required: false,
+                    retry_after_seconds: 0,
+                })),
             },
         ];
 
@@ -1126,29 +1068,25 @@ mod v3_envelope_tests {
         // TerminalInput is field 2 in ClientEnvelope.
         let env = v3::ClientEnvelope {
             request_id: 0,
-            command: Some(v3::client_envelope::Command::TerminalInput(
-                v3::TerminalInput {
-                    runtime_id: rid(),
-                    pane_id: pid(),
-                    kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
-                        data: bytes::Bytes::from_static(b"a"),
-                    })),
-                },
-            )),
+            command: Some(v3::client_envelope::Command::TerminalInput(v3::TerminalInput {
+                runtime_id: rid(),
+                pane_id: pid(),
+                kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                    data: bytes::Bytes::from_static(b"a"),
+                })),
+            })),
         };
         let mut buf = BytesMut::new();
         encode_frame(&env, &mut buf).unwrap();
         // OutputDelta is field 2, TerminalModeChanged is field 3 in ServerEnvelope.
         let senv = v3::ServerEnvelope {
             request_id: 0,
-            payload: Some(v3::server_envelope::Payload::OutputDelta(
-                v3::OutputDelta {
-                    runtime_id: rid(),
-                    pane_id: pid(),
-                    data: bytes::Bytes::from_static(b"b"),
-                    pane_output_seq: 1,
-                },
-            )),
+            payload: Some(v3::server_envelope::Payload::OutputDelta(v3::OutputDelta {
+                runtime_id: rid(),
+                pane_id: pid(),
+                data: bytes::Bytes::from_static(b"b"),
+                pane_output_seq: 1,
+            })),
         };
         let mut buf2 = BytesMut::new();
         encode_frame(&senv, &mut buf2).unwrap();

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -13,9 +13,14 @@ pub const PROTOCOL_VERSION: u32 = 2;
 /// Maximum message size (16 MB). Prevents unbounded allocations.
 pub const MAX_MESSAGE_SIZE: u32 = 16 * 1024 * 1024;
 
-/// Generated protobuf types.
+/// Generated v2 protobuf types (current wire protocol).
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/rttx.rs"));
+}
+
+/// Generated v3 protobuf types (RFC-021).
+pub mod v3 {
+    include!(concat!(env!("OUT_DIR"), "/rttx.v3.rs"));
 }
 
 /// Convert a `uuid::Uuid` to protobuf bytes.
@@ -434,5 +439,806 @@ mod tests {
                 panic!("expected CreatePane");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod v3_tests {
+    use super::*;
+
+    fn rid() -> Vec<u8> {
+        uuid_to_bytes(uuid::Uuid::new_v4())
+    }
+
+    fn pid() -> Vec<u8> {
+        uuid_to_bytes(uuid::Uuid::new_v4())
+    }
+
+    // ── Handshake roundtrips ──
+
+    #[test]
+    fn v3_client_hello_roundtrip() {
+        let msg = v3::ClientHello {
+            min_protocol_version: 3,
+            max_protocol_version: 3,
+            client_id: rid(),
+            client_name: "rttx".into(),
+            client_version: "0.4.0".into(),
+            capabilities: vec![
+                v3::Capability::CoreRuntimeLifecycle as i32,
+                v3::Capability::CorePaneLifecycle as i32,
+                v3::Capability::CoreTerminalIo as i32,
+                v3::Capability::CoreTerminalModes as i32,
+                v3::Capability::CorePasteIntent as i32,
+                v3::Capability::CoreFocusEvents as i32,
+                v3::Capability::OptDiagnostics as i32,
+            ],
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::ClientHello = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn v3_server_hello_roundtrip() {
+        let msg = v3::ServerHello {
+            negotiated_protocol_version: 3,
+            server_id: rid(),
+            server_version: "0.4.0".into(),
+            capabilities: vec![
+                v3::Capability::CoreRuntimeLifecycle as i32,
+                v3::Capability::CorePaneLifecycle as i32,
+            ],
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::ServerHello = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    // ── Capability enum values match RFC ──
+
+    #[test]
+    fn v3_capability_enum_values() {
+        assert_eq!(v3::Capability::Unspecified as i32, 0);
+        assert_eq!(v3::Capability::CoreRuntimeLifecycle as i32, 1);
+        assert_eq!(v3::Capability::CorePaneLifecycle as i32, 2);
+        assert_eq!(v3::Capability::CoreTerminalIo as i32, 3);
+        assert_eq!(v3::Capability::CoreTerminalModes as i32, 4);
+        assert_eq!(v3::Capability::CorePasteIntent as i32, 5);
+        assert_eq!(v3::Capability::CoreFocusEvents as i32, 6);
+        assert_eq!(v3::Capability::OptRuntimeInventoryV2 as i32, 100);
+        assert_eq!(v3::Capability::OptRuntimeTakeover as i32, 101);
+        assert_eq!(v3::Capability::OptResync as i32, 102);
+        assert_eq!(v3::Capability::OptChunkedScrollback as i32, 103);
+        assert_eq!(v3::Capability::OptDiagnostics as i32, 104);
+    }
+
+    // ── Enum zero values ──
+
+    #[test]
+    fn v3_enum_zero_values() {
+        assert_eq!(v3::RuntimePolicy::Unspecified as i32, 0);
+        assert_eq!(v3::RuntimeAttachMode::Unspecified as i32, 0);
+        assert_eq!(v3::RuntimeClientRole::Unspecified as i32, 0);
+        assert_eq!(v3::RuntimeTerminationReason::Unspecified as i32, 0);
+        assert_eq!(v3::MouseMode::None as i32, 0);
+        assert_eq!(v3::ErrorKind::Unspecified as i32, 0);
+    }
+
+    // ── Error kind enum values match RFC ──
+
+    #[test]
+    fn v3_error_kind_values() {
+        assert_eq!(v3::ErrorKind::ProtocolMismatch as i32, 1);
+        assert_eq!(v3::ErrorKind::UnsupportedCapability as i32, 2);
+        assert_eq!(v3::ErrorKind::InvalidArgument as i32, 3);
+        assert_eq!(v3::ErrorKind::RuntimeNotFound as i32, 4);
+        assert_eq!(v3::ErrorKind::PaneNotFound as i32, 5);
+        assert_eq!(v3::ErrorKind::OwnershipConflict as i32, 6);
+        assert_eq!(v3::ErrorKind::TakeoverRequired as i32, 7);
+        assert_eq!(v3::ErrorKind::StreamOverflow as i32, 8);
+        assert_eq!(v3::ErrorKind::Internal as i32, 9);
+    }
+
+    // ── TerminalModeState roundtrip ──
+
+    #[test]
+    fn v3_terminal_mode_state_roundtrip() {
+        let msg = v3::TerminalModeState {
+            bracketed_paste: true,
+            focus_reporting: true,
+            application_cursor_keys: false,
+            application_keypad: true,
+            alternate_screen: true,
+            cursor_hidden: false,
+            mouse_mode: v3::MouseMode::Any as i32,
+            sgr_mouse: true,
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::TerminalModeState = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    // ── TerminalInput variants ──
+
+    #[test]
+    fn v3_terminal_input_raw_roundtrip() {
+        let msg = v3::TerminalInput {
+            runtime_id: rid(),
+            pane_id: pid(),
+            kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                data: bytes::Bytes::from_static(b"hello"),
+            })),
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::TerminalInput = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn v3_terminal_input_paste_roundtrip() {
+        let msg = v3::TerminalInput {
+            runtime_id: rid(),
+            pane_id: pid(),
+            kind: Some(v3::terminal_input::Kind::Paste(v3::PasteInput {
+                text: bytes::Bytes::from_static(b"pasted text"),
+            })),
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::TerminalInput = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn v3_terminal_input_focus_roundtrip() {
+        let msg = v3::TerminalInput {
+            runtime_id: rid(),
+            pane_id: pid(),
+            kind: Some(v3::terminal_input::Kind::Focus(v3::FocusInput {
+                focused: true,
+            })),
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::TerminalInput = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    // ── ProtocolError roundtrip ──
+
+    #[test]
+    fn v3_protocol_error_roundtrip() {
+        let msg = v3::ProtocolError {
+            kind: v3::ErrorKind::RuntimeNotFound as i32,
+            message: "runtime abc not found".into(),
+            operation: "AttachRuntime".into(),
+            retryable: false,
+            user_action_required: true,
+            retry_after_seconds: 0,
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::ProtocolError = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    // ── Snapshot roundtrip ──
+
+    #[test]
+    fn v3_runtime_snapshot_roundtrip() {
+        let msg = v3::RuntimeSnapshot {
+            runtime_id: rid(),
+            runtime_revision: 42,
+            client_role: v3::RuntimeClientRole::Writer as i32,
+            panes: vec![v3::PaneSnapshot {
+                pane_id: pid(),
+                pane_output_seq: 100,
+                title: "bash".into(),
+                cwd: "/home/user".into(),
+                cols: 120,
+                rows: 40,
+                exit_status: None,
+                terminal_modes: Some(v3::TerminalModeState {
+                    bracketed_paste: true,
+                    focus_reporting: false,
+                    application_cursor_keys: false,
+                    application_keypad: false,
+                    alternate_screen: false,
+                    cursor_hidden: false,
+                    mouse_mode: v3::MouseMode::None as i32,
+                    sgr_mouse: false,
+                }),
+                scrollback_tail: bytes::Bytes::from_static(b"$ ls\nfile.txt\n"),
+                total_scrollback_bytes: 4096,
+                scrollback_complete: false,
+            }],
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::RuntimeSnapshot = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    // ── Scrollback roundtrip ──
+
+    #[test]
+    fn v3_scrollback_roundtrip() {
+        let rt = rid();
+        let pn = pid();
+        let req = v3::GetScrollback {
+            runtime_id: rt.clone(),
+            pane_id: pn.clone(),
+            offset: 0,
+            limit: 65536,
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&req, &mut buf).unwrap();
+        let decoded: v3::GetScrollback = decode_frame(&mut buf).unwrap();
+        assert_eq!(req, decoded);
+
+        let chunk = v3::ScrollbackChunk {
+            runtime_id: rt,
+            pane_id: pn,
+            offset: 0,
+            data: bytes::Bytes::from_static(b"scrollback data"),
+            is_last: true,
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&chunk, &mut buf).unwrap();
+        let decoded: v3::ScrollbackChunk = decode_frame(&mut buf).unwrap();
+        assert_eq!(chunk, decoded);
+    }
+
+    // ── StreamOverflow roundtrip ──
+
+    #[test]
+    fn v3_stream_overflow_roundtrip() {
+        for pane_id in [Some(pid()), None] {
+            let msg = v3::StreamOverflow {
+                runtime_id: rid(),
+                pane_id,
+                dropped_count: 42,
+            };
+            let mut buf = BytesMut::new();
+            encode_frame(&msg, &mut buf).unwrap();
+            let decoded: v3::StreamOverflow = decode_frame(&mut buf).unwrap();
+            assert_eq!(msg, decoded);
+        }
+    }
+}
+
+#[cfg(test)]
+mod v3_envelope_tests {
+    use super::*;
+
+    fn rid() -> Vec<u8> {
+        uuid_to_bytes(uuid::Uuid::new_v4())
+    }
+
+    fn pid() -> Vec<u8> {
+        uuid_to_bytes(uuid::Uuid::new_v4())
+    }
+
+    #[test]
+    fn v3_client_envelope_all_commands() {
+        let rt = rid();
+        let pn = pid();
+
+        let envelopes: Vec<v3::ClientEnvelope> = vec![
+            // Terminal I/O
+            v3::ClientEnvelope {
+                request_id: 0,
+                command: Some(v3::client_envelope::Command::TerminalInput(
+                    v3::TerminalInput {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                            data: bytes::Bytes::from_static(b"x"),
+                        })),
+                    },
+                )),
+            },
+            // Control
+            v3::ClientEnvelope {
+                request_id: 1,
+                command: Some(v3::client_envelope::Command::Ping(v3::Ping { nonce: 7 })),
+            },
+            v3::ClientEnvelope {
+                request_id: 0,
+                command: Some(v3::client_envelope::Command::Shutdown(v3::Shutdown {})),
+            },
+            // Runtime lifecycle
+            v3::ClientEnvelope {
+                request_id: 2,
+                command: Some(v3::client_envelope::Command::CreateRuntime(
+                    v3::CreateRuntime {
+                        name: "dev".into(),
+                        policy: v3::RuntimePolicy::Persistent as i32,
+                    },
+                )),
+            },
+            v3::ClientEnvelope {
+                request_id: 3,
+                command: Some(v3::client_envelope::Command::AttachRuntime(
+                    v3::AttachRuntime {
+                        runtime_id: rt.clone(),
+                        attach_mode: v3::RuntimeAttachMode::ReadWrite as i32,
+                    },
+                )),
+            },
+            v3::ClientEnvelope {
+                request_id: 4,
+                command: Some(v3::client_envelope::Command::DetachRuntime(
+                    v3::DetachRuntime {
+                        runtime_id: rt.clone(),
+                    },
+                )),
+            },
+            v3::ClientEnvelope {
+                request_id: 5,
+                command: Some(v3::client_envelope::Command::TerminateRuntime(
+                    v3::TerminateRuntime {
+                        runtime_id: rt.clone(),
+                    },
+                )),
+            },
+            v3::ClientEnvelope {
+                request_id: 6,
+                command: Some(v3::client_envelope::Command::RenameRuntime(
+                    v3::RenameRuntime {
+                        runtime_id: rt.clone(),
+                        name: "prod".into(),
+                    },
+                )),
+            },
+            v3::ClientEnvelope {
+                request_id: 7,
+                command: Some(v3::client_envelope::Command::ListRuntimes(
+                    v3::ListRuntimes {},
+                )),
+            },
+            // Pane lifecycle
+            v3::ClientEnvelope {
+                request_id: 8,
+                command: Some(v3::client_envelope::Command::CreatePane(v3::CreatePane {
+                    runtime_id: rt.clone(),
+                    cwd: Some("/tmp".into()),
+                    dark_background: Some(true),
+                    cols: 80,
+                    rows: 24,
+                })),
+            },
+            v3::ClientEnvelope {
+                request_id: 9,
+                command: Some(v3::client_envelope::Command::ClosePane(v3::ClosePane {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                })),
+            },
+            v3::ClientEnvelope {
+                request_id: 0,
+                command: Some(v3::client_envelope::Command::ResizePane(v3::ResizePane {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                    cols: 132,
+                    rows: 43,
+                })),
+            },
+            v3::ClientEnvelope {
+                request_id: 0,
+                command: Some(v3::client_envelope::Command::SetPaneTitle(
+                    v3::SetPaneTitle {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        title: "my pane".into(),
+                    },
+                )),
+            },
+            // Recovery
+            v3::ClientEnvelope {
+                request_id: 10,
+                command: Some(v3::client_envelope::Command::ResyncRuntime(
+                    v3::ResyncRuntime {
+                        runtime_id: rt.clone(),
+                    },
+                )),
+            },
+            // Scrollback
+            v3::ClientEnvelope {
+                request_id: 11,
+                command: Some(v3::client_envelope::Command::GetScrollback(
+                    v3::GetScrollback {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        offset: 0,
+                        limit: 262_144,
+                    },
+                )),
+            },
+            // Diagnostics
+            v3::ClientEnvelope {
+                request_id: 12,
+                command: Some(v3::client_envelope::Command::GetDiagnostics(
+                    v3::GetDiagnostics {},
+                )),
+            },
+        ];
+
+        for env in &envelopes {
+            let mut buf = BytesMut::new();
+            encode_frame(env, &mut buf).unwrap();
+            let decoded: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+            assert_eq!(env, &decoded);
+        }
+    }
+
+    #[test]
+    fn v3_server_envelope_all_payloads() {
+        let rt = rid();
+        let pn = pid();
+
+        let envelopes: Vec<v3::ServerEnvelope> = vec![
+            // Terminal I/O
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::OutputDelta(
+                    v3::OutputDelta {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        data: bytes::Bytes::from_static(b"output"),
+                        pane_output_seq: 1,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::TerminalModeChanged(
+                    v3::TerminalModeChanged {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        runtime_revision: 5,
+                        modes: Some(v3::TerminalModeState {
+                            bracketed_paste: true,
+                            ..Default::default()
+                        }),
+                    },
+                )),
+            },
+            // Control
+            v3::ServerEnvelope {
+                request_id: 1,
+                payload: Some(v3::server_envelope::Payload::Pong(v3::Pong { nonce: 7 })),
+            },
+            // Runtime lifecycle
+            v3::ServerEnvelope {
+                request_id: 2,
+                payload: Some(v3::server_envelope::Payload::RuntimeCreated(
+                    v3::RuntimeCreated {
+                        runtime_id: rt.clone(),
+                        runtime_revision: 1,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 3,
+                payload: Some(v3::server_envelope::Payload::RuntimeSnapshot(
+                    v3::RuntimeSnapshot {
+                        runtime_id: rt.clone(),
+                        runtime_revision: 10,
+                        client_role: v3::RuntimeClientRole::Writer as i32,
+                        panes: vec![],
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 4,
+                payload: Some(v3::server_envelope::Payload::RuntimeDetached(
+                    v3::RuntimeDetached {
+                        runtime_id: rt.clone(),
+                        runtime_revision: 11,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 5,
+                payload: Some(v3::server_envelope::Payload::RuntimeTerminated(
+                    v3::RuntimeTerminated {
+                        runtime_id: rt.clone(),
+                        final_revision: 12,
+                        reason: v3::RuntimeTerminationReason::Explicit as i32,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 6,
+                payload: Some(v3::server_envelope::Payload::RuntimeRenamed(
+                    v3::RuntimeRenamed {
+                        runtime_id: rt.clone(),
+                        name: "renamed".into(),
+                        runtime_revision: 13,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 7,
+                payload: Some(v3::server_envelope::Payload::RuntimeList(
+                    v3::RuntimeList { runtimes: vec![] },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::AttachBlocked(
+                    v3::AttachBlocked {
+                        runtime_id: rt.clone(),
+                        current_client_role: v3::RuntimeClientRole::Unattached as i32,
+                        attached_client_count: 1,
+                        read_only_client_count: 0,
+                    },
+                )),
+            },
+            // Pane lifecycle
+            v3::ServerEnvelope {
+                request_id: 8,
+                payload: Some(v3::server_envelope::Payload::PaneCreated(
+                    v3::PaneCreated {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        runtime_revision: 14,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 9,
+                payload: Some(v3::server_envelope::Payload::PaneClosed(
+                    v3::PaneClosed {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        runtime_revision: 15,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::PaneResized(
+                    v3::PaneResized {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        cols: 100,
+                        rows: 30,
+                        runtime_revision: 16,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::PaneExited(
+                    v3::PaneExited {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        status: 0,
+                        runtime_revision: 17,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::TitleChanged(
+                    v3::TitleChanged {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        title: "new title".into(),
+                        runtime_revision: 18,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::CwdChanged(
+                    v3::CwdChanged {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        cwd: "/home".into(),
+                        runtime_revision: 19,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::Bell(v3::Bell {
+                    runtime_id: rt.clone(),
+                    pane_id: pn.clone(),
+                })),
+            },
+            // Recovery
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::StreamOverflow(
+                    v3::StreamOverflow {
+                        runtime_id: rt.clone(),
+                        pane_id: Some(pn.clone()),
+                        dropped_count: 5,
+                    },
+                )),
+            },
+            // Scrollback
+            v3::ServerEnvelope {
+                request_id: 11,
+                payload: Some(v3::server_envelope::Payload::ScrollbackChunk(
+                    v3::ScrollbackChunk {
+                        runtime_id: rt.clone(),
+                        pane_id: pn.clone(),
+                        offset: 0,
+                        data: bytes::Bytes::from_static(b"chunk"),
+                        is_last: true,
+                    },
+                )),
+            },
+            // Diagnostics
+            v3::ServerEnvelope {
+                request_id: 12,
+                payload: Some(v3::server_envelope::Payload::DiagnosticsReport(
+                    v3::DiagnosticsReport {
+                        runtime_count: 1,
+                        total_pane_count: 2,
+                        total_active_panes: 2,
+                        total_exited_panes: 0,
+                        client_count: 1,
+                        pty_writer_count: 1,
+                        total_raw_bytes: 1024,
+                        total_pending_flush: 0,
+                        total_command_history: 5,
+                        runtimes: vec![],
+                    },
+                )),
+            },
+            // Error
+            v3::ServerEnvelope {
+                request_id: 99,
+                payload: Some(v3::server_envelope::Payload::Error(
+                    v3::ProtocolError {
+                        kind: v3::ErrorKind::RuntimeNotFound as i32,
+                        message: "not found".into(),
+                        operation: "AttachRuntime".into(),
+                        retryable: false,
+                        user_action_required: false,
+                        retry_after_seconds: 0,
+                    },
+                )),
+            },
+        ];
+
+        for env in &envelopes {
+            let mut buf = BytesMut::new();
+            encode_frame(env, &mut buf).unwrap();
+            let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+            assert_eq!(env, &decoded);
+        }
+    }
+
+    #[test]
+    fn v3_envelope_field_numbers_match_rfc() {
+        // Verify high-frequency paths use single-byte tags (field < 16).
+        // TerminalInput is field 2 in ClientEnvelope.
+        let env = v3::ClientEnvelope {
+            request_id: 0,
+            command: Some(v3::client_envelope::Command::TerminalInput(
+                v3::TerminalInput {
+                    runtime_id: rid(),
+                    pane_id: pid(),
+                    kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                        data: bytes::Bytes::from_static(b"a"),
+                    })),
+                },
+            )),
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        // OutputDelta is field 2, TerminalModeChanged is field 3 in ServerEnvelope.
+        let senv = v3::ServerEnvelope {
+            request_id: 0,
+            payload: Some(v3::server_envelope::Payload::OutputDelta(
+                v3::OutputDelta {
+                    runtime_id: rid(),
+                    pane_id: pid(),
+                    data: bytes::Bytes::from_static(b"b"),
+                    pane_output_seq: 1,
+                },
+            )),
+        };
+        let mut buf2 = BytesMut::new();
+        encode_frame(&senv, &mut buf2).unwrap();
+        // Both encode successfully — field numbers are valid.
+        let decoded: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+        let decoded: v3::ServerEnvelope = decode_frame(&mut buf2).unwrap();
+        assert_eq!(senv, decoded);
+    }
+
+    #[test]
+    fn v3_runtime_info_inventory_fields() {
+        let msg = v3::RuntimeInfo {
+            id: rid(),
+            name: "dev-workspace".into(),
+            policy: v3::RuntimePolicy::Persistent as i32,
+            pane_count: 3,
+            has_write_owner: true,
+            read_only_client_count: 1,
+            current_client_role: v3::RuntimeClientRole::Writer as i32,
+            runtime_revision: 42,
+            reconstructed: false,
+            active_pane_summary: "bash, vim, htop".into(),
+            takeover_eligible: true,
+            disabled_reason: String::new(),
+            panes: vec![v3::PaneInfo {
+                id: pid(),
+                title: "bash".into(),
+                cwd: "/home/user".into(),
+                cols: 80,
+                rows: 24,
+                exit_status: None,
+                reconstructed: false,
+            }],
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::RuntimeInfo = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn v3_runtime_termination_ephemeral_detach() {
+        let msg = v3::RuntimeTerminated {
+            runtime_id: rid(),
+            final_revision: 99,
+            reason: v3::RuntimeTerminationReason::EphemeralDetach as i32,
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::RuntimeTerminated = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn v3_mouse_mode_values() {
+        assert_eq!(v3::MouseMode::None as i32, 0);
+        assert_eq!(v3::MouseMode::X10 as i32, 1);
+        assert_eq!(v3::MouseMode::Normal as i32, 2);
+        assert_eq!(v3::MouseMode::Button as i32, 3);
+        assert_eq!(v3::MouseMode::Any as i32, 4);
+    }
+
+    #[test]
+    fn v3_pane_snapshot_with_all_modes() {
+        let msg = v3::PaneSnapshot {
+            pane_id: pid(),
+            pane_output_seq: 500,
+            title: "vim".into(),
+            cwd: "/project".into(),
+            cols: 120,
+            rows: 40,
+            exit_status: Some(0),
+            terminal_modes: Some(v3::TerminalModeState {
+                bracketed_paste: true,
+                focus_reporting: true,
+                application_cursor_keys: true,
+                application_keypad: true,
+                alternate_screen: true,
+                cursor_hidden: true,
+                mouse_mode: v3::MouseMode::Any as i32,
+                sgr_mouse: true,
+            }),
+            scrollback_tail: bytes::Bytes::from_static(b"scrollback"),
+            total_scrollback_bytes: 1_000_000,
+            scrollback_complete: false,
+        };
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::PaneSnapshot = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
     }
 }

--- a/services/rttx-server/tests/v3_proto_integration.rs
+++ b/services/rttx-server/tests/v3_proto_integration.rs
@@ -36,44 +36,40 @@ fn v3_client_hello_frames_through_shared_codec() {
 #[test]
 fn v3_envelope_roundtrip_create_runtime_and_response() {
     let request_id = 1;
+    let runtime_name = "integration-test";
     let cmd = v3::ClientEnvelope {
         request_id,
-        command: Some(v3::client_envelope::Command::CreateRuntime(
-            v3::CreateRuntime {
-                name: "integration-test".into(),
-                policy: v3::RuntimePolicy::Persistent as i32,
-            },
-        )),
+        command: Some(v3::client_envelope::Command::CreateRuntime(v3::CreateRuntime {
+            name: runtime_name.into(),
+            policy: v3::RuntimePolicy::Persistent as i32,
+        })),
     };
     let mut buf = BytesMut::new();
     encode_frame(&cmd, &mut buf).unwrap();
     let decoded: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
     assert_eq!(decoded.request_id, request_id);
-    assert!(matches!(
-        decoded.command,
-        Some(v3::client_envelope::Command::CreateRuntime(_))
-    ));
+    let Some(v3::client_envelope::Command::CreateRuntime(cr)) = decoded.command else {
+        panic!("expected CreateRuntime");
+    };
+    assert_eq!(cr.name, runtime_name);
 
     let runtime_id = uuid_to_bytes(uuid::Uuid::new_v4());
     let resp = v3::ServerEnvelope {
         request_id,
-        payload: Some(v3::server_envelope::Payload::RuntimeCreated(
-            v3::RuntimeCreated {
-                runtime_id: runtime_id.clone(),
-                runtime_revision: 1,
-            },
-        )),
+        payload: Some(v3::server_envelope::Payload::RuntimeCreated(v3::RuntimeCreated {
+            runtime_id: runtime_id.clone(),
+            runtime_revision: 1,
+        })),
     };
     let mut buf = BytesMut::new();
     encode_frame(&resp, &mut buf).unwrap();
     let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
     assert_eq!(decoded.request_id, request_id);
-    if let Some(v3::server_envelope::Payload::RuntimeCreated(created)) = decoded.payload {
-        assert_eq!(created.runtime_id, runtime_id);
-        assert_eq!(created.runtime_revision, 1);
-    } else {
+    let Some(v3::server_envelope::Payload::RuntimeCreated(created)) = decoded.payload else {
         panic!("expected RuntimeCreated");
-    }
+    };
+    assert_eq!(created.runtime_id, runtime_id);
+    assert_eq!(created.runtime_revision, 1);
 }
 
 #[test]
@@ -103,8 +99,7 @@ fn v3_protocol_error_frames_as_bare_and_in_envelope() {
     encode_frame(&env, &mut buf).unwrap();
     let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
     assert_eq!(decoded.request_id, 42);
-    assert!(matches!(
-        decoded.payload,
-        Some(v3::server_envelope::Payload::Error(_))
-    ));
+    let Some(v3::server_envelope::Payload::Error(_)) = decoded.payload else {
+        panic!("expected ProtocolError");
+    };
 }

--- a/services/rttx-server/tests/v3_proto_integration.rs
+++ b/services/rttx-server/tests/v3_proto_integration.rs
@@ -1,0 +1,110 @@
+//! Integration test: v3 proto definitions compile and frame correctly.
+//!
+//! Verifies that the v3 protobuf types generated from `rttx-v3.proto` can be
+//! used with the shared framing functions, and that the envelope structure
+//! matches the RFC-021 command/response table.
+
+use bytes::BytesMut;
+use rttx_proto::{decode_frame, encode_frame, uuid_to_bytes, v3};
+
+#[test]
+fn v3_client_hello_frames_through_shared_codec() {
+    let msg = v3::ClientHello {
+        min_protocol_version: 3,
+        max_protocol_version: 3,
+        client_id: uuid_to_bytes(uuid::Uuid::new_v4()),
+        client_name: "rttx".into(),
+        client_version: env!("CARGO_PKG_VERSION").into(),
+        capabilities: vec![
+            v3::Capability::CoreRuntimeLifecycle as i32,
+            v3::Capability::CorePaneLifecycle as i32,
+            v3::Capability::CoreTerminalIo as i32,
+            v3::Capability::CoreTerminalModes as i32,
+            v3::Capability::CorePasteIntent as i32,
+            v3::Capability::CoreFocusEvents as i32,
+        ],
+    };
+    let mut buf = BytesMut::new();
+    encode_frame(&msg, &mut buf).unwrap();
+    let decoded: v3::ClientHello = decode_frame(&mut buf).unwrap();
+    assert_eq!(msg.min_protocol_version, decoded.min_protocol_version);
+    assert_eq!(msg.max_protocol_version, decoded.max_protocol_version);
+    assert_eq!(msg.client_id, decoded.client_id);
+    assert_eq!(msg.capabilities, decoded.capabilities);
+}
+
+#[test]
+fn v3_envelope_roundtrip_create_runtime_and_response() {
+    let request_id = 1;
+    let cmd = v3::ClientEnvelope {
+        request_id,
+        command: Some(v3::client_envelope::Command::CreateRuntime(
+            v3::CreateRuntime {
+                name: "integration-test".into(),
+                policy: v3::RuntimePolicy::Persistent as i32,
+            },
+        )),
+    };
+    let mut buf = BytesMut::new();
+    encode_frame(&cmd, &mut buf).unwrap();
+    let decoded: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded.request_id, request_id);
+    assert!(matches!(
+        decoded.command,
+        Some(v3::client_envelope::Command::CreateRuntime(_))
+    ));
+
+    let runtime_id = uuid_to_bytes(uuid::Uuid::new_v4());
+    let resp = v3::ServerEnvelope {
+        request_id,
+        payload: Some(v3::server_envelope::Payload::RuntimeCreated(
+            v3::RuntimeCreated {
+                runtime_id: runtime_id.clone(),
+                runtime_revision: 1,
+            },
+        )),
+    };
+    let mut buf = BytesMut::new();
+    encode_frame(&resp, &mut buf).unwrap();
+    let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded.request_id, request_id);
+    if let Some(v3::server_envelope::Payload::RuntimeCreated(created)) = decoded.payload {
+        assert_eq!(created.runtime_id, runtime_id);
+        assert_eq!(created.runtime_revision, 1);
+    } else {
+        panic!("expected RuntimeCreated");
+    }
+}
+
+#[test]
+fn v3_protocol_error_frames_as_bare_and_in_envelope() {
+    let err = v3::ProtocolError {
+        kind: v3::ErrorKind::ProtocolMismatch as i32,
+        message: "daemon supports v3, client requires v4".into(),
+        operation: String::new(),
+        retryable: false,
+        user_action_required: true,
+        retry_after_seconds: 0,
+    };
+
+    // Bare (handshake phase)
+    let mut buf = BytesMut::new();
+    encode_frame(&err, &mut buf).unwrap();
+    let decoded: v3::ProtocolError = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded.kind, v3::ErrorKind::ProtocolMismatch as i32);
+    assert!(decoded.user_action_required);
+
+    // Inside envelope (post-handshake)
+    let env = v3::ServerEnvelope {
+        request_id: 42,
+        payload: Some(v3::server_envelope::Payload::Error(err)),
+    };
+    let mut buf = BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded.request_id, 42);
+    assert!(matches!(
+        decoded.payload,
+        Some(v3::server_envelope::Payload::Error(_))
+    ));
+}


### PR DESCRIPTION
## What changed and why

Implements RFC-021 Step 2: defines the authoritative `rttx-v3.proto` file with all messages from the RFC plus the ~24 envelope-referenced messages that the RFC defers to implementation.

This is the single source of truth for the v3 wire format. All field numbers, enum values, and message structures match the RFC.

### Key additions

- **Handshake**: `ClientHello`/`ServerHello` with version range negotiation and capability advertisement
- **Envelopes**: `ClientEnvelope`/`ServerEnvelope` with `request_id` correlation and domain-grouped field numbers
- **Terminal I/O**: `TerminalInput` with `oneof kind` (RawInput, PasteInput, FocusInput), `OutputDelta` with `pane_output_seq`
- **Terminal modes**: Consolidated `TerminalModeState` and `TerminalModeChanged` events
- **Error model**: `ProtocolError` with typed `ErrorKind`, retryability, and operation context
- **Recovery**: `ResyncRuntime`/`StreamOverflow` (OPT_RESYNC)
- **Scrollback**: `GetScrollback`/`ScrollbackChunk` (OPT_CHUNKED_SCROLLBACK)
- **Diagnostics**: `GetDiagnostics`/`DiagnosticsReport` (OPT_DIAGNOSTICS)
- **All enums**: `Capability`, `MouseMode`, `RuntimePolicy`, `RuntimeAttachMode`, `RuntimeClientRole`, `RuntimeTerminationReason`, `ErrorKind`

The v3 proto compiles alongside the existing v2 proto. The v2 module remains at `rttx_proto::proto`, the v3 module is at `rttx_proto::v3`. No existing code is changed.

### How to verify

```bash
cargo build -p rttx-proto
cargo test -p rttx-proto
```

### Tests added (20 new tests)

**v3_tests module:**
- `v3_client_hello_roundtrip` — handshake encode/decode
- `v3_server_hello_roundtrip` — handshake encode/decode
- `v3_capability_enum_values` — all capability values match RFC
- `v3_enum_zero_values` — all enums have correct zero/unspecified values
- `v3_error_kind_values` — all error kinds match RFC
- `v3_terminal_mode_state_roundtrip` — consolidated mode state
- `v3_terminal_input_raw_roundtrip` — raw input variant
- `v3_terminal_input_paste_roundtrip` — paste input variant
- `v3_terminal_input_focus_roundtrip` — focus input variant
- `v3_protocol_error_roundtrip` — typed error with all fields
- `v3_runtime_snapshot_roundtrip` — snapshot with pane and modes
- `v3_scrollback_roundtrip` — GetScrollback and ScrollbackChunk
- `v3_stream_overflow_roundtrip` — with and without pane_id

**v3_envelope_tests module:**
- `v3_client_envelope_all_commands` — all 16 client command variants
- `v3_server_envelope_all_payloads` — all 21 server payload variants
- `v3_envelope_field_numbers_match_rfc` — high-frequency paths use single-byte tags
- `v3_runtime_info_inventory_fields` — OPT_RUNTIME_INVENTORY_V2 fields
- `v3_runtime_termination_ephemeral_detach` — ephemeral detach reason
- `v3_mouse_mode_values` — all mouse mode enum values
- `v3_pane_snapshot_with_all_modes` — snapshot with all terminal modes active

### Tests run

- `cargo test -p rttx-proto` — 29 passed (9 existing + 20 new)
- `cargo test -p rttx-server` — all passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed

Fixes #671