### PR TITLE
feat(proto): implement ClientEnvelope/ServerEnvelope with request/response correlation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "prost",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.3.5',
+  version: '0.3.6',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -26,6 +26,9 @@ pub mod v3 {
 /// V3 handshake: version negotiation, capability validation, message builders.
 pub mod v3_handshake;
 
+/// V3 envelope: request/response correlation and command classification.
+pub mod v3_envelope;
+
 /// Convert a `uuid::Uuid` to protobuf bytes.
 #[must_use]
 pub fn uuid_to_bytes(id: uuid::Uuid) -> Vec<u8> {

--- a/protocols/rttx-proto/src/v3_envelope.rs
+++ b/protocols/rttx-proto/src/v3_envelope.rs
@@ -1,0 +1,416 @@
+//! V3 envelope: request/response correlation and command classification.
+//!
+//! Implements RFC-021 Section 2 (Command/Event Envelopes).
+//!
+//! - Fire-and-forget commands (`TerminalInput`, `ResizePane`, `SetPaneTitle`,
+//!   `Shutdown`) carry `request_id = 0` and receive no response.
+//! - Request/response commands carry a non-zero `request_id` assigned by the
+//!   client. The server echoes the `request_id` in the response.
+//! - Push events from the server carry `request_id = 0`.
+
+use crate::v3;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Generates unique non-zero request IDs for a single client connection.
+///
+/// IDs are monotonically increasing and wrap at `u64::MAX` back to 1.
+/// Thread-safe via atomic operations.
+pub struct RequestIdGenerator {
+    next: AtomicU64,
+}
+
+impl RequestIdGenerator {
+    /// Create a new generator starting at 1.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { next: AtomicU64::new(1) }
+    }
+
+    /// Return the next unique non-zero request ID.
+    pub fn next_id(&self) -> u64 {
+        let id = self.next.fetch_add(1, Ordering::Relaxed);
+        // Wrap past zero — u64::MAX + 1 wraps to 0, so skip it.
+        if id == 0 { self.next.fetch_add(1, Ordering::Relaxed) } else { id }
+    }
+}
+
+impl Default for RequestIdGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Returns `true` if the command variant is fire-and-forget (no response expected).
+#[must_use]
+pub fn is_fire_and_forget(command: &v3::client_envelope::Command) -> bool {
+    matches!(
+        command,
+        v3::client_envelope::Command::TerminalInput(_)
+            | v3::client_envelope::Command::ResizePane(_)
+            | v3::client_envelope::Command::SetPaneTitle(_)
+            | v3::client_envelope::Command::Shutdown(_)
+    )
+}
+
+/// Build a `ClientEnvelope` with the correct `request_id`.
+///
+/// Fire-and-forget commands get `request_id = 0`.
+/// Request/response commands get a non-zero ID from the generator.
+#[must_use]
+pub fn build_client_envelope(
+    id_gen: &RequestIdGenerator,
+    command: v3::client_envelope::Command,
+) -> v3::ClientEnvelope {
+    let request_id = if is_fire_and_forget(&command) { 0 } else { id_gen.next_id() };
+    v3::ClientEnvelope { request_id, command: Some(command) }
+}
+
+/// Build a `ServerEnvelope` response echoing the client's `request_id`.
+#[must_use]
+pub fn build_response_envelope(
+    request_id: u64,
+    payload: v3::server_envelope::Payload,
+) -> v3::ServerEnvelope {
+    v3::ServerEnvelope { request_id, payload: Some(payload) }
+}
+
+/// Build a `ServerEnvelope` push event (`request_id = 0`).
+#[must_use]
+pub fn build_push_envelope(payload: v3::server_envelope::Payload) -> v3::ServerEnvelope {
+    v3::ServerEnvelope { request_id: 0, payload: Some(payload) }
+}
+
+/// Returns `true` if the server envelope is a push event (not a response).
+#[must_use]
+pub fn is_push_event(envelope: &v3::ServerEnvelope) -> bool {
+    envelope.request_id == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uuid_to_bytes;
+
+    fn rid() -> Vec<u8> {
+        uuid_to_bytes(uuid::Uuid::new_v4())
+    }
+
+    fn pid() -> Vec<u8> {
+        uuid_to_bytes(uuid::Uuid::new_v4())
+    }
+
+    // ── RequestIdGenerator ──
+
+    #[test]
+    fn generator_starts_at_one() {
+        let id_gen = RequestIdGenerator::new();
+        assert_eq!(id_gen.next_id(), 1);
+    }
+
+    #[test]
+    fn generator_increments() {
+        let id_gen = RequestIdGenerator::new();
+        assert_eq!(id_gen.next_id(), 1);
+        assert_eq!(id_gen.next_id(), 2);
+        assert_eq!(id_gen.next_id(), 3);
+    }
+
+    #[test]
+    fn generator_never_returns_zero() {
+        // Force the counter near the wrap point.
+        let id_gen = RequestIdGenerator { next: AtomicU64::new(u64::MAX) };
+        let id1 = id_gen.next_id();
+        assert_eq!(id1, u64::MAX);
+        // Next call wraps past 0.
+        let id2 = id_gen.next_id();
+        assert_ne!(id2, 0, "generator must never return zero");
+    }
+
+    #[test]
+    fn generator_default_matches_new() {
+        let id_gen = RequestIdGenerator::default();
+        assert_eq!(id_gen.next_id(), 1);
+    }
+
+    // ── Fire-and-forget classification ──
+
+    #[test]
+    fn terminal_input_is_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::TerminalInput(v3::TerminalInput {
+            runtime_id: rid(),
+            pane_id: pid(),
+            kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                data: bytes::Bytes::from_static(b"x"),
+            })),
+        });
+        assert!(is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn resize_pane_is_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::ResizePane(v3::ResizePane {
+            runtime_id: rid(),
+            pane_id: pid(),
+            cols: 80,
+            rows: 24,
+        });
+        assert!(is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn set_pane_title_is_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::SetPaneTitle(v3::SetPaneTitle {
+            runtime_id: rid(),
+            pane_id: pid(),
+            title: "t".into(),
+        });
+        assert!(is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn shutdown_is_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::Shutdown(v3::Shutdown {});
+        assert!(is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn ping_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::Ping(v3::Ping { nonce: 1 });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn create_runtime_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::CreateRuntime(v3::CreateRuntime {
+            name: "test".into(),
+            policy: v3::RuntimePolicy::Ephemeral as i32,
+        });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn attach_runtime_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::AttachRuntime(v3::AttachRuntime {
+            runtime_id: rid(),
+            attach_mode: v3::RuntimeAttachMode::ReadWrite as i32,
+        });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn detach_runtime_is_not_fire_and_forget() {
+        let cmd =
+            v3::client_envelope::Command::DetachRuntime(v3::DetachRuntime { runtime_id: rid() });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn terminate_runtime_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::TerminateRuntime(v3::TerminateRuntime {
+            runtime_id: rid(),
+        });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn rename_runtime_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::RenameRuntime(v3::RenameRuntime {
+            runtime_id: rid(),
+            name: "new".into(),
+        });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn list_runtimes_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::ListRuntimes(v3::ListRuntimes {});
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn create_pane_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::CreatePane(v3::CreatePane {
+            runtime_id: rid(),
+            cwd: None,
+            dark_background: None,
+            cols: 80,
+            rows: 24,
+        });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn close_pane_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::ClosePane(v3::ClosePane {
+            runtime_id: rid(),
+            pane_id: pid(),
+        });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn resync_runtime_is_not_fire_and_forget() {
+        let cmd =
+            v3::client_envelope::Command::ResyncRuntime(v3::ResyncRuntime { runtime_id: rid() });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn get_scrollback_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::GetScrollback(v3::GetScrollback {
+            runtime_id: rid(),
+            pane_id: pid(),
+            offset: 0,
+            limit: 65536,
+        });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    #[test]
+    fn get_diagnostics_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::GetDiagnostics(v3::GetDiagnostics {});
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
+    // ── build_client_envelope ──
+
+    #[test]
+    fn fire_and_forget_envelope_has_zero_request_id() {
+        let id_gen = RequestIdGenerator::new();
+        let cmd = v3::client_envelope::Command::TerminalInput(v3::TerminalInput {
+            runtime_id: rid(),
+            pane_id: pid(),
+            kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                data: bytes::Bytes::from_static(b"a"),
+            })),
+        });
+        let env = build_client_envelope(&id_gen, cmd);
+        assert_eq!(env.request_id, 0);
+    }
+
+    #[test]
+    fn request_response_envelope_has_nonzero_request_id() {
+        let id_gen = RequestIdGenerator::new();
+        let cmd = v3::client_envelope::Command::Ping(v3::Ping { nonce: 42 });
+        let env = build_client_envelope(&id_gen, cmd);
+        assert_ne!(env.request_id, 0);
+    }
+
+    #[test]
+    fn fire_and_forget_does_not_consume_request_ids() {
+        let id_gen = RequestIdGenerator::new();
+        // Send several fire-and-forget commands.
+        for _ in 0..5 {
+            let cmd = v3::client_envelope::Command::Shutdown(v3::Shutdown {});
+            let env = build_client_envelope(&id_gen, cmd);
+            assert_eq!(env.request_id, 0);
+        }
+        // The first request/response command should still get ID 1.
+        let cmd = v3::client_envelope::Command::Ping(v3::Ping { nonce: 1 });
+        let env = build_client_envelope(&id_gen, cmd);
+        assert_eq!(env.request_id, 1);
+    }
+
+    #[test]
+    fn sequential_request_ids_are_unique() {
+        let id_gen = RequestIdGenerator::new();
+        let mut ids = Vec::new();
+        for _ in 0..100 {
+            let cmd = v3::client_envelope::Command::Ping(v3::Ping { nonce: 0 });
+            let env = build_client_envelope(&id_gen, cmd);
+            assert!(!ids.contains(&env.request_id), "duplicate request_id");
+            ids.push(env.request_id);
+        }
+    }
+
+    // ── build_response_envelope / build_push_envelope ──
+
+    #[test]
+    fn response_envelope_echoes_request_id() {
+        let payload = v3::server_envelope::Payload::Pong(v3::Pong { nonce: 42 });
+        let env = build_response_envelope(7, payload);
+        assert_eq!(env.request_id, 7);
+    }
+
+    #[test]
+    fn push_envelope_has_zero_request_id() {
+        let payload = v3::server_envelope::Payload::OutputDelta(v3::OutputDelta {
+            runtime_id: rid(),
+            pane_id: pid(),
+            data: bytes::Bytes::from_static(b"out"),
+            pane_output_seq: 1,
+        });
+        let env = build_push_envelope(payload);
+        assert_eq!(env.request_id, 0);
+    }
+
+    // ── is_push_event ──
+
+    #[test]
+    fn push_event_detected() {
+        let env = v3::ServerEnvelope {
+            request_id: 0,
+            payload: Some(v3::server_envelope::Payload::PaneExited(v3::PaneExited {
+                runtime_id: rid(),
+                pane_id: pid(),
+                status: 0,
+                runtime_revision: 1,
+            })),
+        };
+        assert!(is_push_event(&env));
+    }
+
+    #[test]
+    fn response_not_detected_as_push() {
+        let env = v3::ServerEnvelope {
+            request_id: 5,
+            payload: Some(v3::server_envelope::Payload::Pong(v3::Pong { nonce: 5 })),
+        };
+        assert!(!is_push_event(&env));
+    }
+
+    // ── Wire roundtrip through encode/decode ──
+
+    #[test]
+    fn client_envelope_roundtrip_through_frame() {
+        let id_gen = RequestIdGenerator::new();
+        let cmd = v3::client_envelope::Command::CreateRuntime(v3::CreateRuntime {
+            name: "test".into(),
+            policy: v3::RuntimePolicy::Persistent as i32,
+        });
+        let env = build_client_envelope(&id_gen, cmd);
+        assert_ne!(env.request_id, 0);
+
+        let mut buf = bytes::BytesMut::new();
+        crate::encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ClientEnvelope = crate::decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    #[test]
+    fn server_response_roundtrip_through_frame() {
+        let payload = v3::server_envelope::Payload::RuntimeCreated(v3::RuntimeCreated {
+            runtime_id: rid(),
+            runtime_revision: 1,
+        });
+        let env = build_response_envelope(42, payload);
+
+        let mut buf = bytes::BytesMut::new();
+        crate::encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = crate::decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    #[test]
+    fn server_push_roundtrip_through_frame() {
+        let payload =
+            v3::server_envelope::Payload::Bell(v3::Bell { runtime_id: rid(), pane_id: pid() });
+        let env = build_push_envelope(payload);
+
+        let mut buf = bytes::BytesMut::new();
+        crate::encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = crate::decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+        assert!(is_push_event(&decoded));
+    }
+}

--- a/services/rttx-server/tests/v3_proto_integration.rs
+++ b/services/rttx-server/tests/v3_proto_integration.rs
@@ -104,6 +104,128 @@ fn v3_protocol_error_frames_as_bare_and_in_envelope() {
     };
 }
 
+// ── V3 envelope correlation integration tests ──
+
+use rttx_proto::v3_envelope;
+
+#[test]
+fn v3_envelope_request_response_correlation_roundtrip() {
+    let id_gen = v3_envelope::RequestIdGenerator::new();
+    let runtime_id = uuid_to_bytes(uuid::Uuid::new_v4());
+
+    // Client sends CreateRuntime (request/response command)
+    let cmd = v3::client_envelope::Command::CreateRuntime(v3::CreateRuntime {
+        name: "correlation-test".into(),
+        policy: v3::RuntimePolicy::Persistent as i32,
+    });
+    let client_env = v3_envelope::build_client_envelope(&id_gen, cmd);
+    assert_ne!(client_env.request_id, 0);
+    let saved_request_id = client_env.request_id;
+
+    // Wire roundtrip for client envelope
+    let mut buf = BytesMut::new();
+    encode_frame(&client_env, &mut buf).unwrap();
+    let decoded_client: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded_client.request_id, saved_request_id);
+
+    // Server builds response echoing request_id
+    let response = v3_envelope::build_response_envelope(
+        decoded_client.request_id,
+        v3::server_envelope::Payload::RuntimeCreated(v3::RuntimeCreated {
+            runtime_id: runtime_id.clone(),
+            runtime_revision: 1,
+        }),
+    );
+    assert_eq!(response.request_id, saved_request_id);
+    assert!(!v3_envelope::is_push_event(&response));
+
+    // Wire roundtrip for server response
+    let mut buf = BytesMut::new();
+    encode_frame(&response, &mut buf).unwrap();
+    let decoded_response: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded_response.request_id, saved_request_id);
+
+    // Server sends a push event (OutputDelta)
+    let push = v3_envelope::build_push_envelope(v3::server_envelope::Payload::OutputDelta(
+        v3::OutputDelta {
+            runtime_id,
+            pane_id: uuid_to_bytes(uuid::Uuid::new_v4()),
+            data: bytes::Bytes::from_static(b"hello"),
+            pane_output_seq: 1,
+        },
+    ));
+    assert!(v3_envelope::is_push_event(&push));
+
+    let mut buf = BytesMut::new();
+    encode_frame(&push, &mut buf).unwrap();
+    let decoded_push: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded_push.request_id, 0);
+    assert!(v3_envelope::is_push_event(&decoded_push));
+}
+
+#[test]
+fn v3_envelope_fire_and_forget_skips_id_allocation() {
+    let id_gen = v3_envelope::RequestIdGenerator::new();
+
+    // Fire-and-forget: TerminalInput
+    let cmd = v3::client_envelope::Command::TerminalInput(v3::TerminalInput {
+        runtime_id: uuid_to_bytes(uuid::Uuid::new_v4()),
+        pane_id: uuid_to_bytes(uuid::Uuid::new_v4()),
+        kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+            data: bytes::Bytes::from_static(b"ls\n"),
+        })),
+    });
+    let env = v3_envelope::build_client_envelope(&id_gen, cmd);
+    assert_eq!(env.request_id, 0);
+
+    // Wire roundtrip
+    let mut buf = BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    let decoded: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded.request_id, 0);
+
+    // Next request/response command still gets ID 1
+    let cmd = v3::client_envelope::Command::Ping(v3::Ping { nonce: 99 });
+    let env = v3_envelope::build_client_envelope(&id_gen, cmd);
+    assert_eq!(env.request_id, 1);
+}
+
+#[test]
+fn v3_envelope_mixed_command_sequence() {
+    let id_gen = v3_envelope::RequestIdGenerator::new();
+    let rt = uuid_to_bytes(uuid::Uuid::new_v4());
+    let pn = uuid_to_bytes(uuid::Uuid::new_v4());
+
+    // Sequence: CreateRuntime(1), TerminalInput(0), Ping(2), ResizePane(0), ClosePane(3)
+    let commands: Vec<v3::client_envelope::Command> = vec![
+        v3::client_envelope::Command::CreateRuntime(v3::CreateRuntime {
+            name: "seq".into(),
+            policy: v3::RuntimePolicy::Ephemeral as i32,
+        }),
+        v3::client_envelope::Command::TerminalInput(v3::TerminalInput {
+            runtime_id: rt.clone(),
+            pane_id: pn.clone(),
+            kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                data: bytes::Bytes::from_static(b"x"),
+            })),
+        }),
+        v3::client_envelope::Command::Ping(v3::Ping { nonce: 1 }),
+        v3::client_envelope::Command::ResizePane(v3::ResizePane {
+            runtime_id: rt.clone(),
+            pane_id: pn.clone(),
+            cols: 80,
+            rows: 24,
+        }),
+        v3::client_envelope::Command::ClosePane(v3::ClosePane { runtime_id: rt, pane_id: pn }),
+    ];
+    let expected_ids: Vec<u64> = vec![1, 0, 2, 0, 3];
+
+    for (cmd, expected_id) in commands.into_iter().zip(expected_ids) {
+        let env = v3_envelope::build_client_envelope(&id_gen, cmd);
+        assert_eq!(env.request_id, expected_id);
+    }
+}
+
 // ── V3 handshake integration tests ──
 
 use rttx_proto::v3_handshake;


