### PR TITLE
feat(proto): implement OPT_RESYNC (StreamOverflow/ResyncRuntime)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "bytes",
  "prost",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.10"
+version = "0.3.11"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.3.10',
+  version: '0.3.11',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -44,6 +44,9 @@ pub mod v3_snapshot;
 /// V3 chunked scrollback: builders, validation, and capability gating (RFC-021 Section 8, `OPT_CHUNKED_SCROLLBACK`).
 pub mod v3_scrollback;
 
+/// V3 resync: capability gating, builders, and overflow handling (RFC-021 Section 8, `OPT_RESYNC`).
+pub mod v3_resync;
+
 /// Convert a `uuid::Uuid` to protobuf bytes.
 #[must_use]
 pub fn uuid_to_bytes(id: uuid::Uuid) -> Vec<u8> {

--- a/protocols/rttx-proto/src/v3_resync.rs
+++ b/protocols/rttx-proto/src/v3_resync.rs
@@ -1,0 +1,412 @@
+//! V3 resync: capability gating, builders, and overflow handling.
+//!
+//! Implements RFC-021 Section 8 (`OPT_RESYNC`).
+//!
+//! When the server's bounded push channel drops messages for a client, it
+//! sends `StreamOverflow`. The client requests `ResyncRuntime`, and the
+//! server responds with a fresh `RuntimeSnapshot`.
+//!
+//! Without `OPT_RESYNC`, the server forcibly disconnects the client on
+//! overflow. The client's connection state machine reconnects and receives
+//! a fresh snapshot on reattach.
+
+use crate::v3;
+
+/// Check whether `OPT_RESYNC` is in the effective capability set.
+#[must_use]
+pub fn is_supported(effective_caps: &[i32]) -> bool {
+    effective_caps.contains(&(v3::Capability::OptResync as i32))
+}
+
+/// Build a `StreamOverflow` push event.
+///
+/// `pane_id` is `Some` for pane-level overflow, `None` for runtime-level.
+#[must_use]
+pub fn build_stream_overflow(
+    runtime_id: uuid::Uuid,
+    pane_id: Option<uuid::Uuid>,
+    dropped_count: u64,
+) -> v3::StreamOverflow {
+    v3::StreamOverflow {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        pane_id: pane_id.map(crate::uuid_to_bytes),
+        dropped_count,
+    }
+}
+
+/// Build a `ServerEnvelope` push event containing a `StreamOverflow`.
+#[must_use]
+pub fn build_stream_overflow_envelope(overflow: v3::StreamOverflow) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_push_envelope(v3::server_envelope::Payload::StreamOverflow(overflow))
+}
+
+/// Build a `ResyncRuntime` request.
+#[must_use]
+pub fn build_resync_runtime(runtime_id: uuid::Uuid) -> v3::ResyncRuntime {
+    v3::ResyncRuntime { runtime_id: crate::uuid_to_bytes(runtime_id) }
+}
+
+/// Build a `ClientEnvelope` for a `ResyncRuntime` request.
+#[must_use]
+pub fn build_resync_runtime_envelope(
+    id_gen: &crate::v3_envelope::RequestIdGenerator,
+    request: v3::ResyncRuntime,
+) -> v3::ClientEnvelope {
+    crate::v3_envelope::build_client_envelope(
+        id_gen,
+        v3::client_envelope::Command::ResyncRuntime(request),
+    )
+}
+
+/// Build a `ServerEnvelope` response containing a `RuntimeSnapshot` for resync.
+///
+/// This reuses the snapshot response builder — the wire format is identical
+/// to an attach snapshot response.
+#[must_use]
+pub fn build_resync_response(request_id: u64, snapshot: v3::RuntimeSnapshot) -> v3::ServerEnvelope {
+    crate::v3_snapshot::build_snapshot_response(request_id, snapshot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{decode_frame, encode_frame, uuid_to_bytes, v3_envelope::RequestIdGenerator};
+    use bytes::BytesMut;
+
+    fn rt() -> uuid::Uuid {
+        uuid::Uuid::new_v4()
+    }
+
+    fn pn() -> uuid::Uuid {
+        uuid::Uuid::new_v4()
+    }
+
+    // ── is_supported ──
+
+    #[test]
+    fn supported_when_capability_present() {
+        let caps =
+            vec![v3::Capability::CoreRuntimeLifecycle as i32, v3::Capability::OptResync as i32];
+        assert!(is_supported(&caps));
+    }
+
+    #[test]
+    fn not_supported_when_capability_absent() {
+        let caps = vec![
+            v3::Capability::CoreRuntimeLifecycle as i32,
+            v3::Capability::OptDiagnostics as i32,
+        ];
+        assert!(!is_supported(&caps));
+    }
+
+    #[test]
+    fn not_supported_with_empty_caps() {
+        assert!(!is_supported(&[]));
+    }
+
+    // ── build_stream_overflow ──
+
+    #[test]
+    fn stream_overflow_with_pane_id() {
+        let r = rt();
+        let p = pn();
+        let overflow = build_stream_overflow(r, Some(p), 42);
+        assert_eq!(overflow.runtime_id, uuid_to_bytes(r));
+        assert_eq!(overflow.pane_id, Some(uuid_to_bytes(p)));
+        assert_eq!(overflow.dropped_count, 42);
+    }
+
+    #[test]
+    fn stream_overflow_without_pane_id() {
+        let r = rt();
+        let overflow = build_stream_overflow(r, None, 10);
+        assert_eq!(overflow.runtime_id, uuid_to_bytes(r));
+        assert_eq!(overflow.pane_id, None);
+        assert_eq!(overflow.dropped_count, 10);
+    }
+
+    #[test]
+    fn stream_overflow_zero_dropped() {
+        let overflow = build_stream_overflow(rt(), None, 0);
+        assert_eq!(overflow.dropped_count, 0);
+    }
+
+    #[test]
+    fn stream_overflow_wire_roundtrip() {
+        for pane_id in [Some(pn()), None] {
+            let overflow = build_stream_overflow(rt(), pane_id, 100);
+            let mut buf = BytesMut::new();
+            encode_frame(&overflow, &mut buf).unwrap();
+            let decoded: v3::StreamOverflow = decode_frame(&mut buf).unwrap();
+            assert_eq!(overflow, decoded);
+        }
+    }
+
+    // ── build_stream_overflow_envelope ──
+
+    #[test]
+    fn stream_overflow_envelope_is_push_event() {
+        let overflow = build_stream_overflow(rt(), Some(pn()), 5);
+        let env = build_stream_overflow_envelope(overflow);
+        assert_eq!(env.request_id, 0);
+        assert!(crate::v3_envelope::is_push_event(&env));
+    }
+
+    #[test]
+    fn stream_overflow_envelope_contains_correct_payload() {
+        let r = rt();
+        let p = pn();
+        let overflow = build_stream_overflow(r, Some(p), 7);
+        let env = build_stream_overflow_envelope(overflow);
+        match env.payload {
+            Some(v3::server_envelope::Payload::StreamOverflow(ref so)) => {
+                assert_eq!(so.runtime_id, uuid_to_bytes(r));
+                assert_eq!(so.pane_id, Some(uuid_to_bytes(p)));
+                assert_eq!(so.dropped_count, 7);
+            }
+            _ => panic!("expected StreamOverflow payload"),
+        }
+    }
+
+    #[test]
+    fn stream_overflow_envelope_wire_roundtrip() {
+        let overflow = build_stream_overflow(rt(), None, 50);
+        let env = build_stream_overflow_envelope(overflow);
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    // ── build_resync_runtime ──
+
+    #[test]
+    fn resync_runtime_populates_runtime_id() {
+        let r = rt();
+        let req = build_resync_runtime(r);
+        assert_eq!(req.runtime_id, uuid_to_bytes(r));
+    }
+
+    #[test]
+    fn resync_runtime_wire_roundtrip() {
+        let req = build_resync_runtime(rt());
+        let mut buf = BytesMut::new();
+        encode_frame(&req, &mut buf).unwrap();
+        let decoded: v3::ResyncRuntime = decode_frame(&mut buf).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    // ── build_resync_runtime_envelope ──
+
+    #[test]
+    fn resync_envelope_has_nonzero_request_id() {
+        let id_gen = RequestIdGenerator::new();
+        let req = build_resync_runtime(rt());
+        let env = build_resync_runtime_envelope(&id_gen, req);
+        assert_ne!(env.request_id, 0);
+    }
+
+    #[test]
+    fn resync_envelope_contains_correct_command() {
+        let id_gen = RequestIdGenerator::new();
+        let r = rt();
+        let req = build_resync_runtime(r);
+        let env = build_resync_runtime_envelope(&id_gen, req);
+        match env.command {
+            Some(v3::client_envelope::Command::ResyncRuntime(ref rs)) => {
+                assert_eq!(rs.runtime_id, uuid_to_bytes(r));
+            }
+            _ => panic!("expected ResyncRuntime command"),
+        }
+    }
+
+    #[test]
+    fn resync_envelope_wire_roundtrip() {
+        let id_gen = RequestIdGenerator::new();
+        let req = build_resync_runtime(rt());
+        let env = build_resync_runtime_envelope(&id_gen, req);
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    // ── build_resync_response ──
+
+    #[test]
+    fn resync_response_echoes_request_id() {
+        let snap = crate::v3_snapshot::build_runtime_snapshot(
+            rt(),
+            42,
+            v3::RuntimeClientRole::Writer,
+            vec![],
+        );
+        let env = build_resync_response(7, snap.clone());
+        assert_eq!(env.request_id, 7);
+        match env.payload {
+            Some(v3::server_envelope::Payload::RuntimeSnapshot(ref s)) => {
+                assert_eq!(s, &snap);
+            }
+            _ => panic!("expected RuntimeSnapshot payload"),
+        }
+    }
+
+    #[test]
+    fn resync_response_is_not_push_event() {
+        let snap = crate::v3_snapshot::build_runtime_snapshot(
+            rt(),
+            1,
+            v3::RuntimeClientRole::Writer,
+            vec![],
+        );
+        let env = build_resync_response(42, snap);
+        assert!(!crate::v3_envelope::is_push_event(&env));
+    }
+
+    #[test]
+    fn resync_response_wire_roundtrip() {
+        let pane =
+            crate::v3_snapshot::build_pane_snapshot(crate::v3_snapshot::PaneSnapshotParams {
+                pane_id: pn(),
+                pane_output_seq: 50,
+                title: "bash".into(),
+                cwd: "/home".into(),
+                cols: 80,
+                rows: 24,
+                exit_status: None,
+                terminal_modes: v3::TerminalModeState::default(),
+                scrollback_tail: bytes::Bytes::from_static(b"$ "),
+                total_scrollback_bytes: 2,
+            });
+        let snap = crate::v3_snapshot::build_runtime_snapshot(
+            rt(),
+            99,
+            v3::RuntimeClientRole::Writer,
+            vec![pane],
+        );
+        let env = build_resync_response(55, snap);
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    // ── Integration: unsupported capability error ──
+
+    #[test]
+    fn unsupported_capability_error_for_resync() {
+        let err = crate::v3_error::build_error(
+            v3::ErrorKind::UnsupportedCapability,
+            "OPT_RESYNC not negotiated",
+            "ResyncRuntime",
+        );
+        let env = crate::v3_error::build_error_response(42, err);
+        assert_eq!(env.request_id, 42);
+        match env.payload {
+            Some(v3::server_envelope::Payload::Error(ref e)) => {
+                assert_eq!(e.kind, v3::ErrorKind::UnsupportedCapability as i32);
+                assert_eq!(e.operation, "ResyncRuntime");
+            }
+            _ => panic!("expected Error payload"),
+        }
+    }
+
+    // ── Integration: overflow → resync → snapshot flow ──
+
+    #[test]
+    fn overflow_triggers_resync_flow() {
+        let id_gen = RequestIdGenerator::new();
+        let r = rt();
+        let p = pn();
+
+        // 1. Server detects overflow and sends StreamOverflow push event
+        let overflow = build_stream_overflow(r, Some(p), 3);
+        let overflow_env = build_stream_overflow_envelope(overflow);
+        assert!(crate::v3_envelope::is_push_event(&overflow_env));
+
+        // 2. Client receives overflow and sends ResyncRuntime request
+        let resync_req = build_resync_runtime(r);
+        let resync_env = build_resync_runtime_envelope(&id_gen, resync_req);
+        let saved_request_id = resync_env.request_id;
+        assert_ne!(saved_request_id, 0);
+
+        // 3. Server responds with fresh RuntimeSnapshot
+        let pane =
+            crate::v3_snapshot::build_pane_snapshot(crate::v3_snapshot::PaneSnapshotParams {
+                pane_id: p,
+                pane_output_seq: 100,
+                title: "bash".into(),
+                cwd: "/home".into(),
+                cols: 80,
+                rows: 24,
+                exit_status: None,
+                terminal_modes: v3::TerminalModeState::default(),
+                scrollback_tail: bytes::Bytes::from_static(b"$ "),
+                total_scrollback_bytes: 2,
+            });
+        let snap = crate::v3_snapshot::build_runtime_snapshot(
+            r,
+            50,
+            v3::RuntimeClientRole::Writer,
+            vec![pane],
+        );
+        let snap_env = build_resync_response(saved_request_id, snap);
+        assert_eq!(snap_env.request_id, saved_request_id);
+        assert!(!crate::v3_envelope::is_push_event(&snap_env));
+    }
+
+    // ── Integration: gap detection triggers resync as fallback ──
+
+    #[test]
+    fn seq_gap_detection_as_resync_fallback() {
+        let id_gen = RequestIdGenerator::new();
+        let r = rt();
+
+        // Client detects a gap in pane_output_seq
+        let gap = crate::v3_snapshot::detect_output_seq_gap(5, 8);
+        assert_eq!(gap, Some(3));
+
+        // Client has OPT_RESYNC, so it sends ResyncRuntime
+        let caps =
+            vec![v3::Capability::CoreRuntimeLifecycle as i32, v3::Capability::OptResync as i32];
+        assert!(is_supported(&caps));
+
+        let req = build_resync_runtime(r);
+        let env = build_resync_runtime_envelope(&id_gen, req);
+        assert_ne!(env.request_id, 0);
+        match env.command {
+            Some(v3::client_envelope::Command::ResyncRuntime(ref rs)) => {
+                assert_eq!(rs.runtime_id, uuid_to_bytes(r));
+            }
+            _ => panic!("expected ResyncRuntime command"),
+        }
+    }
+
+    // ── Integration: without OPT_RESYNC, server sends disconnect error ──
+
+    #[test]
+    fn without_resync_server_disconnects_on_overflow() {
+        let caps = vec![v3::Capability::CoreRuntimeLifecycle as i32];
+        assert!(!is_supported(&caps));
+
+        // Server builds a stream overflow error to disconnect the client
+        let err = crate::v3_error::build_error(
+            v3::ErrorKind::StreamOverflow,
+            "push channel overflow; client does not support OPT_RESYNC",
+            "push",
+        );
+        assert!(err.retryable);
+
+        let env = crate::v3_error::build_error_response(0, err);
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+        match decoded.payload {
+            Some(v3::server_envelope::Payload::Error(ref e)) => {
+                assert_eq!(e.kind, v3::ErrorKind::StreamOverflow as i32);
+                assert!(e.retryable);
+            }
+            _ => panic!("expected Error payload"),
+        }
+    }
+}

--- a/services/rttx-server/tests/v3_proto_integration.rs
+++ b/services/rttx-server/tests/v3_proto_integration.rs
@@ -880,3 +880,180 @@ fn v3_chunked_scrollback_capability_gating() {
     assert_eq!(e.kind, v3::ErrorKind::UnsupportedCapability as i32);
     assert_eq!(e.operation, "GetScrollback");
 }
+
+// ── V3 resync integration tests (OPT_RESYNC) ──
+
+use rttx_proto::v3_resync;
+
+#[test]
+fn v3_resync_overflow_and_resync_roundtrip() {
+    let runtime_id = uuid::Uuid::new_v4();
+    let pane_id = uuid::Uuid::new_v4();
+    let id_gen = v3_envelope::RequestIdGenerator::new();
+
+    // 1. Server sends StreamOverflow push event
+    let overflow = v3_resync::build_stream_overflow(runtime_id, Some(pane_id), 5);
+    let overflow_env = v3_resync::build_stream_overflow_envelope(overflow);
+    assert!(v3_envelope::is_push_event(&overflow_env));
+
+    // Wire roundtrip for overflow
+    let mut buf = BytesMut::new();
+    encode_frame(&overflow_env, &mut buf).unwrap();
+    let decoded_overflow: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded_overflow.request_id, 0);
+    let Some(v3::server_envelope::Payload::StreamOverflow(so)) = decoded_overflow.payload else {
+        panic!("expected StreamOverflow");
+    };
+    assert_eq!(so.runtime_id, uuid_to_bytes(runtime_id));
+    assert_eq!(so.pane_id, Some(uuid_to_bytes(pane_id)));
+    assert_eq!(so.dropped_count, 5);
+
+    // 2. Client sends ResyncRuntime request
+    let resync_req = v3_resync::build_resync_runtime(runtime_id);
+    let resync_env = v3_resync::build_resync_runtime_envelope(&id_gen, resync_req);
+    assert_ne!(resync_env.request_id, 0);
+    let saved_request_id = resync_env.request_id;
+
+    // Wire roundtrip for resync request
+    let mut buf = BytesMut::new();
+    encode_frame(&resync_env, &mut buf).unwrap();
+    let decoded_resync: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded_resync.request_id, saved_request_id);
+    let Some(v3::client_envelope::Command::ResyncRuntime(rs)) = decoded_resync.command else {
+        panic!("expected ResyncRuntime command");
+    };
+    assert_eq!(rs.runtime_id, uuid_to_bytes(runtime_id));
+
+    // 3. Server responds with fresh RuntimeSnapshot
+    let pane = v3_snapshot::build_pane_snapshot(PaneSnapshotParams {
+        pane_id,
+        pane_output_seq: 200,
+        title: "bash".into(),
+        cwd: "/home/user".into(),
+        cols: 120,
+        rows: 40,
+        exit_status: None,
+        terminal_modes: v3::TerminalModeState::default(),
+        scrollback_tail: bytes::Bytes::from_static(b"$ ls\n"),
+        total_scrollback_bytes: 5,
+    });
+    let snapshot = v3_snapshot::build_runtime_snapshot(
+        runtime_id,
+        50,
+        v3::RuntimeClientRole::Writer,
+        vec![pane],
+    );
+    let snap_env = v3_resync::build_resync_response(saved_request_id, snapshot);
+    assert_eq!(snap_env.request_id, saved_request_id);
+    assert!(!v3_envelope::is_push_event(&snap_env));
+
+    // Wire roundtrip for snapshot response
+    let mut buf = BytesMut::new();
+    encode_frame(&snap_env, &mut buf).unwrap();
+    let decoded_snap: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(decoded_snap.request_id, saved_request_id);
+    let Some(v3::server_envelope::Payload::RuntimeSnapshot(snap)) = decoded_snap.payload else {
+        panic!("expected RuntimeSnapshot");
+    };
+    assert_eq!(snap.runtime_id, uuid_to_bytes(runtime_id));
+    assert_eq!(snap.runtime_revision, 50);
+    assert_eq!(snap.panes.len(), 1);
+    assert_eq!(snap.panes[0].pane_output_seq, 200);
+}
+
+#[test]
+fn v3_resync_capability_gating() {
+    // With OPT_RESYNC negotiated
+    let caps_with =
+        vec![v3::Capability::CoreRuntimeLifecycle as i32, v3::Capability::OptResync as i32];
+    assert!(v3_resync::is_supported(&caps_with));
+
+    // Without OPT_RESYNC
+    let caps_without = vec![v3::Capability::CoreRuntimeLifecycle as i32];
+    assert!(!v3_resync::is_supported(&caps_without));
+
+    // Server returns error when capability not negotiated
+    let err = rttx_proto::v3_error::build_error(
+        v3::ErrorKind::UnsupportedCapability,
+        "OPT_RESYNC not negotiated",
+        "ResyncRuntime",
+    );
+    let env = rttx_proto::v3_error::build_error_response(1, err);
+    let mut buf = BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    let Some(v3::server_envelope::Payload::Error(e)) = decoded.payload else {
+        panic!("expected Error payload");
+    };
+    assert_eq!(e.kind, v3::ErrorKind::UnsupportedCapability as i32);
+    assert_eq!(e.operation, "ResyncRuntime");
+}
+
+#[test]
+fn v3_resync_runtime_level_overflow() {
+    // Runtime-level overflow (no pane_id)
+    let runtime_id = uuid::Uuid::new_v4();
+    let overflow = v3_resync::build_stream_overflow(runtime_id, None, 10);
+    let env = v3_resync::build_stream_overflow_envelope(overflow);
+
+    let mut buf = BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    let Some(v3::server_envelope::Payload::StreamOverflow(so)) = decoded.payload else {
+        panic!("expected StreamOverflow");
+    };
+    assert_eq!(so.runtime_id, uuid_to_bytes(runtime_id));
+    assert!(so.pane_id.is_none());
+    assert_eq!(so.dropped_count, 10);
+}
+
+#[test]
+fn v3_resync_seq_gap_triggers_resync_when_supported() {
+    let id_gen = v3_envelope::RequestIdGenerator::new();
+    let runtime_id = uuid::Uuid::new_v4();
+
+    // Client detects gap in pane_output_seq
+    let gap = v3_snapshot::detect_output_seq_gap(10, 15);
+    assert_eq!(gap, Some(5));
+
+    // Client has OPT_RESYNC → sends ResyncRuntime
+    let caps = vec![v3::Capability::CoreRuntimeLifecycle as i32, v3::Capability::OptResync as i32];
+    assert!(v3_resync::is_supported(&caps));
+
+    let req = v3_resync::build_resync_runtime(runtime_id);
+    let env = v3_resync::build_resync_runtime_envelope(&id_gen, req);
+    assert_ne!(env.request_id, 0);
+
+    // Wire roundtrip
+    let mut buf = BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    let decoded: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+    let Some(v3::client_envelope::Command::ResyncRuntime(rs)) = decoded.command else {
+        panic!("expected ResyncRuntime");
+    };
+    assert_eq!(rs.runtime_id, uuid_to_bytes(runtime_id));
+}
+
+#[test]
+fn v3_without_resync_server_disconnects_client() {
+    // Without OPT_RESYNC, server sends ProtocolError with StreamOverflow kind
+    let caps = vec![v3::Capability::CoreRuntimeLifecycle as i32];
+    assert!(!v3_resync::is_supported(&caps));
+
+    let err = rttx_proto::v3_error::build_error(
+        v3::ErrorKind::StreamOverflow,
+        "push channel overflow; client does not support OPT_RESYNC — disconnecting",
+        "push",
+    );
+    assert!(err.retryable);
+
+    let env = rttx_proto::v3_error::build_error_response(0, err);
+    let mut buf = BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    let Some(v3::server_envelope::Payload::Error(e)) = decoded.payload else {
+        panic!("expected Error payload");
+    };
+    assert_eq!(e.kind, v3::ErrorKind::StreamOverflow as i32);
+    assert!(e.retryable);
+}


### PR DESCRIPTION
## What changed and why

Implements RFC-021 Section 8 `OPT_RESYNC` capability — protocol-level backpressure recovery for the v3 wire protocol.

When the server's bounded push channel drops messages for a client, it sends a `StreamOverflow` push event. The client requests `ResyncRuntime`, and the server responds with a fresh `RuntimeSnapshot`. Without `OPT_RESYNC`, the server forcibly disconnects the client (which reconnects automatically via the connection state machine).

### New module: `v3_resync`

- `is_supported()` — capability gating for `OPT_RESYNC`
- `build_stream_overflow()` — pane-level and runtime-level overflow events
- `build_stream_overflow_envelope()` — push event wrapper
- `build_resync_runtime()` — request builder
- `build_resync_runtime_envelope()` — with request/response correlation
- `build_resync_response()` — reuses snapshot response builder

Version bumped to 0.3.11 for protocol change.

## Manual verification

- `cargo test -p rttx-proto` — 243 tests pass (includes 24 new v3_resync unit tests)
- `cargo test -p rttx-server --test v3_proto_integration` — 34 tests pass (includes 5 new integration tests)
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass, zero failures

## Tests added

### Unit tests (v3_resync module, 24 tests):
- Capability gating: supported/not supported/empty caps
- StreamOverflow: with pane_id, without pane_id, zero dropped, wire roundtrip
- StreamOverflow envelope: push event classification, payload correctness, wire roundtrip
- ResyncRuntime: field population, wire roundtrip
- ResyncRuntime envelope: nonzero request_id, correct command, wire roundtrip
- Resync response: echoes request_id, not push event, wire roundtrip
- Integration: unsupported capability error, overflow→resync→snapshot flow, seq gap fallback, disconnect without OPT_RESYNC

### Integration tests (v3_proto_integration, 5 tests):
- `v3_resync_overflow_and_resync_roundtrip` — full overflow→resync→snapshot wire roundtrip
- `v3_resync_capability_gating` — supported/unsupported/error response
- `v3_resync_runtime_level_overflow` — runtime-level overflow (no pane_id)
- `v3_resync_seq_gap_triggers_resync_when_supported` — gap detection → resync
- `v3_without_resync_server_disconnects_client` — forced disconnect error

## Limitations / follow-ups

- Server-side `try_send` overflow detection and `StreamOverflow` emission will be implemented when the server adopts v3 protocol handling
- Client-side `pane_output_seq` gap detection triggering resync will be implemented in the GUI client v3 integration

Fixes #679