### PR TITLE
docs(rfc): accept RFC-022 with review feedback

### DIFF
--- a/designs/RFC-022-daemon-state-storage.md
+++ b/designs/RFC-022-daemon-state-storage.md
@@ -2,7 +2,7 @@
 
 | Field         | Value          |
 |---------------|----------------|
-| Status        | Draft          |
+| Status        | Accepted       |
 | Author(s)     | Illya Yalovyy  |
 | Supersedes    | —              |
 | Superseded by | —              |
@@ -11,37 +11,39 @@
 
 ## Summary
 
-The rttx daemon persists every session's runtime state into a single monolithic
+The rttx daemon persists every runtime's state into a single monolithic
 `state.json` file, rewritten in full on every serialization tick, stored under the
 user's XDG **cache** directory. Scrollback and shell history are written as raw
-per-pane files next to it. There is no schema version, no migration hook, no backup,
-no dirty-tracking, and no separation between durable spec and transient runtime
+per-pane files next to it. There is no schema version, no backup, no
+dirty-tracking, and no separation between durable spec and transient runtime
 instance data.
 
-This works for the tens-of-sessions case today. It does not scale, does not survive
+This works for the tens-of-runtimes case today. It does not scale, does not survive
 cache eviction, and makes every future persistence-adjacent feature (encrypted
 scrollback, per-host state, cross-machine sync, crash-safe recovery, selective
 export) a load-bearing rewrite rather than an additive change.
 
-Because we have explicit permission to break backward compatibility now, this RFC
-proposes a clean v2 layout: a **per-session directory with versioned, typed files
-under `$XDG_STATE_HOME/rttx`**, a small top-level index, explicit schema versioning
-with a migration module, dirty-flag-driven writes, deterministic screen snapshots
-separate from append-only scrollback logs, and a durable-vs-ephemeral split.
+This RFC proposes a clean v2 layout: a **per-runtime directory with versioned, typed
+files under `$XDG_STATE_HOME/rttx/daemon/`**, a small top-level index, explicit
+schema versioning, dirty-flag-driven writes, deterministic screen snapshots separate
+from append-only scrollback logs, and a durable-vs-ephemeral split.
+
+There is no migration from v1. On first v2 startup the daemon starts with a clean
+state. Users get a loud log line explaining the change.
 
 ---
 
 ## Goals
 
 - **G1** — State that survives OS/user cache cleanup (move out of `XDG_CACHE_HOME`)
-- **G2** — Per-session files so write cost scales with churn, not with total session count
+- **G2** — Per-runtime files so write cost scales with churn, not with total runtime count
 - **G3** — Explicit `schema_version` and a typed migration path on every persisted struct
 - **G4** — A single corrupt file never takes down the whole daemon's history
 - **G5** — Clean separation between *durable* state (id, name, policy, layout) and
   *transient* runtime state (revision, attached_clients, pending_replies)
 - **G6** — Reconnect snapshots are reconstructed from a deterministic screen model,
   not raw byte tails that may start mid-escape-sequence
-- **G7** — Pruning of removed sessions' on-disk artefacts is automatic
+- **G7** — Pruning of removed runtimes' on-disk artefacts is automatic
 - **G8** — The layout is extensible to future features (encrypted panes, per-host
   stores, sync to relay) without another flag-day migration
 
@@ -52,8 +54,9 @@ separate from append-only scrollback logs, and a durable-vs-ephemeral split.
   RFC makes it possible, not present)
 - **NG3** — Replacing JSON with a binary format. We stay on JSON for diff-ability
   and hand-editability; binary can be swapped per-file later
-- **NG4** — Backward compatibility with the v1 `state.json` layout. Migration is
-  one-way: a v1 file loads once, is upgraded in place, and v1 is no longer written
+- **NG4** — Backward compatibility with the v1 `state.json` layout. There is no
+  migration: v2 starts clean. The old cache directory is left untouched for manual
+  inspection but never read
 - **NG5** — A new IPC surface for state inspection — this RFC concerns on-disk
   storage only
 
@@ -65,13 +68,13 @@ separate from append-only scrollback logs, and a durable-vs-ephemeral split.
 
 ```
 $XDG_CACHE_HOME/rttx-server/
-├── state.json                              # all sessions, rewritten every tick
-├── scrollback/<session_id>/<pane_id>.log   # raw bytes, tail-truncated at 10MB
-└── history/<session_id>/<pane_id>.hist     # per-pane shell history
+├── state.json                              # all runtimes, rewritten every tick
+├── scrollback/<runtime_id>/<pane_id>.log   # raw bytes, tail-truncated at 10MB
+└── history/<runtime_id>/<pane_id>.hist     # per-pane shell history
 ```
 
-`state.json` contains a single `ServerState { sessions, serialized_at, server_version }`.
-See `services/rttx-server/src/serialization.rs` and `session.rs:PersistedSession`.
+`state.json` contains a single `ServerState { runtimes, serialized_at, server_version }`.
+See `services/rttx-server/src/serialization.rs` and `runtime.rs:PersistedRuntime`.
 
 In dev mode (`RTTX_DEV_MODE=1`), the daemon uses `$XDG_CACHE_HOME/rttx-server-devel/`
 instead, so development and production state are fully isolated.