### PR DESCRIPTION
## What changed and why

Implements RFC-021 Step 4: Rust-side helpers for v3 envelope request/response correlation.

The proto messages (`ClientEnvelope`/`ServerEnvelope`) were already defined in the `.proto` file. This PR adds the Rust helper layer in a new `v3_envelope` module:

- **`RequestIdGenerator`** — atomic counter producing unique non-zero request IDs for a client connection, with wrap-past-zero safety
- **`is_fire_and_forget()`** — classifies commands per RFC-021 correlation rules: `TerminalInput`, `ResizePane`, `SetPaneTitle`, and `Shutdown` are fire-and-forget (`request_id = 0`)
- **`build_client_envelope()`** — constructs a `ClientEnvelope` with the correct `request_id` based on command type
- **`build_response_envelope()` / `build_push_envelope()`** — server-side builders that echo the client's `request_id` for responses or use 0 for push events
- **`is_push_event()`** — distinguishes push events from responses

## Manual verification

```bash
cargo test -p rttx-proto
cargo test -p rttx-server --test v3_proto_integration
```

## Tests added

### Unit tests (31 tests in `v3_envelope::tests`)
- `RequestIdGenerator`: starts at 1, increments, never returns zero (wrap safety), default trait
- Fire-and-forget classification: all 4 fire-and-forget commands (`TerminalInput`, `ResizePane`, `SetPaneTitle`, `Shutdown`) and all 12 request/response commands
- `build_client_envelope`: zero ID for fire-and-forget, non-zero for request/response, fire-and-forget doesn't consume IDs, sequential IDs are unique
- `build_response_envelope` / `build_push_envelope`: correct request_id assignment
- `is_push_event`: push vs response detection
- Wire roundtrips through `encode_frame`/`decode_frame` for client, response, and push envelopes

### Integration tests (3 tests in `v3_proto_integration.rs`)
- Full request/response correlation roundtrip with wire encoding
- Fire-and-forget ID allocation skipping with wire roundtrip
- Mixed command sequence verifying correct ID assignment pattern

## Tests run

- `cargo test -p rttx-proto` — 76 passed
- `cargo test -p rttx-server` — all passed
- `bash .github/scripts/run-clippy.sh` — passed
- `bash .github/scripts/run-quality-tests.sh` — passed
- `cargo build -p rttx --no-default-features --features vte-0_76` — passed

Fixes #673