### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.3.16"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.3.16"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.3.16"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.16"
+version = "0.4.0"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.3.16',
+  version: '0.4.0',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -1,5 +1,5 @@
 Name:           rttx
-Version:        0.2.0
+Version:        0.4.0
 Release:        1%{?dist}
 Summary:        A tiling terminal emulator for GNOME
 


### PR DESCRIPTION
## What changed and why

Bump the project version from 0.3.16 to 0.4.0 across all version sources:
- `Cargo.toml` (workspace version)
- `meson.build` (Meson project version)
- `packaging/rttx/rttx.spec` (RPM spec version)

## Manual verification

- `cargo build --workspace` compiles all three crates at v0.4.0
- All existing tests pass unchanged

## Tests added

None — this is a version-only change with no behavioral impact.

## Tests run

- `cargo test -p rttx-proto -p rttx-server` — all pass
- `cargo test -p rttx --no-default-features --features vte-0_76` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass

Fixes #713