@@ -80,18 +83,18 @@ instead, so development and production state are fully isolated.
 
 1. **Cache directory is the wrong home.** `XDG_CACHE_HOME` is explicitly defined as
    *data the user can regenerate or delete*. Distro cleaners, Flatpak refresh, and
-   `systemd-tmpfiles` can all wipe it. Our sessions are not regenerable.
+   `systemd-tmpfiles` can all wipe it. Our runtimes are not regenerable.
 
 2. **Monolithic rewrite.** Every serialization tick builds a full snapshot under
    the server mutex, pretty-prints it, writes to `.tmp`, renames over the old file
    (see `serialization_loop` in `server.rs` and `write_state_atomic` in
-   `serialization.rs`). Cost grows linearly with total session count even if
-   only one session actually changed.
+   `serialization.rs`). Cost grows linearly with total runtime count even if
+   only one runtime actually changed.
 
 3. **No schema version.** The only version marker is `server_version: String` —
    the Cargo package version. There is no `schema_version`, no migration entry
    point, and `#[serde(default)]` is used ad-hoc per field (e.g., on `policy`
-   and `revision` in `PersistedSession`). A non-trivial schema change today
+   and `revision` in `PersistedRuntime`). A non-trivial schema change today
    requires bespoke logic scattered across struct definitions.
 
 4. **Scrollback truncation corrupts replay.** `Pane::flush_scrollback` appends
@@ -102,20 +105,20 @@ instead, so development and production state are fully isolated.
    `MAX_SNAPSHOT_BYTES = 256 KB` (defined in `pane.rs`) masks but does not fix
    this.
 
-5. **Durable and transient are mixed.** `PersistedSession` holds `revision` and
+5. **Durable and transient are mixed.** `PersistedRuntime` holds `revision` and
    `last_active_at` alongside `policy`, `panes`, `command_history`, and
    `active_pane_id`, but not `attached_clients` (which is correctly ephemeral).
    The boundary is implicit and easy to get wrong on the next field.
 
-6. **No cleanup.** When a session is deleted, its scrollback and history
+6. **No cleanup.** When a runtime is deleted, its scrollback and history
    directories remain on disk. Over months of use the cache grows unboundedly.
 
 7. **Corruption is fatal to the entire history.** `load_state` returns
    `Err(InvalidData)` on a bad parse, logs it, and the daemon starts empty. One
    bad byte in the monolith loses everything.
 
-8. **No write coalescing or dirty tracking.** A session that hasn't changed in
-   an hour is rewritten identically 3 600+ times. `Session` has a `revision: u64`
+8. **No write coalescing or dirty tracking.** A runtime that hasn't changed in
+   an hour is rewritten identically 3 600+ times. `Runtime` has a `revision: u64`
    field that bumps on every mutation, but there is no `persisted_revision` to
    compare against.
 
@@ -132,14 +135,14 @@ reconstruct state. This is the foundation for the screen-snapshot proposal in
 The fixes cut across:
 - Directory layout (breaking)
 - Serde schema (breaking)
-- Migration story (new subsystem)
 - Screen-state model (new abstraction — serialized grid vs raw bytes)
 - Cleanup lifecycle (new scheduler work)
 
-…and they interlock: you cannot introduce per-session files without a
+…and they interlock: you cannot introduce per-runtime files without a
 schema-version story; you cannot make scrollback replay correct without a
 screen-model serialization; you cannot move to `$XDG_STATE_HOME` without also
-deciding the migration-from-v1 behaviour. This needs one consistent design.
+deciding the directory namespace shared with RFC-023. This needs one consistent
+design.
 
 ---
 
@@ -147,9 +150,9 @@ deciding the migration-from-v1 behaviour. This needs one consistent design.
 
 | Audience     | Impact |
 |--------------|--------|
-| End users    | Sessions survive cache cleanup; corruption is contained to one session, not the whole daemon; reconnect shows the correct screen, not garbled bytes |
-| Contributors | Adding a field to a persisted struct is a one-line schema bump with a typed migration; per-session files mean smaller diffs and faster tests |
-| Packagers    | State moves to `$XDG_STATE_HOME/rttx`; packaging docs updated; no cache-cleaner collateral damage |
+| End users    | Runtimes survive cache cleanup; corruption is contained to one runtime, not the whole daemon; reconnect shows the correct screen, not garbled bytes. Existing sessions are lost on upgrade (clean start) |
+| Contributors | Adding a field to a persisted struct is a one-line schema bump with a typed migration; per-runtime files mean smaller diffs and faster tests |
+| Packagers    | State moves to `$XDG_STATE_HOME/rttx/daemon/`; packaging docs updated; no cache-cleaner collateral damage |
 
 ---
 
@@ -160,15 +163,15 @@ deciding the migration-from-v1 behaviour. This needs one consistent design.
 **Pros**: Smallest change. Only adds a version field and a migration hook.
 
 **Cons**: Does nothing for cache-eviction, write scaling, corruption blast radius,
-or dead-session pruning. We will be back here within a release.
+or dead-runtime pruning. We will be back here within a release.
 
