### PR TITLE
feat(server): introduce state::layout module with v2 path helpers

### DIFF
--- a/services/rttx-server/src/lib.rs
+++ b/services/rttx-server/src/lib.rs
@@ -12,4 +12,5 @@ pub mod runtime;
 pub mod screen;
 pub mod serialization;
 pub mod server;
+pub mod state;
 pub mod single_instance;

--- a/services/rttx-server/src/lib.rs
+++ b/services/rttx-server/src/lib.rs
@@ -12,5 +12,5 @@ pub mod runtime;
 pub mod screen;
 pub mod serialization;
 pub mod server;
-pub mod state;
 pub mod single_instance;
+pub mod state;

--- a/services/rttx-server/src/state/layout.rs
+++ b/services/rttx-server/src/state/layout.rs
@@ -1,0 +1,204 @@
+//! V2 per-runtime directory layout path helpers (RFC-022 §1).
+//!
+//! All paths are relative to the daemon state directory returned by
+//! [`OsInterface::state_dir`](crate::os::OsInterface::state_dir).
+//!
+//! ```text
+//! $XDG_STATE_HOME/rttx/daemon/          ← state_dir()
+//! ├── daemon.json
+//! └── runtimes/
+//!     └── <runtime_id>/
+//!         ├── runtime.json
+//!         ├── screen/<pane_id>.snap
+//!         ├── scrollback/<pane_id>.log
+//!         └── history/<pane_id>.hist
+//! ```
+
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+/// Filename for the top-level daemon index.
+const DAEMON_INDEX_FILE: &str = "daemon.json";
+
+/// Directory containing per-runtime subdirectories.
+const RUNTIMES_DIR: &str = "runtimes";
+
+/// Filename for a runtime's metadata inside its directory.
+const RUNTIME_FILE: &str = "runtime.json";
+
+/// Subdirectory for deterministic screen snapshots.
+const SCREEN_DIR: &str = "screen";
+
+/// Subdirectory for append-only scrollback logs.
+const SCROLLBACK_DIR: &str = "scrollback";
+
+/// Subdirectory for per-pane shell history.
+const HISTORY_DIR: &str = "history";
+
+/// Path to the top-level daemon index file.
+#[must_use]
+pub fn daemon_index(state_dir: &Path) -> PathBuf {
+    state_dir.join(DAEMON_INDEX_FILE)
+}
+
+/// Path to the `runtimes/` directory.
+#[must_use]
+pub fn runtimes_dir(state_dir: &Path) -> PathBuf {
+    state_dir.join(RUNTIMES_DIR)
+}
+
+/// Path to a specific runtime's directory.
+#[must_use]
+pub fn runtime_dir(state_dir: &Path, runtime_id: Uuid) -> PathBuf {
+    runtimes_dir(state_dir).join(runtime_id.to_string())
+}
+
+/// Path to a runtime's metadata file (`runtime.json`).
+#[must_use]
+pub fn runtime_file(state_dir: &Path, runtime_id: Uuid) -> PathBuf {
+    runtime_dir(state_dir, runtime_id).join(RUNTIME_FILE)
+}
+
+/// Path to a pane's screen snapshot file.
+#[must_use]
+pub fn screen_snapshot(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) -> PathBuf {
+    runtime_dir(state_dir, runtime_id).join(SCREEN_DIR).join(format!("{pane_id}.snap"))
+}
+
+/// Path to a pane's scrollback log file.
+#[must_use]
+pub fn scrollback_log(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) -> PathBuf {
+    runtime_dir(state_dir, runtime_id).join(SCROLLBACK_DIR).join(format!("{pane_id}.log"))
+}
+
+/// Path to a pane's shell history file.
+#[must_use]
+pub fn history_file(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) -> PathBuf {
+    runtime_dir(state_dir, runtime_id).join(HISTORY_DIR).join(format!("{pane_id}.hist"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    const STATE: &str = "/xdg/state/rttx/daemon";
+
+    fn ids() -> (Uuid, Uuid) {
+        let rt = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+        let pane = Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").unwrap();
+        (rt, pane)
+    }
+
+    #[test]
+    fn daemon_index_path() {
+        let p = daemon_index(Path::new(STATE));
+        assert_eq!(p, Path::new("/xdg/state/rttx/daemon/daemon.json"));
+    }
+
+    #[test]
+    fn runtimes_dir_path() {
+        let p = runtimes_dir(Path::new(STATE));
+        assert_eq!(p, Path::new("/xdg/state/rttx/daemon/runtimes"));
+    }
+
+    #[test]
+    fn runtime_dir_path() {
+        let (rt, _) = ids();
+        let p = runtime_dir(Path::new(STATE), rt);
+        assert_eq!(
+            p,
+            Path::new("/xdg/state/rttx/daemon/runtimes/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        );
+    }
+
+    #[test]
+    fn runtime_file_path() {
+        let (rt, _) = ids();
+        let p = runtime_file(Path::new(STATE), rt);
+        assert!(p.ends_with("runtime.json"));
+        assert!(p.starts_with(runtime_dir(Path::new(STATE), rt)));
+    }
+
+    #[test]
+    fn screen_snapshot_path() {
+        let (rt, pane) = ids();
+        let p = screen_snapshot(Path::new(STATE), rt, pane);
+        assert!(p.to_string_lossy().contains("/screen/"));
+        assert!(p.to_string_lossy().ends_with(".snap"));
+        assert!(p.starts_with(runtime_dir(Path::new(STATE), rt)));
+    }
+
+    #[test]
+    fn scrollback_log_path() {
+        let (rt, pane) = ids();
+        let p = scrollback_log(Path::new(STATE), rt, pane);
+        assert!(p.to_string_lossy().contains("/scrollback/"));
+        assert!(p.to_string_lossy().ends_with(".log"));
+        assert!(p.starts_with(runtime_dir(Path::new(STATE), rt)));
+    }
+
+    #[test]
+    fn history_file_path() {
+        let (rt, pane) = ids();
+        let p = history_file(Path::new(STATE), rt, pane);
+        assert!(p.to_string_lossy().contains("/history/"));
+        assert!(p.to_string_lossy().ends_with(".hist"));
+        assert!(p.starts_with(runtime_dir(Path::new(STATE), rt)));
+    }
+
+    #[test]
+    fn different_panes_produce_different_paths() {
+        let rt = Uuid::new_v4();
+        let p1 = Uuid::new_v4();
+        let p2 = Uuid::new_v4();
+        let base = Path::new(STATE);
+
+        assert_ne!(screen_snapshot(base, rt, p1), screen_snapshot(base, rt, p2));
+        assert_ne!(scrollback_log(base, rt, p1), scrollback_log(base, rt, p2));
+        assert_ne!(history_file(base, rt, p1), history_file(base, rt, p2));
+    }
+
+    #[test]
+    fn different_runtimes_produce_different_paths() {
+        let r1 = Uuid::new_v4();
+        let r2 = Uuid::new_v4();
+        let pane = Uuid::new_v4();
+        let base = Path::new(STATE);
+
+        assert_ne!(runtime_dir(base, r1), runtime_dir(base, r2));
+        assert_ne!(runtime_file(base, r1), runtime_file(base, r2));
+        assert_ne!(scrollback_log(base, r1, pane), scrollback_log(base, r2, pane));
+    }
+
+    #[test]
+    fn v2_paths_are_disjoint_from_v1_paths() {
+        let rt = Uuid::new_v4();
+        let pane = Uuid::new_v4();
+        let cache = Path::new("/xdg/cache/rttx-server");
+        let state = Path::new(STATE);
+
+        let v1_scrollback = crate::serialization::scrollback_log_path(cache, rt, pane);
+        let v2_scrollback = scrollback_log(state, rt, pane);
+        assert_ne!(v1_scrollback, v2_scrollback);
+        assert!(!v2_scrollback.starts_with(cache));
+
+        let v1_history = crate::serialization::history_path(cache, rt, pane);
+        let v2_history = history_file(state, rt, pane);
+        assert_ne!(v1_history, v2_history);
+        assert!(!v2_history.starts_with(cache));
+    }
+
+    #[test]
+    fn all_pane_artifacts_share_runtime_dir_prefix() {
+        let rt = Uuid::new_v4();
+        let pane = Uuid::new_v4();
+        let base = Path::new(STATE);
+        let rt_dir = runtime_dir(base, rt);
+
+        assert!(screen_snapshot(base, rt, pane).starts_with(&rt_dir));
+        assert!(scrollback_log(base, rt, pane).starts_with(&rt_dir));
+        assert!(history_file(base, rt, pane).starts_with(&rt_dir));
+        assert!(runtime_file(base, rt).starts_with(&rt_dir));
+    }
+}

--- a/services/rttx-server/src/state/mod.rs
+++ b/services/rttx-server/src/state/mod.rs
@@ -1,0 +1,7 @@
+//! State storage modules for the rttx daemon.
+//!
+//! This module organizes the v2 per-runtime directory layout defined by
+//! RFC-022. The v1 monolithic `state.json` path helpers remain in
+//! [`crate::serialization`] until the migration is complete.
+
+pub mod layout;

--- a/services/rttx-server/tests/v2_layout.rs
+++ b/services/rttx-server/tests/v2_layout.rs
@@ -1,0 +1,69 @@
+//! Integration test verifying the v2 state layout path helpers (RFC-022 §1)
+//! produce correct paths when composed with `OsInterface::state_dir`.
+
+use rttx_server::os::OsInterface;
+use rttx_server::state::layout;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+#[derive(Debug)]
+struct FakeOs(PathBuf);
+
+impl OsInterface for FakeOs {
+    fn runtime_dir(&self) -> PathBuf {
+        PathBuf::from("/unused")
+    }
+    fn cache_dir(&self) -> PathBuf {
+        PathBuf::from("/unused")
+    }
+    fn state_dir(&self) -> PathBuf {
+        self.0.clone()
+    }
+}
+
+#[test]
+fn v2_layout_rooted_at_state_dir() {
+    let os = FakeOs(PathBuf::from("/home/user/.local/state/rttx/daemon"));
+    let state = os.state_dir();
+
+    let idx = layout::daemon_index(&state);
+    assert_eq!(idx, PathBuf::from("/home/user/.local/state/rttx/daemon/daemon.json"));
+
+    let runtimes = layout::runtimes_dir(&state);
+    assert_eq!(runtimes, PathBuf::from("/home/user/.local/state/rttx/daemon/runtimes"));
+}
+
+#[test]
+fn v2_runtime_tree_is_self_contained() {
+    let os = FakeOs(PathBuf::from("/state/rttx/daemon"));
+    let state = os.state_dir();
+    let rt = Uuid::new_v4();
+    let pane = Uuid::new_v4();
+
+    let rt_dir = layout::runtime_dir(&state, rt);
+
+    // Every artifact lives under the runtime directory.
+    assert!(layout::runtime_file(&state, rt).starts_with(&rt_dir));
+    assert!(layout::screen_snapshot(&state, rt, pane).starts_with(&rt_dir));
+    assert!(layout::scrollback_log(&state, rt, pane).starts_with(&rt_dir));
+    assert!(layout::history_file(&state, rt, pane).starts_with(&rt_dir));
+}
+
+#[test]
+fn v2_paths_never_overlap_v1_cache_paths() {
+    let os = rttx_server::os::unix::UnixOs;
+    let cache = os.cache_dir();
+    let state = os.state_dir();
+
+    let rt = Uuid::new_v4();
+    let pane = Uuid::new_v4();
+
+    let v2_index = layout::daemon_index(&state);
+    let v2_scrollback = layout::scrollback_log(&state, rt, pane);
+    let v2_history = layout::history_file(&state, rt, pane);
+
+    // v2 paths must not fall under the v1 cache directory.
+    assert!(!v2_index.starts_with(&cache));
+    assert!(!v2_scrollback.starts_with(&cache));
+    assert!(!v2_history.starts_with(&cache));
+}


### PR DESCRIPTION
## What changed and why

Adds a `state::layout` module to `rttx-server` with path helpers for the RFC-022 §1 per-runtime directory tree. This is Step 1 of the RFC-022 development plan.

The helpers map the v2 on-disk layout:

```
$XDG_STATE_HOME/rttx/daemon/
├── daemon.json
└── runtimes/
    └── <runtime_id>/
        ├── runtime.json
        ├── screen/<pane_id>.snap
        ├── scrollback/<pane_id>.log
        └── history/<pane_id>.hist
```

The v1 monolithic `state.json` helpers in `serialization.rs` remain unchanged. Both coexist until the v2 migration is complete.

## How to verify

```bash
cargo test -p rttx-server --lib state::layout
cargo test -p rttx-server --test v2_layout
```

## Tests added

### Unit tests (11) in `state::layout::tests`:
- `daemon_index_path` — exact path for daemon.json
- `runtimes_dir_path` — exact path for runtimes/
- `runtime_dir_path` — exact path for a runtime directory
- `runtime_file_path` — runtime.json under runtime dir
- `screen_snapshot_path` — .snap under screen/
- `scrollback_log_path` — .log under scrollback/
- `history_file_path` — .hist under history/
- `different_panes_produce_different_paths` — uniqueness across panes
- `different_runtimes_produce_different_paths` — uniqueness across runtimes
- `v2_paths_are_disjoint_from_v1_paths` — no overlap with v1 cache paths
- `all_pane_artifacts_share_runtime_dir_prefix` — containment invariant

### Integration tests (3) in `tests/v2_layout.rs`:
- `v2_layout_rooted_at_state_dir` — helpers compose with OsInterface
- `v2_runtime_tree_is_self_contained` — all artifacts under runtime dir
- `v2_paths_never_overlap_v1_cache_paths` — real UnixOs disjointness

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #717