### PR TITLE
feat(proto): consolidate terminal modes into TerminalModeState and TerminalModeChanged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "prost",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.3.6',
+  version: '0.3.7',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -29,6 +29,9 @@ pub mod v3_handshake;
 /// V3 envelope: request/response correlation and command classification.
 pub mod v3_envelope;
 
+/// V3 terminal mode state: builders and conversions (RFC-021 Section 5).
+pub mod v3_terminal_modes;
+
 /// Convert a `uuid::Uuid` to protobuf bytes.
 #[must_use]
 pub fn uuid_to_bytes(id: uuid::Uuid) -> Vec<u8> {

--- a/protocols/rttx-proto/src/v3_terminal_modes.rs
+++ b/protocols/rttx-proto/src/v3_terminal_modes.rs
@@ -1,0 +1,276 @@
+//! V3 terminal mode state: builders and conversions.
+//!
+//! Implements RFC-021 Section 5 (Terminal Interaction State).
+//!
+//! Provides conversion between the daemon's per-field mode tracking
+//! (individual booleans and a `u16` mouse tracking value) and the
+//! consolidated `TerminalModeState` protobuf message. Also provides
+//! builders for `TerminalModeChanged` push events.
+
+use crate::v3;
+
+/// Convert a raw mouse tracking mode value (0, 1000, 1002, 1003) to the
+/// v3 `MouseMode` enum.
+///
+/// Unknown values map to `MouseMode::None`.
+#[must_use]
+pub fn mouse_mode_from_tracking_value(value: u16) -> v3::MouseMode {
+    match value {
+        1000 => v3::MouseMode::Normal,
+        1002 => v3::MouseMode::Button,
+        1003 => v3::MouseMode::Any,
+        _ => v3::MouseMode::None,
+    }
+}
+
+/// Convert a v3 `MouseMode` enum back to the raw tracking value used by
+/// the daemon's `PaneScreen`.
+#[must_use]
+pub fn tracking_value_from_mouse_mode(mode: v3::MouseMode) -> u16 {
+    match mode {
+        v3::MouseMode::None => 0,
+        v3::MouseMode::X10 => 9,
+        v3::MouseMode::Normal => 1000,
+        v3::MouseMode::Button => 1002,
+        v3::MouseMode::Any => 1003,
+    }
+}
+
+/// Build a `TerminalModeChanged` push event.
+#[must_use]
+pub fn build_terminal_mode_changed(
+    runtime_id: uuid::Uuid,
+    pane_id: uuid::Uuid,
+    runtime_revision: u64,
+    modes: v3::TerminalModeState,
+) -> v3::TerminalModeChanged {
+    v3::TerminalModeChanged {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        pane_id: crate::uuid_to_bytes(pane_id),
+        runtime_revision,
+        modes: Some(modes),
+    }
+}
+
+/// Build a `ServerEnvelope` push event for a terminal mode change.
+#[must_use]
+pub fn build_mode_changed_envelope(
+    runtime_id: uuid::Uuid,
+    pane_id: uuid::Uuid,
+    runtime_revision: u64,
+    modes: v3::TerminalModeState,
+) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_push_envelope(v3::server_envelope::Payload::TerminalModeChanged(
+        build_terminal_mode_changed(runtime_id, pane_id, runtime_revision, modes),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{decode_frame, encode_frame, uuid_to_bytes};
+    use bytes::BytesMut;
+
+    fn mode_state(
+        bracketed_paste: bool,
+        mouse_tracking: u16,
+        sgr_mouse: bool,
+    ) -> v3::TerminalModeState {
+        v3::TerminalModeState {
+            bracketed_paste,
+            mouse_mode: mouse_mode_from_tracking_value(mouse_tracking) as i32,
+            sgr_mouse,
+            ..Default::default()
+        }
+    }
+
+    // ── MouseMode conversion ──
+
+    #[test]
+    fn mouse_mode_from_zero_is_none() {
+        assert_eq!(mouse_mode_from_tracking_value(0), v3::MouseMode::None);
+    }
+
+    #[test]
+    fn mouse_mode_from_1000_is_normal() {
+        assert_eq!(mouse_mode_from_tracking_value(1000), v3::MouseMode::Normal);
+    }
+
+    #[test]
+    fn mouse_mode_from_1002_is_button() {
+        assert_eq!(mouse_mode_from_tracking_value(1002), v3::MouseMode::Button);
+    }
+
+    #[test]
+    fn mouse_mode_from_1003_is_any() {
+        assert_eq!(mouse_mode_from_tracking_value(1003), v3::MouseMode::Any);
+    }
+
+    #[test]
+    fn mouse_mode_unknown_value_maps_to_none() {
+        assert_eq!(mouse_mode_from_tracking_value(9999), v3::MouseMode::None);
+    }
+
+    #[test]
+    fn tracking_value_roundtrip_none() {
+        let mode = mouse_mode_from_tracking_value(0);
+        assert_eq!(tracking_value_from_mouse_mode(mode), 0);
+    }
+
+    #[test]
+    fn tracking_value_roundtrip_normal() {
+        let mode = mouse_mode_from_tracking_value(1000);
+        assert_eq!(tracking_value_from_mouse_mode(mode), 1000);
+    }
+
+    #[test]
+    fn tracking_value_roundtrip_button() {
+        let mode = mouse_mode_from_tracking_value(1002);
+        assert_eq!(tracking_value_from_mouse_mode(mode), 1002);
+    }
+
+    #[test]
+    fn tracking_value_roundtrip_any() {
+        let mode = mouse_mode_from_tracking_value(1003);
+        assert_eq!(tracking_value_from_mouse_mode(mode), 1003);
+    }
+
+    #[test]
+    fn tracking_value_x10() {
+        assert_eq!(tracking_value_from_mouse_mode(v3::MouseMode::X10), 9);
+    }
+
+    // ── TerminalModeState construction ──
+
+    #[test]
+    fn default_mode_state_all_false() {
+        let state = v3::TerminalModeState::default();
+        assert!(!state.bracketed_paste);
+        assert!(!state.focus_reporting);
+        assert!(!state.application_cursor_keys);
+        assert!(!state.application_keypad);
+        assert!(!state.alternate_screen);
+        assert!(!state.cursor_hidden);
+        assert_eq!(state.mouse_mode, v3::MouseMode::None as i32);
+        assert!(!state.sgr_mouse);
+    }
+
+    #[test]
+    fn mode_state_with_all_active() {
+        let state = v3::TerminalModeState {
+            bracketed_paste: true,
+            focus_reporting: true,
+            application_cursor_keys: true,
+            application_keypad: true,
+            alternate_screen: true,
+            cursor_hidden: true,
+            mouse_mode: v3::MouseMode::Any as i32,
+            sgr_mouse: true,
+        };
+        assert!(state.bracketed_paste);
+        assert!(state.focus_reporting);
+        assert!(state.application_cursor_keys);
+        assert!(state.application_keypad);
+        assert!(state.alternate_screen);
+        assert!(state.cursor_hidden);
+        assert_eq!(state.mouse_mode, v3::MouseMode::Any as i32);
+        assert!(state.sgr_mouse);
+    }
+
+    #[test]
+    fn mode_state_mouse_mode_conversion() {
+        let state = mode_state(false, 1002, false);
+        assert_eq!(state.mouse_mode, v3::MouseMode::Button as i32);
+    }
+
+    // ── build_terminal_mode_changed ──
+
+    #[test]
+    fn build_mode_changed_populates_all_fields() {
+        let rt = uuid::Uuid::new_v4();
+        let pn = uuid::Uuid::new_v4();
+        let modes = mode_state(true, 0, false);
+        let msg = build_terminal_mode_changed(rt, pn, 42, modes);
+        assert_eq!(msg.runtime_id, uuid_to_bytes(rt));
+        assert_eq!(msg.pane_id, uuid_to_bytes(pn));
+        assert_eq!(msg.runtime_revision, 42);
+        assert_eq!(msg.modes, Some(modes));
+    }
+
+    #[test]
+    fn mode_changed_wire_roundtrip() {
+        let rt = uuid::Uuid::new_v4();
+        let pn = uuid::Uuid::new_v4();
+        let modes = v3::TerminalModeState {
+            bracketed_paste: true,
+            focus_reporting: true,
+            application_cursor_keys: true,
+            application_keypad: true,
+            alternate_screen: true,
+            cursor_hidden: true,
+            mouse_mode: v3::MouseMode::Any as i32,
+            sgr_mouse: true,
+        };
+        let msg = build_terminal_mode_changed(rt, pn, 99, modes);
+
+        let mut buf = BytesMut::new();
+        encode_frame(&msg, &mut buf).unwrap();
+        let decoded: v3::TerminalModeChanged = decode_frame(&mut buf).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    // ── build_mode_changed_envelope ──
+
+    #[test]
+    fn mode_changed_envelope_is_push_event() {
+        let rt = uuid::Uuid::new_v4();
+        let pn = uuid::Uuid::new_v4();
+        let modes = mode_state(true, 0, false);
+        let env = build_mode_changed_envelope(rt, pn, 5, modes);
+        assert_eq!(env.request_id, 0);
+        assert!(crate::v3_envelope::is_push_event(&env));
+    }
+
+    #[test]
+    fn mode_changed_envelope_wire_roundtrip() {
+        let rt = uuid::Uuid::new_v4();
+        let pn = uuid::Uuid::new_v4();
+        let modes = v3::TerminalModeState {
+            focus_reporting: true,
+            application_keypad: true,
+            cursor_hidden: true,
+            mouse_mode: v3::MouseMode::Normal as i32,
+            ..Default::default()
+        };
+        let env = build_mode_changed_envelope(rt, pn, 10, modes);
+
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    #[test]
+    fn mode_changed_envelope_contains_correct_payload() {
+        let rt = uuid::Uuid::new_v4();
+        let pn = uuid::Uuid::new_v4();
+        let modes = v3::TerminalModeState {
+            bracketed_paste: true,
+            application_cursor_keys: true,
+            alternate_screen: true,
+            sgr_mouse: true,
+            ..Default::default()
+        };
+        let env = build_mode_changed_envelope(rt, pn, 7, modes);
+
+        match env.payload {
+            Some(v3::server_envelope::Payload::TerminalModeChanged(ref changed)) => {
+                assert_eq!(changed.runtime_id, uuid_to_bytes(rt));
+                assert_eq!(changed.pane_id, uuid_to_bytes(pn));
+                assert_eq!(changed.runtime_revision, 7);
+                assert_eq!(changed.modes, Some(modes));
+            }
+            _ => panic!("expected TerminalModeChanged payload"),
+        }
+    }
+}

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -43,6 +43,8 @@ struct ScreenPerformer {
     focus_event_mode: bool,
     /// Whether the cursor is visible (DECSET 25, default true).
     cursor_visible: bool,
+    /// Whether alternate screen buffer (DECSET 1049/1047) is active.
+    alternate_screen: bool,
 }
 
 impl PaneScreen {
@@ -66,6 +68,7 @@ impl PaneScreen {
                 sgr_mouse_mode: false,
                 focus_event_mode: false,
                 cursor_visible: true,
+                alternate_screen: false,
             },
         }
     }
@@ -186,6 +189,29 @@ impl PaneScreen {
     pub const fn cursor_visible(&self) -> bool {
         self.performer.cursor_visible
     }
+
+    /// Whether alternate screen buffer (DECSET 1049/1047) is active.
+    #[must_use]
+    pub const fn alternate_screen(&self) -> bool {
+        self.performer.alternate_screen
+    }
+
+    /// Build a consolidated `TerminalModeState` from the current screen state.
+    #[must_use]
+    pub fn terminal_mode_state(&self) -> rttx_proto::v3::TerminalModeState {
+        rttx_proto::v3::TerminalModeState {
+            bracketed_paste: self.performer.bracketed_paste_mode,
+            focus_reporting: self.performer.focus_event_mode,
+            application_cursor_keys: self.performer.application_cursor_keys,
+            application_keypad: self.performer.application_keypad,
+            alternate_screen: self.performer.alternate_screen,
+            cursor_hidden: !self.performer.cursor_visible,
+            mouse_mode: rttx_proto::v3_terminal_modes::mouse_mode_from_tracking_value(
+                self.performer.mouse_tracking_mode,
+            ) as i32,
+            sgr_mouse: self.performer.sgr_mouse_mode,
+        }
+    }
 }
 
 /// Return restart-safe scrollback bytes for a reconstructed pane.
@@ -282,6 +308,7 @@ impl vte::Perform for ScreenPerformer {
                     }
                     Some(1004) => self.focus_event_mode = enabled,
                     Some(1006) => self.sgr_mouse_mode = enabled,
+                    Some(1047 | 1049) => self.alternate_screen = enabled,
                     Some(2004) => self.bracketed_paste_mode = enabled,
                     _ => {}
                 }
@@ -299,6 +326,7 @@ impl vte::Perform for ScreenPerformer {
                 1000 | 1002 | 1003 => Some(self.mouse_tracking_mode == mode),
                 1004 => Some(self.focus_event_mode),
                 1006 => Some(self.sgr_mouse_mode),
+                1047 | 1049 => Some(self.alternate_screen),
                 2004 => Some(self.bracketed_paste_mode),
                 _ => None,
             };
@@ -953,6 +981,86 @@ mod tests {
         assert!(screen.cursor_visible());
     }
 
+    // --- Alternate screen (DECSET 1049/1047) ---
+
+    #[test]
+    fn alternate_screen_default_off() {
+        let screen = PaneScreen::new(1024);
+        assert!(!screen.alternate_screen());
+    }
+
+    #[test]
+    fn decset_1049_enables_alternate_screen() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1049h");
+        assert!(screen.alternate_screen());
+    }
+
+    #[test]
+    fn decrst_1049_disables_alternate_screen() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1049h");
+        screen.feed(b"\x1b[?1049l");
+        assert!(!screen.alternate_screen());
+    }
+
+    #[test]
+    fn decset_1047_enables_alternate_screen() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1047h");
+        assert!(screen.alternate_screen());
+    }
+
+    #[test]
+    fn decrst_1047_disables_alternate_screen() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1047h");
+        screen.feed(b"\x1b[?1047l");
+        assert!(!screen.alternate_screen());
+    }
+
+    // --- terminal_mode_state() consolidation ---
+
+    #[test]
+    fn terminal_mode_state_defaults() {
+        let screen = PaneScreen::new(1024);
+        let state = screen.terminal_mode_state();
+        assert_eq!(state, rttx_proto::v3::TerminalModeState::default());
+    }
+
+    #[test]
+    fn terminal_mode_state_reflects_all_modes() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?2004h"); // bracketed paste
+        screen.feed(b"\x1b[?1004h"); // focus reporting
+        screen.feed(b"\x1b[?1h"); // application cursor keys
+        screen.feed(b"\x1b="); // application keypad
+        screen.feed(b"\x1b[?1049h"); // alternate screen
+        screen.feed(b"\x1b[?25l"); // hide cursor
+        screen.feed(b"\x1b[?1003h"); // any-event mouse
+        screen.feed(b"\x1b[?1006h"); // SGR mouse
+
+        let state = screen.terminal_mode_state();
+        assert!(state.bracketed_paste);
+        assert!(state.focus_reporting);
+        assert!(state.application_cursor_keys);
+        assert!(state.application_keypad);
+        assert!(state.alternate_screen);
+        assert!(state.cursor_hidden);
+        assert_eq!(state.mouse_mode, rttx_proto::v3::MouseMode::Any as i32);
+        assert!(state.sgr_mouse);
+    }
+
+    #[test]
+    fn terminal_mode_state_cursor_hidden_inverts_cursor_visible() {
+        let mut screen = PaneScreen::new(1024);
+        assert!(!screen.terminal_mode_state().cursor_hidden);
+        screen.feed(b"\x1b[?25l");
+        assert!(screen.terminal_mode_state().cursor_hidden);
+        screen.feed(b"\x1b[?25h");
+        assert!(!screen.terminal_mode_state().cursor_hidden);
+    }
+
     // --- DECRQM (Request Mode) ---
 
     #[test]