-### Option B — Per-session directory, versioned files, durable/transient split
+### Option B — Per-runtime directory, versioned files, durable/transient split
 
-**Pros**: Addresses every pain point listed. Each session is its own unit of
+**Pros**: Addresses every pain point listed. Each runtime is its own unit of
 durability, corruption, and migration. Diffs are tractable.
 
-**Cons**: Breaking layout change. Needs a one-time v1→v2 importer. More files on
-disk (trivial; filesystems handle this fine — tmux/zellij already do).
+**Cons**: Breaking layout change. More files on disk (trivial; filesystems handle
+this fine — tmux/zellij already do).
 
 ### Option C — Embedded SQLite
 
@@ -176,7 +179,7 @@ disk (trivial; filesystems handle this fine — tmux/zellij already do).
 
 **Cons**: Binary file is not diff-able or hand-editable; adds a non-trivial
 dependency; the concurrency model (single writer, many readers) gives us no
-benefit over per-session JSON since the daemon is already the sole writer.
+benefit over per-runtime JSON since the daemon is already the sole writer.
 Scrollback as BLOBs in SQLite is measurably worse than append-only log files.
 
 ### Option D — Event-sourced log + periodic snapshot
@@ -192,7 +195,7 @@ have replication requirements.
 
 ## Decision
 
-**Chosen option: Option B — per-session versioned files with a clean durable/transient split.**
+**Chosen option: Option B — per-runtime versioned files with a clean durable/transient split.**
 
 Rationale:
 
@@ -200,11 +203,12 @@ Rationale:
 - Stays on JSON, so diffs, review, and manual recovery all keep working
 - Leaves the door open to swap specific files (screen snapshot, scrollback) to
   binary later without changing the layout
-- Does not preclude Option D as a future addition: the per-session file becomes
+- Does not preclude Option D as a future addition: the per-runtime file becomes
   the "snapshot" in an event-sourced model
 
-We take the one-time break now while we still can. Migration is a single
-best-effort import of v1 `state.json` on first v2 startup.
+There is no v1 migration. On first v2 startup the daemon starts fresh with a
+clean state directory. The old `$XDG_CACHE_HOME/rttx-server/` is left untouched
+for manual inspection. A loud log line announces the change.
 
 ---
 
@@ -213,28 +217,35 @@ best-effort import of v1 `state.json` on first v2 startup.
 ### 1. On-disk layout
 
 ```
-$XDG_STATE_HOME/rttx/                   # (was: $XDG_CACHE_HOME/rttx-server/)
-├── daemon.json                         # server-level index, schema v1
-├── daemon.json.bak                     # previous good copy
-└── sessions/
-    └── <session_id>/
-        ├── session.json                # durable spec + last-known instance, schema v1
-        ├── session.json.bak            # previous good copy
-        ├── screen/<pane_id>.snap       # deterministic screen snapshot, schema v1
-        ├── scrollback/<pane_id>.log    # append-only, rotated not truncated
-        ├── scrollback/<pane_id>.log.1  # rotated segments (keep last N)
-        └── history/<pane_id>.hist      # unchanged semantics
+$XDG_STATE_HOME/rttx/                       # shared root (daemon + client)
+└── daemon/                                  # RFC-022 owns everything below
+    ├── daemon.json                          # server-level index, schema v1
+    ├── daemon.json.bak -> daemon.json.prev  # symlink to previous good copy
+    ├── daemon.json.prev                     # actual previous copy
+    └── runtimes/
+        └── <runtime_id>/
+            ├── runtime.json                 # durable spec + last-known instance
+            ├── runtime.json.bak -> runtime.json.prev
+            ├── runtime.json.prev
+            ├── screen/<pane_id>.snap        # deterministic screen snapshot
+            ├── scrollback/<pane_id>.log     # append-only, rotated not truncated
+            ├── scrollback/<pane_id>.log.1   # rotated segments (keep last N)
+            └── history/<pane_id>.hist       # unchanged semantics
 ```
 
-The scrollback log remains under the session directory so deleting the session
+The `daemon/` subdirectory isolates daemon-owned state from client-owned state
+(RFC-023 owns `$XDG_STATE_HOME/rttx/client/`). This avoids naming conflicts and
+makes ownership unambiguous.
+
+The scrollback log remains under the runtime directory so deleting the runtime
 directory is one `remove_dir_all` call.
 
 The `OsInterface` trait currently exposes `cache_dir()` backed by
-`$XDG_CACHE_HOME`. Implementation will add a `state_dir()` method (or rename
-`cache_dir`) backed by `$XDG_STATE_HOME`, with the dev-mode variant using
-`rttx-server-devel` as it does today.
+`$XDG_CACHE_HOME`. Implementation will add a `state_dir()` method backed by
+`$XDG_STATE_HOME`, with the dev-mode variant using `rttx-devel` as it does
+today.
 
-### 2. Versioning & migration
+### 2. Versioning & schema evolution
 
 Every persisted file has a top-level `schema_version: u32` field.
 
@@ -243,7 +254,7 @@ Every persisted file has a top-level `schema_version: u32` field.
 struct DaemonIndexV1 {
     schema_version: u32,    // must be 1
     server_version: String, // informational only
-    session_ids: Vec<Uuid>,
+    runtime_ids: Vec<Uuid>,
     created_at: SystemTime,
     last_serialized_at: SystemTime,
 }
