### PR TITLE
feat(proto): implement OPT_RUNTIME_TAKEOVER

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "bytes",
  "prost",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.12"
+version = "0.3.13"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.3.12',
+  version: '0.3.13',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/proto/rttx-v3.proto
+++ b/protocols/rttx-proto/proto/rttx-v3.proto
@@ -205,6 +205,28 @@ message AttachBlocked {
   uint32 read_only_client_count = 4;
 }
 
+// ─── Runtime takeover (OPT_RUNTIME_TAKEOVER) ─────────────────────────
+
+message TakeoverRuntime {
+  bytes runtime_id = 1;
+}
+
+message TakeoverCompleted {
+  bytes runtime_id = 1;
+  uint64 runtime_revision = 2;
+}
+
+message LeaseLost {
+  bytes runtime_id = 1;
+  uint64 runtime_revision = 2;
+  bytes new_owner_id = 3;
+}
+
+message OwnerDisconnected {
+  bytes runtime_id = 1;
+  uint64 runtime_revision = 2;
+}
+
 // ─── Runtime inventory ───────────────────────────────────────────────
 
 message RuntimeList {
@@ -430,6 +452,7 @@ message ClientEnvelope {
     TerminateRuntime terminate_runtime = 23;
     RenameRuntime rename_runtime = 24;
     ListRuntimes list_runtimes = 25;
+    TakeoverRuntime takeover_runtime = 26;  // OPT_RUNTIME_TAKEOVER
 
     // Pane lifecycle
     CreatePane create_pane = 30;
@@ -466,6 +489,9 @@ message ServerEnvelope {
     RuntimeRenamed runtime_renamed = 24;
     RuntimeList runtime_list = 25;
     AttachBlocked attach_blocked = 26;
+    TakeoverCompleted takeover_completed = 27;  // OPT_RUNTIME_TAKEOVER
+    LeaseLost lease_lost = 28;                  // OPT_RUNTIME_TAKEOVER
+    OwnerDisconnected owner_disconnected = 29;  // OPT_RUNTIME_TAKEOVER
 
     // Pane lifecycle events
     PaneCreated pane_created = 30;

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -50,6 +50,9 @@ pub mod v3_resync;
 /// V3 runtime inventory: capability gating, builders, and field stripping (RFC-021 Section 9, `OPT_RUNTIME_INVENTORY_V2`).
 pub mod v3_inventory;
 
+/// V3 runtime takeover: capability gating, builders, and lease events (RFC-021 Section 10, `OPT_RUNTIME_TAKEOVER`).
+pub mod v3_takeover;
+
 /// Convert a `uuid::Uuid` to protobuf bytes.
 #[must_use]
 pub fn uuid_to_bytes(id: uuid::Uuid) -> Vec<u8> {
@@ -866,6 +869,13 @@ mod v3_envelope_tests {
                 request_id: 12,
                 command: Some(v3::client_envelope::Command::GetDiagnostics(v3::GetDiagnostics {})),
             },
+            // Takeover (OPT_RUNTIME_TAKEOVER)
+            v3::ClientEnvelope {
+                request_id: 13,
+                command: Some(v3::client_envelope::Command::TakeoverRuntime(
+                    v3::TakeoverRuntime { runtime_id: rt.clone() },
+                )),
+            },
         ];
 
         for env in &envelopes {
@@ -1078,6 +1088,33 @@ mod v3_envelope_tests {
                     user_action_required: false,
                     retry_after_seconds: 0,
                 })),
+            },
+            // Takeover events (OPT_RUNTIME_TAKEOVER)
+            v3::ServerEnvelope {
+                request_id: 13,
+                payload: Some(v3::server_envelope::Payload::TakeoverCompleted(
+                    v3::TakeoverCompleted {
+                        runtime_id: rt.clone(),
+                        runtime_revision: 50,
+                    },
+                )),
+            },
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::LeaseLost(v3::LeaseLost {
+                    runtime_id: rt.clone(),
+                    runtime_revision: 51,
+                    new_owner_id: rid(),
+                })),
+            },
+            v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::OwnerDisconnected(
+                    v3::OwnerDisconnected {
+                        runtime_id: rt.clone(),
+                        runtime_revision: 52,
+                    },
+                )),
             },
         ];
 

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -872,9 +872,9 @@ mod v3_envelope_tests {
             // Takeover (OPT_RUNTIME_TAKEOVER)
             v3::ClientEnvelope {
                 request_id: 13,
-                command: Some(v3::client_envelope::Command::TakeoverRuntime(
-                    v3::TakeoverRuntime { runtime_id: rt.clone() },
-                )),
+                command: Some(v3::client_envelope::Command::TakeoverRuntime(v3::TakeoverRuntime {
+                    runtime_id: rt.clone(),
+                })),
             },
         ];
 
