### PR TITLE
chore: coordinate XDG_STATE_HOME/rttx/ directory layout with RFC-023

### DIFF
--- a/clients/rttx/src/config.rs
+++ b/clients/rttx/src/config.rs
@@ -242,10 +242,7 @@ mod tests {
         let development = app_profile_from_dev_mode(true);
         let base = Path::new("/tmp/state");
 
-        assert_eq!(
-            state_dir_path_for(base, production),
-            Path::new("/tmp/state/rttx/client")
-        );
+        assert_eq!(state_dir_path_for(base, production), Path::new("/tmp/state/rttx/client"));
         assert_eq!(
             state_dir_path_for(base, development),
             Path::new("/tmp/state/rttx-devel/client")

--- a/clients/rttx/src/config.rs
+++ b/clients/rttx/src/config.rs
@@ -22,12 +22,20 @@ pub const CONFIG_DIR: &str = "rttx";
 pub const DEV_CONFIG_DIR: &str = "rttx-devel";
 pub const SCHEMES_DIR: &str = "schemes";
 
+/// State directory name under `$XDG_STATE_HOME`.
+///
+/// RFC-023 owns `client/` under this root. RFC-022 owns `daemon/`.
+pub const STATE_DIR: &str = "rttx";
+pub const DEV_STATE_DIR: &str = "rttx-devel";
+const CLIENT_SUBDIR: &str = "client";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AppProfile {
     pub app_id: &'static str,
     pub icon_name: &'static str,
     pub display_name: &'static str,
     pub config_dir: &'static str,
+    pub state_dir: &'static str,
     pub settings_id: &'static str,
     pub settings_path: &'static str,
     pub badge_label: Option<&'static str>,
@@ -89,6 +97,26 @@ pub fn config_dir_path_for(base: &Path, profile: AppProfile) -> PathBuf {
     base.join(profile.config_dir)
 }
 
+/// Return the client state directory under `$XDG_STATE_HOME`.
+///
+/// Layout: `$XDG_STATE_HOME/rttx/client/` (production) or
+/// `$XDG_STATE_HOME/rttx-devel/client/` (dev mode).
+#[must_use]
+pub fn state_dir_path() -> PathBuf {
+    let base = xdg_state_home();
+    state_dir_path_for(&base, app_profile())
+}
+
+#[must_use]
+pub fn state_dir_path_for(base: &Path, profile: AppProfile) -> PathBuf {
+    base.join(profile.state_dir).join(CLIENT_SUBDIR)
+}
+
+fn xdg_state_home() -> PathBuf {
+    std::env::var_os("XDG_STATE_HOME")
+        .map_or_else(|| glib::home_dir().join(".local").join("state"), PathBuf::from)
+}
+
 #[must_use]
 pub fn dev_icon_search_path() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("data").join("icons")
@@ -102,6 +130,7 @@ pub const fn app_profile_from_dev_mode(is_dev: bool) -> AppProfile {
             icon_name: DEV_ICON_NAME,
             display_name: DEV_APP_NAME,
             config_dir: DEV_CONFIG_DIR,
+            state_dir: DEV_STATE_DIR,
             settings_id: DEV_SETTINGS_ID,
             settings_path: DEV_SETTINGS_PATH,
             badge_label: Some("Devel"),
@@ -113,6 +142,7 @@ pub const fn app_profile_from_dev_mode(is_dev: bool) -> AppProfile {
             icon_name: APP_ID,
             display_name: APP_NAME,
             config_dir: CONFIG_DIR,
+            state_dir: STATE_DIR,
             settings_id: SETTINGS_ID,
             settings_path: SETTINGS_PATH,
             badge_label: None,
@@ -161,6 +191,7 @@ mod tests {
         assert_eq!(profile.app_id, APP_ID);
         assert_eq!(profile.icon_name, APP_ID);
         assert_eq!(profile.config_dir, CONFIG_DIR);
+        assert_eq!(profile.state_dir, STATE_DIR);
         assert_eq!(profile.display_name, APP_NAME);
         assert!(!profile.is_development);
     }
@@ -171,6 +202,7 @@ mod tests {
         assert_eq!(profile.app_id, "io.github.IllyaYalovyy.rttx.Devel");
         assert_eq!(profile.icon_name, "io.github.IllyaYalovyy.rttx.Devel");
         assert_eq!(profile.config_dir, "rttx-devel");
+        assert_eq!(profile.state_dir, "rttx-devel");
         assert_eq!(profile.display_name, "rttx (Devel)");
         assert_eq!(profile.badge_label, Some("Devel"));
         assert!(profile.is_development);
@@ -202,6 +234,31 @@ mod tests {
             config_dir_path_for(base, development),
             Path::new("/tmp/rttx-profile-test/rttx-devel")
         );
+    }
+
+    #[test]
+    fn state_dir_path_uses_client_subdir() {
+        let production = app_profile_from_dev_mode(false);
+        let development = app_profile_from_dev_mode(true);
+        let base = Path::new("/tmp/state");
+
+        assert_eq!(
+            state_dir_path_for(base, production),
+            Path::new("/tmp/state/rttx/client")
+        );
+        assert_eq!(
+            state_dir_path_for(base, development),
+            Path::new("/tmp/state/rttx-devel/client")
+        );
+    }
+
+    #[test]
+    fn state_and_config_dirs_are_disjoint() {
+        let profile = app_profile_from_dev_mode(false);
+        let config = config_dir_path_for(Path::new("/xdg/config"), profile);
+        let state = state_dir_path_for(Path::new("/xdg/state"), profile);
+        assert!(!state.starts_with(&config));
+        assert!(!config.starts_with(&state));
     }
 
     #[test]

--- a/services/rttx-server/src/diagnostics.rs
+++ b/services/rttx-server/src/diagnostics.rs
@@ -188,6 +188,9 @@ mod tests {
             fn cache_dir(&self) -> PathBuf {
                 PathBuf::from("/tmp/test-cache")
             }
+            fn state_dir(&self) -> PathBuf {
+                PathBuf::from("/tmp/test-state/rttx/daemon")
+            }
         }
         Server::new(Box::new(TestOs))
     }

--- a/services/rttx-server/src/os/mod.rs
+++ b/services/rttx-server/src/os/mod.rs
@@ -10,5 +10,17 @@ pub trait OsInterface: Send + Sync {
     fn runtime_dir(&self) -> PathBuf;
 
     /// Return the cache directory for persistent state and scrollback logs.
+    ///
+    /// This is the v1 storage location (`$XDG_CACHE_HOME/rttx-server/`).
+    /// New code should prefer [`state_dir`](Self::state_dir) for durable state
+    /// that must survive cache cleanup.
     fn cache_dir(&self) -> PathBuf;
+
+    /// Return the daemon state directory under `$XDG_STATE_HOME`.
+    ///
+    /// Layout: `$XDG_STATE_HOME/rttx/daemon/` (production) or
+    /// `$XDG_STATE_HOME/rttx-devel/daemon/` (dev mode).
+    ///
+    /// RFC-022 owns everything under `daemon/`. RFC-023 owns `client/`.
+    fn state_dir(&self) -> PathBuf;
 }

--- a/services/rttx-server/src/os/unix.rs
+++ b/services/rttx-server/src/os/unix.rs
@@ -86,10 +86,8 @@ fn dirs_fallback_cache_dir() -> PathBuf {
 }
 
 fn dirs_fallback_state_dir() -> PathBuf {
-    std::env::var("HOME").map_or_else(
-        |_| PathBuf::from("/tmp"),
-        |h| PathBuf::from(h).join(".local").join("state"),
-    )
+    std::env::var("HOME")
+        .map_or_else(|_| PathBuf::from("/tmp"), |h| PathBuf::from(h).join(".local").join("state"))
 }
 
 #[cfg(test)]

--- a/services/rttx-server/src/os/unix.rs
+++ b/services/rttx-server/src/os/unix.rs
@@ -6,10 +6,19 @@ use std::path::PathBuf;
 /// Environment variable that enables dev mode (same as rttx GUI).
 const DEV_MODE_ENV: &str = "RTTX_DEV_MODE";
 
-/// Production directory name.
+/// Production top-level directory name under `$XDG_STATE_HOME`.
+const PROD_STATE_DIR: &str = "rttx";
+
+/// Development top-level directory name under `$XDG_STATE_HOME`.
+const DEV_STATE_DIR: &str = "rttx-devel";
+
+/// Subdirectory owned by the daemon (RFC-022).
+const DAEMON_SUBDIR: &str = "daemon";
+
+/// Production directory name for cache and runtime.
 const PROD_DIR: &str = "rttx-server";
 
-/// Development directory name — separate from production.
+/// Development directory name for cache and runtime.
 const DEV_DIR: &str = "rttx-server-devel";
 
 /// Check if dev mode is enabled via the environment variable.
@@ -19,15 +28,20 @@ pub fn dev_mode_enabled() -> bool {
 }
 
 #[must_use]
-const fn dir_name_for(is_dev: bool) -> &'static str {
+const fn cache_dir_name_for(is_dev: bool) -> &'static str {
     if is_dev { DEV_DIR } else { PROD_DIR }
+}
+
+#[must_use]
+const fn state_top_dir_for(is_dev: bool) -> &'static str {
+    if is_dev { DEV_STATE_DIR } else { PROD_STATE_DIR }
 }
 
 /// Real Unix implementation using XDG directories.
 ///
-/// In dev mode (`RTTX_DEV_MODE=1`), uses `rttx-server-devel` instead of
-/// `rttx-server` for all paths, so a development daemon can run
-/// alongside a stable production daemon without interference.
+/// In dev mode (`RTTX_DEV_MODE=1`), uses `rttx-server-devel` / `rttx-devel`
+/// instead of `rttx-server` / `rttx` for all paths, so a development daemon
+/// can run alongside a stable production daemon without interference.
 #[derive(Debug)]
 pub struct UnixOs;
 
@@ -43,21 +57,39 @@ impl OsInterface for UnixOs {
             .map_or_else(|_| dirs_fallback_cache_dir(), PathBuf::from);
         cache_dir_for(&base, dev_mode_enabled())
     }
+
+    fn state_dir(&self) -> PathBuf {
+        let base = std::env::var("XDG_STATE_HOME")
+            .map_or_else(|_| dirs_fallback_state_dir(), PathBuf::from);
+        state_dir_for(&base, dev_mode_enabled())
+    }
 }
 
 #[must_use]
 fn runtime_dir_for(base: &std::path::Path, is_dev: bool) -> PathBuf {
-    base.join(dir_name_for(is_dev)).join("v1")
+    base.join(cache_dir_name_for(is_dev)).join("v1")
 }
 
 #[must_use]
 fn cache_dir_for(base: &std::path::Path, is_dev: bool) -> PathBuf {
-    base.join(dir_name_for(is_dev))
+    base.join(cache_dir_name_for(is_dev))
+}
+
+#[must_use]
+fn state_dir_for(base: &std::path::Path, is_dev: bool) -> PathBuf {
+    base.join(state_top_dir_for(is_dev)).join(DAEMON_SUBDIR)
 }
 
 fn dirs_fallback_cache_dir() -> PathBuf {
     std::env::var("HOME")
         .map_or_else(|_| PathBuf::from("/tmp"), |h| PathBuf::from(h).join(".cache"))
+}
+
+fn dirs_fallback_state_dir() -> PathBuf {
+    std::env::var("HOME").map_or_else(
+        |_| PathBuf::from("/tmp"),
+        |h| PathBuf::from(h).join(".local").join("state"),
+    )
 }
 
 #[cfg(test)]
@@ -75,7 +107,7 @@ mod tests {
     fn cache_dir_contains_dir_name() {
         let os = UnixOs;
         let path = os.cache_dir();
-        let name = dir_name_for(dev_mode_enabled());
+        let name = cache_dir_name_for(dev_mode_enabled());
         assert!(path.to_string_lossy().contains(name));
     }
 
@@ -102,5 +134,37 @@ mod tests {
     fn cache_dir_for_dev_uses_development_daemon_dir() {
         let path = cache_dir_for(std::path::Path::new("/tmp/cache"), true);
         assert_eq!(path, std::path::Path::new("/tmp/cache/rttx-server-devel"));
+    }
+
+    #[test]
+    fn state_dir_for_production_uses_daemon_subdir() {
+        let path = state_dir_for(std::path::Path::new("/tmp/state"), false);
+        assert_eq!(path, std::path::Path::new("/tmp/state/rttx/daemon"));
+    }
+
+    #[test]
+    fn state_dir_for_dev_uses_devel_daemon_subdir() {
+        let path = state_dir_for(std::path::Path::new("/tmp/state"), true);
+        assert_eq!(path, std::path::Path::new("/tmp/state/rttx-devel/daemon"));
+    }
+
+    #[test]
+    fn state_dir_fallback_uses_dot_local_state() {
+        let fallback = dirs_fallback_state_dir();
+        assert!(
+            fallback.to_string_lossy().contains(".local/state")
+                || fallback == std::path::Path::new("/tmp"),
+            "fallback should be $HOME/.local/state or /tmp, got {}",
+            fallback.display()
+        );
+    }
+
+    #[test]
+    fn state_and_cache_dirs_are_disjoint() {
+        let state = state_dir_for(std::path::Path::new("/xdg/state"), false);
+        let cache = cache_dir_for(std::path::Path::new("/xdg/cache"), false);
+        assert_ne!(state, cache);
+        assert!(!state.starts_with(&cache));
+        assert!(!cache.starts_with(&state));
     }
 }

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -14,6 +14,9 @@ impl OsInterface for StubOs {
     fn cache_dir(&self) -> PathBuf {
         PathBuf::from("/tmp/test-cache")
     }
+    fn state_dir(&self) -> PathBuf {
+        PathBuf::from("/tmp/test-state/rttx/daemon")
+    }
 }
 
 fn new_server() -> Arc<Mutex<Server>> {

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -110,6 +110,9 @@ pub async fn start_test_server(
         fn cache_dir(&self) -> PathBuf {
             self.cache_dir.clone()
         }
+        fn state_dir(&self) -> PathBuf {
+            self.cache_dir.parent().unwrap_or(self.cache_dir.as_path()).join("state/rttx/daemon")
+        }
     }
 
     let runtime_dir = tmp_dir.join("runtime");

--- a/services/rttx-server/tests/state_dir_layout.rs
+++ b/services/rttx-server/tests/state_dir_layout.rs
@@ -1,0 +1,44 @@
+//! Integration test verifying the `XDG_STATE_HOME` directory layout
+//! coordinated between RFC-022 (daemon) and RFC-023 (client).
+
+use rttx_server::os::OsInterface;
+use rttx_server::os::unix::UnixOs;
+use std::path::PathBuf;
+
+#[test]
+fn state_dir_lives_under_xdg_state_home_with_daemon_subdir() {
+    let os = UnixOs;
+    let state = os.state_dir();
+
+    assert!(state.ends_with("daemon"), "state_dir must end with 'daemon', got {}", state.display());
+
+    let cache = os.cache_dir();
+    assert!(
+        !state.starts_with(&cache) && !cache.starts_with(&state),
+        "state_dir ({}) and cache_dir ({}) must be disjoint",
+        state.display(),
+        cache.display()
+    );
+}
+
+#[test]
+fn test_os_state_dir_follows_rfc_022_layout() {
+    #[derive(Debug)]
+    struct TestOs {
+        state_base: PathBuf,
+    }
+    impl OsInterface for TestOs {
+        fn runtime_dir(&self) -> PathBuf {
+            PathBuf::from("/unused")
+        }
+        fn cache_dir(&self) -> PathBuf {
+            PathBuf::from("/unused")
+        }
+        fn state_dir(&self) -> PathBuf {
+            self.state_base.join("rttx").join("daemon")
+        }
+    }
+
+    let os = TestOs { state_base: PathBuf::from("/home/user/.local/state") };
+    assert_eq!(os.state_dir(), PathBuf::from("/home/user/.local/state/rttx/daemon"));
+}


### PR DESCRIPTION
## What changed and why

RFC-022 (daemon state storage) and RFC-023 (client configuration and state store) both target `$XDG_STATE_HOME/rttx/` as their shared root. This PR is Step 0 from RFC-022's development plan: coordinate the directory layout before either RFC lands code.

### Changes

**Server (`rttx-server`):**
- Added `state_dir()` to the `OsInterface` trait returning `$XDG_STATE_HOME/rttx/daemon/` (or `rttx-devel/daemon/` in dev mode)
- Implemented in `UnixOs` with `XDG_STATE_HOME` env var support and `$HOME/.local/state` fallback
- Updated all test mocks (`StubOs`, `TestOs`) to implement the new trait method

**Client (`rttx`):**
- Added `state_dir` field to `AppProfile`
- Added `state_dir_path()` and `state_dir_path_for()` helpers returning `$XDG_STATE_HOME/rttx/client/` (or `rttx-devel/client/` in dev mode)
- Uses `XDG_STATE_HOME` env var with `$HOME/.local/state` fallback (manual lookup since `glib::user_state_dir()` requires the `v2_72` feature gate)

### Directory layout

```
$XDG_STATE_HOME/rttx/          # shared root (production)
├── daemon/                     # RFC-022 owns everything below
└── client/                     # RFC-023 owns everything below

$XDG_STATE_HOME/rttx-devel/    # shared root (dev mode)
├── daemon/
└── client/
```

## How to manually verify

```rust
// Server
let os = UnixOs;
println!("{}", os.state_dir().display());
// → ~/.local/state/rttx/daemon

// Client
println!("{}", config::state_dir_path().display());
// → ~/.local/state/rttx/client
```

## Tests added

**Server (`os::unix`):**
- `state_dir_for_production_uses_daemon_subdir` — verifies production path
- `state_dir_for_dev_uses_devel_daemon_subdir` — verifies dev mode path
- `state_dir_fallback_uses_dot_local_state` — verifies XDG fallback
- `state_and_cache_dirs_are_disjoint` — ensures no path overlap

**Client (`config`):**
- `state_dir_path_uses_client_subdir` — verifies both production and dev paths
- `state_and_config_dirs_are_disjoint` — ensures no path overlap
- Updated `production_profile_matches_existing_identity` and `development_profile_uses_distinct_identity_state_and_labeling` to assert `state_dir`

## Tests run

- `cargo test -p rttx-server --lib` — 279 passed
- `cargo test -p rttx-server --tests` — all integration tests passed
- `cargo test -p rttx --no-default-features --features vte-0_76` — 43+11 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed (one pre-existing flaky `pty_coalesce` test passed on retry)

Fixes #716