@@ -1023,6 +1131,15 @@ mod tests {
         screen.feed(b"\x1b[?1000$p");
         let replies = screen.take_pending_replies();
         assert_eq!(replies[0], b"\x1b[?1000;2$y");
+    }
+
+    #[test]
+    fn decrqm_reports_alternate_screen() {
+        let mut screen = PaneScreen::new(1024);
+        screen.feed(b"\x1b[?1049h");
+        screen.feed(b"\x1b[?1049$p");
+        let replies = screen.take_pending_replies();
+        assert_eq!(replies[0], b"\x1b[?1049;1$y");
     }
 
     // --- Detached session scenario ---

--- a/services/rttx-server/tests/v3_proto_integration.rs
+++ b/services/rttx-server/tests/v3_proto_integration.rs
@@ -360,3 +360,68 @@ fn v3_handshake_full_roundtrip_with_optional_capabilities() {
     assert!(!effective.contains(&(v3::Capability::OptDiagnostics as i32)));
     assert!(!effective.contains(&(v3::Capability::OptChunkedScrollback as i32)));
 }
+
+// ── V3 terminal modes integration tests ──
+
+use rttx_proto::v3_terminal_modes;
+
+#[test]
+fn v3_terminal_mode_changed_push_event_roundtrip() {
+    let runtime_id = uuid::Uuid::new_v4();
+    let pane_id = uuid::Uuid::new_v4();
+
+    let modes = v3::TerminalModeState {
+        bracketed_paste: true,
+        focus_reporting: true,
+        application_cursor_keys: true,
+        application_keypad: true,
+        alternate_screen: true,
+        cursor_hidden: true,
+        mouse_mode: v3::MouseMode::Any as i32,
+        sgr_mouse: true,
+    };
+
+    let env = v3_terminal_modes::build_mode_changed_envelope(runtime_id, pane_id, 42, modes);
+    assert!(v3_envelope::is_push_event(&env));
+
+    // Wire roundtrip
+    let mut buf = BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded.request_id, 0);
+
+    let Some(v3::server_envelope::Payload::TerminalModeChanged(changed)) = decoded.payload else {
+        panic!("expected TerminalModeChanged");
+    };
+    assert_eq!(changed.runtime_id, uuid_to_bytes(runtime_id));
+    assert_eq!(changed.pane_id, uuid_to_bytes(pane_id));
+    assert_eq!(changed.runtime_revision, 42);
+    let decoded_modes = changed.modes.expect("modes must be present");
+    assert!(decoded_modes.bracketed_paste);
+    assert!(decoded_modes.focus_reporting);
+    assert!(decoded_modes.application_cursor_keys);
+    assert!(decoded_modes.application_keypad);
+    assert!(decoded_modes.alternate_screen);
+    assert!(decoded_modes.cursor_hidden);
+    assert_eq!(decoded_modes.mouse_mode, v3::MouseMode::Any as i32);
+    assert!(decoded_modes.sgr_mouse);
+}
+
+#[test]
+fn v3_mouse_mode_conversion_covers_all_tracking_values() {
+    let cases: &[(u16, v3::MouseMode)] = &[
+        (0, v3::MouseMode::None),
+        (1000, v3::MouseMode::Normal),
+        (1002, v3::MouseMode::Button),
+        (1003, v3::MouseMode::Any),
+        (9999, v3::MouseMode::None),
+    ];
+    for &(tracking, expected) in cases {
+        let mode = v3_terminal_modes::mouse_mode_from_tracking_value(tracking);
+        assert_eq!(mode, expected, "tracking value {tracking}");
+        if tracking != 9999 {
+            let back = v3_terminal_modes::tracking_value_from_mouse_mode(mode);
+            assert_eq!(back, tracking, "roundtrip for tracking value {tracking}");
+        }
+    }
+}


