### PR TITLE
feat(client): wire v3 protocol into GUI daemon connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,13 +1250,14 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "bytes",
  "gtk4",
  "libadwaita",
  "pretty_assertions",
  "proptest",
+ "prost",
  "rstest",
  "rttx-proto",
  "serde",
@@ -1273,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "bytes",
  "prost",
@@ -1284,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1292,6 +1293,7 @@ dependencies = [
  "daemonize",
  "nix",
  "pretty_assertions",
+ "prost",
  "pty-process",
  "rttx-proto",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.15"
+version = "0.3.16"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/Cargo.toml
+++ b/clients/rttx/Cargo.toml
@@ -49,6 +49,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rttx-proto = { path = "../../protocols/rttx-proto" }
+prost = "0.13"
 bytes = "1"
 tokio = { version = "1", features = ["net", "io-util", "sync", "rt", "rt-multi-thread", "macros", "process", "time"] }
 thiserror = "2"

--- a/clients/rttx/src/connect_existing_dialog.rs
+++ b/clients/rttx/src/connect_existing_dialog.rs
@@ -1,7 +1,7 @@
 use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
-use rttx_proto::proto;
+use rttx_proto::v3;
 
 use crate::host::Host;
 use crate::window::Window;
@@ -32,7 +32,7 @@ pub struct RuntimeEntry {
 /// `open_runtime_ids` contains runtime IDs already attached by this client.
 #[must_use]
 pub fn classify_runtimes(
-    runtimes: &[proto::RuntimeInfo],
+    runtimes: &[v3::RuntimeInfo],
     open_runtime_ids: &[String],
 ) -> Vec<RuntimeEntry> {
     runtimes
@@ -77,7 +77,7 @@ pub fn matches_query(entry: &RuntimeEntry, query: &str) -> bool {
 }
 
 /// Show the Connect to Existing dialog for a specific host.
-pub fn show(window: &Window, host: &Host, runtimes: &[proto::RuntimeInfo]) {
+pub fn show(window: &Window, host: &Host, runtimes: &[v3::RuntimeInfo]) {
     let title = format!("Connect to Existing: {}", host.name);
     let dialog = adw::Dialog::builder().title(&title).content_width(400).build();
 
@@ -244,21 +244,21 @@ mod tests {
         name: &str,
         pane_count: u32,
         has_write_owner: bool,
-    ) -> proto::RuntimeInfo {
-        proto::RuntimeInfo {
+    ) -> v3::RuntimeInfo {
+        v3::RuntimeInfo {
             id: rttx_proto::uuid_to_bytes(id),
             name: name.into(),
             pane_count,
-            has_attached_client: has_write_owner,
-            active_pane_id: None,
-            panes: vec![],
-            policy: 0,
-            attached_client_count: u32::from(has_write_owner),
-            reconstructed: false,
-            revision: 1,
-            current_client_role: 0,
             has_write_owner,
+            policy: 0,
             read_only_client_count: 0,
+            current_client_role: 0,
+            runtime_revision: 1,
+            reconstructed: false,
+            active_pane_summary: String::new(),
+            takeover_eligible: false,
+            disabled_reason: String::new(),
+            panes: vec![],
         }
     }
 

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -7,10 +7,9 @@
 //! from the glib main loop. This module has no GTK dependency.
 
 use bytes::BytesMut;
-use rttx_proto::{
-    PROTOCOL_VERSION, bytes_to_uuid, decode_frame, encode_frame, proto, uuid_to_bytes,
-};
+use rttx_proto::{bytes_to_uuid, decode_frame, encode_frame, uuid_to_bytes, v3, v3_handshake};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::UnixStream;
 use uuid::Uuid;
@@ -60,7 +59,18 @@ pub enum DaemonError {
         client: u32,
     },
 
-    /// Server returned an error message.
+    /// Server returned a typed v3 protocol error.
+    #[error("server error: {message}")]
+    ProtocolError {
+        /// Error kind from the server.
+        kind: v3::ErrorKind,
+        /// Human-readable error message.
+        message: String,
+        /// Whether the error is retryable.
+        retryable: bool,
+    },
+
+    /// Server returned a legacy v2 error message.
     #[error("server error ({code}): {message}")]
     ServerError {
         /// Error code from the server.
@@ -75,7 +85,7 @@ pub enum DaemonError {
 
     /// Attach was blocked because another client already owns the runtime.
     #[error("runtime attach blocked")]
-    AttachBlocked(proto::AttachBlocked),
+    AttachBlocked(v3::AttachBlocked),
 
     /// Connection was closed by the server.
     #[error("connection closed")]
@@ -85,9 +95,24 @@ pub enum DaemonError {
 /// Successful detach outcome from the daemon.
 #[derive(Debug, Clone)]
 pub enum DetachResponse {
-    Detached(proto::RuntimeDetached),
-    Terminated(proto::RuntimeTerminated),
+    Detached(v3::RuntimeDetached),
+    Terminated(v3::RuntimeTerminated),
 }
+
+/// Client capabilities advertised during v3 handshake.
+const CLIENT_CAPABILITIES: &[v3::Capability] = &[
+    v3::Capability::CoreRuntimeLifecycle,
+    v3::Capability::CorePaneLifecycle,
+    v3::Capability::CoreTerminalIo,
+    v3::Capability::CoreTerminalModes,
+    v3::Capability::CorePasteIntent,
+    v3::Capability::CoreFocusEvents,
+    v3::Capability::OptRuntimeInventoryV2,
+    v3::Capability::OptResync,
+    v3::Capability::OptChunkedScrollback,
+    v3::Capability::OptDiagnostics,
+    v3::Capability::OptRuntimeTakeover,
+];
 
 /// A connection to a running `rttx-server` instance (pre-split).
 ///
@@ -100,6 +125,8 @@ pub struct DaemonConnection {
     writer: Box<dyn AsyncWrite + Unpin + Send>,
     read_buf: BytesMut,
     client_id: Uuid,
+    effective_caps: Vec<i32>,
+    id_gen: RequestIdGenerator,
 }
 
 impl std::fmt::Debug for DaemonConnection {
@@ -107,6 +134,23 @@ impl std::fmt::Debug for DaemonConnection {
         f.debug_struct("DaemonConnection")
             .field("client_id", &self.client_id)
             .finish_non_exhaustive()
+    }
+}
+
+/// Atomic request ID generator for v3 envelope correlation.
+#[derive(Debug)]
+struct RequestIdGenerator {
+    next: AtomicU64,
+}
+
+impl RequestIdGenerator {
+    const fn new() -> Self {
+        Self { next: AtomicU64::new(1) }
+    }
+
+    fn next_id(&self) -> u64 {
+        let id = self.next.fetch_add(1, Ordering::Relaxed);
+        if id == 0 { self.next.fetch_add(1, Ordering::Relaxed) } else { id }
     }
 }
 
@@ -120,16 +164,14 @@ impl DaemonConnection {
             writer: Box::new(write_half),
             read_buf: BytesMut::with_capacity(8192),
             client_id: Uuid::new_v4(),
+            effective_caps: Vec::new(),
+            id_gen: RequestIdGenerator::new(),
         };
         conn.handshake().await?;
         Ok(conn)
     }
 
     /// Connect to `rttx-server` on a remote host via SSH.
-    ///
-    /// Spawns `ssh <host> rttx-server attach-stdio` and speaks the protocol
-    /// over the subprocess's stdin/stdout. The returned `SshHandle` must be
-    /// kept alive for the connection to persist.
     pub async fn connect_ssh(host: &str) -> Result<(Self, SshHandle), DaemonError> {
         let mut child = tokio::process::Command::new("ssh")
             .args(["-o", "BatchMode=yes"])
@@ -154,6 +196,8 @@ impl DaemonConnection {
             writer: Box::new(child_stdin),
             read_buf: BytesMut::with_capacity(8192),
             client_id: Uuid::new_v4(),
+            effective_caps: Vec::new(),
+            id_gen: RequestIdGenerator::new(),
         };
         conn.handshake().await?;
         Ok((conn, SshHandle { child }))
@@ -164,24 +208,33 @@ impl DaemonConnection {
     pub fn into_split(self) -> (DaemonReader, DaemonWriter) {
         (
             DaemonReader { stream: self.reader, read_buf: self.read_buf },
-            DaemonWriter { stream: self.writer },
+            DaemonWriter { stream: self.writer, id_gen: self.id_gen },
         )
     }
 
-    /// Send a client message to the daemon.
-    pub(crate) async fn send(&mut self, msg: &proto::ClientMessage) -> Result<(), DaemonError> {
+    /// Return the effective capabilities negotiated during handshake.
+    #[must_use]
+    pub fn effective_caps(&self) -> &[i32] {
+        &self.effective_caps
+    }
+
+    /// Send a v3 client envelope to the daemon.
+    pub(crate) async fn send_envelope(
+        &mut self,
+        env: &v3::ClientEnvelope,
+    ) -> Result<(), DaemonError> {
         let mut buf = BytesMut::new();
-        encode_frame(msg, &mut buf)?;
+        encode_frame(env, &mut buf)?;
         self.writer.write_all(&buf).await?;
         self.writer.flush().await?;
         Ok(())
     }
 
-    /// Read the next server message. Returns `None` on clean disconnect.
-    pub async fn recv(&mut self) -> Result<Option<proto::ServerMessage>, DaemonError> {
+    /// Read the next v3 server envelope. Returns `None` on clean disconnect.
+    pub async fn recv_envelope(&mut self) -> Result<Option<v3::ServerEnvelope>, DaemonError> {
         loop {
-            match decode_frame::<proto::ServerMessage>(&mut self.read_buf) {
-                Ok(msg) => return Ok(Some(msg)),
+            match decode_frame::<v3::ServerEnvelope>(&mut self.read_buf) {
+                Ok(env) => return Ok(Some(env)),
                 Err(rttx_proto::FrameError::Incomplete) => {}
                 Err(e) => return Err(DaemonError::Frame(e)),
             }
@@ -192,105 +245,153 @@ impl DaemonConnection {
         }
     }
 
-    /// Perform the Hello/HelloAck handshake.
+    /// Send a request and wait for the correlated response, dispatching
+    /// push events encountered along the way.
+    async fn request(
+        &mut self,
+        command: v3::client_envelope::Command,
+    ) -> Result<v3::ServerEnvelope, DaemonError> {
+        let request_id = self.id_gen.next_id();
+        let env = v3::ClientEnvelope { request_id, command: Some(command) };
+        self.send_envelope(&env).await?;
+        loop {
+            let response = self.recv_envelope().await?.ok_or(DaemonError::Disconnected)?;
+            if response.request_id == request_id {
+                return Ok(response);
+            }
+            // Push event (request_id == 0) — skip during request/response.
+        }
+    }
+
+    /// Perform the v3 `ClientHello`/`ServerHello` handshake.
     async fn handshake(&mut self) -> Result<(), DaemonError> {
-        let hello = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Hello(proto::Hello {
-                protocol_version: PROTOCOL_VERSION,
-                client_id: uuid_to_bytes(self.client_id),
-            })),
-        };
-        self.send(&hello).await?;
+        let client_hello = v3_handshake::build_client_hello(
+            self.client_id,
+            "rttx",
+            env!("CARGO_PKG_VERSION"),
+            CLIENT_CAPABILITIES,
+        );
+        let mut buf = BytesMut::new();
+        encode_frame(&client_hello, &mut buf)?;
+        self.writer.write_all(&buf).await?;
+        self.writer.flush().await?;
 
-        let response = self.recv().await?.ok_or(DaemonError::Disconnected)?;
-        match response.msg {
-            Some(proto::server_message::Msg::HelloAck(ack)) => {
-                if ack.protocol_version != PROTOCOL_VERSION {
-                    return Err(DaemonError::VersionMismatch {
-                        server: ack.protocol_version,
-                        client: PROTOCOL_VERSION,
-                    });
+        // Server responds with bare ServerHello (not wrapped in ServerEnvelope).
+        // Read the raw frame and try to decode as ServerHello or ProtocolError.
+        let raw = self.read_raw_frame().await?.ok_or(DaemonError::Disconnected)?;
+        let payload = &raw[4..]; // skip 4-byte length prefix
+
+        // Try ServerHello first.
+        if let Ok(server_hello) = <v3::ServerHello as prost::Message>::decode(payload) {
+            if let Err(missing) =
+                v3_handshake::validate_server_capabilities(&server_hello.capabilities)
+            {
+                let err = v3_handshake::missing_capabilities_error(&missing);
+                return Err(DaemonError::ProtocolError {
+                    kind: v3::ErrorKind::try_from(err.kind).unwrap_or(v3::ErrorKind::Unspecified),
+                    message: err.message,
+                    retryable: false,
+                });
+            }
+            let client_caps: Vec<i32> = CLIENT_CAPABILITIES.iter().map(|c| *c as i32).collect();
+            self.effective_caps =
+                v3_handshake::effective_capabilities(&client_caps, &server_hello.capabilities);
+            return Ok(());
+        }
+
+        // Try ProtocolError.
+        if let Ok(err) = <v3::ProtocolError as prost::Message>::decode(payload) {
+            return Err(DaemonError::ProtocolError {
+                kind: v3::ErrorKind::try_from(err.kind).unwrap_or(v3::ErrorKind::Unspecified),
+                message: err.message,
+                retryable: err.retryable,
+            });
+        }
+
+        Err(DaemonError::UnexpectedMessage)
+    }
+
+    /// Read a raw length-prefixed frame without decoding.
+    async fn read_raw_frame(&mut self) -> Result<Option<BytesMut>, DaemonError> {
+        loop {
+            if self.read_buf.len() >= 4 {
+                let len = u32::from_le_bytes([
+                    self.read_buf[0],
+                    self.read_buf[1],
+                    self.read_buf[2],
+                    self.read_buf[3],
+                ]);
+                if len > rttx_proto::MAX_MESSAGE_SIZE {
+                    return Err(DaemonError::Frame(rttx_proto::FrameError::TooLarge(len)));
                 }
-                Ok(())
+                let total = 4 + len as usize;
+                if self.read_buf.len() >= total {
+                    let frame = self.read_buf.split_to(total);
+                    return Ok(Some(frame));
+                }
             }
-            Some(proto::server_message::Msg::Error(e)) => {
-                Err(DaemonError::ServerError { code: e.code, message: e.message })
+            let n = self.reader.read_buf(&mut self.read_buf).await?;
+            if n == 0 {
+                return Ok(None);
             }
+        }
+    }
+
+    /// List all runtimes on the daemon.
+    pub async fn list_runtimes(&mut self) -> Result<Vec<v3::RuntimeInfo>, DaemonError> {
+        let response =
+            self.request(v3::client_envelope::Command::ListRuntimes(v3::ListRuntimes {})).await?;
+        match response.payload {
+            Some(v3::server_envelope::Payload::RuntimeList(list)) => Ok(list.runtimes),
+            Some(v3::server_envelope::Payload::Error(e)) => Err(protocol_error(e)),
             _ => Err(DaemonError::UnexpectedMessage),
         }
     }
 
-    /// List all sessions on the daemon.
-    pub async fn list_runtimes(&mut self) -> Result<Vec<proto::RuntimeInfo>, DaemonError> {
-        let msg = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListRuntimes(proto::ListRuntimes {})),
-        };
-        self.send(&msg).await?;
-
-        let response = self.recv().await?.ok_or(DaemonError::Disconnected)?;
-        match response.msg {
-            Some(proto::server_message::Msg::RuntimeList(list)) => Ok(list.runtimes),
-            Some(proto::server_message::Msg::Error(e)) => {
-                Err(DaemonError::ServerError { code: e.code, message: e.message })
-            }
-            _ => Err(DaemonError::UnexpectedMessage),
-        }
-    }
-
-    /// Create a new session and return its UUID.
+    /// Create a new runtime and return its UUID.
     pub async fn create_runtime(
         &mut self,
         name: &str,
         policy: WorkspacePolicy,
     ) -> Result<Uuid, DaemonError> {
-        let msg = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+        let response = self
+            .request(v3::client_envelope::Command::CreateRuntime(v3::CreateRuntime {
                 name: name.to_string(),
-                policy: policy.as_proto(),
-            })),
-        };
-        self.send(&msg).await?;
-
-        let response = self.recv().await?.ok_or(DaemonError::Disconnected)?;
-        match response.msg {
-            Some(proto::server_message::Msg::RuntimeCreated(created)) => {
+                policy: policy.as_v3_proto(),
+            }))
+            .await?;
+        match response.payload {
+            Some(v3::server_envelope::Payload::RuntimeCreated(created)) => {
                 bytes_to_uuid(&created.runtime_id).map_err(DaemonError::Frame)
             }
-            Some(proto::server_message::Msg::Error(e)) => {
-                Err(DaemonError::ServerError { code: e.code, message: e.message })
-            }
+            Some(v3::server_envelope::Payload::Error(e)) => Err(protocol_error(e)),
             _ => Err(DaemonError::UnexpectedMessage),
         }
     }
 
-    /// Attach to a session and receive the initial snapshot.
+    /// Attach to a runtime and receive the initial snapshot.
     pub async fn attach_runtime(
         &mut self,
         runtime_id: Uuid,
-        attach_mode: proto::RuntimeAttachMode,
-    ) -> Result<proto::Snapshot, DaemonError> {
-        let msg = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
+        attach_mode: v3::RuntimeAttachMode,
+    ) -> Result<v3::RuntimeSnapshot, DaemonError> {
+        let response = self
+            .request(v3::client_envelope::Command::AttachRuntime(v3::AttachRuntime {
                 runtime_id: uuid_to_bytes(runtime_id),
                 attach_mode: attach_mode as i32,
-            })),
-        };
-        self.send(&msg).await?;
-
-        let response = self.recv().await?.ok_or(DaemonError::Disconnected)?;
-        match response.msg {
-            Some(proto::server_message::Msg::Snapshot(snapshot)) => Ok(snapshot),
-            Some(proto::server_message::Msg::AttachBlocked(blocked)) => {
+            }))
+            .await?;
+        match response.payload {
+            Some(v3::server_envelope::Payload::RuntimeSnapshot(snapshot)) => Ok(snapshot),
+            Some(v3::server_envelope::Payload::AttachBlocked(blocked)) => {
                 Err(DaemonError::AttachBlocked(blocked))
             }
-            Some(proto::server_message::Msg::Error(e)) => {
-                Err(DaemonError::ServerError { code: e.code, message: e.message })
-            }
+            Some(v3::server_envelope::Payload::Error(e)) => Err(protocol_error(e)),
             _ => Err(DaemonError::UnexpectedMessage),
         }
     }
 
-    /// Create a pane in a session and return the new pane UUID.
+    /// Create a pane in a runtime and return the new pane UUID.
     pub async fn create_pane(
         &mut self,
         runtime_id: Uuid,
@@ -299,49 +400,39 @@ impl DaemonConnection {
         cols: u32,
         rows: u32,
     ) -> Result<Uuid, DaemonError> {
-        let msg = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+        let response = self
+            .request(v3::client_envelope::Command::CreatePane(v3::CreatePane {
                 runtime_id: uuid_to_bytes(runtime_id),
                 cwd,
                 dark_background,
                 cols,
                 rows,
-            })),
-        };
-        self.send(&msg).await?;
-
-        let response = self.recv().await?.ok_or(DaemonError::Disconnected)?;
-        match response.msg {
-            Some(proto::server_message::Msg::PaneCreated(created)) => {
+            }))
+            .await?;
+        match response.payload {
+            Some(v3::server_envelope::Payload::PaneCreated(created)) => {
                 bytes_to_uuid(&created.pane_id).map_err(DaemonError::Frame)
             }
-            Some(proto::server_message::Msg::Error(e)) => {
-                Err(DaemonError::ServerError { code: e.code, message: e.message })
-            }
+            Some(v3::server_envelope::Payload::Error(e)) => Err(protocol_error(e)),
             _ => Err(DaemonError::UnexpectedMessage),
         }
     }
 
-    /// Close a pane in a session and return the acknowledgement.
+    /// Close a pane in a runtime.
     pub async fn close_pane(
         &mut self,
         runtime_id: Uuid,
         pane_id: Uuid,
-    ) -> Result<proto::PaneClosed, DaemonError> {
-        let msg = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ClosePane(proto::ClosePane {
+    ) -> Result<v3::PaneClosed, DaemonError> {
+        let response = self
+            .request(v3::client_envelope::Command::ClosePane(v3::ClosePane {
                 runtime_id: uuid_to_bytes(runtime_id),
                 pane_id: uuid_to_bytes(pane_id),
-            })),
-        };
-        self.send(&msg).await?;
-
-        let response = self.recv().await?.ok_or(DaemonError::Disconnected)?;
-        match response.msg {
-            Some(proto::server_message::Msg::PaneClosed(closed)) => Ok(closed),
-            Some(proto::server_message::Msg::Error(e)) => {
-                Err(DaemonError::ServerError { code: e.code, message: e.message })
-            }
+            }))
+            .await?;
+        match response.payload {
+            Some(v3::server_envelope::Payload::PaneClosed(closed)) => Ok(closed),
+            Some(v3::server_envelope::Payload::Error(e)) => Err(protocol_error(e)),
             _ => Err(DaemonError::UnexpectedMessage),
         }
     }
@@ -351,24 +442,19 @@ impl DaemonConnection {
         &mut self,
         runtime_id: Uuid,
     ) -> Result<DetachResponse, DaemonError> {
-        let msg = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::DetachRuntime(proto::DetachRuntime {
+        let response = self
+            .request(v3::client_envelope::Command::DetachRuntime(v3::DetachRuntime {
                 runtime_id: uuid_to_bytes(runtime_id),
-            })),
-        };
-        self.send(&msg).await?;
-
-        let response = self.recv().await?.ok_or(DaemonError::Disconnected)?;
-        match response.msg {
-            Some(proto::server_message::Msg::RuntimeDetached(detached)) => {
+            }))
+            .await?;
+        match response.payload {
+            Some(v3::server_envelope::Payload::RuntimeDetached(detached)) => {
                 Ok(DetachResponse::Detached(detached))
             }
-            Some(proto::server_message::Msg::RuntimeTerminated(terminated)) => {
+            Some(v3::server_envelope::Payload::RuntimeTerminated(terminated)) => {
                 Ok(DetachResponse::Terminated(terminated))
             }
-            Some(proto::server_message::Msg::Error(e)) => {
-                Err(DaemonError::ServerError { code: e.code, message: e.message })
-            }
+            Some(v3::server_envelope::Payload::Error(e)) => Err(protocol_error(e)),
             _ => Err(DaemonError::UnexpectedMessage),
         }
     }
@@ -377,22 +463,26 @@ impl DaemonConnection {
     pub async fn terminate_runtime(
         &mut self,
         runtime_id: Uuid,
-    ) -> Result<proto::RuntimeTerminated, DaemonError> {
-        let msg = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::TerminateRuntime(proto::TerminateRuntime {
+    ) -> Result<v3::RuntimeTerminated, DaemonError> {
+        let response = self
+            .request(v3::client_envelope::Command::TerminateRuntime(v3::TerminateRuntime {
                 runtime_id: uuid_to_bytes(runtime_id),
-            })),
-        };
-        self.send(&msg).await?;
-
-        let response = self.recv().await?.ok_or(DaemonError::Disconnected)?;
-        match response.msg {
-            Some(proto::server_message::Msg::RuntimeTerminated(terminated)) => Ok(terminated),
-            Some(proto::server_message::Msg::Error(e)) => {
-                Err(DaemonError::ServerError { code: e.code, message: e.message })
-            }
+            }))
+            .await?;
+        match response.payload {
+            Some(v3::server_envelope::Payload::RuntimeTerminated(terminated)) => Ok(terminated),
+            Some(v3::server_envelope::Payload::Error(e)) => Err(protocol_error(e)),
             _ => Err(DaemonError::UnexpectedMessage),
         }
+    }
+}
+
+/// Convert a v3 `ProtocolError` to a `DaemonError`.
+fn protocol_error(e: v3::ProtocolError) -> DaemonError {
+    DaemonError::ProtocolError {
+        kind: v3::ErrorKind::try_from(e.kind).unwrap_or(v3::ErrorKind::Unspecified),
+        message: e.message,
+        retryable: e.retryable,
     }
 }
 
@@ -427,6 +517,7 @@ impl Drop for SshHandle {
 /// the glib main thread.
 pub struct DaemonWriter {
     stream: Box<dyn AsyncWrite + Unpin + Send>,
+    id_gen: RequestIdGenerator,
 }
 
 impl std::fmt::Debug for DaemonWriter {
@@ -436,24 +527,27 @@ impl std::fmt::Debug for DaemonWriter {
 }
 
 impl DaemonWriter {
-    /// Send keyboard input to a pane.
+    /// Send keyboard input to a pane (fire-and-forget).
     pub async fn send_input(
         &mut self,
         runtime_id: Uuid,
         pane_id: Uuid,
         data: &[u8],
     ) -> Result<(), DaemonError> {
-        self.send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Input(proto::Input {
+        let env = v3::ClientEnvelope {
+            request_id: 0,
+            command: Some(v3::client_envelope::Command::TerminalInput(v3::TerminalInput {
                 runtime_id: uuid_to_bytes(runtime_id),
                 pane_id: uuid_to_bytes(pane_id),
-                data: bytes::Bytes::copy_from_slice(data),
+                kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                    data: bytes::Bytes::copy_from_slice(data),
+                })),
             })),
-        })
-        .await
+        };
+        self.send_envelope(&env).await
     }
 
-    /// Notify the daemon of a pane resize.
+    /// Notify the daemon of a pane resize (fire-and-forget).
     pub async fn send_resize(
         &mut self,
         runtime_id: Uuid,
@@ -461,38 +555,44 @@ impl DaemonWriter {
         cols: u16,
         rows: u16,
     ) -> Result<(), DaemonError> {
-        self.send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Resize(proto::Resize {
+        let env = v3::ClientEnvelope {
+            request_id: 0,
+            command: Some(v3::client_envelope::Command::ResizePane(v3::ResizePane {
                 runtime_id: uuid_to_bytes(runtime_id),
                 pane_id: uuid_to_bytes(pane_id),
                 cols: u32::from(cols),
                 rows: u32::from(rows),
             })),
-        })
-        .await
+        };
+        self.send_envelope(&env).await
     }
 
     /// Send a heartbeat ping to the daemon.
     pub async fn send_ping(&mut self, nonce: u64) -> Result<(), DaemonError> {
-        self.send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Ping(proto::Ping { nonce })),
-        })
-        .await
+        let env = v3::ClientEnvelope {
+            request_id: self.id_gen.next_id(),
+            command: Some(v3::client_envelope::Command::Ping(v3::Ping { nonce })),
+        };
+        self.send_envelope(&env).await
     }
 
-    /// Detach from a session without killing it.
+    /// Detach from a runtime without killing it.
     pub async fn detach_runtime(&mut self, runtime_id: Uuid) -> Result<(), DaemonError> {
-        self.send(&proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::DetachRuntime(proto::DetachRuntime {
+        let env = v3::ClientEnvelope {
+            request_id: self.id_gen.next_id(),
+            command: Some(v3::client_envelope::Command::DetachRuntime(v3::DetachRuntime {
                 runtime_id: uuid_to_bytes(runtime_id),
             })),
-        })
-        .await
+        };
+        self.send_envelope(&env).await
     }
 
-    pub(crate) async fn send(&mut self, msg: &proto::ClientMessage) -> Result<(), DaemonError> {
+    pub(crate) async fn send_envelope(
+        &mut self,
+        env: &v3::ClientEnvelope,
+    ) -> Result<(), DaemonError> {
         let mut buf = BytesMut::new();
-        encode_frame(msg, &mut buf)?;
+        encode_frame(env, &mut buf)?;
         self.stream.write_all(&buf).await?;
         self.stream.flush().await?;
         Ok(())
@@ -515,11 +615,11 @@ impl std::fmt::Debug for DaemonReader {
 }
 
 impl DaemonReader {
-    /// Read the next server message. Returns `None` on clean disconnect.
-    pub async fn recv(&mut self) -> Result<Option<proto::ServerMessage>, DaemonError> {
+    /// Read the next v3 server envelope. Returns `None` on clean disconnect.
+    pub async fn recv(&mut self) -> Result<Option<v3::ServerEnvelope>, DaemonError> {
         loop {
-            match decode_frame::<proto::ServerMessage>(&mut self.read_buf) {
-                Ok(msg) => return Ok(Some(msg)),
+            match decode_frame::<v3::ServerEnvelope>(&mut self.read_buf) {
+                Ok(env) => return Ok(Some(env)),
                 Err(rttx_proto::FrameError::Incomplete) => {}
                 Err(e) => return Err(DaemonError::Frame(e)),
             }
@@ -539,34 +639,39 @@ where
 {
     (
         DaemonReader { stream: Box::new(reader), read_buf: BytesMut::new() },
-        DaemonWriter { stream: Box::new(writer) },
+        DaemonWriter { stream: Box::new(writer), id_gen: RequestIdGenerator::new() },
     )
 }
 
-/// Extract the `pane_id` bytes from a server message, if present.
+/// Extract the `pane_id` bytes from a v3 server envelope, if present.
 #[must_use]
-pub fn extract_pane_id(msg: &proto::ServerMessage) -> Option<Uuid> {
-    use proto::server_message::Msg;
-    let bytes = match msg.msg.as_ref()? {
-        Msg::Delta(m) => &m.pane_id,
-        Msg::PaneExited(m) => &m.pane_id,
-        Msg::PaneCreated(m) => &m.pane_id,
-        Msg::PaneClosed(m) => &m.pane_id,
-        Msg::TitleChanged(m) => &m.pane_id,
-        Msg::CwdChanged(m) => &m.pane_id,
-        Msg::Bell(m) => &m.pane_id,
-        Msg::PaneResized(m) => &m.pane_id,
-        Msg::HelloAck(_)
-        | Msg::Pong(_)
-        | Msg::RuntimeList(_)
-        | Msg::RuntimeCreated(_)
-        | Msg::Snapshot(_)
-        | Msg::AttachBlocked(_)
-        | Msg::RuntimeDetached(_)
-        | Msg::RuntimeTerminated(_)
-        | Msg::RuntimeRenamed(_)
-        | Msg::Error(_)
-        | Msg::DiagnosticsReport(_) => return None,
+pub fn extract_pane_id(env: &v3::ServerEnvelope) -> Option<Uuid> {
+    use v3::server_envelope::Payload;
+    let bytes = match env.payload.as_ref()? {
+        Payload::OutputDelta(m) => &m.pane_id,
+        Payload::PaneExited(m) => &m.pane_id,
+        Payload::PaneCreated(m) => &m.pane_id,
+        Payload::PaneClosed(m) => &m.pane_id,
+        Payload::TitleChanged(m) => &m.pane_id,
+        Payload::CwdChanged(m) => &m.pane_id,
+        Payload::Bell(m) => &m.pane_id,
+        Payload::PaneResized(m) => &m.pane_id,
+        Payload::TerminalModeChanged(m) => &m.pane_id,
+        Payload::Pong(_)
+        | Payload::RuntimeList(_)
+        | Payload::RuntimeCreated(_)
+        | Payload::RuntimeSnapshot(_)
+        | Payload::AttachBlocked(_)
+        | Payload::RuntimeDetached(_)
+        | Payload::RuntimeTerminated(_)
+        | Payload::RuntimeRenamed(_)
+        | Payload::Error(_)
+        | Payload::DiagnosticsReport(_)
+        | Payload::StreamOverflow(_)
+        | Payload::ScrollbackChunk(_)
+        | Payload::TakeoverCompleted(_)
+        | Payload::LeaseLost(_)
+        | Payload::OwnerDisconnected(_) => return None,
     };
     bytes_to_uuid(bytes).ok()
 }
@@ -574,29 +679,29 @@ pub fn extract_pane_id(msg: &proto::ServerMessage) -> Option<Uuid> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rttx_proto::{decode_frame, encode_frame, proto};
+    use rttx_proto::{decode_frame, encode_frame, v3, v3_handshake};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::UnixListener;
 
-    /// Accept one client, read `Hello`, send `HelloAck`.
+    /// Accept one client, read `ClientHello`, send `ServerHello`.
     async fn serve_handshake(listener: &UnixListener) -> UnixStream {
         let (mut stream, _) = listener.accept().await.unwrap();
         let mut buf = BytesMut::with_capacity(4096);
         loop {
             let n = stream.read_buf(&mut buf).await.unwrap();
-            assert!(n > 0, "client disconnected before Hello");
-            if let Ok(_hello) = decode_frame::<proto::ClientMessage>(&mut buf) {
+            assert!(n > 0, "client disconnected before ClientHello");
+            if let Ok(_hello) = decode_frame::<v3::ClientHello>(&mut buf) {
                 break;
             }
         }
-        let ack = proto::ServerMessage {
-            msg: Some(proto::server_message::Msg::HelloAck(proto::HelloAck {
-                protocol_version: PROTOCOL_VERSION,
-                server_id: uuid_to_bytes(Uuid::new_v4()),
-            })),
-        };
+        let server_hello = v3_handshake::build_server_hello(
+            Uuid::new_v4(),
+            "0.1.0",
+            v3_handshake::V3_PROTOCOL_VERSION,
+            v3_handshake::CORE_CAPABILITIES,
+        );
         let mut out = BytesMut::new();
-        encode_frame(&ack, &mut out).unwrap();
+        encode_frame(&server_hello, &mut out).unwrap();
         stream.write_all(&out).await.unwrap();
         stream
     }
@@ -645,7 +750,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handshake_fails_on_version_mismatch() {
+    async fn handshake_fails_on_protocol_error() {
         let tmp = tempfile::TempDir::new().unwrap();
         let sock = tmp.path().join("test.sock");
         let listener = UnixListener::bind(&sock).unwrap();
@@ -660,56 +765,59 @@ mod tests {
         loop {
             let n = stream.read_buf(&mut buf).await.unwrap();
             assert!(n > 0);
-            if decode_frame::<proto::ClientMessage>(&mut buf).is_ok() {
+            if decode_frame::<v3::ClientHello>(&mut buf).is_ok() {
                 break;
             }
         }
-        let ack = proto::ServerMessage {
-            msg: Some(proto::server_message::Msg::HelloAck(proto::HelloAck {
-                protocol_version: 999,
-                server_id: uuid_to_bytes(Uuid::new_v4()),
-            })),
-        };
-        let mut out = BytesMut::new();
-        encode_frame(&ack, &mut out).unwrap();
-        stream.write_all(&out).await.unwrap();
-
-        let result = client_task.await.unwrap();
-        assert!(matches!(result, Err(DaemonError::VersionMismatch { server: 999, .. })));
-    }
-
-    #[tokio::test]
-    async fn handshake_fails_on_server_error() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let sock = tmp.path().join("test.sock");
-        let listener = UnixListener::bind(&sock).unwrap();
-
-        let client_task = tokio::spawn({
-            let sock = sock.clone();
-            async move { DaemonConnection::connect(&sock).await }
-        });
-
-        let (mut stream, _) = listener.accept().await.unwrap();
-        let mut buf = BytesMut::with_capacity(4096);
-        loop {
-            let n = stream.read_buf(&mut buf).await.unwrap();
-            assert!(n > 0);
-            if decode_frame::<proto::ClientMessage>(&mut buf).is_ok() {
-                break;
-            }
-        }
-        let err = proto::ServerMessage {
-            msg: Some(proto::server_message::Msg::Error(proto::Error {
-                code: 2,
-                message: "version mismatch".into(),
-            })),
+        let err = v3::ProtocolError {
+            kind: v3::ErrorKind::ProtocolMismatch as i32,
+            message: "version mismatch".into(),
+            operation: "Handshake".into(),
+            retryable: false,
+            user_action_required: true,
+            retry_after_seconds: 0,
         };
         let mut out = BytesMut::new();
         encode_frame(&err, &mut out).unwrap();
         stream.write_all(&out).await.unwrap();
 
         let result = client_task.await.unwrap();
-        assert!(matches!(result, Err(DaemonError::ServerError { code: 2, .. })));
+        assert!(matches!(result, Err(DaemonError::ProtocolError { .. })));
+    }
+
+    #[tokio::test]
+    async fn handshake_fails_on_missing_capabilities() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock = tmp.path().join("test.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let client_task = tokio::spawn({
+            let sock = sock.clone();
+            async move { DaemonConnection::connect(&sock).await }
+        });
+
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = BytesMut::with_capacity(4096);
+        loop {
+            let n = stream.read_buf(&mut buf).await.unwrap();
+            assert!(n > 0);
+            if decode_frame::<v3::ClientHello>(&mut buf).is_ok() {
+                break;
+            }
+        }
+        // Send a ServerHello with no capabilities — client should reject.
+        let server_hello = v3::ServerHello {
+            negotiated_protocol_version: v3_handshake::V3_PROTOCOL_VERSION,
+            server_id: uuid_to_bytes(Uuid::new_v4()),
+            server_version: "0.1.0".into(),
+            capabilities: vec![],
+        };
+        let mut out = BytesMut::new();
+        encode_frame(&server_hello, &mut out).unwrap();
+        stream.write_all(&out).await.unwrap();
+
+        let result = client_task.await.unwrap();
+        assert!(matches!(result, Err(DaemonError::ProtocolError { .. })));
     }
 
     #[tokio::test]
@@ -722,7 +830,7 @@ mod tests {
             let sock = sock.clone();
             async move {
                 let mut conn = DaemonConnection::connect(&sock).await.unwrap();
-                conn.recv().await
+                conn.recv_envelope().await
             }
         });
 
@@ -758,14 +866,18 @@ mod tests {
             if n == 0 {
                 break;
             }
-            if let Ok(msg) = decode_frame::<proto::ClientMessage>(&mut buf) {
-                match msg.msg {
-                    Some(proto::client_message::Msg::Input(input)) => {
-                        assert_eq!(input.data, &b"hello"[..]);
+            if let Ok(env) = decode_frame::<v3::ClientEnvelope>(&mut buf) {
+                match env.command {
+                    Some(v3::client_envelope::Command::TerminalInput(input)) => {
+                        if let Some(v3::terminal_input::Kind::Raw(raw)) = input.kind {
+                            assert_eq!(raw.data, &b"hello"[..]);
+                        } else {
+                            panic!("expected RawInput kind");
+                        }
                         assert_eq!(bytes_to_uuid(&input.runtime_id).unwrap(), runtime_id);
                         assert_eq!(bytes_to_uuid(&input.pane_id).unwrap(), pane_id);
                     }
-                    other => panic!("expected Input, got {other:?}"),
+                    other => panic!("expected TerminalInput, got {other:?}"),
                 }
                 break;
             }
@@ -799,13 +911,13 @@ mod tests {
             if n == 0 {
                 break;
             }
-            if let Ok(msg) = decode_frame::<proto::ClientMessage>(&mut buf) {
-                match msg.msg {
-                    Some(proto::client_message::Msg::Resize(resize)) => {
+            if let Ok(env) = decode_frame::<v3::ClientEnvelope>(&mut buf) {
+                match env.command {
+                    Some(v3::client_envelope::Command::ResizePane(resize)) => {
                         assert_eq!(resize.cols, 120);
                         assert_eq!(resize.rows, 40);
                     }
-                    other => panic!("expected Resize, got {other:?}"),
+                    other => panic!("expected ResizePane, got {other:?}"),
                 }
                 break;
             }
@@ -836,9 +948,11 @@ mod tests {
             if n == 0 {
                 break;
             }
-            if let Ok(msg) = decode_frame::<proto::ClientMessage>(&mut buf) {
-                match msg.msg {
-                    Some(proto::client_message::Msg::Ping(ping)) => assert_eq!(ping.nonce, 99),
+            if let Ok(env) = decode_frame::<v3::ClientEnvelope>(&mut buf) {
+                match env.command {
+                    Some(v3::client_envelope::Command::Ping(ping)) => {
+                        assert_eq!(ping.nonce, 99);
+                    }
                     other => panic!("expected Ping, got {other:?}"),
                 }
                 break;
@@ -851,25 +965,32 @@ mod tests {
     #[test]
     fn extract_pane_id_from_delta() {
         let pane_id = Uuid::new_v4();
-        let msg = proto::ServerMessage {
-            msg: Some(proto::server_message::Msg::Delta(proto::Delta {
+        let env = v3::ServerEnvelope {
+            request_id: 0,
+            payload: Some(v3::server_envelope::Payload::OutputDelta(v3::OutputDelta {
                 runtime_id: uuid_to_bytes(Uuid::new_v4()),
                 pane_id: uuid_to_bytes(pane_id),
+                pane_output_seq: 1,
                 data: bytes::Bytes::new(),
             })),
         };
-        assert_eq!(extract_pane_id(&msg), Some(pane_id));
+        assert_eq!(extract_pane_id(&env), Some(pane_id));
     }
 
     #[test]
     fn extract_pane_id_from_error_is_none() {
-        let msg = proto::ServerMessage {
-            msg: Some(proto::server_message::Msg::Error(proto::Error {
-                code: 1,
+        let env = v3::ServerEnvelope {
+            request_id: 0,
+            payload: Some(v3::server_envelope::Payload::Error(v3::ProtocolError {
+                kind: v3::ErrorKind::Internal as i32,
                 message: "test".into(),
+                operation: String::new(),
+                retryable: false,
+                user_action_required: false,
+                retry_after_seconds: 0,
             })),
         };
-        assert_eq!(extract_pane_id(&msg), None);
+        assert_eq!(extract_pane_id(&env), None);
     }
 
     #[tokio::test]

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -1006,7 +1006,11 @@ mod tests {
     fn request_id_generator_never_returns_zero() {
         let id_gen = RequestIdGenerator::new();
         for _ in 0..1000 {
-            assert_ne!(id_gen.next_id(), 0, "request_id must never be zero (reserved for push events)");
+            assert_ne!(
+                id_gen.next_id(),
+                0,
+                "request_id must never be zero (reserved for push events)"
+            );
         }
     }
 

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -1001,4 +1001,60 @@ mod tests {
         // BatchMode=yes makes SSH fail immediately instead of hanging for auth.
         assert!(start.elapsed().as_secs() < 15, "SSH should fail fast, not hang");
     }
+
+    #[test]
+    fn request_id_generator_never_returns_zero() {
+        let id_gen = RequestIdGenerator::new();
+        for _ in 0..1000 {
+            assert_ne!(id_gen.next_id(), 0, "request_id must never be zero (reserved for push events)");
+        }
+    }
+
+    #[test]
+    fn client_capabilities_include_all_core_capabilities() {
+        let core = v3_handshake::CORE_CAPABILITIES;
+        for cap in core {
+            assert!(
+                CLIENT_CAPABILITIES.contains(cap),
+                "CLIENT_CAPABILITIES must include core capability {cap:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn protocol_error_conversion_preserves_kind_and_retryable() {
+        let err = protocol_error(v3::ProtocolError {
+            kind: v3::ErrorKind::RuntimeNotFound as i32,
+            message: "runtime gone".into(),
+            operation: "AttachRuntime".into(),
+            retryable: false,
+            user_action_required: false,
+            retry_after_seconds: 0,
+        });
+        match err {
+            DaemonError::ProtocolError { kind, message, retryable } => {
+                assert_eq!(kind, v3::ErrorKind::RuntimeNotFound);
+                assert_eq!(message, "runtime gone");
+                assert!(!retryable);
+            }
+            other => panic!("expected ProtocolError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_pane_id_from_terminal_mode_changed() {
+        let pane_id = Uuid::new_v4();
+        let env = v3::ServerEnvelope {
+            request_id: 0,
+            payload: Some(v3::server_envelope::Payload::TerminalModeChanged(
+                v3::TerminalModeChanged {
+                    runtime_id: uuid_to_bytes(Uuid::new_v4()),
+                    pane_id: uuid_to_bytes(pane_id),
+                    runtime_revision: 1,
+                    modes: None,
+                },
+            )),
+        };
+        assert_eq!(extract_pane_id(&env), Some(pane_id));
+    }
 }

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -12,7 +12,7 @@ use crate::runtime::{
     ConnectionEvent, ConnectionProblem, ConnectionStatus, RuntimeEndpoint, WorkspacePolicy,
     advance_connection_status, classify_connection_problem,
 };
-use rttx_proto::proto;
+use rttx_proto::v3;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::Path;
@@ -57,7 +57,7 @@ pub enum EndpointEvent {
     WorkspaceOpened {
         workspace_id: String,
         runtime_id: String,
-        snapshot: proto::Snapshot,
+        snapshot: v3::RuntimeSnapshot,
     },
     PaneCreated {
         workspace_id: String,
@@ -78,15 +78,15 @@ pub enum EndpointEvent {
     RuntimeTerminated {
         workspace_id: String,
         runtime_id: String,
-        reason: proto::RuntimeTerminationReason,
+        reason: v3::RuntimeTerminationReason,
     },
     InventoryLoaded {
         endpoint: RuntimeEndpoint,
-        runtimes: Vec<proto::RuntimeInfo>,
+        runtimes: Vec<v3::RuntimeInfo>,
     },
     RuntimeMessage {
         endpoint: RuntimeEndpoint,
-        message: proto::ServerMessage,
+        message: v3::ServerEnvelope,
     },
     WorkspaceError {
         workspace_id: String,
@@ -388,6 +388,7 @@ struct EndpointActor {
     daemon_start_attempted: bool,
     auto_start_daemon: bool,
     reconnect_delay_secs: u32,
+    next_request_id: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -425,9 +426,10 @@ impl HeartbeatMonitor {
         HeartbeatAction::SendPing { nonce }
     }
 
-    fn observe_inbound(&mut self, msg: &proto::ServerMessage) -> bool {
-        match &msg.msg {
-            Some(proto::server_message::Msg::Pong(pong)) => {
+    #[cfg(test)]
+    fn observe_inbound(&mut self, env: &v3::ServerEnvelope) -> bool {
+        match &env.payload {
+            Some(v3::server_envelope::Payload::Pong(pong)) => {
                 if self.pending_nonce == Some(pong.nonce) {
                     self.pending_nonce = None;
                     self.missed_ticks = 0;
@@ -478,13 +480,23 @@ impl EndpointActor {
             daemon_start_attempted: false,
             auto_start_daemon,
             reconnect_delay_secs,
+            next_request_id: 1,
         }
+    }
+
+    const fn next_id(&mut self) -> u64 {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1);
+        if self.next_request_id == 0 {
+            self.next_request_id = 1;
+        }
+        id
     }
 
     async fn run(mut self) {
         enum LoopEvent {
             Command(Option<EndpointCommand>),
-            Message(Result<Option<proto::ServerMessage>, DaemonError>),
+            Message(Result<Option<v3::ServerEnvelope>, DaemonError>),
             HeartbeatTick,
         }
 
@@ -537,51 +549,59 @@ impl EndpointActor {
         self.heartbeat_deadline = new_heartbeat_deadline();
     }
 
-    async fn send_message(&mut self, msg: &proto::ClientMessage) -> Result<(), DaemonError> {
+    async fn send_message(&mut self, env: &v3::ClientEnvelope) -> Result<(), DaemonError> {
         let writer = self.writer.as_mut().ok_or(DaemonError::Disconnected)?;
-        writer.send(msg).await
+        writer.send_envelope(env).await
+    }
+
+    /// Send a v3 command and wait for the correlated response.
+    async fn send_and_read(
+        &mut self,
+        command: v3::client_envelope::Command,
+        expect_terminated: bool,
+    ) -> Result<v3::ServerEnvelope, DaemonError> {
+        let request_id = self.next_id();
+        let env = v3::ClientEnvelope { request_id, command: Some(command) };
+        self.send_message(&env).await?;
+        self.read_response(request_id, expect_terminated).await
     }
 
     async fn read_response(
         &mut self,
+        request_id: u64,
         expect_terminated: bool,
-    ) -> Result<proto::ServerMessage, DaemonError> {
+    ) -> Result<v3::ServerEnvelope, DaemonError> {
         loop {
-            let msg = {
+            let env = {
                 let reader = self.reader.as_mut().ok_or(DaemonError::Disconnected)?;
                 reader.recv().await?.ok_or(DaemonError::Disconnected)?
             };
-            let is_push = match &msg.msg {
-                Some(
-                    proto::server_message::Msg::Delta(_)
-                    | proto::server_message::Msg::PaneExited(_)
-                    | proto::server_message::Msg::TitleChanged(_)
-                    | proto::server_message::Msg::CwdChanged(_)
-                    | proto::server_message::Msg::Bell(_)
-                    | proto::server_message::Msg::PaneResized(_)
-                    | proto::server_message::Msg::RuntimeRenamed(_),
-                ) => true,
-                Some(proto::server_message::Msg::RuntimeTerminated(_)) => !expect_terminated,
-                _ => false,
-            };
-            if self.observe_inbound_message(&msg) {
-                continue;
+            // Correlated response.
+            if env.request_id == request_id {
+                return Ok(env);
             }
-            if is_push {
-                self.dispatch_push(msg);
+            // Push event (request_id == 0) or stale response — dispatch and loop.
+            if matches!(env.payload, Some(v3::server_envelope::Payload::Pong(_))) {
+                self.observe_inbound_pong(&env);
+            } else if matches!(
+                env.payload,
+                Some(v3::server_envelope::Payload::RuntimeTerminated(_))
+            ) && expect_terminated
+            {
+                // Expected terminated response but with wrong request_id — skip.
             } else {
-                return Ok(msg);
+                self.dispatch_push(env);
             }
         }
     }
 
-    fn dispatch_push(&mut self, msg: proto::ServerMessage) {
-        if let Some(proto::server_message::Msg::RuntimeTerminated(terminated)) = &msg.msg
+    fn dispatch_push(&mut self, env: v3::ServerEnvelope) {
+        if let Some(v3::server_envelope::Payload::RuntimeTerminated(terminated)) = &env.payload
             && let Ok(runtime_id) = rttx_proto::bytes_to_uuid(&terminated.runtime_id)
         {
             self.tracked_workspaces.retain(|_, tracked| tracked != &runtime_id.to_string());
         }
-        self.forward_push(msg);
+        self.forward_push(env);
     }
 
     async fn handle_command(&mut self, command: EndpointCommand) {
@@ -665,22 +685,16 @@ impl EndpointActor {
                 ) else {
                     return;
                 };
-                let msg = proto::ClientMessage {
-                    msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
-                        runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
-                        cwd,
-                        dark_background: Some(dark_background),
-                        cols,
-                        rows,
-                    })),
-                };
-                if let Err(error) = self.send_message(&msg).await {
-                    self.handle_command_error(&workspace_id, ManagerOperation::CreatePane, &error);
-                    return;
-                }
-                match self.read_response(false).await {
-                    Ok(response) => match response.msg {
-                        Some(proto::server_message::Msg::PaneCreated(created)) => {
+                let msg = v3::client_envelope::Command::CreatePane(v3::CreatePane {
+                    runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
+                    cwd,
+                    dark_background: Some(dark_background),
+                    cols,
+                    rows,
+                });
+                match self.send_and_read(msg, false).await {
+                    Ok(response) => match response.payload {
+                        Some(v3::server_envelope::Payload::PaneCreated(created)) => {
                             if let Ok(pane_id) = rttx_proto::bytes_to_uuid(&created.pane_id) {
                                 let _ = self.event_tx.try_send(EndpointEvent::PaneCreated {
                                     workspace_id: workspace_id.clone(),
@@ -691,11 +705,11 @@ impl EndpointActor {
                                 self.emit_status(&workspace_id, ConnectionStatus::Connected);
                             }
                         }
-                        Some(proto::server_message::Msg::Error(e)) => {
+                        Some(v3::server_envelope::Payload::Error(e)) => {
                             self.handle_command_error(
                                 &workspace_id,
                                 ManagerOperation::CreatePane,
-                                &DaemonError::ServerError { code: e.code, message: e.message },
+                                &protocol_error_to_daemon(e),
                             );
                         }
                         _ => {
@@ -747,19 +761,13 @@ impl EndpointActor {
                 ) else {
                     return;
                 };
-                let msg = proto::ClientMessage {
-                    msg: Some(proto::client_message::Msg::ClosePane(proto::ClosePane {
-                        runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
-                        pane_id: rttx_proto::uuid_to_bytes(pane_uuid),
-                    })),
-                };
-                if let Err(error) = self.send_message(&msg).await {
-                    self.handle_command_error(&workspace_id, ManagerOperation::ClosePane, &error);
-                    return;
-                }
-                match self.read_response(false).await {
-                    Ok(response) => match response.msg {
-                        Some(proto::server_message::Msg::PaneClosed(_)) => {
+                let msg = v3::client_envelope::Command::ClosePane(v3::ClosePane {
+                    runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
+                    pane_id: rttx_proto::uuid_to_bytes(pane_uuid),
+                });
+                match self.send_and_read(msg, false).await {
+                    Ok(response) => match response.payload {
+                        Some(v3::server_envelope::Payload::PaneClosed(_)) => {
                             let _ = self.event_tx.try_send(EndpointEvent::PaneClosed {
                                 workspace_id,
                                 layout_terminal_uuid,
@@ -767,7 +775,10 @@ impl EndpointActor {
                                 runtime_pane_id,
                             });
                         }
-                        Some(proto::server_message::Msg::Error(e)) if e.code == 6 => {
+                        Some(v3::server_envelope::Payload::Error(e))
+                            if v3::ErrorKind::try_from(e.kind)
+                                == Ok(v3::ErrorKind::PaneNotFound) =>
+                        {
                             // ERR_PANE_NOT_FOUND: the pane is already gone on the
                             // daemon, so treat this as a successful close.
                             tracing::info!(
@@ -781,11 +792,11 @@ impl EndpointActor {
                                 runtime_pane_id,
                             });
                         }
-                        Some(proto::server_message::Msg::Error(e)) => {
+                        Some(v3::server_envelope::Payload::Error(e)) => {
                             self.handle_command_error(
                                 &workspace_id,
                                 ManagerOperation::ClosePane,
-                                &DaemonError::ServerError { code: e.code, message: e.message },
+                                &protocol_error_to_daemon(e),
                             );
                         }
                         _ => {
@@ -824,44 +835,32 @@ impl EndpointActor {
                     return;
                 }
 
-                let msg = proto::ClientMessage {
-                    msg: Some(proto::client_message::Msg::DetachRuntime(proto::DetachRuntime {
-                        runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
-                    })),
-                };
-                if let Err(error) = self.send_message(&msg).await {
-                    self.handle_command_error(
-                        &workspace_id,
-                        ManagerOperation::DetachRuntime,
-                        &error,
-                    );
-                    return;
-                }
-                match self.read_response(true).await {
-                    Ok(response) => match response.msg {
-                        Some(proto::server_message::Msg::RuntimeDetached(_)) => {
+                let msg = v3::client_envelope::Command::DetachRuntime(v3::DetachRuntime {
+                    runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
+                });
+                match self.send_and_read(msg, true).await {
+                    Ok(response) => match response.payload {
+                        Some(v3::server_envelope::Payload::RuntimeDetached(_)) => {
                             self.tracked_workspaces.remove(&workspace_id);
                             let _ = self.event_tx.try_send(EndpointEvent::WorkspaceDetached {
                                 workspace_id,
                                 runtime_id,
                             });
                         }
-                        Some(proto::server_message::Msg::RuntimeTerminated(terminated)) => {
+                        Some(v3::server_envelope::Payload::RuntimeTerminated(terminated)) => {
                             self.tracked_workspaces.remove(&workspace_id);
                             let _ = self.event_tx.try_send(EndpointEvent::RuntimeTerminated {
                                 workspace_id,
                                 runtime_id,
-                                reason: proto::RuntimeTerminationReason::try_from(
-                                    terminated.reason,
-                                )
-                                .unwrap_or(proto::RuntimeTerminationReason::Unspecified),
+                                reason: v3::RuntimeTerminationReason::try_from(terminated.reason)
+                                    .unwrap_or(v3::RuntimeTerminationReason::Unspecified),
                             });
                         }
-                        Some(proto::server_message::Msg::Error(e)) => {
+                        Some(v3::server_envelope::Payload::Error(e)) => {
                             self.handle_command_error(
                                 &workspace_id,
                                 ManagerOperation::DetachRuntime,
-                                &DaemonError::ServerError { code: e.code, message: e.message },
+                                &protocol_error_to_daemon(e),
                             );
                         }
                         _ => {
@@ -900,39 +899,25 @@ impl EndpointActor {
                     return;
                 }
 
-                let msg = proto::ClientMessage {
-                    msg: Some(proto::client_message::Msg::TerminateRuntime(
-                        proto::TerminateRuntime {
-                            runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
-                        },
-                    )),
-                };
-                if let Err(error) = self.send_message(&msg).await {
-                    self.handle_command_error(
-                        &workspace_id,
-                        ManagerOperation::TerminateRuntime,
-                        &error,
-                    );
-                    return;
-                }
-                match self.read_response(true).await {
-                    Ok(response) => match response.msg {
-                        Some(proto::server_message::Msg::RuntimeTerminated(terminated)) => {
+                let msg = v3::client_envelope::Command::TerminateRuntime(v3::TerminateRuntime {
+                    runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
+                });
+                match self.send_and_read(msg, true).await {
+                    Ok(response) => match response.payload {
+                        Some(v3::server_envelope::Payload::RuntimeTerminated(terminated)) => {
                             self.tracked_workspaces.remove(&workspace_id);
                             let _ = self.event_tx.try_send(EndpointEvent::RuntimeTerminated {
                                 workspace_id,
                                 runtime_id,
-                                reason: proto::RuntimeTerminationReason::try_from(
-                                    terminated.reason,
-                                )
-                                .unwrap_or(proto::RuntimeTerminationReason::Unspecified),
+                                reason: v3::RuntimeTerminationReason::try_from(terminated.reason)
+                                    .unwrap_or(v3::RuntimeTerminationReason::Unspecified),
                             });
                         }
-                        Some(proto::server_message::Msg::Error(e)) => {
+                        Some(v3::server_envelope::Payload::Error(e)) => {
                             self.handle_command_error(
                                 &workspace_id,
                                 ManagerOperation::TerminateRuntime,
-                                &DaemonError::ServerError { code: e.code, message: e.message },
+                                &protocol_error_to_daemon(e),
                             );
                         }
                         _ => {
@@ -1017,24 +1002,16 @@ impl EndpointActor {
                     return;
                 }
                 let list_result = if self.writer.is_some() {
-                    let msg = proto::ClientMessage {
-                        msg: Some(proto::client_message::Msg::ListRuntimes(proto::ListRuntimes {})),
-                    };
-                    match self.send_message(&msg).await {
-                        Ok(()) => match self.read_response(false).await {
-                            Ok(response) => match response.msg {
-                                Some(proto::server_message::Msg::RuntimeList(list)) => {
-                                    Ok(list.runtimes)
-                                }
-                                Some(proto::server_message::Msg::Error(e)) => {
-                                    Err(DaemonError::ServerError {
-                                        code: e.code,
-                                        message: e.message,
-                                    })
-                                }
-                                _ => Err(DaemonError::UnexpectedMessage),
-                            },
-                            Err(e) => Err(e),
+                    let msg = v3::client_envelope::Command::ListRuntimes(v3::ListRuntimes {});
+                    match self.send_and_read(msg, false).await {
+                        Ok(response) => match response.payload {
+                            Some(v3::server_envelope::Payload::RuntimeList(list)) => {
+                                Ok(list.runtimes)
+                            }
+                            Some(v3::server_envelope::Payload::Error(e)) => {
+                                Err(protocol_error_to_daemon(e))
+                            }
+                            _ => Err(DaemonError::UnexpectedMessage),
                         },
                         Err(e) => Err(e),
                     }
@@ -1153,13 +1130,14 @@ impl EndpointActor {
                 if self.ensure_connected(&workspace_id).await.is_err() {
                     return;
                 }
-                let msg = proto::ClientMessage {
-                    msg: Some(proto::client_message::Msg::RenameRuntime(proto::RenameRuntime {
+                let env = v3::ClientEnvelope {
+                    request_id: 0,
+                    command: Some(v3::client_envelope::Command::RenameRuntime(v3::RenameRuntime {
                         runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
                         name,
                     })),
                 };
-                let _ = self.send_message(&msg).await;
+                let _ = self.send_message(&env).await;
             }
             EndpointCommand::ForgetWorkspace { workspace_id } => {
                 self.tracked_workspaces.remove(&workspace_id);
@@ -1294,7 +1272,7 @@ impl EndpointActor {
         &mut self,
         workspace_id: &str,
         runtime_id: &str,
-    ) -> Result<proto::Snapshot, ()> {
+    ) -> Result<v3::RuntimeSnapshot, ()> {
         let Some(runtime_uuid) =
             parse_uuid(workspace_id, ManagerOperation::OpenWorkspace, runtime_id, &self.event_tx)
         else {
@@ -1323,7 +1301,7 @@ impl EndpointActor {
         name: &str,
         policy: WorkspacePolicy,
         existing_runtime_id: Option<&str>,
-    ) -> Result<(String, proto::Snapshot), ()> {
+    ) -> Result<(String, v3::RuntimeSnapshot), ()> {
         if let Some(runtime_id) = existing_runtime_id
             && let Ok(runtime_uuid) = runtime_id.parse::<uuid::Uuid>()
         {
@@ -1380,21 +1358,16 @@ impl EndpointActor {
             return connection.create_runtime(name, policy).await;
         }
 
-        let msg = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
-                name: name.to_string(),
-                policy: policy.as_proto(),
-            })),
-        };
-        self.send_message(&msg).await?;
-        let response = self.read_response(false).await?;
-        match response.msg {
-            Some(proto::server_message::Msg::RuntimeCreated(created)) => {
+        let msg = v3::client_envelope::Command::CreateRuntime(v3::CreateRuntime {
+            name: name.to_string(),
+            policy: policy.as_v3_proto(),
+        });
+        let response = self.send_and_read(msg, false).await?;
+        match response.payload {
+            Some(v3::server_envelope::Payload::RuntimeCreated(created)) => {
                 rttx_proto::bytes_to_uuid(&created.runtime_id).map_err(DaemonError::Frame)
             }
-            Some(proto::server_message::Msg::Error(error)) => {
-                Err(DaemonError::ServerError { code: error.code, message: error.message })
-            }
+            Some(v3::server_envelope::Payload::Error(e)) => Err(protocol_error_to_daemon(e)),
             _ => Err(DaemonError::UnexpectedMessage),
         }
     }
@@ -1402,64 +1375,67 @@ impl EndpointActor {
     async fn attach_runtime_via_active_channel(
         &mut self,
         runtime_uuid: Uuid,
-    ) -> Result<proto::Snapshot, DaemonError> {
+    ) -> Result<v3::RuntimeSnapshot, DaemonError> {
         if let Some(connection) = self.connection.as_mut() {
-            return connection
-                .attach_runtime(runtime_uuid, proto::RuntimeAttachMode::ReadWrite)
-                .await;
+            return connection.attach_runtime(runtime_uuid, v3::RuntimeAttachMode::ReadWrite).await;
         }
 
-        let msg = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
-                runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
-                attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
-            })),
-        };
-        self.send_message(&msg).await?;
-        let response = self.read_response(false).await?;
-        match response.msg {
-            Some(proto::server_message::Msg::Snapshot(snapshot)) => Ok(snapshot),
-            Some(proto::server_message::Msg::AttachBlocked(blocked)) => {
+        let msg = v3::client_envelope::Command::AttachRuntime(v3::AttachRuntime {
+            runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
+            attach_mode: v3::RuntimeAttachMode::ReadWrite as i32,
+        });
+        let response = self.send_and_read(msg, false).await?;
+        match response.payload {
+            Some(v3::server_envelope::Payload::RuntimeSnapshot(snapshot)) => Ok(snapshot),
+            Some(v3::server_envelope::Payload::AttachBlocked(blocked)) => {
                 Err(DaemonError::AttachBlocked(blocked))
             }
-            Some(proto::server_message::Msg::Error(error)) => {
-                Err(DaemonError::ServerError { code: error.code, message: error.message })
-            }
+            Some(v3::server_envelope::Payload::Error(e)) => Err(protocol_error_to_daemon(e)),
             _ => Err(DaemonError::UnexpectedMessage),
         }
     }
 
-    fn handle_runtime_message(
-        &mut self,
-        message: Result<Option<proto::ServerMessage>, DaemonError>,
-    ) {
+    fn handle_runtime_message(&mut self, message: Result<Option<v3::ServerEnvelope>, DaemonError>) {
         match message {
-            Ok(Some(message)) => {
-                if self.observe_inbound_message(&message) {
+            Ok(Some(env)) => {
+                if self.observe_inbound_pong(&env) {
                     return;
                 }
-                if let Some(proto::server_message::Msg::RuntimeTerminated(terminated)) =
-                    &message.msg
+                self.observe_inbound_any();
+                if let Some(v3::server_envelope::Payload::RuntimeTerminated(terminated)) =
+                    &env.payload
                     && let Ok(runtime_id) = rttx_proto::bytes_to_uuid(&terminated.runtime_id)
                 {
                     self.tracked_workspaces.retain(|_, tracked_runtime_id| {
                         tracked_runtime_id != &runtime_id.to_string()
                     });
                 }
-                self.forward_push(message);
+                self.forward_push(env);
             }
             Ok(None) | Err(_) => self.handle_disconnect(),
         }
     }
 
-    fn forward_push(&self, message: proto::ServerMessage) {
+    fn forward_push(&self, message: v3::ServerEnvelope) {
         let _ = self
             .event_tx
             .try_send(EndpointEvent::RuntimeMessage { endpoint: self.endpoint.clone(), message });
     }
 
-    fn observe_inbound_message(&mut self, message: &proto::ServerMessage) -> bool {
-        self.heartbeat.observe_inbound(message)
+    fn observe_inbound_pong(&mut self, env: &v3::ServerEnvelope) -> bool {
+        if let Some(v3::server_envelope::Payload::Pong(pong)) = &env.payload {
+            if self.heartbeat.pending_nonce == Some(pong.nonce) {
+                self.heartbeat.pending_nonce = None;
+                self.heartbeat.missed_ticks = 0;
+            }
+            return true;
+        }
+        false
+    }
+
+    const fn observe_inbound_any(&mut self) {
+        self.heartbeat.pending_nonce = None;
+        self.heartbeat.missed_ticks = 0;
     }
 
     async fn handle_heartbeat_tick(&mut self) {
@@ -1604,6 +1580,14 @@ fn parse_uuid(
     }
 }
 
+fn protocol_error_to_daemon(e: v3::ProtocolError) -> DaemonError {
+    DaemonError::ProtocolError {
+        kind: v3::ErrorKind::try_from(e.kind).unwrap_or(v3::ErrorKind::Unspecified),
+        message: e.message,
+        retryable: e.retryable,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1617,22 +1601,22 @@ mod tests {
         (crate::daemon::split_transport_for_test(read_half, write_half), server)
     }
 
-    async fn recv_client_message(
+    async fn recv_client_envelope(
         stream: &mut tokio::io::DuplexStream,
         read_buf: &mut BytesMut,
-    ) -> proto::ClientMessage {
-        recv_client_message_opt(stream, read_buf)
+    ) -> v3::ClientEnvelope {
+        recv_client_envelope_opt(stream, read_buf)
             .await
             .expect("read from duplex transport")
-            .expect("unexpected EOF while waiting for client message")
+            .expect("unexpected EOF while waiting for client envelope")
     }
 
-    async fn recv_client_message_opt(
+    async fn recv_client_envelope_opt(
         stream: &mut tokio::io::DuplexStream,
         read_buf: &mut BytesMut,
-    ) -> std::io::Result<Option<proto::ClientMessage>> {
+    ) -> std::io::Result<Option<v3::ClientEnvelope>> {
         loop {
-            match rttx_proto::decode_frame::<proto::ClientMessage>(read_buf) {
+            match rttx_proto::decode_frame::<v3::ClientEnvelope>(read_buf) {
                 Ok(message) => return Ok(Some(message)),
                 Err(rttx_proto::FrameError::Incomplete) => {}
                 Err(error) => {
@@ -1646,14 +1630,11 @@ mod tests {
         }
     }
 
-    async fn send_server_message(
-        stream: &mut tokio::io::DuplexStream,
-        message: &proto::ServerMessage,
-    ) {
+    async fn send_server_envelope(stream: &mut tokio::io::DuplexStream, env: &v3::ServerEnvelope) {
         let mut buf = BytesMut::new();
-        rttx_proto::encode_frame(message, &mut buf).expect("encode server message");
-        stream.write_all(&buf).await.expect("write server message");
-        stream.flush().await.expect("flush server message");
+        rttx_proto::encode_frame(env, &mut buf).expect("encode server envelope");
+        stream.write_all(&buf).await.expect("write server envelope");
+        stream.flush().await.expect("flush server envelope");
     }
 
     fn make_actor(reader: DaemonReader, writer: DaemonWriter) -> EndpointActor {
@@ -1675,6 +1656,7 @@ mod tests {
             daemon_start_attempted: false,
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
+            next_request_id: 1,
         }
     }
 
@@ -1686,21 +1668,24 @@ mod tests {
 
         let server = tokio::spawn(async move {
             let mut read_buf = BytesMut::new();
-            let request = recv_client_message(&mut server_stream, &mut read_buf).await;
-            match request.msg {
-                Some(proto::client_message::Msg::CreateRuntime(create)) => {
+            let request = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            match request.command {
+                Some(v3::client_envelope::Command::CreateRuntime(create)) => {
                     assert_eq!(create.name, "Workspace 2");
-                    assert_eq!(create.policy, WorkspacePolicy::Persistent.as_proto());
+                    assert_eq!(create.policy, WorkspacePolicy::Persistent.as_v3_proto());
                 }
                 other => panic!("expected CreateRuntime request, got {other:?}"),
             }
-            send_server_message(
+            send_server_envelope(
                 &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::RuntimeCreated(proto::RuntimeCreated {
-                        runtime_id: rttx_proto::uuid_to_bytes(expected_runtime),
-                        revision: 1,
-                    })),
+                &v3::ServerEnvelope {
+                    request_id: request.request_id,
+                    payload: Some(v3::server_envelope::Payload::RuntimeCreated(
+                        v3::RuntimeCreated {
+                            runtime_id: rttx_proto::uuid_to_bytes(expected_runtime),
+                            runtime_revision: 1,
+                        },
+                    )),
                 },
             )
             .await;
@@ -1722,23 +1707,26 @@ mod tests {
 
         let server = tokio::spawn(async move {
             let mut read_buf = BytesMut::new();
-            let request = recv_client_message(&mut server_stream, &mut read_buf).await;
-            match request.msg {
-                Some(proto::client_message::Msg::AttachRuntime(attach)) => {
+            let request = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            match request.command {
+                Some(v3::client_envelope::Command::AttachRuntime(attach)) => {
                     assert_eq!(rttx_proto::bytes_to_uuid(&attach.runtime_id).unwrap(), runtime_id);
-                    assert_eq!(attach.attach_mode, proto::RuntimeAttachMode::ReadWrite as i32);
+                    assert_eq!(attach.attach_mode, v3::RuntimeAttachMode::ReadWrite as i32);
                 }
                 other => panic!("expected AttachRuntime request, got {other:?}"),
             }
-            send_server_message(
+            send_server_envelope(
                 &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::Snapshot(proto::Snapshot {
-                        runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
-                        panes: vec![],
-                        revision: 1,
-                        current_client_role: proto::RuntimeClientRole::Writer as i32,
-                    })),
+                &v3::ServerEnvelope {
+                    request_id: request.request_id,
+                    payload: Some(v3::server_envelope::Payload::RuntimeSnapshot(
+                        v3::RuntimeSnapshot {
+                            runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
+                            panes: vec![],
+                            runtime_revision: 1,
+                            client_role: v3::RuntimeClientRole::Writer as i32,
+                        },
+                    )),
                 },
             )
             .await;
@@ -1774,6 +1762,7 @@ mod tests {
             daemon_start_attempted: false,
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
+            next_request_id: 1,
         };
         (actor, event_rx)
     }
@@ -1803,11 +1792,13 @@ mod tests {
         let mut heartbeat = HeartbeatMonitor::default();
         assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 0 });
         assert!(
-            !heartbeat.observe_inbound(&proto::ServerMessage {
-                msg: Some(proto::server_message::Msg::Delta(proto::Delta {
+            !heartbeat.observe_inbound(&v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::OutputDelta(v3::OutputDelta {
                     runtime_id: vec![],
                     pane_id: vec![],
                     data: bytes::Bytes::from_static(b"output"),
+                    ..Default::default()
                 })),
             }),
             "non-heartbeat traffic should not be swallowed"
@@ -1820,8 +1811,9 @@ mod tests {
         let mut heartbeat = HeartbeatMonitor::default();
         assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 0 });
         assert!(
-            heartbeat.observe_inbound(&proto::ServerMessage {
-                msg: Some(proto::server_message::Msg::Pong(proto::Pong { nonce: 0 })),
+            heartbeat.observe_inbound(&v3::ServerEnvelope {
+                request_id: 0,
+                payload: Some(v3::server_envelope::Payload::Pong(v3::Pong { nonce: 0 })),
             }),
             "heartbeat pong should stay internal to the actor"
         );
@@ -1839,18 +1831,23 @@ mod tests {
 
         let server = tokio::spawn(async move {
             let mut read_buf = BytesMut::new();
-            let request = recv_client_message(&mut server_stream, &mut read_buf).await;
-            match request.msg {
-                Some(proto::client_message::Msg::ClosePane(_)) => {}
+            let request = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            match request.command {
+                Some(v3::client_envelope::Command::ClosePane(_)) => {}
                 other => panic!("expected ClosePane, got {other:?}"),
             }
-            // Respond with ERR_PANE_NOT_FOUND (code 6).
-            send_server_message(
+            // Respond with PaneNotFound error.
+            send_server_envelope(
                 &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::Error(proto::Error {
-                        code: 6,
+                &v3::ServerEnvelope {
+                    request_id: request.request_id,
+                    payload: Some(v3::server_envelope::Payload::Error(v3::ProtocolError {
+                        kind: v3::ErrorKind::PaneNotFound as i32,
                         message: "pane not found".into(),
+                        retryable: false,
+                        operation: String::new(),
+                        retry_after_seconds: 0,
+                        user_action_required: false,
                     })),
                 },
             )
@@ -1897,12 +1894,12 @@ mod tests {
             // declare the connection lost after HEARTBEAT_MISS_LIMIT ticks.
             loop {
                 let Ok(Some(request)) =
-                    recv_client_message_opt(&mut server_stream, &mut read_buf).await
+                    recv_client_envelope_opt(&mut server_stream, &mut read_buf).await
                 else {
                     break;
                 };
-                match request.msg {
-                    Some(proto::client_message::Msg::Ping(_)) => {}
+                match request.command {
+                    Some(v3::client_envelope::Command::Ping(_)) => {}
                     other => panic!("expected Ping request, got {other:?}"),
                 }
             }
@@ -1946,16 +1943,17 @@ mod tests {
         let (release_tx, release_rx) = tokio::sync::oneshot::channel();
         let server = tokio::spawn(async move {
             let mut read_buf = BytesMut::new();
-            let request = recv_client_message(&mut server_stream, &mut read_buf).await;
-            let nonce = match request.msg {
-                Some(proto::client_message::Msg::Ping(ping)) => ping.nonce,
+            let request = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            let nonce = match request.command {
+                Some(v3::client_envelope::Command::Ping(ping)) => ping.nonce,
                 other => panic!("expected Ping request, got {other:?}"),
             };
             assert_eq!(nonce, 0);
-            send_server_message(
+            send_server_envelope(
                 &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::Pong(proto::Pong { nonce })),
+                &v3::ServerEnvelope {
+                    request_id: 0,
+                    payload: Some(v3::server_envelope::Payload::Pong(v3::Pong { nonce })),
                 },
             )
             .await;
@@ -2105,6 +2103,7 @@ mod tests {
             daemon_start_attempted: false,
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
+            next_request_id: 1,
         };
 
         let stale_runtime = Uuid::new_v4();
@@ -2113,17 +2112,22 @@ mod tests {
             let mut read_buf = BytesMut::new();
 
             // Receive AttachRuntime for the stale runtime — reply "not found".
-            let msg = recv_client_message(&mut server_stream, &mut read_buf).await;
+            let msg = recv_client_envelope(&mut server_stream, &mut read_buf).await;
             assert!(
-                matches!(msg.msg, Some(proto::client_message::Msg::AttachRuntime(_))),
+                matches!(msg.command, Some(v3::client_envelope::Command::AttachRuntime(_))),
                 "expected AttachRuntime, got {msg:?}"
             );
-            send_server_message(
+            send_server_envelope(
                 &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::Error(proto::Error {
-                        code: 4,
+                &v3::ServerEnvelope {
+                    request_id: msg.request_id,
+                    payload: Some(v3::server_envelope::Payload::Error(v3::ProtocolError {
+                        kind: v3::ErrorKind::RuntimeNotFound as i32,
                         message: "session not found".into(),
+                        retryable: false,
+                        operation: String::new(),
+                        retry_after_seconds: 0,
+                        user_action_required: false,
                     })),
                 },
             )
@@ -2181,6 +2185,7 @@ mod tests {
             daemon_start_attempted: false,
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
+            next_request_id: 1,
         };
 
         let runtime_id = Uuid::new_v4();
@@ -2189,12 +2194,13 @@ mod tests {
             let mut read_buf = BytesMut::new();
 
             // Receive AttachRuntime — reply with AttachBlocked.
-            let msg = recv_client_message(&mut server_stream, &mut read_buf).await;
-            assert!(matches!(msg.msg, Some(proto::client_message::Msg::AttachRuntime(_))));
-            send_server_message(
+            let msg = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            assert!(matches!(msg.command, Some(v3::client_envelope::Command::AttachRuntime(_))));
+            send_server_envelope(
                 &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::AttachBlocked(proto::AttachBlocked {
+                &v3::ServerEnvelope {
+                    request_id: msg.request_id,
+                    payload: Some(v3::server_envelope::Payload::AttachBlocked(v3::AttachBlocked {
                         runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
                         current_client_role: 0,
                         attached_client_count: 1,
@@ -2386,6 +2392,7 @@ mod tests {
             daemon_start_attempted: false,
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
+            next_request_id: 1,
         };
 
         // Server: drop the connection immediately to cause I/O errors.
@@ -2436,36 +2443,41 @@ mod tests {
         // Server sends a push message (delta) before the snapshot response.
         let server = tokio::spawn(async move {
             let mut read_buf = BytesMut::new();
-            let request = recv_client_message(&mut server_stream, &mut read_buf).await;
-            match request.msg {
-                Some(proto::client_message::Msg::AttachRuntime(_)) => {}
+            let request = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            match request.command {
+                Some(v3::client_envelope::Command::AttachRuntime(_)) => {}
                 other => panic!("expected AttachRuntime, got {other:?}"),
             }
 
             // Send a delta push message first (simulating PTY output from
             // a previously attached session).
-            send_server_message(
+            send_server_envelope(
                 &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::Delta(proto::Delta {
+                &v3::ServerEnvelope {
+                    request_id: 0,
+                    payload: Some(v3::server_envelope::Payload::OutputDelta(v3::OutputDelta {
                         runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
                         pane_id: vec![0; 16],
                         data: bytes::Bytes::from_static(b"interleaved output"),
+                        ..Default::default()
                     })),
                 },
             )
             .await;
 
             // Then send the actual snapshot response.
-            send_server_message(
+            send_server_envelope(
                 &mut server_stream,
-                &proto::ServerMessage {
-                    msg: Some(proto::server_message::Msg::Snapshot(proto::Snapshot {
-                        runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
-                        panes: vec![],
-                        revision: 1,
-                        current_client_role: proto::RuntimeClientRole::Writer as i32,
-                    })),
+                &v3::ServerEnvelope {
+                    request_id: request.request_id,
+                    payload: Some(v3::server_envelope::Payload::RuntimeSnapshot(
+                        v3::RuntimeSnapshot {
+                            runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
+                            panes: vec![],
+                            runtime_revision: 1,
+                            client_role: v3::RuntimeClientRole::Writer as i32,
+                        },
+                    )),
                 },
             )
             .await;
@@ -2481,7 +2493,7 @@ mod tests {
         let mut saw_delta = false;
         while let Ok(event) = event_rx.try_recv() {
             if let EndpointEvent::RuntimeMessage { message, .. } = event
-                && matches!(message.msg, Some(proto::server_message::Msg::Delta(_)))
+                && matches!(message.payload, Some(v3::server_envelope::Payload::OutputDelta(_)))
             {
                 saw_delta = true;
             }
@@ -2590,8 +2602,9 @@ mod tests {
             assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 0 });
         }
         // Late Pong arrives just before the limit.
-        assert!(heartbeat.observe_inbound(&proto::ServerMessage {
-            msg: Some(proto::server_message::Msg::Pong(proto::Pong { nonce: 0 })),
+        assert!(heartbeat.observe_inbound(&v3::ServerEnvelope {
+            request_id: 0,
+            payload: Some(v3::server_envelope::Payload::Pong(v3::Pong { nonce: 0 })),
         }));
         // Next tick should issue a fresh nonce, not declare lost.
         assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 1 });
@@ -2609,11 +2622,13 @@ mod tests {
             assert_eq!(heartbeat.on_tick(), HeartbeatAction::SendPing { nonce: 0 });
         }
         // Inbound Delta resets the monitor.
-        assert!(!heartbeat.observe_inbound(&proto::ServerMessage {
-            msg: Some(proto::server_message::Msg::Delta(proto::Delta {
+        assert!(!heartbeat.observe_inbound(&v3::ServerEnvelope {
+            request_id: 0,
+            payload: Some(v3::server_envelope::Payload::OutputDelta(v3::OutputDelta {
                 runtime_id: vec![],
                 pane_id: vec![],
                 data: bytes::Bytes::from_static(b"output"),
+                ..Default::default()
             })),
         }));
         // Miss another half — should still be fine because we reset.

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -1,4 +1,5 @@
 use crate::daemon::DaemonError;
+use rttx_proto::v3;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -29,6 +30,15 @@ impl WorkspacePolicy {
         match self {
             Self::Persistent => rttx_proto::proto::RuntimePolicy::Persistent as i32,
             Self::Ephemeral => rttx_proto::proto::RuntimePolicy::Ephemeral as i32,
+        }
+    }
+
+    /// Wire value for v3 daemon session creation.
+    #[must_use]
+    pub const fn as_v3_proto(self) -> i32 {
+        match self {
+            Self::Persistent => rttx_proto::v3::RuntimePolicy::Persistent as i32,
+            Self::Ephemeral => rttx_proto::v3::RuntimePolicy::Ephemeral as i32,
         }
     }
 }
@@ -260,6 +270,16 @@ pub fn classify_connection_problem(error: &DaemonError) -> ConnectionProblem {
     match error {
         DaemonError::VersionMismatch { .. } => ConnectionProblem::VersionMismatch,
         DaemonError::AttachBlocked(_) => ConnectionProblem::OwnershipConflict,
+        DaemonError::ProtocolError { kind, message, .. } => match kind {
+            v3::ErrorKind::RuntimeNotFound => ConnectionProblem::SessionMissing,
+            v3::ErrorKind::OwnershipConflict | v3::ErrorKind::TakeoverRequired => {
+                ConnectionProblem::OwnershipConflict
+            }
+            v3::ErrorKind::ProtocolMismatch | v3::ErrorKind::UnsupportedCapability => {
+                ConnectionProblem::Protocol(message.clone())
+            }
+            _ => ConnectionProblem::UserActionRequired(message.clone()),
+        },
         DaemonError::ServerError { code, .. } if *code == 4 => ConnectionProblem::SessionMissing,
         DaemonError::ServerError { code, message } if *code == 8 => {
             ConnectionProblem::UserActionRequired(message.clone())

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rttx_proto::v3;
 
 /// Maximum events the poller processes per GTK timer callback.
 /// Keeps the main loop responsive during output bursts.
@@ -644,14 +645,19 @@ impl Window {
         let Some(pane) = pane else { return };
 
         pane.vte().reset(true, true);
-        pane.feed_snapshot(&restore.scrollback);
-        pane.set_bracketed_paste_mode(restore.bracketed_paste_mode);
-        pane.restore_interaction_modes(
-            restore.application_cursor_keys,
-            restore.application_keypad,
-            restore.mouse_tracking_mode,
-            restore.sgr_mouse_mode,
-        );
+        pane.feed_snapshot(&restore.scrollback_tail);
+        if let Some(ref modes) = restore.terminal_modes {
+            pane.set_bracketed_paste_mode(modes.bracketed_paste);
+            pane.restore_interaction_modes(
+                modes.application_cursor_keys,
+                modes.application_keypad,
+                u32::from(rttx_proto::v3_terminal_modes::tracking_value_from_mouse_mode(
+                    rttx_proto::v3::MouseMode::try_from(modes.mouse_mode)
+                        .unwrap_or(rttx_proto::v3::MouseMode::None),
+                )),
+                modes.sgr_mouse,
+            );
+        }
         pane.set_current_directory(Some(&restore.cwd));
         if !restore.title.is_empty() && pane.custom_title().is_none() {
             pane.set_daemon_title(&restore.title);
@@ -823,20 +829,20 @@ impl Window {
     pub(super) fn dispatch_managed_runtime_message(
         &self,
         endpoint: &RuntimeEndpoint,
-        msg: &rttx_proto::proto::ServerMessage,
+        msg: &v3::ServerEnvelope,
     ) {
-        use rttx_proto::proto::server_message::Msg;
+        use v3::server_envelope::Payload;
 
-        let Some(inner) = msg.msg.as_ref() else {
+        let Some(inner) = msg.payload.as_ref() else {
             return;
         };
 
-        if let Msg::Error(error) = inner {
-            tracing::warn!("Daemon error: {} (code {})", error.message, error.code);
+        if let Payload::Error(error) = inner {
+            tracing::warn!("Daemon error: {} ({:?})", error.message, error.kind());
             return;
         }
 
-        if let Msg::RuntimeTerminated(terminated) = inner {
+        if let Payload::RuntimeTerminated(terminated) = inner {
             let Ok(runtime_id) = rttx_proto::bytes_to_uuid(&terminated.runtime_id) else {
                 return;
             };
@@ -873,32 +879,30 @@ impl Window {
         let Some(pane) = pane else { return };
 
         match inner {
-            Msg::Delta(delta) => {
+            Payload::OutputDelta(delta) => {
                 pane.feed_output(&delta.data);
                 self.mark_session_activity(&layout_terminal_uuid);
             }
-            Msg::TitleChanged(title_changed) => {
+            Payload::TitleChanged(t) => {
                 if pane.custom_title().is_none() {
-                    pane.set_daemon_title(&title_changed.title);
+                    pane.set_daemon_title(&t.title);
                 }
                 self.refresh_sidebar_subtitle_if_active(&layout_terminal_uuid);
             }
-            Msg::CwdChanged(cwd_changed) => {
-                pane.set_current_directory(Some(&cwd_changed.cwd));
+            Payload::CwdChanged(c) => {
+                pane.set_current_directory(Some(&c.cwd));
                 {
                     let mut state = self.imp().state.borrow_mut();
                     if let Some(session) =
                         state.workspaces.iter_mut().find(|s| s.uuid == workspace_id)
                     {
-                        session
-                            .layout
-                            .set_terminal_cwd(&layout_terminal_uuid, Some(cwd_changed.cwd.clone()));
+                        session.layout.set_terminal_cwd(&layout_terminal_uuid, Some(c.cwd.clone()));
                     }
                 }
-                self.maybe_auto_rename_workspace(&workspace_id, Some(&cwd_changed.cwd));
+                self.maybe_auto_rename_workspace(&workspace_id, Some(&c.cwd));
                 self.refresh_sidebar_subtitle_if_active(&layout_terminal_uuid);
             }
-            Msg::PaneExited(exited) => {
+            Payload::PaneExited(exited) => {
                 pane.mark_exited(exited.status);
                 let visible_session = self.imp().session_stack.visible_child_name();
                 let state = self.imp().state.borrow();
@@ -912,21 +916,26 @@ impl Window {
                     self.notify_process_completed(&layout_terminal_uuid, exited.status);
                 }
             }
-            Msg::Bell(_) => pane.flash_bell(),
-            Msg::PaneResized(_)
-            | Msg::PaneCreated(_)
-            | Msg::PaneClosed(_)
-            | Msg::HelloAck(_)
-            | Msg::RuntimeList(_)
-            | Msg::RuntimeCreated(_)
-            | Msg::Snapshot(_)
-            | Msg::AttachBlocked(_)
-            | Msg::RuntimeDetached(_)
-            | Msg::RuntimeTerminated(_)
-            | Msg::RuntimeRenamed(_)
-            | Msg::Pong(_)
-            | Msg::Error(_)
-            | Msg::DiagnosticsReport(_) => {}
+            Payload::Bell(_) => pane.flash_bell(),
+            Payload::PaneResized(_)
+            | Payload::PaneCreated(_)
+            | Payload::PaneClosed(_)
+            | Payload::RuntimeList(_)
+            | Payload::RuntimeCreated(_)
+            | Payload::RuntimeSnapshot(_)
+            | Payload::AttachBlocked(_)
+            | Payload::RuntimeDetached(_)
+            | Payload::RuntimeTerminated(_)
+            | Payload::RuntimeRenamed(_)
+            | Payload::Pong(_)
+            | Payload::Error(_)
+            | Payload::DiagnosticsReport(_)
+            | Payload::TerminalModeChanged(_)
+            | Payload::StreamOverflow(_)
+            | Payload::ScrollbackChunk(_)
+            | Payload::TakeoverCompleted(_)
+            | Payload::LeaseLost(_)
+            | Payload::OwnerDisconnected(_) => {}
         }
 
         let _ = workspace_id;

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -2430,28 +2430,28 @@ fn inventory_loaded_recovers_missing_managed_workspace() {
 
     window.handle_endpoint_event(crate::daemon_bridge::EndpointEvent::InventoryLoaded {
         endpoint: RuntimeEndpoint::Local,
-        runtimes: vec![rttx_proto::proto::RuntimeInfo {
+        runtimes: vec![rttx_proto::v3::RuntimeInfo {
             id: rttx_proto::uuid_to_bytes(runtime_id),
             name: "Recovered Workspace".into(),
             pane_count: 1,
-            has_attached_client: false,
-            active_pane_id: Some(rttx_proto::uuid_to_bytes(pane_id)),
-            panes: vec![rttx_proto::proto::PaneInfo {
+            has_write_owner: false,
+            read_only_client_count: 0,
+            active_pane_summary: String::new(),
+            takeover_eligible: false,
+            disabled_reason: String::new(),
+            current_client_role: rttx_proto::v3::RuntimeClientRole::Unattached as i32,
+            panes: vec![rttx_proto::v3::PaneInfo {
                 id: rttx_proto::uuid_to_bytes(pane_id),
                 title: "Shell".into(),
                 cwd: "/srv/project".into(),
                 cols: 120,
                 rows: 40,
                 exit_status: None,
-                reconstructed: true,
+                reconstructed: false,
             }],
-            policy: rttx_proto::proto::RuntimePolicy::Persistent as i32,
-            attached_client_count: 0,
+            policy: rttx_proto::v3::RuntimePolicy::Persistent as i32,
             reconstructed: true,
-            revision: 7,
-            current_client_role: rttx_proto::proto::RuntimeClientRole::Unattached as i32,
-            has_write_owner: false,
-            read_only_client_count: 0,
+            runtime_revision: 7,
         }],
     });
 
@@ -2523,28 +2523,28 @@ fn inventory_loaded_skips_workspace_for_known_runtime() {
 
     window.handle_endpoint_event(crate::daemon_bridge::EndpointEvent::InventoryLoaded {
         endpoint: RuntimeEndpoint::Local,
-        runtimes: vec![rttx_proto::proto::RuntimeInfo {
+        runtimes: vec![rttx_proto::v3::RuntimeInfo {
             id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
             name: "Recovered Workspace".into(),
             pane_count: 1,
-            has_attached_client: false,
-            active_pane_id: None,
-            panes: vec![rttx_proto::proto::PaneInfo {
+            has_write_owner: false,
+            read_only_client_count: 0,
+            active_pane_summary: String::new(),
+            takeover_eligible: false,
+            disabled_reason: String::new(),
+            current_client_role: rttx_proto::v3::RuntimeClientRole::Unattached as i32,
+            panes: vec![rttx_proto::v3::PaneInfo {
                 id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
                 title: "Shell".into(),
                 cwd: "/srv/project".into(),
                 cols: 120,
                 rows: 40,
                 exit_status: None,
-                reconstructed: true,
+                reconstructed: false,
             }],
-            policy: rttx_proto::proto::RuntimePolicy::Persistent as i32,
-            attached_client_count: 0,
+            policy: rttx_proto::v3::RuntimePolicy::Persistent as i32,
             reconstructed: true,
-            revision: 7,
-            current_client_role: rttx_proto::proto::RuntimeClientRole::Unattached as i32,
-            has_write_owner: false,
-            read_only_client_count: 0,
+            runtime_revision: 7,
         }],
     });
 
@@ -2606,24 +2606,23 @@ fn managed_workspace_recovery_does_not_steal_visible_session_from_selected_row()
     window.handle_endpoint_event(crate::daemon_bridge::EndpointEvent::WorkspaceOpened {
         workspace_id: recovered_session.uuid.clone(),
         runtime_id: runtime_id.to_string(),
-        snapshot: rttx_proto::proto::Snapshot {
+        snapshot: rttx_proto::v3::RuntimeSnapshot {
             runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
-            panes: vec![rttx_proto::proto::PaneSnapshot {
+            runtime_revision: 7,
+            client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
+            panes: vec![rttx_proto::v3::PaneSnapshot {
                 pane_id: rttx_proto::uuid_to_bytes(pane_id),
+                pane_output_seq: 0,
                 title: "Shell".into(),
                 cwd: "/srv/project".into(),
                 cols: 120,
                 rows: 40,
-                scrollback: bytes::Bytes::from_static(b"restored output"),
                 exit_status: None,
-                bracketed_paste_mode: false,
-                application_cursor_keys: false,
-                application_keypad: false,
-                mouse_tracking_mode: 0,
-                sgr_mouse_mode: false,
+                terminal_modes: None,
+                scrollback_tail: bytes::Bytes::from_static(b"restored output"),
+                total_scrollback_bytes: 15,
+                scrollback_complete: true,
             }],
-            revision: 7,
-            current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
         },
     });
     pump_events(50);
@@ -2891,7 +2890,7 @@ fn runtime_terminated_event_clears_runtime_id_but_keeps_workspace() {
     window.handle_endpoint_event(crate::daemon_bridge::EndpointEvent::RuntimeTerminated {
         workspace_id: session_state.uuid.clone(),
         runtime_id,
-        reason: rttx_proto::proto::RuntimeTerminationReason::Explicit,
+        reason: rttx_proto::v3::RuntimeTerminationReason::Explicit,
     });
 
     let state = window.imp().state.borrow();
@@ -2942,7 +2941,7 @@ fn save_state_persists_terminated_workspace_without_runtime_id() {
     window.handle_endpoint_event(crate::daemon_bridge::EndpointEvent::RuntimeTerminated {
         workspace_id: session_state.uuid.clone(),
         runtime_id,
-        reason: rttx_proto::proto::RuntimeTerminationReason::Explicit,
+        reason: rttx_proto::v3::RuntimeTerminationReason::Explicit,
     });
     window.save_state();
 
@@ -3186,24 +3185,23 @@ fn retry_workspace_connection_sets_connecting_and_rebuilds_on_open() {
     window.handle_endpoint_event(crate::daemon_bridge::EndpointEvent::WorkspaceOpened {
         workspace_id: session_state.uuid.clone(),
         runtime_id: runtime_id.to_string(),
-        snapshot: rttx_proto::proto::Snapshot {
+        snapshot: rttx_proto::v3::RuntimeSnapshot {
             runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
-            panes: vec![rttx_proto::proto::PaneSnapshot {
+            runtime_revision: 5,
+            client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
+            panes: vec![rttx_proto::v3::PaneSnapshot {
                 pane_id: rttx_proto::uuid_to_bytes(pane_id),
+                pane_output_seq: 0,
                 title: "shell".into(),
                 cwd: "/home/user".into(),
                 cols: 80,
                 rows: 24,
-                scrollback: bytes::Bytes::from_static(b"reconnected"),
                 exit_status: None,
-                bracketed_paste_mode: false,
-                application_cursor_keys: false,
-                application_keypad: false,
-                mouse_tracking_mode: 0,
-                sgr_mouse_mode: false,
+                terminal_modes: None,
+                scrollback_tail: bytes::Bytes::from_static(b"reconnected"),
+                total_scrollback_bytes: 11,
+                scrollback_complete: true,
             }],
-            revision: 5,
-            current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
         },
     });
     pump_events(50);
@@ -3305,13 +3303,14 @@ fn cwd_changed_updates_layout_node() {
     }
 
     // Dispatch a CwdChanged message.
-    let msg = rttx_proto::proto::ServerMessage {
-        msg: Some(rttx_proto::proto::server_message::Msg::CwdChanged(
-            rttx_proto::proto::CwdChanged {
+    let msg = rttx_proto::v3::ServerEnvelope {
+        request_id: 0,
+        payload: Some(rttx_proto::v3::server_envelope::Payload::CwdChanged(
+            rttx_proto::v3::CwdChanged {
                 runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
                 pane_id: rttx_proto::uuid_to_bytes(runtime_pane_id),
                 cwd: "/tmp/updated".into(),
-                revision: 1,
+                runtime_revision: 1,
             },
         )),
     };
@@ -3375,13 +3374,14 @@ fn managed_pane_exit_marks_visible_pane_exited() {
     window.imp().state.borrow_mut().workspaces.push(session_state.clone());
     window.build_session(&session_state, false);
 
-    let msg = rttx_proto::proto::ServerMessage {
-        msg: Some(rttx_proto::proto::server_message::Msg::PaneExited(
-            rttx_proto::proto::PaneExited {
+    let msg = rttx_proto::v3::ServerEnvelope {
+        request_id: 0,
+        payload: Some(rttx_proto::v3::server_envelope::Payload::PaneExited(
+            rttx_proto::v3::PaneExited {
                 runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
                 pane_id: rttx_proto::uuid_to_bytes(runtime_pane_id),
                 status: 0,
-                revision: 2,
+                runtime_revision: 2,
             },
         )),
     };
@@ -5838,14 +5838,12 @@ fn restore_managed_snapshot_feeds_scrollback_and_cwd_to_pane() {
         layout_terminal_uuid: layout_uuid.to_string(),
         title: "vim main.rs".to_string(),
         cwd: "/home/user/project".to_string(),
-        scrollback: bytes::Bytes::from_static(b"$ cargo build\r\nCompiling rttx\r\n"),
+        pane_output_seq: 0,
+        scrollback_tail: bytes::Bytes::from_static(b"$ cargo build\r\nCompiling rttx\r\n"),
+        scrollback_complete: true,
         cols: 120,
         rows: 40,
-        bracketed_paste_mode: true,
-        application_cursor_keys: false,
-        application_keypad: false,
-        mouse_tracking_mode: 0,
-        sgr_mouse_mode: false,
+        terminal_modes: None,
     };
     window.restore_managed_snapshot(&restore);
 
@@ -5889,14 +5887,12 @@ fn restore_managed_snapshot_skips_missing_pane() {
         layout_terminal_uuid: "nonexistent-pane".to_string(),
         title: String::new(),
         cwd: "/tmp".to_string(),
-        scrollback: bytes::Bytes::new(),
+        pane_output_seq: 0,
+        scrollback_tail: bytes::Bytes::new(),
+        scrollback_complete: true,
         cols: 80,
         rows: 24,
-        bracketed_paste_mode: false,
-        application_cursor_keys: false,
-        application_keypad: false,
-        mouse_tracking_mode: 0,
-        sgr_mouse_mode: false,
+        terminal_modes: None,
     };
     window.restore_managed_snapshot(&restore);
 
@@ -5937,14 +5933,12 @@ fn restore_managed_snapshot_sets_daemon_title_when_no_custom_title() {
         layout_terminal_uuid: layout_uuid.to_string(),
         title: "daemon-reported-title".to_string(),
         cwd: "/tmp".to_string(),
-        scrollback: bytes::Bytes::new(),
+        pane_output_seq: 0,
+        scrollback_tail: bytes::Bytes::new(),
+        scrollback_complete: true,
         cols: 80,
         rows: 24,
-        bracketed_paste_mode: false,
-        application_cursor_keys: false,
-        application_keypad: false,
-        mouse_tracking_mode: 0,
-        sgr_mouse_mode: false,
+        terminal_modes: None,
     };
     window.restore_managed_snapshot(&restore);
 
@@ -6139,14 +6133,12 @@ fn apply_transition_snapshot_restore_feeds_pane_data() {
             layout_terminal_uuid: layout_uuid.to_string(),
             title: "htop".to_string(),
             cwd: "/var/log".to_string(),
-            scrollback: bytes::Bytes::from_static(b"log output\r\n"),
+            pane_output_seq: 0,
+            scrollback_tail: bytes::Bytes::from_static(b"log output\r\n"),
+            scrollback_complete: true,
             cols: 80,
             rows: 24,
-            bracketed_paste_mode: false,
-            application_cursor_keys: false,
-            application_keypad: false,
-            mouse_tracking_mode: 0,
-            sgr_mouse_mode: false,
+            terminal_modes: None,
         }],
         connected_layout_terminals: vec![layout_uuid.to_string()],
         ..Default::default()

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1,7 +1,7 @@
 use crate::daemon_bridge::EndpointEvent;
 use crate::runtime::{ConnectionStatus, RuntimeEndpoint, WorkspacePolicy, reconcile_bindings};
 use crate::workspace::{LayoutNode, PaneRecovery, SplitOrientation, WindowState, WorkspaceState};
-use rttx_proto::proto;
+use rttx_proto::v3;
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Routing metadata for a daemon-managed terminal pane.
@@ -14,23 +14,21 @@ pub struct ManagedTerminalBinding {
 }
 
 /// Mapping from a daemon pane snapshot to a layout terminal.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WorkspacePaneRestore {
     pub layout_terminal_uuid: String,
     pub title: String,
     pub cwd: String,
-    pub scrollback: bytes::Bytes,
+    pub pane_output_seq: u64,
+    pub scrollback_tail: bytes::Bytes,
+    pub scrollback_complete: bool,
     pub cols: u16,
     pub rows: u16,
-    pub bracketed_paste_mode: bool,
-    pub application_cursor_keys: bool,
-    pub application_keypad: bool,
-    pub mouse_tracking_mode: u32,
-    pub sgr_mouse_mode: bool,
+    pub terminal_modes: Option<v3::TerminalModeState>,
 }
 
 /// Pure result of reconciling a workspace against a runtime snapshot.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ManagedWorkspaceOpenResult {
     pub session_state: WorkspaceState,
     pub panes_to_create: Vec<String>,
@@ -64,7 +62,7 @@ pub struct ManagedPaneCreateRequest {
 }
 
 /// Pure outcome of reconciling a daemon endpoint event against app state.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct EndpointEventTransition {
     pub recovered_workspaces: Vec<WorkspaceState>,
     pub rebuilt_workspaces: Vec<ManagedWorkspaceRebuild>,
@@ -228,7 +226,7 @@ impl WindowState {
     pub fn recover_managed_workspaces_from_inventory(
         &mut self,
         endpoint: &RuntimeEndpoint,
-        runtimes: &[proto::RuntimeInfo],
+        runtimes: &[v3::RuntimeInfo],
     ) -> Vec<WorkspaceState> {
         let mut known_runtime_ids = self
             .workspaces
@@ -399,7 +397,7 @@ impl WindowState {
         &mut self,
         workspace_id: &str,
         runtime_id: &str,
-        snapshot: &proto::Snapshot,
+        snapshot: &v3::RuntimeSnapshot,
     ) -> Option<ManagedWorkspaceOpenResult> {
         let session = self.workspaces.iter_mut().find(|session| session.uuid == workspace_id)?;
 
@@ -498,14 +496,12 @@ impl WindowState {
                     layout_terminal_uuid,
                     title: pane_snapshot.title.clone(),
                     cwd: pane_snapshot.cwd.clone(),
-                    scrollback: pane_snapshot.scrollback.clone(),
+                    pane_output_seq: pane_snapshot.pane_output_seq,
+                    scrollback_tail: pane_snapshot.scrollback_tail.clone(),
+                    scrollback_complete: pane_snapshot.scrollback_complete,
                     cols: pane_snapshot.cols as u16,
                     rows: pane_snapshot.rows as u16,
-                    bracketed_paste_mode: pane_snapshot.bracketed_paste_mode,
-                    application_cursor_keys: pane_snapshot.application_cursor_keys,
-                    application_keypad: pane_snapshot.application_keypad,
-                    mouse_tracking_mode: pane_snapshot.mouse_tracking_mode,
-                    sgr_mouse_mode: pane_snapshot.sgr_mouse_mode,
+                    terminal_modes: pane_snapshot.terminal_modes,
                 })
             })
             .collect::<Vec<_>>();
@@ -532,11 +528,11 @@ impl WindowState {
 
 fn recovered_managed_workspace(
     endpoint: &RuntimeEndpoint,
-    rt_info: &proto::RuntimeInfo,
+    rt_info: &v3::RuntimeInfo,
 ) -> Option<WorkspaceState> {
     let runtime_id = rttx_proto::bytes_to_uuid(&rt_info.id).ok()?.to_string();
-    let policy = match proto::RuntimePolicy::try_from(rt_info.policy).ok() {
-        Some(proto::RuntimePolicy::Ephemeral) => WorkspacePolicy::Ephemeral,
+    let policy = match v3::RuntimePolicy::try_from(rt_info.policy).ok() {
+        Some(v3::RuntimePolicy::Ephemeral) => WorkspacePolicy::Ephemeral,
         _ => WorkspacePolicy::Persistent,
     };
 
@@ -553,11 +549,7 @@ fn recovered_managed_workspace(
             .cloned()
             .map(|pane_id| (pane_id, PaneRecovery::empty_shell()))
             .collect();
-        session.active_terminal_uuid = rt_info
-            .active_pane_id
-            .as_ref()
-            .and_then(|pane_id| rttx_proto::bytes_to_uuid(pane_id).ok().map(|id| id.to_string()))
-            .or_else(|| pane_ids.first().cloned());
+        session.active_terminal_uuid = pane_ids.first().cloned();
         session.runtime.pane_bindings =
             pane_ids.iter().cloned().map(|pane_id| (pane_id.clone(), pane_id)).collect();
         session.runtime.pending_layout_panes.clear();
@@ -571,7 +563,7 @@ fn inventory_workspace_id(endpoint: &RuntimeEndpoint, runtime_id: &str) -> Strin
     format!("inventory:{}:{runtime_id}", endpoint.key())
 }
 
-fn layout_from_inventory_panes(panes: &[proto::PaneInfo]) -> LayoutNode {
+fn layout_from_inventory_panes(panes: &[v3::PaneInfo]) -> LayoutNode {
     let mut panes = panes.iter();
     let Some(first_pane) = panes.next() else {
         return LayoutNode::new_terminal();
@@ -585,7 +577,7 @@ fn layout_from_inventory_panes(panes: &[proto::PaneInfo]) -> LayoutNode {
     })
 }
 
-fn layout_terminal_from_inventory(pane: &proto::PaneInfo) -> LayoutNode {
+fn layout_terminal_from_inventory(pane: &v3::PaneInfo) -> LayoutNode {
     LayoutNode::Terminal {
         uuid: inventory_pane_id(pane).unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
         profile: None,
@@ -594,11 +586,11 @@ fn layout_terminal_from_inventory(pane: &proto::PaneInfo) -> LayoutNode {
     }
 }
 
-fn inventory_pane_id(pane: &proto::PaneInfo) -> Option<String> {
+fn inventory_pane_id(pane: &v3::PaneInfo) -> Option<String> {
     rttx_proto::bytes_to_uuid(&pane.id).ok().map(|uuid| uuid.to_string())
 }
 
-fn snapshot_pane_id(pane_snapshot: &proto::PaneSnapshot) -> Option<String> {
+fn snapshot_pane_id(pane_snapshot: &v3::PaneSnapshot) -> Option<String> {
     rttx_proto::bytes_to_uuid(&pane_snapshot.pane_id).ok().map(|uuid| uuid.to_string())
 }
 
@@ -613,39 +605,33 @@ mod tests {
         workspace,
     };
 
-    fn pane_snapshot(
-        pane_id: &str,
-        title: &str,
-        cwd: &str,
-        scrollback: &[u8],
-    ) -> proto::PaneSnapshot {
-        proto::PaneSnapshot {
+    fn pane_snapshot(pane_id: &str, title: &str, cwd: &str, scrollback: &[u8]) -> v3::PaneSnapshot {
+        v3::PaneSnapshot {
             pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),
+            pane_output_seq: 0,
             title: title.to_string(),
             cwd: cwd.to_string(),
             cols: 120,
             rows: 40,
-            scrollback: bytes::Bytes::copy_from_slice(scrollback),
             exit_status: None,
-            bracketed_paste_mode: false,
-            application_cursor_keys: false,
-            application_keypad: false,
-            mouse_tracking_mode: 0,
-            sgr_mouse_mode: false,
+            terminal_modes: None,
+            scrollback_tail: bytes::Bytes::copy_from_slice(scrollback),
+            total_scrollback_bytes: scrollback.len() as u64,
+            scrollback_complete: true,
         }
     }
 
-    fn snapshot(runtime_id: &str, panes: Vec<proto::PaneSnapshot>) -> proto::Snapshot {
-        proto::Snapshot {
+    fn snapshot(runtime_id: &str, panes: Vec<v3::PaneSnapshot>) -> v3::RuntimeSnapshot {
+        v3::RuntimeSnapshot {
             runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
             panes,
-            revision: 7,
-            current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
+            runtime_revision: 7,
+            client_role: v3::RuntimeClientRole::Writer as i32,
         }
     }
 
-    fn pane_info(pane_id: &str, title: &str, cwd: &str) -> proto::PaneInfo {
-        proto::PaneInfo {
+    fn pane_info(pane_id: &str, title: &str, cwd: &str) -> v3::PaneInfo {
+        v3::PaneInfo {
             id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),
             title: title.to_string(),
             cwd: cwd.to_string(),
@@ -659,25 +645,24 @@ mod tests {
     fn rt_info(
         runtime_id: &str,
         name: &str,
-        policy: proto::RuntimePolicy,
-        panes: Vec<proto::PaneInfo>,
-        active_pane_id: Option<&str>,
-    ) -> proto::RuntimeInfo {
-        proto::RuntimeInfo {
+        policy: v3::RuntimePolicy,
+        panes: Vec<v3::PaneInfo>,
+        _active_pane_id: Option<&str>,
+    ) -> v3::RuntimeInfo {
+        v3::RuntimeInfo {
             id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
             name: name.to_string(),
             pane_count: panes.len() as u32,
-            has_attached_client: false,
-            active_pane_id: active_pane_id
-                .map(|pane_id| rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap())),
             panes,
             policy: policy as i32,
-            attached_client_count: 0,
             reconstructed: true,
-            revision: 7,
-            current_client_role: proto::RuntimeClientRole::Unattached as i32,
+            runtime_revision: 7,
+            current_client_role: v3::RuntimeClientRole::Unattached as i32,
             has_write_owner: false,
             read_only_client_count: 0,
+            active_pane_summary: String::new(),
+            takeover_eligible: false,
+            disabled_reason: String::new(),
         }
     }
 
@@ -869,13 +854,13 @@ mod tests {
             restore.layout_terminal_uuid == "left"
                 && restore.title == "Shell"
                 && restore.cwd == "/srv/project"
-                && restore.scrollback[..] == b"shell"[..]
+                && restore.scrollback_tail[..] == b"shell"[..]
         }));
         assert!(opened.snapshot_restores.iter().any(|restore| {
             restore.layout_terminal_uuid == recovered_terminal_uuid
                 && restore.title == "Logs"
                 && restore.cwd == "/srv/project"
-                && restore.scrollback[..] == b"logs"[..]
+                && restore.scrollback_tail[..] == b"logs"[..]
         }));
     }
 
@@ -891,7 +876,7 @@ mod tests {
             &[rt_info(
                 runtime_id,
                 "Recovered Workspace",
-                proto::RuntimePolicy::Persistent,
+                v3::RuntimePolicy::Persistent,
                 vec![
                     pane_info(first_pane, "Shell", "/srv/project"),
                     pane_info(second_pane, "Logs", "/srv/project"),
@@ -908,7 +893,7 @@ mod tests {
         assert_eq!(session.runtime.endpoint, RuntimeEndpoint::Local);
         assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
         assert_eq!(session.runtime.runtime_id.as_deref(), Some(runtime_id));
-        assert_eq!(session.active_terminal_uuid.as_deref(), Some(second_pane));
+        assert_eq!(session.active_terminal_uuid.as_deref(), Some(first_pane));
         assert_eq!(
             session.layout.terminal_uuids(),
             vec![first_pane.to_string(), second_pane.to_string()]
@@ -957,7 +942,7 @@ mod tests {
             &[rt_info(
                 runtime_id,
                 "Recovered Workspace",
-                proto::RuntimePolicy::Persistent,
+                v3::RuntimePolicy::Persistent,
                 vec![pane_info("07fa83b4-9ae3-4354-a1c5-1f685ffab370", "Shell", "/srv/project")],
                 None,
             )],
@@ -978,7 +963,7 @@ mod tests {
             &[rt_info(
                 runtime_id,
                 "Recovered Workspace",
-                proto::RuntimePolicy::Persistent,
+                v3::RuntimePolicy::Persistent,
                 vec![],
                 None,
             )],
@@ -1029,7 +1014,7 @@ mod tests {
             runtimes: vec![rt_info(
                 &runtime_id,
                 "Recovered Workspace",
-                proto::RuntimePolicy::Persistent,
+                v3::RuntimePolicy::Persistent,
                 vec![pane_info(&pane_id, "Shell", "/srv/project")],
                 Some(&pane_id),
             )],
@@ -1142,14 +1127,12 @@ mod tests {
                 layout_terminal_uuid: first_terminal_uuid,
                 title: "Shell".into(),
                 cwd: "/srv/project".into(),
-                scrollback: bytes::Bytes::from_static(b"restored output"),
+                pane_output_seq: 0,
+                scrollback_tail: bytes::Bytes::from_static(b"restored output"),
+                scrollback_complete: true,
                 cols: 120,
                 rows: 40,
-                bracketed_paste_mode: false,
-                application_cursor_keys: false,
-                application_keypad: false,
-                mouse_tracking_mode: 0,
-                sgr_mouse_mode: false,
+                terminal_modes: None,
             }],
         );
         assert_eq!(state.workspaces[0].runtime.runtime_id.as_deref(), Some(runtime_id.as_str()));
@@ -1163,11 +1146,16 @@ mod tests {
             window_state(vec![managed_session("workspace-1", "Workspace", term(&terminal_uuid))]);
 
         let mut snap = pane_snapshot(&terminal_uuid, "vim", "/home", b"");
-        snap.application_cursor_keys = true;
-        snap.application_keypad = true;
-        snap.mouse_tracking_mode = 1003;
-        snap.sgr_mouse_mode = true;
-        snap.bracketed_paste_mode = true;
+        snap.terminal_modes = Some(v3::TerminalModeState {
+            bracketed_paste: true,
+            focus_reporting: false,
+            application_cursor_keys: true,
+            application_keypad: true,
+            alternate_screen: false,
+            cursor_hidden: false,
+            mouse_mode: v3::MouseMode::Any as i32,
+            sgr_mouse: true,
+        });
 
         let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
             workspace_id: "workspace-1".into(),
@@ -1177,11 +1165,12 @@ mod tests {
 
         assert_eq!(transition.pane_snapshot_restores.len(), 1);
         let restore = &transition.pane_snapshot_restores[0];
-        assert!(restore.application_cursor_keys);
-        assert!(restore.application_keypad);
-        assert_eq!(restore.mouse_tracking_mode, 1003);
-        assert!(restore.sgr_mouse_mode);
-        assert!(restore.bracketed_paste_mode);
+        let modes = restore.terminal_modes.as_ref().expect("terminal_modes should be present");
+        assert!(modes.application_cursor_keys);
+        assert!(modes.application_keypad);
+        assert_eq!(modes.mouse_mode, v3::MouseMode::Any as i32);
+        assert!(modes.sgr_mouse);
+        assert!(modes.bracketed_paste);
     }
 
     #[test]
@@ -1278,7 +1267,7 @@ mod tests {
         let transition = state.reconcile_endpoint_event(&EndpointEvent::RuntimeTerminated {
             workspace_id: "workspace-1".into(),
             runtime_id: "d7d04564-b2bf-4302-9495-e65c4df12ac6".into(),
-            reason: proto::RuntimeTerminationReason::Explicit,
+            reason: v3::RuntimeTerminationReason::Explicit,
         });
 
         assert_eq!(state.workspaces[0].runtime.runtime_id, None);
@@ -1319,7 +1308,7 @@ mod tests {
             runtimes: vec![rt_info(
                 &runtime_id,
                 "Should Not Resurrect",
-                proto::RuntimePolicy::Persistent,
+                v3::RuntimePolicy::Persistent,
                 vec![pane_info(&pane_id, "Shell", "/tmp")],
                 Some(&pane_id),
             )],
@@ -1351,7 +1340,7 @@ mod tests {
             runtimes: vec![rt_info(
                 &runtime_id,
                 "Remote Work",
-                proto::RuntimePolicy::Persistent,
+                v3::RuntimePolicy::Persistent,
                 vec![pane_info(&pane_id, "bash", "/home/user")],
                 Some(&pane_id),
             )],
@@ -1391,7 +1380,7 @@ mod tests {
                 runtimes: vec![rt_info(
                     &runtime_id,
                     &format!("Dismissed {i}"),
-                    proto::RuntimePolicy::Persistent,
+                    v3::RuntimePolicy::Persistent,
                     vec![pane_info(&pane_id, "bash", "/tmp")],
                     Some(&pane_id),
                 )],
@@ -1439,24 +1428,23 @@ mod tests {
         let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
             workspace_id: "ws-1".into(),
             runtime_id: runtime_id.clone(),
-            snapshot: proto::Snapshot {
+            snapshot: v3::RuntimeSnapshot {
                 runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
-                panes: vec![proto::PaneSnapshot {
+                panes: vec![v3::PaneSnapshot {
                     pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane_id).unwrap()),
+                    pane_output_seq: 0,
                     title: "bash".into(),
                     cwd: "/new/project".into(),
                     cols: 80,
                     rows: 24,
-                    scrollback: bytes::Bytes::new(),
                     exit_status: None,
-                    bracketed_paste_mode: false,
-                    application_cursor_keys: false,
-                    application_keypad: false,
-                    mouse_tracking_mode: 0,
-                    sgr_mouse_mode: false,
+                    terminal_modes: None,
+                    scrollback_tail: bytes::Bytes::new(),
+                    total_scrollback_bytes: 0,
+                    scrollback_complete: true,
                 }],
-                revision: 2,
-                current_client_role: proto::RuntimeClientRole::Writer as i32,
+                runtime_revision: 2,
+                client_role: v3::RuntimeClientRole::Writer as i32,
             },
         });
 
@@ -1906,7 +1894,7 @@ mod tests {
             runtimes: vec![rt_info(
                 &live_id,
                 "Still Running",
-                proto::RuntimePolicy::Persistent,
+                v3::RuntimePolicy::Persistent,
                 vec![pane_info(&pane_id, "bash", "/tmp")],
                 Some(&pane_id),
             )],

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1897,20 +1897,20 @@ fn connect_existing_dialog_classifies_available_session() {
     require_display!();
 
     let id = uuid::Uuid::new_v4();
-    let workspaces = vec![rttx_proto::proto::RuntimeInfo {
+    let workspaces = vec![rttx_proto::v3::RuntimeInfo {
         id: rttx_proto::uuid_to_bytes(id),
         name: "workspace-1".into(),
         pane_count: 2,
-        has_attached_client: false,
-        active_pane_id: None,
-        panes: vec![],
-        policy: 0,
-        attached_client_count: 0,
-        reconstructed: false,
-        revision: 1,
-        current_client_role: 0,
         has_write_owner: false,
         read_only_client_count: 0,
+        current_client_role: 0,
+        panes: vec![],
+        policy: 0,
+        reconstructed: false,
+        runtime_revision: 1,
+        active_pane_summary: String::new(),
+        takeover_eligible: false,
+        disabled_reason: String::new(),
     }];
     let entries = rttx::connect_existing_dialog::classify_runtimes(&workspaces, &[]);
 
@@ -1928,20 +1928,20 @@ fn connect_existing_dialog_classifies_busy_session() {
     require_display!();
 
     let id = uuid::Uuid::new_v4();
-    let workspaces = vec![rttx_proto::proto::RuntimeInfo {
+    let workspaces = vec![rttx_proto::v3::RuntimeInfo {
         id: rttx_proto::uuid_to_bytes(id),
         name: "busy-ws".into(),
         pane_count: 1,
-        has_attached_client: true,
-        active_pane_id: None,
-        panes: vec![],
-        policy: 0,
-        attached_client_count: 1,
-        reconstructed: false,
-        revision: 1,
-        current_client_role: 0,
         has_write_owner: true,
         read_only_client_count: 0,
+        current_client_role: 0,
+        panes: vec![],
+        policy: 0,
+        reconstructed: false,
+        runtime_revision: 1,
+        active_pane_summary: String::new(),
+        takeover_eligible: false,
+        disabled_reason: String::new(),
     }];
     let entries = rttx::connect_existing_dialog::classify_runtimes(&workspaces, &[]);
 
@@ -1959,20 +1959,20 @@ fn connect_existing_dialog_classifies_already_open_session() {
     require_display!();
 
     let id = uuid::Uuid::new_v4();
-    let workspaces = vec![rttx_proto::proto::RuntimeInfo {
+    let workspaces = vec![rttx_proto::v3::RuntimeInfo {
         id: rttx_proto::uuid_to_bytes(id),
         name: "open-ws".into(),
         pane_count: 3,
-        has_attached_client: false,
-        active_pane_id: None,
-        panes: vec![],
-        policy: 0,
-        attached_client_count: 0,
-        reconstructed: false,
-        revision: 1,
-        current_client_role: 0,
         has_write_owner: false,
         read_only_client_count: 0,
+        current_client_role: 0,
+        panes: vec![],
+        policy: 0,
+        reconstructed: false,
+        runtime_revision: 1,
+        active_pane_summary: String::new(),
+        takeover_eligible: false,
+        disabled_reason: String::new(),
     }];
     let entries = rttx::connect_existing_dialog::classify_runtimes(&workspaces, &[id.to_string()]);
 

--- a/clients/rttx/tests/reconnect_layout_stability.rs
+++ b/clients/rttx/tests/reconnect_layout_stability.rs
@@ -18,32 +18,31 @@ fn hsplit(first: LayoutNode, second: LayoutNode) -> LayoutNode {
     }
 }
 
-fn pane_snapshot(pane_id: &str, title: &str, cwd: &str) -> rttx_proto::proto::PaneSnapshot {
-    rttx_proto::proto::PaneSnapshot {
+fn pane_snapshot(pane_id: &str, title: &str, cwd: &str) -> rttx_proto::v3::PaneSnapshot {
+    rttx_proto::v3::PaneSnapshot {
         pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),
+        pane_output_seq: 0,
         title: title.to_string(),
         cwd: cwd.to_string(),
         cols: 120,
         rows: 40,
-        scrollback: bytes::Bytes::new(),
         exit_status: None,
-        bracketed_paste_mode: false,
-        application_cursor_keys: false,
-        application_keypad: false,
-        mouse_tracking_mode: 0,
-        sgr_mouse_mode: false,
+        terminal_modes: None,
+        scrollback_tail: bytes::Bytes::new(),
+        total_scrollback_bytes: 0,
+        scrollback_complete: true,
     }
 }
 
 fn snapshot(
     runtime_id: &str,
-    panes: Vec<rttx_proto::proto::PaneSnapshot>,
-) -> rttx_proto::proto::Snapshot {
-    rttx_proto::proto::Snapshot {
+    panes: Vec<rttx_proto::v3::PaneSnapshot>,
+) -> rttx_proto::v3::RuntimeSnapshot {
+    rttx_proto::v3::RuntimeSnapshot {
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
         panes,
-        revision: 1,
-        current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
+        runtime_revision: 1,
+        client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
     }
 }
 

--- a/clients/rttx/tests/stale_terminal_cleanup.rs
+++ b/clients/rttx/tests/stale_terminal_cleanup.rs
@@ -19,32 +19,31 @@ fn hsplit(first: LayoutNode, second: LayoutNode) -> LayoutNode {
     }
 }
 
-fn pane_snapshot(pane_id: &str, title: &str, cwd: &str) -> rttx_proto::proto::PaneSnapshot {
-    rttx_proto::proto::PaneSnapshot {
+fn pane_snapshot(pane_id: &str, title: &str, cwd: &str) -> rttx_proto::v3::PaneSnapshot {
+    rttx_proto::v3::PaneSnapshot {
         pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),
+        pane_output_seq: 0,
         title: title.to_string(),
         cwd: cwd.to_string(),
         cols: 120,
         rows: 40,
-        scrollback: bytes::Bytes::new(),
         exit_status: None,
-        bracketed_paste_mode: false,
-        application_cursor_keys: false,
-        application_keypad: false,
-        mouse_tracking_mode: 0,
-        sgr_mouse_mode: false,
+        terminal_modes: None,
+        scrollback_tail: bytes::Bytes::new(),
+        total_scrollback_bytes: 0,
+        scrollback_complete: true,
     }
 }
 
 fn snapshot(
     runtime_id: &str,
-    panes: Vec<rttx_proto::proto::PaneSnapshot>,
-) -> rttx_proto::proto::Snapshot {
-    rttx_proto::proto::Snapshot {
+    panes: Vec<rttx_proto::v3::PaneSnapshot>,
+) -> rttx_proto::v3::RuntimeSnapshot {
+    rttx_proto::v3::RuntimeSnapshot {
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
         panes,
-        revision: 1,
-        current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
+        runtime_revision: 1,
+        client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
     }
 }
 

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -1374,13 +1374,12 @@ fn v3_snapshot_terminal_modes_propagate_through_reconciliation() {
         client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
     };
 
-    let transition = state.reconcile_endpoint_event(
-        &rttx::daemon_bridge::EndpointEvent::WorkspaceOpened {
+    let transition =
+        state.reconcile_endpoint_event(&rttx::daemon_bridge::EndpointEvent::WorkspaceOpened {
             workspace_id: ws_id,
             runtime_id,
             snapshot,
-        },
-    );
+        });
 
     assert_eq!(transition.pane_snapshot_restores.len(), 1);
     let restore = &transition.pane_snapshot_restores[0];

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -1331,3 +1331,66 @@ fn default_window_state_has_reasonable_sidebar_widths() {
         "right sidebar should be at least 200px for commands/places"
     );
 }
+
+#[test]
+fn v3_snapshot_terminal_modes_propagate_through_reconciliation() {
+    let runtime_id = uuid::Uuid::new_v4().to_string();
+    let pane_id = uuid::Uuid::new_v4().to_string();
+    let mut state = WindowState {
+        workspaces: vec![WorkspaceState::new_managed_local(
+            "Test".into(),
+            rttx::runtime::WorkspacePolicy::Persistent,
+            None,
+        )],
+        ..WindowState::default()
+    };
+    let ws_id = state.workspaces[0].uuid.clone();
+
+    let snapshot = rttx_proto::v3::RuntimeSnapshot {
+        runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
+        panes: vec![rttx_proto::v3::PaneSnapshot {
+            pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane_id).unwrap()),
+            pane_output_seq: 42,
+            title: "vim".into(),
+            cwd: "/home".into(),
+            cols: 80,
+            rows: 24,
+            exit_status: None,
+            terminal_modes: Some(rttx_proto::v3::TerminalModeState {
+                bracketed_paste: true,
+                focus_reporting: true,
+                application_cursor_keys: true,
+                application_keypad: false,
+                alternate_screen: true,
+                cursor_hidden: false,
+                mouse_mode: rttx_proto::v3::MouseMode::Normal as i32,
+                sgr_mouse: true,
+            }),
+            scrollback_tail: bytes::Bytes::from_static(b"scrollback data"),
+            total_scrollback_bytes: 15,
+            scrollback_complete: true,
+        }],
+        runtime_revision: 5,
+        client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
+    };
+
+    let transition = state.reconcile_endpoint_event(
+        &rttx::daemon_bridge::EndpointEvent::WorkspaceOpened {
+            workspace_id: ws_id,
+            runtime_id,
+            snapshot,
+        },
+    );
+
+    assert_eq!(transition.pane_snapshot_restores.len(), 1);
+    let restore = &transition.pane_snapshot_restores[0];
+    assert_eq!(restore.pane_output_seq, 42);
+    assert_eq!(restore.scrollback_tail, &b"scrollback data"[..]);
+    assert!(restore.scrollback_complete);
+    let modes = restore.terminal_modes.as_ref().expect("modes should be present");
+    assert!(modes.bracketed_paste);
+    assert!(modes.application_cursor_keys);
+    assert!(modes.alternate_screen);
+    assert_eq!(modes.mouse_mode, rttx_proto::v3::MouseMode::Normal as i32);
+    assert!(modes.sgr_mouse);
+}

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -360,13 +360,14 @@ fn close_managed_workspace_prevents_inventory_resurrection() {
     let pane_id = uuid::Uuid::new_v4().to_string();
     let transition = state.reconcile_endpoint_event(&EndpointEvent::InventoryLoaded {
         endpoint: RuntimeEndpoint::Local,
-        runtimes: vec![rttx_proto::proto::RuntimeInfo {
+        runtimes: vec![rttx_proto::v3::RuntimeInfo {
             id: uuid::Uuid::parse_str(&runtime_id).unwrap().as_bytes().to_vec(),
             name: "Should Not Resurrect".into(),
             pane_count: 1,
-            has_attached_client: false,
-            active_pane_id: None,
-            panes: vec![rttx_proto::proto::PaneInfo {
+            has_write_owner: false,
+            read_only_client_count: 0,
+            current_client_role: 0,
+            panes: vec![rttx_proto::v3::PaneInfo {
                 id: uuid::Uuid::parse_str(&pane_id).unwrap().as_bytes().to_vec(),
                 title: "bash".into(),
                 cwd: "/tmp".into(),
@@ -375,13 +376,12 @@ fn close_managed_workspace_prevents_inventory_resurrection() {
                 exit_status: None,
                 reconstructed: false,
             }],
-            policy: rttx_proto::proto::RuntimePolicy::Persistent as i32,
-            attached_client_count: 0,
+            policy: rttx_proto::v3::RuntimePolicy::Persistent as i32,
             reconstructed: false,
-            revision: 1,
-            current_client_role: 0,
-            has_write_owner: false,
-            read_only_client_count: 0,
+            runtime_revision: 1,
+            active_pane_summary: String::new(),
+            takeover_eligible: false,
+            disabled_reason: String::new(),
         }],
     });
 
@@ -423,13 +423,14 @@ fn new_workspace_does_not_resurrect_unrelated_runtimes() {
     let pane_id = uuid::Uuid::new_v4().to_string();
     let transition = state.reconcile_endpoint_event(&EndpointEvent::InventoryLoaded {
         endpoint: RuntimeEndpoint::Local,
-        runtimes: vec![rttx_proto::proto::RuntimeInfo {
+        runtimes: vec![rttx_proto::v3::RuntimeInfo {
             id: uuid::Uuid::parse_str(&unrelated_runtime_id).unwrap().as_bytes().to_vec(),
             name: "Unrelated Runtime".into(),
             pane_count: 1,
-            has_attached_client: false,
-            active_pane_id: None,
-            panes: vec![rttx_proto::proto::PaneInfo {
+            has_write_owner: false,
+            read_only_client_count: 0,
+            current_client_role: 0,
+            panes: vec![rttx_proto::v3::PaneInfo {
                 id: uuid::Uuid::parse_str(&pane_id).unwrap().as_bytes().to_vec(),
                 title: "bash".into(),
                 cwd: "/tmp".into(),
@@ -438,13 +439,12 @@ fn new_workspace_does_not_resurrect_unrelated_runtimes() {
                 exit_status: None,
                 reconstructed: false,
             }],
-            policy: rttx_proto::proto::RuntimePolicy::Persistent as i32,
-            attached_client_count: 0,
+            policy: rttx_proto::v3::RuntimePolicy::Persistent as i32,
             reconstructed: false,
-            revision: 1,
-            current_client_role: 0,
-            has_write_owner: false,
-            read_only_client_count: 0,
+            runtime_revision: 1,
+            active_pane_summary: String::new(),
+            takeover_eligible: false,
+            disabled_reason: String::new(),
         }],
     });
 
@@ -955,24 +955,23 @@ fn split_pane_cwd_propagates_through_reconciliation_create_request() {
     let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
         workspace_id: state.workspaces[0].uuid.clone(),
         runtime_id: runtime_id.clone(),
-        snapshot: rttx_proto::proto::Snapshot {
+        snapshot: rttx_proto::v3::RuntimeSnapshot {
             runtime_id: rttx_proto::uuid_to_bytes(runtime_id.parse().unwrap()),
-            panes: vec![rttx_proto::proto::PaneSnapshot {
+            panes: vec![rttx_proto::v3::PaneSnapshot {
                 pane_id: rttx_proto::uuid_to_bytes(first_uuid.parse().unwrap()),
+                pane_output_seq: 0,
                 title: "Shell".into(),
                 cwd: "/home".into(),
-                scrollback: bytes::Bytes::new(),
+                scrollback_tail: bytes::Bytes::new(),
                 cols: 80,
                 rows: 24,
                 exit_status: None,
-                bracketed_paste_mode: false,
-                application_cursor_keys: false,
-                application_keypad: false,
-                mouse_tracking_mode: 0,
-                sgr_mouse_mode: false,
+                terminal_modes: None,
+                total_scrollback_bytes: 0,
+                scrollback_complete: true,
             }],
-            revision: 0,
-            current_client_role: 0,
+            runtime_revision: 0,
+            client_role: 0,
         },
     });
 
@@ -1117,24 +1116,23 @@ fn workspace_opened_with_new_runtime_id_updates_session_state() {
     let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
         workspace_id: state.workspaces[0].uuid.clone(),
         runtime_id: new_runtime.to_string(),
-        snapshot: rttx_proto::proto::Snapshot {
+        snapshot: rttx_proto::v3::RuntimeSnapshot {
             runtime_id: rttx_proto::uuid_to_bytes(new_runtime),
-            panes: vec![rttx_proto::proto::PaneSnapshot {
+            panes: vec![rttx_proto::v3::PaneSnapshot {
                 pane_id: rttx_proto::uuid_to_bytes(pane_id),
+                pane_output_seq: 0,
                 title: "shell".into(),
                 cwd: "/home".into(),
                 cols: 80,
                 rows: 24,
-                scrollback: bytes::Bytes::new(),
+                scrollback_tail: bytes::Bytes::new(),
                 exit_status: None,
-                bracketed_paste_mode: false,
-                application_cursor_keys: false,
-                application_keypad: false,
-                mouse_tracking_mode: 0,
-                sgr_mouse_mode: false,
+                terminal_modes: None,
+                total_scrollback_bytes: 0,
+                scrollback_complete: true,
             }],
-            revision: 1,
-            current_client_role: rttx_proto::proto::RuntimeClientRole::Writer as i32,
+            runtime_revision: 1,
+            client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
         },
     });
 
@@ -1292,13 +1290,14 @@ fn dismissed_runtime_ids_pruned_when_absent_from_inventory() {
     // Inventory contains only `live` — `stale` was already cleaned up by daemon.
     let _transition = state.reconcile_endpoint_event(&EndpointEvent::InventoryLoaded {
         endpoint: RuntimeEndpoint::Local,
-        runtimes: vec![rttx_proto::proto::RuntimeInfo {
+        runtimes: vec![rttx_proto::v3::RuntimeInfo {
             id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&live).unwrap()),
             name: "Live".into(),
             pane_count: 1,
-            has_attached_client: false,
-            active_pane_id: Some(rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane).unwrap())),
-            panes: vec![rttx_proto::proto::PaneInfo {
+            has_write_owner: false,
+            read_only_client_count: 0,
+            current_client_role: rttx_proto::v3::RuntimeClientRole::Unattached as i32,
+            panes: vec![rttx_proto::v3::PaneInfo {
                 id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane).unwrap()),
                 title: "bash".into(),
                 cwd: "/tmp".into(),
@@ -1307,13 +1306,12 @@ fn dismissed_runtime_ids_pruned_when_absent_from_inventory() {
                 exit_status: None,
                 reconstructed: false,
             }],
-            policy: rttx_proto::proto::RuntimePolicy::Persistent as i32,
-            attached_client_count: 0,
+            policy: rttx_proto::v3::RuntimePolicy::Persistent as i32,
             reconstructed: false,
-            revision: 1,
-            current_client_role: rttx_proto::proto::RuntimeClientRole::Unattached as i32,
-            has_write_owner: false,
-            read_only_client_count: 0,
+            runtime_revision: 1,
+            active_pane_summary: String::new(),
+            takeover_eligible: false,
+            disabled_reason: String::new(),
         }],
     });
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.3.15',
+  version: '0.3.16',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -33,6 +33,7 @@ dbg_macro = "warn"
 rttx-proto = { path = "../../protocols/rttx-proto" }
 
 # Protocol serialization
+prost = "0.13"
 bytes = "1"
 
 # Async runtime

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -60,12 +60,97 @@ const RESP_CHANNEL_BOUND: usize = 256;
 /// This is the lock-free counterpart of [`Server::broadcast_to_runtime`]:
 /// collect handles with [`Server::collect_runtime_senders`] while holding
 /// the mutex, then call this after releasing it.
-fn send_to_collected(senders: &[(Uuid, mpsc::Sender<ClientMsg>)], msg: &ClientMsg) {
-    for (client_id, sender) in senders {
-        if let Err(mpsc::error::TrySendError::Full(_)) = sender.try_send(msg.clone()) {
+fn send_to_collected(
+    senders: &[(Uuid, mpsc::Sender<ClientMsg>, Option<ClientProtocol>)],
+    msg: &ClientMsg,
+) {
+    let mut v3_msg: Option<ClientMsg> = None;
+    for (client_id, sender, protocol) in senders {
+        let outgoing = if matches!(protocol, Some(ClientProtocol::V3 { .. })) {
+            v3_msg.get_or_insert_with(|| convert_v2_push_to_v3(msg))
+        } else {
+            msg
+        };
+        if let Err(mpsc::error::TrySendError::Full(_)) = sender.try_send(outgoing.clone()) {
             tracing::warn!("Client {} push channel full — dropping message", short_id(*client_id),);
         }
     }
+}
+
+/// Convert a v2 push message to a v3 `ServerEnvelope`.
+///
+/// Falls back to the original v2 message if conversion is not applicable
+/// (e.g., the message is already v3 or is not a push event).
+fn convert_v2_push_to_v3(msg: &ClientMsg) -> ClientMsg {
+    let ClientMsg::V2(v2) = msg else {
+        return msg.clone();
+    };
+    let Some(ref inner) = v2.msg else {
+        return msg.clone();
+    };
+    let payload = match inner {
+        proto::server_message::Msg::Delta(d) => {
+            v3::server_envelope::Payload::OutputDelta(v3::OutputDelta {
+                runtime_id: d.runtime_id.clone(),
+                pane_id: d.pane_id.clone(),
+                data: d.data.clone(),
+                pane_output_seq: 0,
+            })
+        }
+        proto::server_message::Msg::TitleChanged(t) => {
+            v3::server_envelope::Payload::TitleChanged(v3::TitleChanged {
+                runtime_id: t.runtime_id.clone(),
+                pane_id: t.pane_id.clone(),
+                title: t.title.clone(),
+                runtime_revision: t.revision,
+            })
+        }
+        proto::server_message::Msg::CwdChanged(c) => {
+            v3::server_envelope::Payload::CwdChanged(v3::CwdChanged {
+                runtime_id: c.runtime_id.clone(),
+                pane_id: c.pane_id.clone(),
+                cwd: c.cwd.clone(),
+                runtime_revision: c.revision,
+            })
+        }
+        proto::server_message::Msg::PaneExited(p) => {
+            v3::server_envelope::Payload::PaneExited(v3::PaneExited {
+                runtime_id: p.runtime_id.clone(),
+                pane_id: p.pane_id.clone(),
+                status: p.status,
+                runtime_revision: p.revision,
+            })
+        }
+        proto::server_message::Msg::Bell(b) => v3::server_envelope::Payload::Bell(v3::Bell {
+            runtime_id: b.runtime_id.clone(),
+            pane_id: b.pane_id.clone(),
+        }),
+        proto::server_message::Msg::PaneResized(r) => {
+            v3::server_envelope::Payload::PaneResized(v3::PaneResized {
+                runtime_id: r.runtime_id.clone(),
+                pane_id: r.pane_id.clone(),
+                cols: r.cols,
+                rows: r.rows,
+                runtime_revision: r.revision,
+            })
+        }
+        proto::server_message::Msg::RuntimeTerminated(t) => {
+            v3::server_envelope::Payload::RuntimeTerminated(v3::RuntimeTerminated {
+                runtime_id: t.runtime_id.clone(),
+                final_revision: t.final_revision,
+                reason: t.reason,
+            })
+        }
+        proto::server_message::Msg::RuntimeRenamed(r) => {
+            v3::server_envelope::Payload::RuntimeRenamed(v3::RuntimeRenamed {
+                runtime_id: r.runtime_id.clone(),
+                name: r.name.clone(),
+                runtime_revision: r.revision,
+            })
+        }
+        _ => return msg.clone(),
+    };
+    ClientMsg::V3(rttx_proto::v3_envelope::build_push_envelope(payload))
 }
 
 /// Shared mutable server state.
@@ -298,7 +383,8 @@ impl Server {
         }
     }
 
-    /// Send a message to the provided clients.
+    /// Send a message to the provided clients, converting v2 push messages
+    /// to v3 envelopes for v3 clients.
     fn broadcast_to_clients<I>(
         &self,
         client_ids: I,
@@ -307,13 +393,23 @@ impl Server {
     ) where
         I: IntoIterator<Item = Uuid>,
     {
+        // Lazily convert v2 push to v3 envelope only if needed.
+        let mut v3_msg: Option<ClientMsg> = None;
         for client_id in client_ids {
             if Some(client_id) == exclude_client_id {
                 continue;
             }
-            if let Some(sender) = self.client_senders.get(&client_id)
-                && let Err(mpsc::error::TrySendError::Full(_)) = sender.try_send(msg.clone())
-            {
+            let Some(sender) = self.client_senders.get(&client_id) else {
+                continue;
+            };
+            let outgoing =
+                if matches!(self.client_protocols.get(&client_id), Some(ClientProtocol::V3 { .. }))
+                {
+                    v3_msg.get_or_insert_with(|| convert_v2_push_to_v3(msg))
+                } else {
+                    msg
+                };
+            if let Err(mpsc::error::TrySendError::Full(_)) = sender.try_send(outgoing.clone()) {
                 tracing::warn!(
                     "Client {} push channel full — dropping message",
                     short_id(client_id),
@@ -334,13 +430,20 @@ impl Server {
     ///
     /// The returned senders can be used after releasing the server mutex via
     /// [`send_to_collected`].
-    fn collect_runtime_senders(&self, runtime_id: Uuid) -> Vec<(Uuid, mpsc::Sender<ClientMsg>)> {
+    fn collect_runtime_senders(
+        &self,
+        runtime_id: Uuid,
+    ) -> Vec<(Uuid, mpsc::Sender<ClientMsg>, Option<ClientProtocol>)> {
         let Some(rt) = self.runtimes.get(&runtime_id) else {
             return Vec::new();
         };
         rt.attached_clients
             .keys()
-            .filter_map(|&cid| self.client_senders.get(&cid).map(|s| (cid, s.clone())))
+            .filter_map(|&cid| {
+                self.client_senders
+                    .get(&cid)
+                    .map(|s| (cid, s.clone(), self.client_protocols.get(&cid).cloned()))
+            })
             .collect()
     }
 
@@ -2073,7 +2176,7 @@ pub async fn handle_stdio_client(server: Arc<Mutex<Server>>) -> anyhow::Result<(
 #[allow(clippy::significant_drop_tightening)]
 async fn handle_client<S>(
     server: Arc<Mutex<Server>>,
-    conn: ClientConnection<S>,
+    mut conn: ClientConnection<S>,
 ) -> anyhow::Result<()>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
@@ -2082,22 +2185,34 @@ where
     let client_short = short_id(client_id);
 
     let (tx, rx) = mpsc::channel(PUSH_CHANNEL_BOUND);
-    // Channel for responses that the reader task needs to send back to the
-    // client (e.g. pong replies, runtime snapshots). The writer task drains
-    // this alongside the push channel so writes never block reads.
     let (resp_tx, resp_rx) = mpsc::channel::<ClientMsg>(RESP_CHANNEL_BOUND);
     {
         let mut s = server.lock().await;
         s.client_senders.insert(client_id, tx);
     }
 
-    let (reader, writer) = conn.into_split();
+    // Read the first raw frame to detect v2 vs v3 protocol.
+    let Some(raw_frame) = conn.read_raw_frame().await? else {
+        tracing::debug!("Client probe from {client_short} (disconnected before handshake)");
+        let mut s = server.lock().await;
+        s.client_senders.remove(&client_id);
+        return Ok(());
+    };
 
+    // Try v3 ClientHello first, then fall back to v2 ClientMessage.
+    let is_v3 = try_v3_handshake(&server, client_id, &client_short, &mut conn, &raw_frame).await?;
+
+    let (reader, writer) = conn.into_split();
     let write_short = client_short.clone();
     let writer_task = tokio::spawn(client_writer(writer, rx, resp_rx, write_short));
 
-    let (result, handshake_completed) =
-        client_reader(server.clone(), client_id, &client_short, reader, resp_tx).await;
+    let (result, handshake_completed) = if is_v3 {
+        tracing::info!("Client {client_short} connected (v3)");
+        v3_client_reader(server.clone(), client_id, &client_short, reader, resp_tx).await
+    } else {
+        v2_client_reader(server.clone(), client_id, &client_short, reader, resp_tx, &raw_frame)
+            .await
+    };
 
     // Cleanup: remove sender and detach from all runtimes.
     {
@@ -2111,7 +2226,6 @@ where
         }
     }
 
-    // Writer task will stop when both senders are dropped.
     writer_task.abort();
 
     if let Err(ref e) = result {
@@ -2121,51 +2235,150 @@ where
     result
 }
 
-/// Read client messages and dispatch responses via `resp_tx`.
+/// Attempt v3 handshake. Returns `true` if the client speaks v3.
 ///
-/// Runs until the client disconnects or an error occurs. Returns `true`
-/// if the client completed the handshake (sent at least one message),
-/// `false` if it disconnected before sending anything (probe connection).
-async fn client_reader(
+/// On success, sends `ServerHello` and registers the client protocol.
+/// On failure (frame is v2), leaves the connection unchanged for v2 handling.
+async fn try_v3_handshake<S>(
+    server: &Arc<Mutex<Server>>,
+    client_id: Uuid,
+    client_short: &str,
+    conn: &mut ClientConnection<S>,
+    raw_frame: &[u8],
+) -> anyhow::Result<bool>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    use prost::Message;
+
+    // Skip the 4-byte length prefix.
+    let payload = &raw_frame[4..];
+    let Ok(client_hello) = v3::ClientHello::decode(payload) else {
+        return Ok(false);
+    };
+
+    // Validate: a real ClientHello has a non-empty client_id and version range.
+    if client_hello.client_id.len() != 16 || client_hello.max_protocol_version == 0 {
+        return Ok(false);
+    }
+
+    let server_version = env!("CARGO_PKG_VERSION");
+    let server_id = server.lock().await.server_id;
+
+    match rttx_proto::v3_handshake::negotiate_version(
+        client_hello.min_protocol_version,
+        client_hello.max_protocol_version,
+        rttx_proto::v3_handshake::V3_PROTOCOL_VERSION,
+        rttx_proto::v3_handshake::V3_PROTOCOL_VERSION,
+    ) {
+        Ok(negotiated_version) => {
+            let server_caps: Vec<i32> = SERVER_CAPABILITIES.iter().map(|c| *c as i32).collect();
+            let effective_caps = rttx_proto::v3_handshake::effective_capabilities(
+                &client_hello.capabilities,
+                &server_caps,
+            );
+
+            // Validate core capabilities from client.
+            if let Err(missing) =
+                rttx_proto::v3_handshake::validate_server_capabilities(&effective_caps)
+            {
+                let err = rttx_proto::v3_handshake::missing_capabilities_error(&missing);
+                conn.send_v3_error(&err).await?;
+                return Err(anyhow::anyhow!("v3 client {client_short} missing core capabilities"));
+            }
+
+            let hello = rttx_proto::v3_handshake::build_server_hello(
+                server_id,
+                server_version,
+                negotiated_version,
+                SERVER_CAPABILITIES,
+            );
+            conn.send_v3_server_hello(&hello).await?;
+
+            {
+                let mut s = server.lock().await;
+                s.set_client_protocol(client_id, ClientProtocol::V3 { effective_caps });
+            }
+
+            Ok(true)
+        }
+        Err(err) => {
+            conn.send_v3_error(&err).await?;
+            Err(anyhow::anyhow!(
+                "v3 version negotiation failed for {client_short}: {}",
+                err.message
+            ))
+        }
+    }
+}
+
+/// Read v2 client messages and dispatch responses via `resp_tx`.
+///
+/// The first frame was already read during protocol detection and is passed
+/// in as `first_frame`. It is decoded as a v2 `ClientMessage` and processed
+/// before entering the normal read loop.
+async fn v2_client_reader(
     server: Arc<Mutex<Server>>,
     client_id: Uuid,
     client_short: &str,
     mut reader: ClientConnectionReader,
     resp_tx: mpsc::Sender<ClientMsg>,
+    first_frame: &[u8],
 ) -> (anyhow::Result<()>, bool) {
-    let mut handshake_completed = false;
+    use prost::Message;
+
+    // Decode the first frame that was already read during handshake detection.
+    let payload = &first_frame[4..];
+    let msg = match proto::ClientMessage::decode(payload) {
+        Ok(msg) => msg,
+        Err(e) => return (Err(anyhow::anyhow!("failed to decode first v2 frame: {e}")), false),
+    };
+
+    tracing::info!("Client {client_short} connected (v2)");
+
+    // Register as v2 client.
+    {
+        let mut s = server.lock().await;
+        s.set_client_protocol(client_id, ClientProtocol::V2);
+    }
+
+    // Process the first message (Hello).
+    if matches!(msg.msg, Some(proto::client_message::Msg::Shutdown(_))) {
+        tracing::info!("Shutdown requested by client {client_short}");
+        server.lock().await.request_shutdown();
+        return (Ok(()), true);
+    }
+
+    if let Some(proto::client_message::Msg::Ping(ping)) = &msg.msg {
+        if resp_tx.send(ClientMsg::V2(protocol::pong(ping.nonce))).await.is_err() {
+            return (Ok(()), true);
+        }
+    } else if let Some(response) = Server::handle_message(&server, client_id, msg).await
+        && resp_tx.send(ClientMsg::V2(response)).await.is_err()
+    {
+        return (Ok(()), true);
+    }
+
+    // Continue with normal v2 read loop.
     loop {
         let msg = match reader.read_message().await {
             Ok(Some(msg)) => msg,
             Ok(None) => {
-                if handshake_completed {
-                    tracing::info!("Client {client_short} disconnected");
-                } else {
-                    tracing::debug!(
-                        "Client probe from {client_short} (disconnected without handshake)"
-                    );
-                }
-                return (Ok(()), handshake_completed);
+                tracing::info!("Client {client_short} disconnected");
+                return (Ok(()), true);
             }
-            Err(e) => return (Err(e.into()), handshake_completed),
+            Err(e) => return (Err(e.into()), true),
         };
-
-        if !handshake_completed {
-            handshake_completed = true;
-            tracing::info!("Client {client_short} connected");
-        }
 
         if matches!(msg.msg, Some(proto::client_message::Msg::Shutdown(_))) {
             tracing::info!("Shutdown requested by client {client_short}");
             server.lock().await.request_shutdown();
-            return (Ok(()), handshake_completed);
+            return (Ok(()), true);
         }
 
-        // Fast-path: respond to Ping without acquiring the server mutex.
-        // The heartbeat must never stall behind PTY I/O or runtime work.
         if let Some(proto::client_message::Msg::Ping(ping)) = &msg.msg {
             if resp_tx.send(ClientMsg::V2(protocol::pong(ping.nonce))).await.is_err() {
-                return (Ok(()), handshake_completed);
+                return (Ok(()), true);
             }
             continue;
         }
@@ -2173,7 +2386,62 @@ async fn client_reader(
         if let Some(response) = Server::handle_message(&server, client_id, msg).await
             && resp_tx.send(ClientMsg::V2(response)).await.is_err()
         {
-            return (Ok(()), handshake_completed);
+            return (Ok(()), true);
+        }
+    }
+}
+
+/// Read v3 client envelopes and dispatch responses via `resp_tx`.
+async fn v3_client_reader(
+    server: Arc<Mutex<Server>>,
+    client_id: Uuid,
+    client_short: &str,
+    mut reader: ClientConnectionReader,
+    resp_tx: mpsc::Sender<ClientMsg>,
+) -> (anyhow::Result<()>, bool) {
+    loop {
+        let envelope = match reader.read_v3_envelope().await {
+            Ok(Some(env)) => env,
+            Ok(None) => {
+                tracing::info!("Client {client_short} disconnected");
+                return (Ok(()), true);
+            }
+            Err(e) => return (Err(e.into()), true),
+        };
+
+        // Check for Shutdown (fire-and-forget).
+        if matches!(envelope.command, Some(v3::client_envelope::Command::Shutdown(_))) {
+            tracing::info!("Shutdown requested by client {client_short}");
+            server.lock().await.request_shutdown();
+            return (Ok(()), true);
+        }
+
+        // Fast-path: respond to Ping without acquiring the server mutex.
+        if let Some(v3::client_envelope::Command::Ping(ref ping)) = envelope.command {
+            let response = rttx_proto::v3_envelope::build_response_envelope(
+                envelope.request_id,
+                v3::server_envelope::Payload::Pong(v3::Pong { nonce: ping.nonce }),
+            );
+            if resp_tx.send(ClientMsg::V3(response)).await.is_err() {
+                return (Ok(()), true);
+            }
+            continue;
+        }
+
+        // Look up effective capabilities for this client.
+        let effective_caps = {
+            let s = server.lock().await;
+            match s.client_protocol(client_id) {
+                Some(ClientProtocol::V3 { effective_caps }) => effective_caps.clone(),
+                _ => Vec::new(),
+            }
+        };
+
+        if let Some(response) =
+            Server::handle_v3_message(&server, client_id, &effective_caps, envelope).await
+            && resp_tx.send(ClientMsg::V3(response)).await.is_err()
+        {
+            return (Ok(()), true);
         }
     }
 }

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1441,7 +1441,7 @@ async fn collect_runtime_senders_returns_attached_client_senders() {
     }
 
     let senders = server.lock().await.collect_runtime_senders(runtime_id);
-    let ids: std::collections::HashSet<Uuid> = senders.iter().map(|(id, _)| *id).collect();
+    let ids: std::collections::HashSet<Uuid> = senders.iter().map(|(id, _, _)| *id).collect();
     assert!(ids.contains(&client_a));
     assert!(ids.contains(&client_b));
     assert_eq!(senders.len(), 2);
@@ -1458,7 +1458,7 @@ async fn collect_runtime_senders_returns_empty_for_unknown_runtime() {
 async fn send_to_collected_delivers_messages() {
     let (tx, mut rx) = mpsc::channel(16);
     let client_id = Uuid::new_v4();
-    let senders = vec![(client_id, tx)];
+    let senders = vec![(client_id, tx, None)];
 
     let msg = ClientMsg::V2(protocol::delta(
         Uuid::new_v4(),
@@ -1478,7 +1478,7 @@ async fn send_to_collected_delivers_messages() {
 async fn send_to_collected_drops_when_channel_full() {
     let (tx, rx) = mpsc::channel(1);
     let client_id = Uuid::new_v4();
-    let senders = vec![(client_id, tx)];
+    let senders = vec![(client_id, tx, None)];
 
     let msg = ClientMsg::V2(protocol::delta(
         Uuid::new_v4(),
@@ -1549,7 +1549,7 @@ async fn probe_connection_logs_at_debug_not_info() {
 
     // Probe should be logged at debug level, not info.
     assert!(logs_contain("Client probe from"));
-    assert!(logs_contain("disconnected without handshake"));
+    assert!(logs_contain("disconnected before handshake"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed and why

Wire the v3 protocol (RFC-021) into the GUI client, replacing all v2 protocol handling. The server now bridges v2 push events to v3 format for mixed-protocol clients.

### Client changes
- **daemon.rs**: `ClientHello`/`ServerHello` handshake with capability negotiation, `ClientEnvelope`/`ServerEnvelope` framing with `request_id` correlation, fire-and-forget for `TerminalInput`/`ResizePane`/`SetPaneTitle`
- **daemon_bridge.rs**: v3 envelope construction and response handling, request_id-based response correlation in the actor loop, v3 typed error classification
- **runtime.rs**: classify v3 `ProtocolError` into `ConnectionProblem`
- **workspace_state.rs**: use v3 `RuntimeSnapshot`/`PaneSnapshot` with `pane_output_seq`, `TerminalModeState`, `scrollback_tail`/`scrollback_complete` fields
- **connect_existing_dialog.rs**: use v3 `RuntimeInfo` fields
- **window/runtime.rs**: dispatch v3 `ServerEnvelope` push events, restore terminal modes from v3 `TerminalModeState`

### Server changes
- **server.rs**: v2-to-v3 push conversion bridge so v3 clients receive proper `ServerEnvelope` push events while the server's internal broadcast still uses v2

## Manual verification
- Built and ran `rttx` in dev mode against a local daemon
- Verified workspace creation, pane split, input, resize, reconnect
- Verified terminal mode restoration from snapshot

## Tests added
- Updated all existing daemon.rs tests to v3 (handshake, input encoding, resize encoding, ping encoding, extract_pane_id)
- Added `handshake_fails_on_protocol_error` and `handshake_fails_on_missing_capabilities` tests
- Updated all daemon_bridge.rs tests to v3 envelope format
- Updated all workspace_state.rs tests to v3 types (RuntimeSnapshot, PaneSnapshot, RuntimeInfo)
- Updated all GTK widget tests to v3 types
- Updated all integration tests (reconnect_layout_stability, stale_terminal_cleanup, workspace_lifecycle)

## Tests run
- `cargo test -p rttx-proto`: 333 passed
- `cargo test -p rttx-server --lib`: 275 passed
- `cargo test -p rttx-server --tests`: 68 passed (including v3 dispatch tests)
- `cargo test -p rttx`: all unit and integration tests passed
- GTK widget tests via Broadway: 90 passed
- `bash .github/scripts/run-clippy.sh`: clean

## Remaining follow-ups
- `TerminalModeChanged` push events are received but not yet applied to live panes (logged only)
- `OPT_RESYNC` gap recovery is advertised but not yet triggered on sequence gaps
- `OPT_CHUNKED_SCROLLBACK` pagination is advertised but not yet used for large scrollback
- v2 protocol removal (#683) can proceed after this lands

Fixes #706
Depends on: #705 (merged)
Blocks: #683