@@ -1093,10 +1093,7 @@ mod v3_envelope_tests {
             v3::ServerEnvelope {
                 request_id: 13,
                 payload: Some(v3::server_envelope::Payload::TakeoverCompleted(
-                    v3::TakeoverCompleted {
-                        runtime_id: rt.clone(),
-                        runtime_revision: 50,
-                    },
+                    v3::TakeoverCompleted { runtime_id: rt.clone(), runtime_revision: 50 },
                 )),
             },
             v3::ServerEnvelope {
@@ -1110,10 +1107,7 @@ mod v3_envelope_tests {
             v3::ServerEnvelope {
                 request_id: 0,
                 payload: Some(v3::server_envelope::Payload::OwnerDisconnected(
-                    v3::OwnerDisconnected {
-                        runtime_id: rt.clone(),
-                        runtime_revision: 52,
-                    },
+                    v3::OwnerDisconnected { runtime_id: rt.clone(), runtime_revision: 52 },
                 )),
             },
         ];

--- a/protocols/rttx-proto/src/v3_envelope.rs
+++ b/protocols/rttx-proto/src/v3_envelope.rs
@@ -272,6 +272,14 @@ mod tests {
         assert!(!is_fire_and_forget(&cmd));
     }
 
+    #[test]
+    fn takeover_runtime_is_not_fire_and_forget() {
+        let cmd = v3::client_envelope::Command::TakeoverRuntime(v3::TakeoverRuntime {
+            runtime_id: rid(),
+        });
+        assert!(!is_fire_and_forget(&cmd));
+    }
+
     // ── build_client_envelope ──
 
     #[test]

--- a/protocols/rttx-proto/src/v3_takeover.rs
+++ b/protocols/rttx-proto/src/v3_takeover.rs
@@ -1,0 +1,527 @@
+//! V3 runtime takeover: capability gating, builders, and lease events.
+//!
+//! Implements RFC-021 Section 10 (`OPT_RUNTIME_TAKEOVER`).
+//!
+//! Takeover is an explicit command, not a side effect of attach. One writer
+//! lease per runtime, zero or more readers. Without `OPT_RUNTIME_TAKEOVER`,
+//! the client shows "session busy" without a takeover option.
+//!
+//! Lease events:
+//! - `TakeoverCompleted` — response to the requesting client on success
+//! - `LeaseLost` — push event to the previous writer when their lease is taken
+//! - `OwnerDisconnected` — push event to readers when the writer disconnects
+
+use crate::v3;
+
+/// Check whether `OPT_RUNTIME_TAKEOVER` is in the effective capability set.
+#[must_use]
+pub fn is_supported(effective_caps: &[i32]) -> bool {
+    effective_caps.contains(&(v3::Capability::OptRuntimeTakeover as i32))
+}
+
+/// Build a `TakeoverRuntime` request.
+#[must_use]
+pub fn build_takeover_runtime(runtime_id: uuid::Uuid) -> v3::TakeoverRuntime {
+    v3::TakeoverRuntime { runtime_id: crate::uuid_to_bytes(runtime_id) }
+}
+
+/// Build a `ClientEnvelope` for a `TakeoverRuntime` request.
+#[must_use]
+pub fn build_takeover_runtime_envelope(
+    id_gen: &crate::v3_envelope::RequestIdGenerator,
+    request: v3::TakeoverRuntime,
+) -> v3::ClientEnvelope {
+    crate::v3_envelope::build_client_envelope(
+        id_gen,
+        v3::client_envelope::Command::TakeoverRuntime(request),
+    )
+}
+
+/// Build a `TakeoverCompleted` response.
+#[must_use]
+pub fn build_takeover_completed(
+    runtime_id: uuid::Uuid,
+    runtime_revision: u64,
+) -> v3::TakeoverCompleted {
+    v3::TakeoverCompleted {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        runtime_revision,
+    }
+}
+
+/// Build a `ServerEnvelope` response containing a `TakeoverCompleted`.
+#[must_use]
+pub fn build_takeover_completed_response(
+    request_id: u64,
+    completed: v3::TakeoverCompleted,
+) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_response_envelope(
+        request_id,
+        v3::server_envelope::Payload::TakeoverCompleted(completed),
+    )
+}
+
+/// Build a `LeaseLost` push event sent to the previous writer.
+#[must_use]
+pub fn build_lease_lost(
+    runtime_id: uuid::Uuid,
+    runtime_revision: u64,
+    new_owner_id: uuid::Uuid,
+) -> v3::LeaseLost {
+    v3::LeaseLost {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        runtime_revision,
+        new_owner_id: crate::uuid_to_bytes(new_owner_id),
+    }
+}
+
+/// Build a `ServerEnvelope` push event containing a `LeaseLost`.
+#[must_use]
+pub fn build_lease_lost_envelope(lease_lost: v3::LeaseLost) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_push_envelope(v3::server_envelope::Payload::LeaseLost(lease_lost))
+}
+
+/// Build an `OwnerDisconnected` push event sent to readers.
+#[must_use]
+pub fn build_owner_disconnected(
+    runtime_id: uuid::Uuid,
+    runtime_revision: u64,
+) -> v3::OwnerDisconnected {
+    v3::OwnerDisconnected {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        runtime_revision,
+    }
+}
+
+/// Build a `ServerEnvelope` push event containing an `OwnerDisconnected`.
+#[must_use]
+pub fn build_owner_disconnected_envelope(
+    disconnected: v3::OwnerDisconnected,
+) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_push_envelope(v3::server_envelope::Payload::OwnerDisconnected(
+        disconnected,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{decode_frame, encode_frame, uuid_to_bytes, v3_envelope::RequestIdGenerator};
+    use bytes::BytesMut;
+
+    fn rt() -> uuid::Uuid {
+        uuid::Uuid::new_v4()
+    }
+
+    fn client() -> uuid::Uuid {
+        uuid::Uuid::new_v4()
+    }
+
+    // ── is_supported ──
+
+    #[test]
+    fn supported_when_capability_present() {
+        let caps = vec![
+            v3::Capability::CoreRuntimeLifecycle as i32,
+            v3::Capability::OptRuntimeTakeover as i32,
+        ];
+        assert!(is_supported(&caps));
+    }
+
+    #[test]
+    fn not_supported_when_capability_absent() {
+        let caps = vec![
+            v3::Capability::CoreRuntimeLifecycle as i32,
+            v3::Capability::OptDiagnostics as i32,
+        ];
+        assert!(!is_supported(&caps));
+    }
+
+    #[test]
+    fn not_supported_with_empty_caps() {
+        assert!(!is_supported(&[]));
+    }
+
+    // ── build_takeover_runtime ──
+
+    #[test]
+    fn takeover_runtime_populates_runtime_id() {
+        let r = rt();
+        let req = build_takeover_runtime(r);
+        assert_eq!(req.runtime_id, uuid_to_bytes(r));
+    }
+
+    #[test]
+    fn takeover_runtime_wire_roundtrip() {
+        let req = build_takeover_runtime(rt());
+        let mut buf = BytesMut::new();
+        encode_frame(&req, &mut buf).unwrap();
+        let decoded: v3::TakeoverRuntime = decode_frame(&mut buf).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    // ── build_takeover_runtime_envelope ──
+
+    #[test]
+    fn takeover_envelope_has_nonzero_request_id() {
+        let id_gen = RequestIdGenerator::new();
+        let req = build_takeover_runtime(rt());
+        let env = build_takeover_runtime_envelope(&id_gen, req);
+        assert_ne!(env.request_id, 0);
+    }
+
+    #[test]
+    fn takeover_envelope_contains_correct_command() {
+        let id_gen = RequestIdGenerator::new();
+        let r = rt();
+        let req = build_takeover_runtime(r);
+        let env = build_takeover_runtime_envelope(&id_gen, req);
+        match env.command {
+            Some(v3::client_envelope::Command::TakeoverRuntime(ref tr)) => {
+                assert_eq!(tr.runtime_id, uuid_to_bytes(r));
+            }
+            _ => panic!("expected TakeoverRuntime command"),
+        }
+    }
+
+    #[test]
+    fn takeover_envelope_wire_roundtrip() {
+        let id_gen = RequestIdGenerator::new();
+        let req = build_takeover_runtime(rt());
+        let env = build_takeover_runtime_envelope(&id_gen, req);
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    // ── build_takeover_completed ──
+
+    #[test]
+    fn takeover_completed_populates_fields() {
+        let r = rt();
+        let completed = build_takeover_completed(r, 42);
+        assert_eq!(completed.runtime_id, uuid_to_bytes(r));
+        assert_eq!(completed.runtime_revision, 42);
+    }
+
+    #[test]
+    fn takeover_completed_wire_roundtrip() {
+        let completed = build_takeover_completed(rt(), 99);
+        let mut buf = BytesMut::new();
+        encode_frame(&completed, &mut buf).unwrap();
+        let decoded: v3::TakeoverCompleted = decode_frame(&mut buf).unwrap();
+        assert_eq!(completed, decoded);
+    }
+
+    // ── build_takeover_completed_response ──
+
+    #[test]
+    fn takeover_completed_response_echoes_request_id() {
+        let completed = build_takeover_completed(rt(), 10);
+        let env = build_takeover_completed_response(7, completed);
+        assert_eq!(env.request_id, 7);
+    }
+
+    #[test]
+    fn takeover_completed_response_contains_correct_payload() {
+        let r = rt();
+        let completed = build_takeover_completed(r, 20);
+        let env = build_takeover_completed_response(5, completed);
+        match env.payload {
+            Some(v3::server_envelope::Payload::TakeoverCompleted(ref tc)) => {
+                assert_eq!(tc.runtime_id, uuid_to_bytes(r));
+                assert_eq!(tc.runtime_revision, 20);
+            }
+            _ => panic!("expected TakeoverCompleted payload"),
+        }
+    }
+
+    #[test]
+    fn takeover_completed_response_is_not_push_event() {
+        let completed = build_takeover_completed(rt(), 1);
+        let env = build_takeover_completed_response(42, completed);
+        assert!(!crate::v3_envelope::is_push_event(&env));
+    }
+
+    #[test]
+    fn takeover_completed_response_wire_roundtrip() {
+        let completed = build_takeover_completed(rt(), 55);
+        let env = build_takeover_completed_response(33, completed);
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    // ── build_lease_lost ──
+
+    #[test]
+    fn lease_lost_populates_fields() {
+        let r = rt();
+        let new_owner = client();
+        let lost = build_lease_lost(r, 30, new_owner);
+        assert_eq!(lost.runtime_id, uuid_to_bytes(r));
+        assert_eq!(lost.runtime_revision, 30);
+        assert_eq!(lost.new_owner_id, uuid_to_bytes(new_owner));
+    }
+
+    #[test]
+    fn lease_lost_wire_roundtrip() {
+        let lost = build_lease_lost(rt(), 42, client());
+        let mut buf = BytesMut::new();
+        encode_frame(&lost, &mut buf).unwrap();
+        let decoded: v3::LeaseLost = decode_frame(&mut buf).unwrap();
+        assert_eq!(lost, decoded);
+    }
+
+    // ── build_lease_lost_envelope ──
+
+    #[test]
+    fn lease_lost_envelope_is_push_event() {
+        let lost = build_lease_lost(rt(), 10, client());
+        let env = build_lease_lost_envelope(lost);
+        assert_eq!(env.request_id, 0);
+        assert!(crate::v3_envelope::is_push_event(&env));
+    }
+
+    #[test]
+    fn lease_lost_envelope_contains_correct_payload() {
+        let r = rt();
+        let new_owner = client();
+        let lost = build_lease_lost(r, 15, new_owner);
+        let env = build_lease_lost_envelope(lost);
+        match env.payload {
+            Some(v3::server_envelope::Payload::LeaseLost(ref ll)) => {
+                assert_eq!(ll.runtime_id, uuid_to_bytes(r));
+                assert_eq!(ll.runtime_revision, 15);
+                assert_eq!(ll.new_owner_id, uuid_to_bytes(new_owner));
+            }
+            _ => panic!("expected LeaseLost payload"),
+        }
+    }
+
+    #[test]
+    fn lease_lost_envelope_wire_roundtrip() {
+        let lost = build_lease_lost(rt(), 50, client());
+        let env = build_lease_lost_envelope(lost);
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    // ── build_owner_disconnected ──
+
+    #[test]
+    fn owner_disconnected_populates_fields() {
+        let r = rt();
+        let disconnected = build_owner_disconnected(r, 25);
+        assert_eq!(disconnected.runtime_id, uuid_to_bytes(r));
+        assert_eq!(disconnected.runtime_revision, 25);
+    }
+
+    #[test]
+    fn owner_disconnected_wire_roundtrip() {
+        let disconnected = build_owner_disconnected(rt(), 77);
+        let mut buf = BytesMut::new();
+        encode_frame(&disconnected, &mut buf).unwrap();
+        let decoded: v3::OwnerDisconnected = decode_frame(&mut buf).unwrap();
+        assert_eq!(disconnected, decoded);
+    }
+
+    // ── build_owner_disconnected_envelope ──
+
+    #[test]
+    fn owner_disconnected_envelope_is_push_event() {
+        let disconnected = build_owner_disconnected(rt(), 10);
+        let env = build_owner_disconnected_envelope(disconnected);
+        assert_eq!(env.request_id, 0);
+        assert!(crate::v3_envelope::is_push_event(&env));
+    }
+
+    #[test]
+    fn owner_disconnected_envelope_contains_correct_payload() {
+        let r = rt();
+        let disconnected = build_owner_disconnected(r, 33);
+        let env = build_owner_disconnected_envelope(disconnected);
+        match env.payload {
+            Some(v3::server_envelope::Payload::OwnerDisconnected(ref od)) => {
+                assert_eq!(od.runtime_id, uuid_to_bytes(r));
+                assert_eq!(od.runtime_revision, 33);
+            }
+            _ => panic!("expected OwnerDisconnected payload"),
+        }
+    }
+
+    #[test]
+    fn owner_disconnected_envelope_wire_roundtrip() {
+        let disconnected = build_owner_disconnected(rt(), 88);
+        let env = build_owner_disconnected_envelope(disconnected);
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+    }
+
+    // ── Integration: unsupported capability error ──
+
+    #[test]
+    fn unsupported_capability_error_for_takeover() {
+        let err = crate::v3_error::build_error(
+            v3::ErrorKind::UnsupportedCapability,
+            "OPT_RUNTIME_TAKEOVER not negotiated",
+            "TakeoverRuntime",
+        );
+        let env = crate::v3_error::build_error_response(42, err);
+        assert_eq!(env.request_id, 42);
+        match env.payload {
+            Some(v3::server_envelope::Payload::Error(ref e)) => {
+                assert_eq!(e.kind, v3::ErrorKind::UnsupportedCapability as i32);
+                assert_eq!(e.operation, "TakeoverRuntime");
+            }
+            _ => panic!("expected Error payload"),
+        }
+    }
+
+    // ── Integration: ownership conflict without takeover capability ──
+
+    #[test]
+    fn ownership_conflict_without_takeover() {
+        let caps = vec![v3::Capability::CoreRuntimeLifecycle as i32];
+        assert!(!is_supported(&caps));
+
+        let err = crate::v3_error::build_error(
+            v3::ErrorKind::OwnershipConflict,
+            "runtime owned by another client; takeover not available",
+            "AttachRuntime",
+        );
+        let env = crate::v3_error::build_error_response(10, err);
+        match env.payload {
+            Some(v3::server_envelope::Payload::Error(ref e)) => {
+                assert_eq!(e.kind, v3::ErrorKind::OwnershipConflict as i32);
+                assert!(!e.retryable);
+            }
+            _ => panic!("expected Error payload"),
+        }
+    }
+
+    // ── Integration: takeover_required error ──
+
+    #[test]
+    fn takeover_required_error() {
+        let err = crate::v3_error::build_error(
+            v3::ErrorKind::TakeoverRequired,
+            "runtime has an active writer; use TakeoverRuntime to claim it",
+            "AttachRuntime",
+        );
+        assert!(!err.retryable);
+        assert!(err.user_action_required);
+    }
+
+    // ── Integration: full takeover flow ──
+
+    #[test]
+    fn full_takeover_flow() {
+        let id_gen = RequestIdGenerator::new();
+        let r = rt();
+        let old_owner = client();
+        let new_owner = client();
+
+        // 1. Client sends TakeoverRuntime request
+        let req = build_takeover_runtime(r);
+        let req_env = build_takeover_runtime_envelope(&id_gen, req);
+        let saved_request_id = req_env.request_id;
+        assert_ne!(saved_request_id, 0);
+
+        // 2. Server sends LeaseLost to the previous writer
+        let lost = build_lease_lost(r, 50, new_owner);
+        let lost_env = build_lease_lost_envelope(lost);
+        assert!(crate::v3_envelope::is_push_event(&lost_env));
+        match lost_env.payload {
+            Some(v3::server_envelope::Payload::LeaseLost(ref ll)) => {
+                assert_eq!(ll.new_owner_id, uuid_to_bytes(new_owner));
+            }
+            _ => panic!("expected LeaseLost"),
+        }
+
+        // 3. Server responds to the requesting client with TakeoverCompleted
+        let completed = build_takeover_completed(r, 51);
+        let completed_env = build_takeover_completed_response(saved_request_id, completed);
+        assert_eq!(completed_env.request_id, saved_request_id);
+        assert!(!crate::v3_envelope::is_push_event(&completed_env));
+
+        // Verify the old owner ID is not in the completed response (it's only in LeaseLost)
+        match completed_env.payload {
+            Some(v3::server_envelope::Payload::TakeoverCompleted(ref tc)) => {
+                assert_eq!(tc.runtime_id, uuid_to_bytes(r));
+                assert_eq!(tc.runtime_revision, 51);
+            }
+            _ => panic!("expected TakeoverCompleted"),
+        }
+
+        // 4. Verify old_owner and new_owner are distinct
+        assert_ne!(uuid_to_bytes(old_owner), uuid_to_bytes(new_owner));
+    }
+
+    // ── Integration: owner disconnect notifies readers ──
+
+    #[test]
+    fn owner_disconnect_notifies_readers() {
+        let r = rt();
+
+        // Writer disconnects; server sends OwnerDisconnected to all readers
+        let disconnected = build_owner_disconnected(r, 60);
+        let env = build_owner_disconnected_envelope(disconnected);
+        assert!(crate::v3_envelope::is_push_event(&env));
+        match env.payload {
+            Some(v3::server_envelope::Payload::OwnerDisconnected(ref od)) => {
+                assert_eq!(od.runtime_id, uuid_to_bytes(r));
+                assert_eq!(od.runtime_revision, 60);
+            }
+            _ => panic!("expected OwnerDisconnected"),
+        }
+    }
+
+    // ── Integration: attach blocked then takeover ──
+
+    #[test]
+    fn attach_blocked_then_takeover() {
+        let id_gen = RequestIdGenerator::new();
+        let r = rt();
+
+        // 1. Client tries read-write attach, gets AttachBlocked
+        let blocked = v3::AttachBlocked {
+            runtime_id: uuid_to_bytes(r),
+            current_client_role: v3::RuntimeClientRole::Unattached as i32,
+            attached_client_count: 1,
+            read_only_client_count: 0,
+        };
+        let blocked_env = crate::v3_envelope::build_response_envelope(
+            1,
+            v3::server_envelope::Payload::AttachBlocked(blocked),
+        );
+        match blocked_env.payload {
+            Some(v3::server_envelope::Payload::AttachBlocked(ref ab)) => {
+                assert_eq!(ab.attached_client_count, 1);
+            }
+            _ => panic!("expected AttachBlocked"),
+        }
+
+        // 2. Client has OPT_RUNTIME_TAKEOVER, so it sends TakeoverRuntime
+        let caps = vec![
+            v3::Capability::CoreRuntimeLifecycle as i32,
+            v3::Capability::OptRuntimeTakeover as i32,
+        ];
+        assert!(is_supported(&caps));
+
+        let req = build_takeover_runtime(r);
+        let env = build_takeover_runtime_envelope(&id_gen, req);
+        assert_ne!(env.request_id, 0);
+
+        // 3. Server responds with TakeoverCompleted
+        let completed = build_takeover_completed(r, 70);
+        let resp = build_takeover_completed_response(env.request_id, completed);
+        assert_eq!(resp.request_id, env.request_id);
+    }
+}

--- a/protocols/rttx-proto/src/v3_takeover.rs
+++ b/protocols/rttx-proto/src/v3_takeover.rs
@@ -43,10 +43,7 @@ pub fn build_takeover_completed(
     runtime_id: uuid::Uuid,
     runtime_revision: u64,
 ) -> v3::TakeoverCompleted {
-    v3::TakeoverCompleted {
-        runtime_id: crate::uuid_to_bytes(runtime_id),
-        runtime_revision,
-    }
+    v3::TakeoverCompleted { runtime_id: crate::uuid_to_bytes(runtime_id), runtime_revision }
 }
 
 /// Build a `ServerEnvelope` response containing a `TakeoverCompleted`.
@@ -87,10 +84,7 @@ pub fn build_owner_disconnected(
     runtime_id: uuid::Uuid,
     runtime_revision: u64,
 ) -> v3::OwnerDisconnected {
-    v3::OwnerDisconnected {
-        runtime_id: crate::uuid_to_bytes(runtime_id),
-        runtime_revision,
-    }
+    v3::OwnerDisconnected { runtime_id: crate::uuid_to_bytes(runtime_id), runtime_revision }
 }
 
 /// Build a `ServerEnvelope` push event containing an `OwnerDisconnected`.

--- a/services/rttx-server/tests/v3_takeover.rs
+++ b/services/rttx-server/tests/v3_takeover.rs
@@ -1,0 +1,143 @@
+//! Integration tests for v3 `OPT_RUNTIME_TAKEOVER` protocol builders.
+//!
+//! Validates the end-to-end flow: build takeover request, receive lease
+//! events, gate on capability, and verify wire roundtrip through envelopes.
+
+use rttx_proto::v3;
+use rttx_proto::v3_envelope::RequestIdGenerator;
+use rttx_proto::v3_takeover;
+use rttx_proto::{decode_frame, encode_frame, uuid_to_bytes};
+
+fn rt() -> uuid::Uuid {
+    uuid::Uuid::new_v4()
+}
+
+fn client() -> uuid::Uuid {
+    uuid::Uuid::new_v4()
+}
+
+#[test]
+fn v3_takeover_full_flow_wire_roundtrip() {
+    let id_gen = RequestIdGenerator::new();
+    let r = rt();
+    let new_owner = client();
+
+    // 1. Client sends TakeoverRuntime request
+    let req = v3_takeover::build_takeover_runtime(r);
+    let req_env = v3_takeover::build_takeover_runtime_envelope(&id_gen, req);
+    let mut buf = bytes::BytesMut::new();
+    encode_frame(&req_env, &mut buf).unwrap();
+    let decoded_req: v3::ClientEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(req_env, decoded_req);
+    assert_ne!(decoded_req.request_id, 0);
+
+    // 2. Server sends LeaseLost push event to previous writer
+    let lost = v3_takeover::build_lease_lost(r, 50, new_owner);
+    let lost_env = v3_takeover::build_lease_lost_envelope(lost);
+    let mut buf = bytes::BytesMut::new();
+    encode_frame(&lost_env, &mut buf).unwrap();
+    let decoded_lost: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(lost_env, decoded_lost);
+    assert_eq!(decoded_lost.request_id, 0);
+
+    // 3. Server responds with TakeoverCompleted
+    let completed = v3_takeover::build_takeover_completed(r, 51);
+    let resp_env =
+        v3_takeover::build_takeover_completed_response(decoded_req.request_id, completed);
+    let mut buf = bytes::BytesMut::new();
+    encode_frame(&resp_env, &mut buf).unwrap();
+    let decoded_resp: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(resp_env, decoded_resp);
+    assert_eq!(decoded_resp.request_id, decoded_req.request_id);
+
+    // Verify payload contents
+    let v3::server_envelope::Payload::TakeoverCompleted(ref tc) = decoded_resp.payload.unwrap()
+    else {
+        panic!("expected TakeoverCompleted payload");
+    };
+    assert_eq!(tc.runtime_id, uuid_to_bytes(r));
+    assert_eq!(tc.runtime_revision, 51);
+}
+
+#[test]
+fn v3_takeover_capability_gating_rejects_when_absent() {
+    let caps_without_takeover =
+        vec![v3::Capability::CoreRuntimeLifecycle as i32, v3::Capability::CorePaneLifecycle as i32];
+    assert!(!v3_takeover::is_supported(&caps_without_takeover));
+
+    // Server returns OwnershipConflict error instead of allowing takeover
+    let err = rttx_proto::v3_error::build_error(
+        v3::ErrorKind::OwnershipConflict,
+        "runtime owned by another client; takeover not available",
+        "AttachRuntime",
+    );
+    let env = rttx_proto::v3_error::build_error_response(1, err);
+    let mut buf = bytes::BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    let v3::server_envelope::Payload::Error(ref e) = decoded.payload.unwrap() else {
+        panic!("expected Error payload");
+    };
+    assert_eq!(e.kind, v3::ErrorKind::OwnershipConflict as i32);
+    assert!(!e.retryable);
+}
+
+#[test]
+fn v3_takeover_owner_disconnected_notifies_readers() {
+    let r = rt();
+
+    let disconnected = v3_takeover::build_owner_disconnected(r, 60);
+    let env = v3_takeover::build_owner_disconnected_envelope(disconnected);
+    let mut buf = bytes::BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(env, decoded);
+    assert_eq!(decoded.request_id, 0);
+
+    let v3::server_envelope::Payload::OwnerDisconnected(ref od) = decoded.payload.unwrap() else {
+        panic!("expected OwnerDisconnected payload");
+    };
+    assert_eq!(od.runtime_id, uuid_to_bytes(r));
+    assert_eq!(od.runtime_revision, 60);
+}
+
+#[test]
+fn v3_takeover_attach_blocked_then_takeover_flow() {
+    let id_gen = RequestIdGenerator::new();
+    let r = rt();
+
+    // 1. Attach is blocked
+    let blocked = v3::AttachBlocked {
+        runtime_id: uuid_to_bytes(r),
+        current_client_role: v3::RuntimeClientRole::Unattached as i32,
+        attached_client_count: 1,
+        read_only_client_count: 0,
+    };
+    let blocked_env = rttx_proto::v3_envelope::build_response_envelope(
+        1,
+        v3::server_envelope::Payload::AttachBlocked(blocked),
+    );
+    let mut buf = bytes::BytesMut::new();
+    encode_frame(&blocked_env, &mut buf).unwrap();
+    let decoded_blocked: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(blocked_env, decoded_blocked);
+
+    // 2. Client has OPT_RUNTIME_TAKEOVER, sends takeover
+    let caps = vec![
+        v3::Capability::CoreRuntimeLifecycle as i32,
+        v3::Capability::OptRuntimeTakeover as i32,
+    ];
+    assert!(v3_takeover::is_supported(&caps));
+
+    let req = v3_takeover::build_takeover_runtime(r);
+    let req_env = v3_takeover::build_takeover_runtime_envelope(&id_gen, req);
+
+    // 3. Server responds with TakeoverCompleted
+    let completed = v3_takeover::build_takeover_completed(r, 70);
+    let resp = v3_takeover::build_takeover_completed_response(req_env.request_id, completed);
+    let mut buf = bytes::BytesMut::new();
+    encode_frame(&resp, &mut buf).unwrap();
+    let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+    assert_eq!(resp, decoded);
+    assert_eq!(decoded.request_id, req_env.request_id);
+}


### PR DESCRIPTION
## What changed and why

Implements RFC-021 Step 12 — explicit runtime takeover and lease events for the v3 protocol.

**Proto messages added:**
- `TakeoverRuntime` — client command to take over a runtime from another writer (field 26 in `ClientEnvelope`)
- `TakeoverCompleted` — server response confirming takeover succeeded (field 27 in `ServerEnvelope`)
- `LeaseLost` — push event to the previous writer when their lease is taken (field 28)
- `OwnerDisconnected` — push event to readers when the writer disconnects (field 29)

**Rust module added:**
- `v3_takeover` — capability gating (`is_supported`), builders for all messages and envelopes, following the same pattern as `v3_resync` and `v3_inventory`

**Design:**
- Takeover is an explicit command, not a side effect of attach
- Gated by `OPT_RUNTIME_TAKEOVER` capability — without it, client shows "session busy" without takeover option
- One writer lease per runtime, zero or more readers
- `LeaseLost` carries the new owner's client ID so the previous writer can display context
- `OwnerDisconnected` notifies readers when the writer leaves

## Manual verification

- `cargo build -p rttx-proto -p rttx-server` — builds clean
- `cargo build -p rttx --no-default-features --features vte-0_76` — client builds clean
- `bash .github/scripts/run-clippy.sh` — no warnings
- `bash .github/scripts/run-quality-tests.sh` — all pass

## Tests added

31 new tests in `v3_takeover` module covering:
- Capability gating (`is_supported` / not supported / empty caps)
- Message builders (`build_takeover_runtime`, `build_takeover_completed`, `build_lease_lost`, `build_owner_disconnected`)
- Envelope builders (request IDs, payload types, push event classification)
- Wire roundtrips for all messages and envelopes
- Integration: unsupported capability error, ownership conflict without takeover, takeover_required error
- Integration: full takeover flow (request → lease lost → completed)
- Integration: owner disconnect notifies readers
- Integration: attach blocked then takeover

Existing envelope roundtrip tests updated to include all new message types.
Fire-and-forget classification test added for `TakeoverRuntime`.

## Tests run

- `cargo test -p rttx-proto` — 309 passed (was 278)
- `cargo test -p rttx-server` — all pass
- `cargo test -p rttx --no-default-features --features vte-0_76` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass

Fixes #681