### PR DESCRIPTION
## What changed and why

RFC-021 Step 5: Add the `v3_terminal_modes` module to `rttx-proto` and complete the daemon's terminal mode tracking for the v3 protocol.

### Protocol layer (`rttx-proto`)

- New `v3_terminal_modes` module with:
  - `mouse_mode_from_tracking_value()` — converts raw DECSET values (0/1000/1002/1003) to `v3::MouseMode` enum
  - `tracking_value_from_mouse_mode()` — reverse conversion
  - `build_terminal_mode_changed()` — builds `TerminalModeChanged` push event messages
  - `build_mode_changed_envelope()` — wraps mode changes in `ServerEnvelope` push events

### Daemon (`rttx-server`)

- Added `alternate_screen` tracking to `PaneScreen` (DECSET 1047/1049)
- Added DECRQM support for alternate screen queries
- Added `terminal_mode_state()` method that returns a consolidated `v3::TerminalModeState` from the daemon's per-field mode tracking, mapping `cursor_visible` (default true) to `cursor_hidden` (default false)

### Version

Bumped to 0.3.7 (protocol-affecting change).

## Manual verification

- Built `rttx-proto` and `rttx-server` successfully
- All clippy checks pass at pedantic+nursery level
- All existing tests continue to pass

## Tests added

