### PR TITLE
fix: panes show top of scrollback instead of bottom after reconnect

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1042,6 +1042,54 @@ mod pane_passive_tests {
             "Ctrl+Shift+right-click must not open context menu"
         );
     }
+
+    /// `feed_snapshot` must not scroll synchronously — the scroll is deferred
+    /// so VTE has time to update its layout. Regression for #707.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn feed_snapshot_defers_scroll_to_idle() {
+        if !crate::test_helpers::ensure_gtk() {
+            eprintln!("SKIPPED: no display available");
+            return;
+        }
+
+        let pane = super::persistent_widget::PersistentPaneView::new("defer-mod", "runtime-1");
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 480);
+        window.set_child(Some(&pane));
+        window.present();
+
+        let ctx = gtk4::glib::MainContext::default();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(100);
+        while std::time::Instant::now() < deadline {
+            if !ctx.iteration(false) {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+        }
+
+        let mut data = Vec::new();
+        for i in 0..200 {
+            data.extend_from_slice(format!("line {i}\r\n").as_bytes());
+        }
+        pane.feed_snapshot(&data);
+
+        // After idle fires, viewport must be at the bottom.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(100);
+        while std::time::Instant::now() < deadline {
+            if !ctx.iteration(false) {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+        }
+
+        let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+        let bottom = adj.upper() - adj.page_size();
+        assert!(
+            (adj.value() - bottom).abs() < 1.0,
+            "deferred scroll must land at bottom; got {} expected ~{bottom}",
+            adj.value()
+        );
+        window.close();
+    }
 }
 
 #[cfg(test)]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -516,6 +516,10 @@ impl PersistentPaneView {
     /// Feed a snapshot's scrollback bytes into VTE to restore state on attach.
     /// Bell characters are stripped to prevent historical bells from ringing.
     /// Scrolls to the bottom so the viewport shows the most recent output.
+    ///
+    /// The scroll is deferred to the next main-loop iteration because VTE
+    /// updates its layout asynchronously after `feed()` — the adjustment's
+    /// `upper` value is not yet correct at the point `feed()` returns.
     pub fn feed_snapshot(&self, scrollback: &[u8]) {
         if scrollback.is_empty() {
             return;
@@ -526,10 +530,13 @@ impl PersistentPaneView {
         } else {
             self.imp().vte.feed(scrollback);
         }
-        let adj = self.imp().vte.vadjustment();
-        if let Some(adj) = adj {
-            adj.set_value(adj.upper() - adj.page_size());
-        }
+        let vte_weak = self.imp().vte.downgrade();
+        glib::idle_add_local_once(move || {
+            let Some(vte) = vte_weak.upgrade() else { return };
+            if let Some(adj) = vte.vadjustment() {
+                adj.set_value(adj.upper() - adj.page_size());
+            }
+        });
     }
 
     /// Set the bracketed paste mode state from a snapshot.
@@ -2100,6 +2107,48 @@ mod tests {
         assert!(
             (adj.value() - bottom).abs() < 1.0,
             "feed_snapshot should scroll to bottom, got {} expected ~{bottom}",
+            adj.value()
+        );
+
+        window.close();
+    }
+
+    /// Regression for #707: `feed_snapshot` defers scroll-to-bottom so VTE has
+    /// time to update its layout. Without the deferred idle handler, the
+    /// viewport would show the top of the scrollback after reconnect.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn feed_snapshot_deferred_scroll_after_reconnect() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("scroll-defer", "runtime-1");
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 480);
+        window.set_child(Some(&pane));
+        window.present();
+        pump_events(100);
+
+        // Simulate reconnect: feed a large snapshot.
+        let mut data = Vec::new();
+        for i in 0..300 {
+            data.extend_from_slice(format!("reconnect line {i}\r\n").as_bytes());
+        }
+        pane.feed_snapshot(&data);
+
+        // Pump events to let the deferred idle handler fire.
+        pump_events(100);
+
+        let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+        let bottom = adj.upper() - adj.page_size();
+        assert!(
+            bottom > 0.0,
+            "scrollback should be large enough to scroll, upper={} page_size={}",
+            adj.upper(),
+            adj.page_size()
+        );
+        assert!(
+            (adj.value() - bottom).abs() < 1.0,
+            "after reconnect, viewport must show bottom of scrollback; got {} expected ~{bottom}",
             adj.value()
         );
 

--- a/clients/rttx/tests/scroll_position_tests.rs
+++ b/clients/rttx/tests/scroll_position_tests.rs
@@ -144,3 +144,40 @@ fn scroll_position_restore_clamps_to_valid_range() {
 
     window.close();
 }
+
+/// After reconnect, `feed_snapshot` must scroll the viewport to the bottom
+/// so the user sees the most recent output. The scroll is deferred to the
+/// next main-loop iteration because VTE updates its layout asynchronously.
+/// Regression for #707.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn feed_snapshot_scrolls_to_bottom_after_reconnect() {
+    require_display!();
+
+    let pane = PersistentPaneView::new("reconnect-scroll", "runtime-1");
+    let window = gtk4::Window::new();
+    window.set_default_size(640, 480);
+    window.set_child(Some(&pane));
+    window.present();
+    pump_events(100);
+
+    // Simulate reconnect with scrollback replay.
+    feed_scrollback(&pane, 300);
+    pump_events(100);
+
+    let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+    let bottom = adj.upper() - adj.page_size();
+    assert!(
+        bottom > 0.0,
+        "scrollback must exceed visible area; upper={} page_size={}",
+        adj.upper(),
+        adj.page_size()
+    );
+    assert!(
+        (adj.value() - bottom).abs() < 1.0,
+        "viewport must be at bottom after reconnect snapshot; got {} expected ~{bottom}",
+        adj.value()
+    );
+
+    window.close();
+}


### PR DESCRIPTION
## What changed and why

After reconnecting to a daemon (or replaying scrollback on attach), panes showed the **top** of the scrollback buffer instead of the bottom. Users had to manually scroll down to see their most recent output.

**Root cause:** `feed_snapshot()` called `vte.feed(scrollback)` then immediately set the scroll adjustment to bottom. But VTE processes fed data and updates its layout asynchronously — `adj.upper()` hadn't been updated yet when `set_value` fired, so the scroll landed at position 0 (the top).

**Fix:** Defer the scroll-to-bottom into a `glib::idle_add_local_once` callback. This runs on the next main-loop iteration, after VTE has finished processing the fed data and updated the adjustment extents.

## Manual verification

1. Start daemon: `RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground`
2. Start GUI: `RTTX_DEV_MODE=1 cargo run -p rttx`
3. In a pane, generate scrollback: `for i in $(seq 1 500); do echo "line $i"; done`
4. Restart the daemon (Ctrl+C, re-run)
5. Observe: pane reconnects and viewport shows the **bottom** of the scrollback

## Tests added

- `feed_snapshot_deferred_scroll_after_reconnect` — regression test that feeds 300 lines via `feed_snapshot` and verifies the viewport is at the bottom after the idle handler fires

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass including the new one)

Fixes #707