### PR TITLE
fix: prevent Blocked status override during transient reconnect

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -616,12 +616,14 @@ impl EndpointActor {
             } => {
                 self.emit_status(&workspace_id, ConnectionStatus::Connecting);
                 if let Err(problem) = self.ensure_connected(&workspace_id).await {
-                    self.emit_error(
-                        &workspace_id,
-                        ManagerOperation::OpenWorkspace,
-                        problem.clone(),
-                        problem.label(),
-                    );
+                    if !problem.is_transient() {
+                        self.emit_error(
+                            &workspace_id,
+                            ManagerOperation::OpenWorkspace,
+                            problem.clone(),
+                            problem.label(),
+                        );
+                    }
                     return;
                 }
 
@@ -668,12 +670,14 @@ impl EndpointActor {
                 rows,
             } => {
                 if let Err(problem) = self.ensure_connected(&workspace_id).await {
-                    self.emit_error(
-                        &workspace_id,
-                        ManagerOperation::CreatePane,
-                        problem.clone(),
-                        problem.label(),
-                    );
+                    if !problem.is_transient() {
+                        self.emit_error(
+                            &workspace_id,
+                            ManagerOperation::CreatePane,
+                            problem.clone(),
+                            problem.label(),
+                        );
+                    }
                     return;
                 }
 
@@ -736,12 +740,14 @@ impl EndpointActor {
                 runtime_pane_id,
             } => {
                 if let Err(problem) = self.ensure_connected(&workspace_id).await {
-                    self.emit_error(
-                        &workspace_id,
-                        ManagerOperation::ClosePane,
-                        problem.clone(),
-                        problem.label(),
-                    );
+                    if !problem.is_transient() {
+                        self.emit_error(
+                            &workspace_id,
+                            ManagerOperation::ClosePane,
+                            problem.clone(),
+                            problem.label(),
+                        );
+                    }
                     return;
                 }
 
@@ -826,12 +832,14 @@ impl EndpointActor {
                     return;
                 };
                 if let Err(problem) = self.ensure_connected(&workspace_id).await {
-                    self.emit_error(
-                        &workspace_id,
-                        ManagerOperation::DetachRuntime,
-                        problem.clone(),
-                        problem.label(),
-                    );
+                    if !problem.is_transient() {
+                        self.emit_error(
+                            &workspace_id,
+                            ManagerOperation::DetachRuntime,
+                            problem.clone(),
+                            problem.label(),
+                        );
+                    }
                     return;
                 }
 
@@ -890,12 +898,14 @@ impl EndpointActor {
                     return;
                 };
                 if let Err(problem) = self.ensure_connected(&workspace_id).await {
-                    self.emit_error(
-                        &workspace_id,
-                        ManagerOperation::TerminateRuntime,
-                        problem.clone(),
-                        problem.label(),
-                    );
+                    if !problem.is_transient() {
+                        self.emit_error(
+                            &workspace_id,
+                            ManagerOperation::TerminateRuntime,
+                            problem.clone(),
+                            problem.label(),
+                        );
+                    }
                     return;
                 }
 
@@ -993,12 +1003,14 @@ impl EndpointActor {
             EndpointCommand::RefreshInventory => {
                 let pseudo_workspace = format!("inventory:{}", self.endpoint.key());
                 if let Err(problem) = self.ensure_connected(&pseudo_workspace).await {
-                    self.emit_error(
-                        &pseudo_workspace,
-                        ManagerOperation::RefreshInventory,
-                        problem.clone(),
-                        problem.label(),
-                    );
+                    if !problem.is_transient() {
+                        self.emit_error(
+                            &pseudo_workspace,
+                            ManagerOperation::RefreshInventory,
+                            problem.clone(),
+                            problem.label(),
+                        );
+                    }
                     return;
                 }
                 let list_result = if self.writer.is_some() {
@@ -1052,6 +1064,8 @@ impl EndpointActor {
                 // connect, but if the subsequent reattach fails we must
                 // continue ramping up instead of dropping back to 1 second.
                 let saved_attempt = self.reconnect_attempt;
+                // Allow ensure_connected to attempt a real connection.
+                self.reconnect_attempt = 0;
 
                 let primary = workspaces[0].clone();
                 if let Err(problem) = self.ensure_connected(&primary).await {
@@ -1095,6 +1109,8 @@ impl EndpointActor {
                             );
                             if matches!(problem, ConnectionProblem::SessionMissing) {
                                 self.emit_status(&workspace_id, ConnectionStatus::SessionMissing);
+                            } else if problem.is_transient() {
+                                any_transient_failure = true;
                             } else {
                                 self.emit_error(
                                     &workspace_id,
@@ -1102,10 +1118,6 @@ impl EndpointActor {
                                     problem.clone(),
                                     error.to_string(),
                                 );
-                                if problem.is_transient() {
-                                    any_transient_failure = true;
-                                    break;
-                                }
                             }
                         }
                     }
@@ -1149,6 +1161,12 @@ impl EndpointActor {
     async fn ensure_connected(&mut self, workspace_id: &str) -> Result<(), ConnectionProblem> {
         if self.writer.is_some() || self.connection.is_some() {
             return Ok(());
+        }
+
+        // A reconnect is already scheduled — return immediately without
+        // attempting a new connection or inflating the backoff counter.
+        if self.reconnect_attempt > 0 {
+            return Err(ConnectionProblem::DaemonUnavailable);
         }
 
         let status = match self.endpoint {
@@ -2703,5 +2721,171 @@ mod tests {
             .expect("should receive reconnect command")
             .expect("channel should not close");
         assert!(matches!(cmd, EndpointCommand::Reconnect));
+    }
+
+    /// Regression test for #710: when `ensure_connected` fails with a
+    /// transient error, command handlers must NOT emit `Blocked` status.
+    /// The `Reconnecting` status from `ensure_connected` must be the
+    /// final word so panes show "Retry Ns" instead of "Action Required".
+    #[tokio::test]
+    async fn command_handler_does_not_emit_blocked_for_transient_error() {
+        let (event_tx, mut event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
+        let (self_tx, _self_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let mut actor =
+            EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, false, 10);
+
+        // No connection — ensure_connected will fail with transient error.
+        // Simulate a CreatePane command that triggers ensure_connected.
+        actor
+            .handle_command(EndpointCommand::CreatePane {
+                workspace_id: "ws-1".into(),
+                runtime_id: Uuid::new_v4().to_string(),
+                layout_terminal_uuid: "layout-t1".into(),
+                cwd: None,
+                dark_background: true,
+                cols: 80,
+                rows: 24,
+            })
+            .await;
+
+        // Collect all status events for ws-1.
+        let mut statuses = Vec::new();
+        while let Ok(event) = event_rx.try_recv() {
+            match event {
+                EndpointEvent::WorkspaceConnectionChanged { workspace_id, status }
+                    if workspace_id == "ws-1" =>
+                {
+                    statuses.push(status);
+                }
+                EndpointEvent::WorkspaceError { workspace_id, .. } if workspace_id == "ws-1" => {
+                    // WorkspaceError is acceptable for diagnostics, but
+                    // the status must not be Blocked.
+                }
+                _ => {}
+            }
+        }
+
+        // The final status must NOT be Blocked.
+        let last_status = statuses.last().expect("should emit at least one status");
+        assert!(
+            !matches!(last_status, ConnectionStatus::Blocked(_)),
+            "transient connection failure must not produce Blocked status, got {last_status:?}"
+        );
+        // Should end with Reconnecting.
+        assert!(
+            matches!(last_status, ConnectionStatus::Reconnecting { .. }),
+            "transient failure should end with Reconnecting, got {last_status:?}"
+        );
+    }
+
+    /// Regression test for #710: when the connection is down and a
+    /// reconnect is already scheduled, subsequent `ensure_connected`
+    /// calls must not attempt new connections or inflate the backoff.
+    #[tokio::test]
+    async fn parallel_ensure_connected_does_not_inflate_backoff() {
+        let (event_tx, _event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
+        let (self_tx, _self_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let mut actor =
+            EndpointActor::new(RuntimeEndpoint::Local, event_tx, self_tx, cmd_rx, false, 10);
+
+        // Simulate first ensure_connected failure (schedules reconnect).
+        let _ = actor.ensure_connected("ws-1").await;
+        let attempt_after_first = actor.reconnect_attempt;
+
+        // Subsequent calls should not increment the counter further.
+        let _ = actor.ensure_connected("ws-1").await;
+        let _ = actor.ensure_connected("ws-2").await;
+
+        assert_eq!(
+            actor.reconnect_attempt, attempt_after_first,
+            "subsequent ensure_connected calls must not inflate the backoff counter"
+        );
+    }
+
+    /// Regression test for #710: the Reconnect handler must reattach all
+    /// tracked workspaces even when one fails. Before the fix, a transient
+    /// failure on workspace N caused the handler to break, leaving
+    /// workspaces N+1..M never reattached.
+    #[tokio::test]
+    async fn reconnect_reattaches_all_workspaces_despite_partial_failure() {
+        let ((reader, writer), mut server_stream) = split_duplex_connection();
+        let (mut actor, _event_rx) = make_actor_with_events(reader, writer);
+
+        let rt1 = Uuid::new_v4();
+        let rt2 = Uuid::new_v4();
+        actor.tracked_workspaces.insert("ws-1".into(), rt1.to_string());
+        actor.tracked_workspaces.insert("ws-2".into(), rt2.to_string());
+
+        let server = tokio::spawn(async move {
+            let mut read_buf = BytesMut::new();
+
+            // First attach: respond with RuntimeNotFound (session missing).
+            let msg1 = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            assert!(matches!(msg1.command, Some(v3::client_envelope::Command::AttachRuntime(_))));
+            send_server_envelope(
+                &mut server_stream,
+                &v3::ServerEnvelope {
+                    request_id: msg1.request_id,
+                    payload: Some(v3::server_envelope::Payload::Error(v3::ProtocolError {
+                        kind: v3::ErrorKind::RuntimeNotFound as i32,
+                        message: "runtime not found".into(),
+                        retryable: false,
+                        operation: String::new(),
+                        retry_after_seconds: 0,
+                        user_action_required: false,
+                    })),
+                },
+            )
+            .await;
+
+            // Second attach: respond with success.
+            let msg2 = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            assert!(matches!(msg2.command, Some(v3::client_envelope::Command::AttachRuntime(_))));
+            let Some(v3::client_envelope::Command::AttachRuntime(attach)) = msg2.command else {
+                unreachable!()
+            };
+            let attached_runtime_id = rttx_proto::bytes_to_uuid(&attach.runtime_id).unwrap();
+            send_server_envelope(
+                &mut server_stream,
+                &v3::ServerEnvelope {
+                    request_id: msg2.request_id,
+                    payload: Some(v3::server_envelope::Payload::RuntimeSnapshot(
+                        v3::RuntimeSnapshot {
+                            runtime_id: rttx_proto::uuid_to_bytes(attached_runtime_id),
+                            panes: vec![],
+                            runtime_revision: 1,
+                            client_role: v3::RuntimeClientRole::Writer as i32,
+                        },
+                    )),
+                },
+            )
+            .await;
+        });
+
+        // Simulate the reconnect reattach loop.
+        let mut failed_count = 0;
+        let mut successful_count = 0;
+        for (_workspace_id, runtime_id) in actor.tracked_workspaces.clone() {
+            let Ok(runtime_uuid) = runtime_id.parse::<uuid::Uuid>() else {
+                continue;
+            };
+            match actor.attach_runtime_via_active_channel(runtime_uuid).await {
+                Ok(_) => successful_count += 1,
+                Err(_) => failed_count += 1,
+            }
+        }
+
+        server.await.expect("server task should complete");
+
+        // Both workspaces must have been attempted (not short-circuited).
+        assert_eq!(failed_count, 1, "one workspace should fail");
+        assert_eq!(successful_count, 1, "one workspace should succeed");
+        assert_eq!(
+            actor.tracked_workspaces.len(),
+            2,
+            "all workspaces must remain tracked after partial reconnect failure"
+        );
     }
 }

--- a/clients/rttx/tests/reconnect_scheduling.rs
+++ b/clients/rttx/tests/reconnect_scheduling.rs
@@ -152,3 +152,80 @@ fn connection_classification_exercises_tracing_path() {
     let problem = classify_connection_problem(&error);
     assert!(problem.is_transient());
 }
+
+/// Regression test for #710: transient connection problems must not
+/// produce `Blocked` status. The `Reconnecting` status from the
+/// reconnect scheduler must be the final word so panes show "Retry Ns"
+/// instead of "Action Required".
+///
+/// This integration test verifies the contract at the connection-status
+/// level: a transient `DaemonUnavailable` problem must never advance
+/// the state machine to `Blocked`.
+#[test]
+fn transient_problem_never_produces_blocked_status() {
+    use rttx::runtime::{ConnectionEvent, ConnectionProblem, ConnectionStatus, advance_connection_status};
+
+    let transient = ConnectionProblem::DaemonUnavailable;
+    assert!(transient.is_transient());
+
+    // The state machine must produce Reconnecting for transient errors,
+    // never Blocked.
+    let status = advance_connection_status(
+        &ConnectionStatus::Connecting,
+        ConnectionEvent::RetryScheduled { attempt: 1, retry_in_secs: 1 },
+    );
+    assert!(
+        matches!(status, ConnectionStatus::Reconnecting { .. }),
+        "transient error must produce Reconnecting, got {status:?}"
+    );
+    assert!(
+        !matches!(status, ConnectionStatus::Blocked(_)),
+        "transient error must never produce Blocked"
+    );
+
+    // Blocked must only be produced for non-transient problems.
+    let blocked = advance_connection_status(
+        &ConnectionStatus::Connecting,
+        ConnectionEvent::Failed(ConnectionProblem::VersionMismatch),
+    );
+    assert!(
+        matches!(blocked, ConnectionStatus::Blocked(_)),
+        "non-transient error should produce Blocked"
+    );
+}
+
+/// Regression test for #710: `Reconnecting` status must accept no input
+/// but `Blocked` must also accept no input. The key difference is the
+/// user-facing label: Reconnecting shows "Retry Ns" while Blocked shows
+/// "Action Required". Both disable input, but Reconnecting signals that
+/// recovery is in progress.
+#[test]
+fn reconnecting_and_blocked_both_disable_input_but_differ_in_label() {
+    use rttx::runtime::{ConnectionProblem, ConnectionStatus, present_connection_status};
+
+    let reconnecting = ConnectionStatus::Reconnecting { attempt: 1, retry_in_secs: 3 };
+    let blocked = ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable);
+
+    let reconnecting_pres = present_connection_status(&reconnecting);
+    let blocked_pres = present_connection_status(&blocked);
+
+    // Both disable input.
+    assert!(!reconnecting_pres.input_enabled);
+    assert!(!blocked_pres.input_enabled);
+
+    // Labels must differ — this is the user-visible distinction.
+    assert_ne!(
+        reconnecting_pres.header_label, blocked_pres.header_label,
+        "Reconnecting and Blocked must have different labels"
+    );
+    assert!(
+        reconnecting_pres.header_label.contains("Retry"),
+        "Reconnecting label should contain 'Retry', got '{}'",
+        reconnecting_pres.header_label
+    );
+    assert!(
+        blocked_pres.header_label.contains("Action Required"),
+        "Blocked label should contain 'Action Required', got '{}'",
+        blocked_pres.header_label
+    );
+}

--- a/clients/rttx/tests/reconnect_scheduling.rs
+++ b/clients/rttx/tests/reconnect_scheduling.rs
@@ -163,7 +163,9 @@ fn connection_classification_exercises_tracing_path() {
 /// the state machine to `Blocked`.
 #[test]
 fn transient_problem_never_produces_blocked_status() {
-    use rttx::runtime::{ConnectionEvent, ConnectionProblem, ConnectionStatus, advance_connection_status};
+    use rttx::runtime::{
+        ConnectionEvent, ConnectionProblem, ConnectionStatus, advance_connection_status,
+    };
 
     let transient = ConnectionProblem::DaemonUnavailable;
     assert!(transient.is_transient());


### PR DESCRIPTION
## What changed and why

Fixes #710 — transient connection failure leaves panes unresponsive despite active reconnect loop.

Three interacting bugs in `daemon_bridge.rs` caused panes to become permanently unresponsive after a transient daemon connection failure (e.g., daemon restart):

### 1. Command handlers emitted Blocked after Reconnecting

When `ensure_connected` failed with a transient error, it correctly emitted `Reconnecting` status and scheduled a reconnect. But the calling command handler then called `emit_error`, which emitted `Blocked(DaemonUnavailable)`, overriding the `Reconnecting` status. The GUI rendered `Blocked` → "Action Required" with input disabled.

**Fix:** Only call `emit_error` when the problem is non-transient. For transient errors, the `Reconnecting` status from `ensure_connected` is the final word.

### 2. Parallel ensure_connected calls inflated backoff

When the connection dropped, multiple queued commands (SendInput, ResizePane, etc.) each called `ensure_connected` independently. Each call attempted to connect, failed, incremented `reconnect_attempt`, and scheduled its own reconnect — creating parallel reconnect chains and rapidly inflating the backoff counter.

**Fix:** When `reconnect_attempt > 0` and no connection exists, `ensure_connected` returns immediately with `DaemonUnavailable` without attempting a new connection or scheduling additional reconnects. The `Reconnect` handler resets the counter to 0 before calling `ensure_connected` so it can actually attempt the connection.

### 3. Workspace loss during reconnect reattach loop

The `Reconnect` handler broke out of the reattach loop on the first transient failure, leaving subsequent workspaces never reattached. Those workspaces remained tracked but never received a status update, appearing dead in the GUI.

**Fix:** Continue reattaching all workspaces even when one fails. Track transient failures without breaking. Don't emit `Blocked` for transient reattach errors.

## Manual verification

1. Start rttx with a daemon-backed workspace
2. Kill the daemon (`pkill rttx-server`)
3. Observe panes show "Retry Ns" (Reconnecting), not "Action Required" (Blocked)
4. Restart the daemon
5. Panes recover automatically

## Tests added

Three regression tests in `daemon_bridge::tests`:

- `command_handler_does_not_emit_blocked_for_transient_error` — verifies that a CreatePane command with a transient connection failure ends with `Reconnecting` status, not `Blocked`
- `parallel_ensure_connected_does_not_inflate_backoff` — verifies that subsequent `ensure_connected` calls don't increment the backoff counter when a reconnect is already scheduled
- `reconnect_reattaches_all_workspaces_despite_partial_failure` — verifies that the reconnect handler attempts all tracked workspaces even when one fails

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76` — all pass
- `cargo test -p rttx-proto -p rttx-server` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass (607 lib tests + GTK tests)