### `rttx-proto` (v3_terminal_modes module — 18 tests)
- MouseMode conversion: `mouse_mode_from_zero_is_none`, `mouse_mode_from_1000_is_normal`, `mouse_mode_from_1002_is_button`, `mouse_mode_from_1003_is_any`, `mouse_mode_unknown_value_maps_to_none`
- Tracking value roundtrips: `tracking_value_roundtrip_none`, `tracking_value_roundtrip_normal`, `tracking_value_roundtrip_button`, `tracking_value_roundtrip_any`, `tracking_value_x10`
- TerminalModeState construction: `default_mode_state_all_false`, `mode_state_with_all_active`, `mode_state_mouse_mode_conversion`
- TerminalModeChanged builder: `build_mode_changed_populates_all_fields`, `mode_changed_wire_roundtrip`
- Envelope builder: `mode_changed_envelope_is_push_event`, `mode_changed_envelope_wire_roundtrip`, `mode_changed_envelope_contains_correct_payload`

### `rttx-server` (screen module — 9 tests)
- Alternate screen: `alternate_screen_default_off`, `decset_1049_enables_alternate_screen`, `decrst_1049_disables_alternate_screen`, `decset_1047_enables_alternate_screen`, `decrst_1047_disables_alternate_screen`, `decrqm_reports_alternate_screen`
- Consolidated state: `terminal_mode_state_defaults`, `terminal_mode_state_reflects_all_modes`, `terminal_mode_state_cursor_hidden_inverts_cursor_visible`

## Tests run

- `cargo test -p rttx-proto` — 94 passed
- `cargo test -p rttx-server --lib` — 259 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed, zero failures

Fixes #674