@@ -263,8 +274,8 @@ across the main structs — defaults are migration code, not struct attributes.
 ### 3. Durable vs transient split
 
 ```rust
-// Durable: goes to session.json
-struct SessionSpecV1 {
+// Durable: goes to runtime.json
+struct RuntimeSpecV1 {
     schema_version: u32,
     id: Uuid,
     name: String,
@@ -275,11 +286,11 @@ struct SessionSpecV1 {
     command_history: Vec<HistoryEntry>,
 }
 
-// Semi-durable: also in session.json, but bounded & bounded-age
-struct SessionInstanceV1 {
+// Semi-durable: also in runtime.json, but bounded & bounded-age
+struct RuntimeInstanceV1 {
     revision: u64,
     last_active_at: SystemTime,
-    last_snapshot_at: SystemTime,
+    last_snapshot_at: SystemTime, // when screen snapshots were last flushed
 }
 
 // Ephemeral: never written
@@ -289,12 +300,12 @@ struct SessionInstanceV1 {
 // - in-memory PaneScreen (raw_bytes, cursor, terminal mode flags)
 ```
 
-`session.json` wraps both:
+`runtime.json` wraps both:
 ```rust
-struct SessionFileV1 {
+struct RuntimeFileV1 {
     schema_version: u32,
-    spec: SessionSpecV1,
-    instance: SessionInstanceV1,
+    spec: RuntimeSpecV1,
+    instance: RuntimeInstanceV1,
 }
 ```
 
@@ -303,25 +314,63 @@ struct SessionFileV1 {
 The current design persists raw PTY bytes and replays them into VTE on the
 client. `PaneScreen` stores a `raw_bytes: Vec<u8>` stream and tracks cursor
 position, title, CWD, and terminal mode flags (bracketed paste, application
-cursor keys, mouse tracking, etc.) via a VTE parser. The code explicitly notes
-that a full cell-grid model is deferred to a later iteration.
+cursor keys, application keypad, mouse tracking, SGR mouse, focus events,
+cursor visibility) via a VTE parser.
 
 New contract:
 
-- `screen/<pane_id>.snap` is a **serialized grid**: dimensions + cells with
-  (codepoint, foreground, background, attributes) — the same data the screen
-  engine already holds in memory
-- Produced on flush from `PaneScreen`; consumed on resurrection
-- Reconnect `AttachSession` snapshot encodes this grid directly over the wire
-  (proto change deferred to RFC-021; until then, render grid → ANSI for
+- `screen/<pane_id>.snap` is a **deterministic screen snapshot** produced from
+  the `PaneScreen` state on each flush
+- Consumed on resurrection to restore the visible screen without replaying raw
+  bytes
+- Reconnect `AttachRuntime` snapshot encodes this data directly over the wire
+  (proto change deferred to RFC-021; until then, render snapshot → ANSI for
   backward compatibility)
 - The append-only **scrollback log** is separate: it is the history stream,
   not the reconnect seed. It need not be replayed to restore the visible
   screen — only when the user scrolls back
 
-Consequence: we stop truncating scrollback to fix a rendering bug, because the
-rendering bug moves to the grid file which is bounded by rows×cols, not bytes.
-Scrollback becomes a rotate-not-truncate stream:
+The snapshot schema, aligned with the current `PaneScreen` fields and the v3
+`PaneSnapshot` wire format:
+
+```rust
+#[derive(Serialize, Deserialize)]
+struct ScreenSnapshotV1 {
+    schema_version: u32,       // must be 1
+    pane_id: Uuid,
+    cols: u16,
+    rows: u16,
+    cursor_row: u16,
+    cursor_col: u16,
+    cursor_visible: bool,
+    title: Option<String>,
+    cwd: Option<String>,
+    pane_output_seq: u64,      // monotonic output counter for delta ordering
+    modes: TerminalModeSnapshot,
+    /// Raw bytes representing the visible screen content.
+    /// This is the tail of the PTY stream sufficient to reconstruct the
+    /// visible viewport. Bounded by rows × cols × max_bytes_per_cell.
+    /// Future iterations may replace this with a cell-grid model.
+    screen_bytes: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TerminalModeSnapshot {
+    bracketed_paste: bool,
+    application_cursor_keys: bool,
+    application_keypad: bool,
+    mouse_tracking_mode: u16,
+    sgr_mouse: bool,
+    focus_reporting: bool,
+}
+```
+
+The `screen_bytes` field is bounded by the visible viewport size, not the full
+scrollback. This eliminates the mid-escape-sequence corruption problem: the
+snapshot is produced from the screen engine's current state, not sliced from a
+raw byte stream.
+
+Consequence: scrollback becomes a rotate-not-truncate stream:
 
 - Rotate at 10 MB: `log` → `log.1`, `log.1` → `log.2`, keep up to 3 segments
 - Tail of the oldest segment may still start mid-sequence, but it is only ever
@@ -329,52 +378,63 @@ Scrollback becomes a rotate-not-truncate stream:
 
 ### 5. Dirty-flag-driven writes
 
-`Session` gains a `persisted_revision: u64` alongside `revision`. Serialization
-loop writes only sessions where `revision > persisted_revision`. After a
+`Runtime` gains a `persisted_revision: u64` alongside `revision`. Serialization
+loop writes only runtimes where `revision > persisted_revision`. After a
 successful write, `persisted_revision = revision`.
 
-The top-level `daemon.json` is rewritten only when `session_ids` changes
-(session created or removed), not every tick.
+The top-level `daemon.json` is rewritten only when `runtime_ids` changes
+(runtime created or removed), not every tick.
 
-Expected result: idle daemons with N sessions do ~0 writes per tick, not N.
+Expected result: idle daemons with N runtimes do ~0 writes per tick, not N.
+
+The default serialization interval is 5 seconds. With dirty-flag writes the
+interval is less performance-critical, but it defines the **crash data-loss
+window**: up to 5 seconds of state may be lost on an unclean daemon shutdown.
 
 ### 6. Corruption containment
 
 On load:
 
-1. Parse `daemon.json`. On failure, try `daemon.json.bak`. On second failure,
-   start fresh and log loudly (do not delete the files — let the user
-   inspect).
-2. For each `session_id` in the index, parse its `session.json` / `.bak`
-   independently. A corrupt session is dropped from the working set and logged;
+1. Parse `daemon.json`. On failure (missing, corrupt, or unreadable), try
+   `daemon.json.prev` (the symlink `.bak` target). On second failure, start
+   fresh and log loudly (do not delete the files — let the user inspect).
+2. For each `runtime_id` in the index, parse its `runtime.json` / `.prev`
+   independently. A corrupt runtime is dropped from the working set and logged;
    the rest load normally.
 3. Screen snapshots are best-effort: a corrupt `.snap` resurrects the pane as a
-   blank screen, not a failed session.
+   blank screen, not a failed runtime.
 
 On write:
 
-1. Write to `session.json.tmp`
-2. Rename `session.json` → `session.json.bak` (if it exists)
-3. Rename `session.json.tmp` → `session.json`
+1. Write to `runtime.json.tmp`
+2. Rename `runtime.json.tmp` → `runtime.json.prev`
+3. Update the `runtime.json.bak` symlink to point to `runtime.json.prev`
+4. Rename `runtime.json.prev` → `runtime.json`
 
-This gives us exactly one previous good copy per session at all times.
+Using symlinks for the `.bak` reference instead of renaming the live file
+avoids the window where neither `runtime.json` nor `.bak` exists. The symlink
+update is atomic on all supported Linux filesystems. If the process crashes at
+any point, at least one of `runtime.json` or `runtime.json.prev` (reachable
+via the `.bak` symlink) contains a valid copy.
 
 ### 7. Cleanup
 
-When a session is removed from the daemon:
+When a runtime is removed from the daemon:
 
-- Remove `sessions/<session_id>/` recursively in a background task
+- Remove `runtimes/<runtime_id>/` recursively in a background task
 - Remove its entry from `daemon.json`'s index on the next tick
 
-Orphan sweep on startup: any `sessions/<id>/` directory not referenced by
-`daemon.json` is moved to `sessions/.orphans/<id>/` (not deleted) for manual
-recovery. `.orphans/` is pruned after 30 days.
+Orphan sweep runs **on startup only**: any `runtimes/<id>/` directory not
+referenced by `daemon.json` is moved to `runtimes/.orphans/<id>/` (not deleted)
+for manual recovery. `.orphans/` entries older than 30 days are pruned on the
+same startup sweep. This is sufficient because the daemon restarts infrequently
+enough that orphans won't accumulate between restarts.
 
-### 8. Atomic rename semantics
+### 8. Atomic write semantics
 
-All writes use the existing tmp-rename pattern. The `.bak` rotation is also a
-rename, so the "either the old or the new file is visible" invariant is
-preserved across a crash at any point.
+All writes use the tmp-write + symlink-bak + rename pattern described in §6.
+The "either the old or the new file is visible" invariant is preserved across a
+crash at any point.
 
 ### 9. Secrets and future encryption
 
@@ -382,6 +442,10 @@ Add a `no_persist: bool` hint per pane (default false). When true, scrollback
 and history are not flushed to disk; the screen snapshot is still written so
 reconnect works, but it is marked `confidential: true` in the file and is
 excluded from any future export / sync action.
+
+The `no_persist` flag is surfaced in the **workspace creation dialog** as an
+option alongside the endpoint and policy choices. It can also be toggled
+per-pane after creation via the pane context menu.
 
 Full at-rest encryption is out of scope (NG1) but `no_persist` + file-per-pane
 means the encryption boundary is already in the right place for a future RFC.
@@ -406,7 +470,7 @@ scrollback_rotate_keep = 3
 
 ## Implementation Snapshot
 
-This RFC is in Draft status. None of the proposed changes have been implemented.
+This RFC is in Accepted status. None of the proposed changes have been implemented.
 The sections below document the current v1 state as a baseline for future
 implementation work.
 
@@ -416,7 +480,7 @@ implementation work.
 | --- | --- |
 | State serialization | `services/rttx-server/src/serialization.rs` — `write_state_atomic()`, `load_state()`, `ServerState`, path helpers |
 | Serialization loop | `services/rttx-server/src/server.rs` — `serialization_loop()` (1-second tick, unconditional full rewrite) |
-| Session persistence | `services/rttx-server/src/session.rs` — `PersistedSession`, `Session::persist()`, `Session::resurrect()` |
+| Runtime persistence | `services/rttx-server/src/runtime.rs` — `PersistedRuntime`, `Runtime::persist()`, `Runtime::resurrect()` |
 | Scrollback flush | `services/rttx-server/src/pane.rs` — `flush_scrollback()`, `truncate_log_tail()` |
 | Screen model | `services/rttx-server/src/screen.rs` — `PaneScreen`, `ScreenPerformer` (raw-bytes model, no cell grid) |
 | Snapshot constant | `services/rttx-server/src/pane.rs` — `MAX_SNAPSHOT_BYTES = 256 KB` |
@@ -441,16 +505,16 @@ implementation work.
 | RFC Feature | Current Status |
 | --- | --- |
 | XDG_STATE_HOME | ❌ Uses `$XDG_CACHE_HOME/rttx-server/` via `OsInterface::cache_dir()` |
-| Per-session files | ❌ Monolithic `state.json` with all sessions |
+| Per-runtime files | ❌ Monolithic `state.json` with all runtimes |
 | `schema_version` field | ❌ Only `server_version: String` (Cargo package version) |
-| Migration module | ❌ No `state/` module; ad-hoc `#[serde(default)]` on individual fields |
+| Schema migration module | ❌ No `state/` module; ad-hoc `#[serde(default)]` on individual fields |
 | Dirty-flag writes | ❌ Full rewrite every 1-second tick; `revision` exists but no `persisted_revision` |
 | Screen snapshot type | ❌ Raw byte tails via `PaneScreen::snapshot_bytes()` |
 | Scrollback rotation | ❌ `truncate_log_tail` slices at byte boundary (can corrupt escape sequences) |
-| Corruption containment | ❌ One bad byte in `state.json` loses all sessions |
-| `.bak` backup files | ❌ Atomic tmp+rename only, no backup copy |
-| Dead session cleanup | ❌ Scrollback/history directories accumulate on disk |
-| Durable/transient split | ❌ Mixed in `PersistedSession` (durable + semi-durable fields together) |
+| Corruption containment | ❌ One bad byte in `state.json` loses all runtimes |
+| `.bak` symlink backup | ❌ Atomic tmp+rename only, no backup copy |
+| Dead runtime cleanup | ❌ Scrollback/history directories accumulate on disk |
+| Durable/transient split | ❌ Mixed in `PersistedRuntime` (durable + semi-durable fields together) |
 | Orphan sweep | ❌ Not implemented |
 | `no_persist` pane flag | ❌ Not implemented |
 
@@ -459,36 +523,39 @@ implementation work.
 **Current layout path.** The original Background section listed the current
 layout as `$XDG_CACHE_HOME/rttx/`. The actual production path is
 `$XDG_CACHE_HOME/rttx-server/` (with `rttx-server-devel/` in dev mode). The
-proposed v2 path `$XDG_STATE_HOME/rttx/` drops the `-server` suffix, which is
-intentional — the daemon is the only writer to this directory.
+proposed v2 path `$XDG_STATE_HOME/rttx/daemon/` uses a `daemon/` subdirectory
+to cleanly separate daemon state from client state (RFC-023).
 
-**PersistedSession fields.** The original text listed `revision`,
+**PersistedRuntime fields.** The original text listed `revision`,
 `last_active_at`, `policy`, and `panes` as the persisted fields. The actual
 struct also includes `command_history: Vec<HistoryEntry>` and
 `active_pane_id: Option<Uuid>`, both of which are durable and belong in the
-proposed `SessionSpecV1`.
+proposed `RuntimeSpecV1`.
 
-**Screen model.** The original text described the screen model abstractly.
-`PaneScreen` wraps a VTE parser (`vte::Parser`) and a `ScreenPerformer` that
-tracks `raw_bytes`, cursor position, title, CWD, and terminal mode flags
-(bracketed paste, application cursor keys, application keypad, mouse tracking,
-SGR mouse, focus events, cursor visibility). The code contains an explicit
-comment noting that a full cell-grid model is deferred to a later iteration.
+**Screen model.** `PaneScreen` wraps a VTE parser (`vte::Parser`) and a
+`ScreenPerformer` that tracks `raw_bytes`, cursor position, title, CWD, and
+terminal mode flags (bracketed paste, application cursor keys, application
+keypad, mouse tracking, SGR mouse, focus events, cursor visibility). The code
+contains an explicit comment noting that a full cell-grid model is deferred to
+a later iteration. The `ScreenSnapshotV1` struct defined in §4 captures these
+fields as a serializable type.
 
-**Serialization interval.** The original §10 proposed a default of 5 seconds
-for `serialize_interval_secs`. The current implementation uses 1 second. The
-proposed default should be reconciled with the current behavior during
-implementation — the dirty-flag optimization (§5) makes the interval less
-performance-critical, so a longer default may be acceptable.
+**Serialization interval.** The current implementation uses 1 second. This RFC
+sets the default to 5 seconds. The dirty-flag optimization (§5) makes the
+interval less performance-critical; the tradeoff is a wider crash data-loss
+window (up to 5 seconds vs 1 second).
 
 ### Relationship to RFC-023
 
 RFC-023 (Client Configuration and State Store) proposes a parallel redesign for
 the client side, also targeting `$XDG_STATE_HOME/rttx/`. The two RFCs share the
-same XDG base directory but govern different subdirectories: RFC-022 covers
-daemon-owned runtime state (`daemon.json`, `sessions/`), while RFC-023 covers
-client-owned configuration and UI state. Implementation should coordinate the
-directory layout to avoid conflicts.
+same XDG base directory but govern different subdirectories:
+
+- `$XDG_STATE_HOME/rttx/daemon/` — RFC-022 (this RFC)
+- `$XDG_STATE_HOME/rttx/client/` — RFC-023
+
+Implementation must coordinate the directory layout before either RFC lands
+code. This is Step 0 in the development plan.
 
 ---
 
@@ -497,69 +564,68 @@ directory layout to avoid conflicts.
 | Goal | How addressed |
 |------|---------------|
 | G1 — Survive cache cleanup | §1 moves to `$XDG_STATE_HOME` |
-| G2 — Scale with churn | §5 dirty-flag writes; §1 per-session files |
+| G2 — Scale with churn | §5 dirty-flag writes; §1 per-runtime files |
 | G3 — Schema version & migration | §2 explicit `schema_version` + migration chain |
-| G4 — Corruption isolation | §6 per-file load, `.bak` fallback, orphan quarantine |
+| G4 — Corruption isolation | §6 per-file load, symlink `.bak` fallback, orphan quarantine |
 | G5 — Durable vs transient split | §3 Spec/Instance/Ephemeral tiers |
-| G6 — Deterministic screen replay | §4 grid snapshot separate from scrollback |
-| G7 — Dead-session pruning | §7 directory removal + orphan sweep |
+| G6 — Deterministic screen replay | §4 `ScreenSnapshotV1` separate from scrollback |
+| G7 — Dead-runtime pruning | §7 directory removal + orphan sweep |
 | G8 — Extensibility | §2 + §9 leave encryption, sync, export as additive changes |
 
 ---
 
 ## Development Plan
 
+- [ ] **Step 0** — Coordinate with RFC-023 on shared `$XDG_STATE_HOME/rttx/`
+  directory layout: `daemon/` vs `client/` subdirectories *(prerequisite: —)*
 - [ ] **Step 1** — Introduce `state::layout` module: path helpers for the new
-  directory tree, feature-gated alongside v1 paths *(prerequisite: —)*
-- [ ] **Step 2** — Define `DaemonIndexV1`, `SessionFileV1`, `PaneSpecV1` structs
-  with `schema_version` *(prerequisite: Step 1)*
-- [ ] **Step 3** — Implement `state::migrations::from_legacy_state_json` — one
-  best-effort import from the old monolith *(prerequisite: Step 2)*
-- [ ] **Step 4** — Swap `load_persisted_state` and `serialization_loop` to use
-  per-session files; keep the monolith reader only as a fallback during import
-  *(prerequisite: Step 3)*
-- [ ] **Step 5** — Add `persisted_revision` to `Session` and skip clean-session
-  writes *(prerequisite: Step 4)*
-- [ ] **Step 6** — Define `ScreenSnapshotV1` and replace the raw-bytes
-  reconstruction path; keep scrollback logs but switch truncation to rotation
-  *(prerequisite: Step 4)*
-- [ ] **Step 7** — Implement session-directory removal on delete and the
-  startup orphan sweep *(prerequisite: Step 4)*
-- [ ] **Step 8** — Add `no_persist` pane flag and plumb to flush/snapshot
-  *(prerequisite: Step 6)*
-- [ ] **Step 9** — Tests: migration from a captured v1 `state.json`, corrupt
-  `session.json` does not kill the daemon, dirty-flag skips writes, rotation
-  keeps N segments, orphan sweep quarantines unreferenced directories
-  *(prerequisite: Steps 4–7)*
-- [ ] **Step 10** — Update packaging docs and the first-run log line to
-  announce the new state location *(prerequisite: Step 4)*
-- [ ] **Step 11** — Coordinate with RFC-023 on shared `$XDG_STATE_HOME/rttx/`
-  directory layout to avoid conflicts between daemon and client state
-  *(prerequisite: Step 1)*
+  directory tree, feature-gated alongside v1 paths *(prerequisite: Step 0)*
+- [ ] **Step 2** — Define `DaemonIndexV1`, `RuntimeFileV1`, `PaneSpecV1`,
+  `ScreenSnapshotV1` structs with `schema_version` *(prerequisite: Step 1)*
+- [ ] **Step 3** — Swap `load_persisted_state` and `serialization_loop` to use
+  per-runtime files with symlink-based `.bak` backup; on first startup with no
+  v2 state, start clean and log the change *(prerequisite: Step 2)*
+- [ ] **Step 4** — Add `persisted_revision` to `Runtime` and skip clean-runtime
+  writes *(prerequisite: Step 3)*
+- [ ] **Step 5** — Implement `ScreenSnapshotV1` serialization from `PaneScreen`
+  and replace the raw-bytes reconstruction path; keep scrollback logs but switch
+  truncation to rotation *(prerequisite: Step 3)*
+- [ ] **Step 6** — Implement runtime-directory removal on delete and the
+  startup orphan sweep *(prerequisite: Step 3)*
+- [ ] **Step 7** — Add `no_persist` pane flag, surface in workspace creation
+  dialog and pane context menu, plumb to flush/snapshot *(prerequisite: Step 5)*
+- [ ] **Step 8** — Tests: corrupt `runtime.json` does not kill the daemon,
+  dirty-flag skips writes, rotation keeps N segments, orphan sweep quarantines
+  unreferenced directories, `ScreenSnapshotV1` round-trip
+  *(prerequisite: Steps 3–6)*
+- [ ] **Step 9** — Update packaging docs and the first-run log line to
+  announce the new state location *(prerequisite: Step 3)*
 
-Steps 1–4 can land as a single PR behind a feature flag. Steps 5–8 are
-additive. Step 9 is gating. Step 10 ships with the release that removes the
+Steps 1–3 can land as a single PR behind a feature flag. Steps 4–7 are
+additive. Step 8 is gating. Step 9 ships with the release that removes the
 v1 flag.
 
 ---
 
 ## Open Questions
 
-- [x] **Q1** — Should we keep the legacy `state.json` importer in the code
-  indefinitely, or remove it one minor release after the v2 cutover? **Resolved:**
-  remove after one release; users who skip that release get a clean start and
-  a loud log line.
-- [x] **Q2** — Should `daemon.json` hold any per-session summary (name, pane
-  count) to render a sidebar without reading every `session.json`, or keep it
-  minimal (ids only)? **Resolved:** minimal — the daemon always has sessions
+- [x] **Q1** — Should we keep a legacy `state.json` importer? **Resolved:**
+  No. Clean start on v2. Users get a loud log line. The old cache directory is
+  left untouched for manual inspection.
+- [x] **Q2** — Should `daemon.json` hold any per-runtime summary (name, pane
+  count) to render a sidebar without reading every `runtime.json`, or keep it
+  minimal (ids only)? **Resolved:** minimal — the daemon always has runtimes
   in-memory after startup, so the index is only consulted once.
 - [x] **Q3** — Scrollback rotation default of 3×10 MB = 30 MB per pane may be
-  higher than current effective limit. Acceptable? **Resolved:** yes, the old cap
-  was an artefact of the truncation bug, not a user-facing promise.
+  higher than current effective limit. Acceptable? **Resolved:** yes, the old
+  cap was partly driven by the truncation approach, not a user-facing promise.
 - [x] **Q4** — Is `$XDG_STATE_HOME` correct on macOS / sandboxed Flatpak?
   **Resolved:** rttx targets GNOME/Linux only (RFC-001 principle 1); macOS is
   permanently out of scope. Flatpak sandboxes map `$XDG_STATE_HOME` correctly
   via the portal filesystem, so no special handling is needed.
+- [x] **Q5** — Should `.bak` files use renames or symlinks? **Resolved:**
+  symlinks. A symlink update is atomic on supported Linux filesystems and avoids
+  the window where neither the live file nor the backup exists.
 
 ---
 
@@ -578,7 +644,7 @@ v1 flag.
 - [RFC-023: Client Configuration and State Store](./RFC-023-client-configuration-state-store.md)
   (Review) — parallel client-side storage redesign sharing `$XDG_STATE_HOME/rttx/`
 - `services/rttx-server/src/serialization.rs` — current monolith writer
-- `services/rttx-server/src/session.rs` — `PersistedSession` current schema
+- `services/rttx-server/src/runtime.rs` — `PersistedRuntime` current schema
 - `services/rttx-server/src/pane.rs` — `flush_scrollback()`, `truncate_log_tail()`
 - `services/rttx-server/src/screen.rs` — `PaneScreen` raw-bytes model
 - `services/rttx-server/src/os/unix.rs` — `OsInterface::cache_dir()` path abstraction


### PR DESCRIPTION
## Summary

Accept RFC-022 (Daemon State Storage) with review feedback incorporated.

## Key changes from Draft

- **Terminology**: session → runtime throughout to match current codebase
- **Directory layout**: `$XDG_STATE_HOME/rttx/daemon/` subdirectory to cleanly separate from RFC-023 client state
- **No migration**: clean start on v2, no v1 import. Old cache directory left untouched
- **ScreenSnapshotV1 defined**: concrete struct schema based on current `PaneScreen` fields and v3 `PaneSnapshot` wire format
- **Symlinks for .bak**: avoids the window where neither live file nor backup exists during write rotation
- **Crash data-loss window**: explicitly stated as up to 5 seconds (serialize_interval_secs default)
- **Orphan sweep**: runs on startup only (sufficient given infrequent daemon restarts)
- **no_persist UX**: surfaced in workspace creation dialog and pane context menu
- **Dev plan reordered**: Step 0 is RFC-023 directory coordination (was Step 11)
- **Status**: Draft → Accepted

Refs #622