### PR TITLE
feat(server): define v2 persisted structs with schema_version

### DIFF
--- a/services/rttx-server/src/state/migrations.rs
+++ b/services/rttx-server/src/state/migrations.rs
@@ -1,0 +1,344 @@
+//! Typed schema migration chain (RFC-022 §2).
+//!
+//! Each persisted file type has a current schema version. When loading a
+//! file whose `schema_version` is older than current, the migration chain
+//! walks it forward one version at a time until it reaches the current
+//! struct.
+//!
+//! Migrations are total: any supported past version can be walked forward
+//! to current. Unknown future versions are rejected — the daemon refuses
+//! to load data it does not understand rather than guessing.
+
+use crate::state::types::{
+    DaemonIndexV1, RuntimeFileV1, ScreenSnapshotV1, SchemaVersionEnvelope,
+    DAEMON_INDEX_SCHEMA_VERSION, RUNTIME_FILE_SCHEMA_VERSION, SCREEN_SNAPSHOT_SCHEMA_VERSION,
+};
+use std::fmt;
+
+/// Errors that can occur during schema migration.
+#[derive(Debug)]
+pub enum MigrationError {
+    /// The file's `schema_version` is newer than this daemon understands.
+    UnsupportedFutureVersion {
+        file_kind: &'static str,
+        found: u32,
+        max_supported: u32,
+    },
+    /// JSON deserialization failed during migration.
+    DeserializationFailed {
+        file_kind: &'static str,
+        version: u32,
+        source: serde_json::Error,
+    },
+    /// Could not read the `schema_version` envelope.
+    InvalidEnvelope { source: serde_json::Error },
+}
+
+impl fmt::Display for MigrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedFutureVersion {
+                file_kind,
+                found,
+                max_supported,
+            } => write!(
+                f,
+                "{file_kind}: schema_version {found} is newer than max supported {max_supported}"
+            ),
+            Self::DeserializationFailed {
+                file_kind,
+                version,
+                source,
+            } => write!(
+                f,
+                "{file_kind}: failed to deserialize schema_version {version}: {source}"
+            ),
+            Self::InvalidEnvelope { source } => {
+                write!(f, "failed to read schema_version envelope: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for MigrationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DeserializationFailed { source, .. } | Self::InvalidEnvelope { source } => {
+                Some(source)
+            }
+            Self::UnsupportedFutureVersion { .. } => None,
+        }
+    }
+}
+
+/// Peek at the `schema_version` field without fully deserializing.
+pub fn peek_schema_version(json: &str) -> Result<u32, MigrationError> {
+    let envelope: SchemaVersionEnvelope =
+        serde_json::from_str(json).map_err(|e| MigrationError::InvalidEnvelope { source: e })?;
+    Ok(envelope.schema_version)
+}
+
+/// Load and migrate a daemon index from JSON to the current version.
+pub fn load_daemon_index(json: &str) -> Result<DaemonIndexV1, MigrationError> {
+    let version = peek_schema_version(json)?;
+    match version {
+        1 => serde_json::from_str(json).map_err(|e| MigrationError::DeserializationFailed {
+            file_kind: "DaemonIndex",
+            version: 1,
+            source: e,
+        }),
+        v if v > DAEMON_INDEX_SCHEMA_VERSION => Err(MigrationError::UnsupportedFutureVersion {
+            file_kind: "DaemonIndex",
+            found: v,
+            max_supported: DAEMON_INDEX_SCHEMA_VERSION,
+        }),
+        // Future: add `0 => migrate_daemon_index_v0_to_v1(...)` etc.
+        v => Err(MigrationError::UnsupportedFutureVersion {
+            file_kind: "DaemonIndex",
+            found: v,
+            max_supported: DAEMON_INDEX_SCHEMA_VERSION,
+        }),
+    }
+}
+
+/// Load and migrate a runtime file from JSON to the current version.
+pub fn load_runtime_file(json: &str) -> Result<RuntimeFileV1, MigrationError> {
+    let version = peek_schema_version(json)?;
+    match version {
+        1 => serde_json::from_str(json).map_err(|e| MigrationError::DeserializationFailed {
+            file_kind: "RuntimeFile",
+            version: 1,
+            source: e,
+        }),
+        v if v > RUNTIME_FILE_SCHEMA_VERSION => Err(MigrationError::UnsupportedFutureVersion {
+            file_kind: "RuntimeFile",
+            found: v,
+            max_supported: RUNTIME_FILE_SCHEMA_VERSION,
+        }),
+        v => Err(MigrationError::UnsupportedFutureVersion {
+            file_kind: "RuntimeFile",
+            found: v,
+            max_supported: RUNTIME_FILE_SCHEMA_VERSION,
+        }),
+    }
+}
+
+/// Load and migrate a screen snapshot from JSON to the current version.
+pub fn load_screen_snapshot(json: &str) -> Result<ScreenSnapshotV1, MigrationError> {
+    let version = peek_schema_version(json)?;
+    match version {
+        1 => serde_json::from_str(json).map_err(|e| MigrationError::DeserializationFailed {
+            file_kind: "ScreenSnapshot",
+            version: 1,
+            source: e,
+        }),
+        v if v > SCREEN_SNAPSHOT_SCHEMA_VERSION => {
+            Err(MigrationError::UnsupportedFutureVersion {
+                file_kind: "ScreenSnapshot",
+                found: v,
+                max_supported: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+            })
+        }
+        v => Err(MigrationError::UnsupportedFutureVersion {
+            file_kind: "ScreenSnapshot",
+            found: v,
+            max_supported: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::RuntimePolicy;
+    use crate::state::types::*;
+    use std::time::SystemTime;
+
+    fn sample_daemon_index_json() -> String {
+        let index = DaemonIndexV1 {
+            schema_version: DAEMON_INDEX_SCHEMA_VERSION,
+            server_version: "0.4.0".into(),
+            runtime_ids: vec![uuid::Uuid::new_v4()],
+            created_at: SystemTime::now(),
+            last_serialized_at: SystemTime::now(),
+        };
+        serde_json::to_string_pretty(&index).unwrap()
+    }
+
+    fn sample_runtime_file_json() -> String {
+        let file = RuntimeFileV1 {
+            schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+            spec: RuntimeSpecV1 {
+                id: uuid::Uuid::new_v4(),
+                name: "test".into(),
+                policy: RuntimePolicy::Persistent,
+                created_at: SystemTime::now(),
+                panes: vec![],
+                active_pane_id: None,
+                command_history: vec![],
+            },
+            instance: RuntimeInstanceV1 {
+                revision: 1,
+                last_active_at: SystemTime::now(),
+                last_snapshot_at: SystemTime::now(),
+            },
+        };
+        serde_json::to_string_pretty(&file).unwrap()
+    }
+
+    fn sample_screen_snapshot_json() -> String {
+        let snap = ScreenSnapshotV1 {
+            schema_version: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+            pane_id: uuid::Uuid::new_v4(),
+            cols: 80,
+            rows: 24,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_visible: true,
+            title: None,
+            cwd: None,
+            pane_output_seq: 0,
+            modes: TerminalModeSnapshot {
+                bracketed_paste: false,
+                application_cursor_keys: false,
+                application_keypad: false,
+                mouse_tracking_mode: 0,
+                sgr_mouse: false,
+                focus_reporting: false,
+            },
+            screen_bytes: vec![],
+        };
+        serde_json::to_string_pretty(&snap).unwrap()
+    }
+
+    // ── Happy path: current version loads directly ──────────────────
+
+    #[test]
+    fn load_daemon_index_v1() {
+        let json = sample_daemon_index_json();
+        let result = load_daemon_index(&json);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().schema_version, 1);
+    }
+
+    #[test]
+    fn load_runtime_file_v1() {
+        let json = sample_runtime_file_json();
+        let result = load_runtime_file(&json);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().schema_version, 1);
+    }
+
+    #[test]
+    fn load_screen_snapshot_v1() {
+        let json = sample_screen_snapshot_json();
+        let result = load_screen_snapshot(&json);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().schema_version, 1);
+    }
+
+    // ── Future version rejection ────────────────────────────────────
+
+    #[test]
+    fn daemon_index_rejects_future_version() {
+        let json = r#"{"schema_version": 99, "server_version": "9.0.0", "runtime_ids": [], "created_at": {"secs_since_epoch": 0, "nanos_since_epoch": 0}, "last_serialized_at": {"secs_since_epoch": 0, "nanos_since_epoch": 0}}"#;
+        let err = load_daemon_index(json).unwrap_err();
+        assert!(matches!(
+            err,
+            MigrationError::UnsupportedFutureVersion {
+                file_kind: "DaemonIndex",
+                found: 99,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn runtime_file_rejects_future_version() {
+        let json = r#"{"schema_version": 42}"#;
+        let err = load_runtime_file(json).unwrap_err();
+        assert!(matches!(
+            err,
+            MigrationError::UnsupportedFutureVersion {
+                file_kind: "RuntimeFile",
+                found: 42,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn screen_snapshot_rejects_future_version() {
+        let json = r#"{"schema_version": 200}"#;
+        let err = load_screen_snapshot(json).unwrap_err();
+        assert!(matches!(
+            err,
+            MigrationError::UnsupportedFutureVersion {
+                file_kind: "ScreenSnapshot",
+                found: 200,
+                ..
+            }
+        ));
+    }
+
+    // ── Invalid JSON ────────────────────────────────────────────────
+
+    #[test]
+    fn invalid_json_returns_envelope_error() {
+        let err = peek_schema_version("not json at all").unwrap_err();
+        assert!(matches!(err, MigrationError::InvalidEnvelope { .. }));
+    }
+
+    #[test]
+    fn missing_schema_version_returns_envelope_error() {
+        let err = peek_schema_version(r#"{"server_version": "1.0"}"#).unwrap_err();
+        assert!(matches!(err, MigrationError::InvalidEnvelope { .. }));
+    }
+
+    #[test]
+    fn daemon_index_corrupt_body_returns_deserialization_error() {
+        // Valid schema_version but missing required fields.
+        let json = r#"{"schema_version": 1, "server_version": "0.4.0"}"#;
+        let err = load_daemon_index(json).unwrap_err();
+        assert!(matches!(
+            err,
+            MigrationError::DeserializationFailed {
+                file_kind: "DaemonIndex",
+                version: 1,
+                ..
+            }
+        ));
+    }
+
+    // ── Peek helper ─────────────────────────────────────────────────
+
+    #[test]
+    fn peek_extracts_version_from_any_json_with_schema_version() {
+        let json = r#"{"schema_version": 7, "extra": "ignored"}"#;
+        assert_eq!(peek_schema_version(json).unwrap(), 7);
+    }
+
+    // ── Display formatting ──────────────────────────────────────────
+
+    #[test]
+    fn migration_error_display_future_version() {
+        let err = MigrationError::UnsupportedFutureVersion {
+            file_kind: "DaemonIndex",
+            found: 5,
+            max_supported: 1,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("DaemonIndex"));
+        assert!(msg.contains('5'));
+        assert!(msg.contains('1'));
+    }
+
+    #[test]
+    fn migration_error_display_envelope() {
+        let err = MigrationError::InvalidEnvelope {
+            source: serde_json::from_str::<serde_json::Value>("bad").unwrap_err(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("envelope"));
+    }
+}

--- a/services/rttx-server/src/state/migrations.rs
+++ b/services/rttx-server/src/state/migrations.rs
@@ -10,8 +10,8 @@
 //! to load data it does not understand rather than guessing.
 
 use crate::state::types::{
-    DaemonIndexV1, RuntimeFileV1, ScreenSnapshotV1, SchemaVersionEnvelope,
-    DAEMON_INDEX_SCHEMA_VERSION, RUNTIME_FILE_SCHEMA_VERSION, SCREEN_SNAPSHOT_SCHEMA_VERSION,
+    DAEMON_INDEX_SCHEMA_VERSION, DaemonIndexV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1,
+    SCREEN_SNAPSHOT_SCHEMA_VERSION, SchemaVersionEnvelope, ScreenSnapshotV1,
 };
 use std::fmt;
 
@@ -19,17 +19,9 @@ use std::fmt;
 #[derive(Debug)]
 pub enum MigrationError {
     /// The file's `schema_version` is newer than this daemon understands.
-    UnsupportedFutureVersion {
-        file_kind: &'static str,
-        found: u32,
-        max_supported: u32,
-    },
+    UnsupportedFutureVersion { file_kind: &'static str, found: u32, max_supported: u32 },
     /// JSON deserialization failed during migration.
-    DeserializationFailed {
-        file_kind: &'static str,
-        version: u32,
-        source: serde_json::Error,
-    },
+    DeserializationFailed { file_kind: &'static str, version: u32, source: serde_json::Error },
     /// Could not read the `schema_version` envelope.
     InvalidEnvelope { source: serde_json::Error },
 }
@@ -37,22 +29,13 @@ pub enum MigrationError {
 impl fmt::Display for MigrationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::UnsupportedFutureVersion {
-                file_kind,
-                found,
-                max_supported,
-            } => write!(
+            Self::UnsupportedFutureVersion { file_kind, found, max_supported } => write!(
                 f,
                 "{file_kind}: schema_version {found} is newer than max supported {max_supported}"
             ),
-            Self::DeserializationFailed {
-                file_kind,
-                version,
-                source,
-            } => write!(
-                f,
-                "{file_kind}: failed to deserialize schema_version {version}: {source}"
-            ),
+            Self::DeserializationFailed { file_kind, version, source } => {
+                write!(f, "{file_kind}: failed to deserialize schema_version {version}: {source}")
+            }
             Self::InvalidEnvelope { source } => {
                 write!(f, "failed to read schema_version envelope: {source}")
             }
@@ -132,13 +115,11 @@ pub fn load_screen_snapshot(json: &str) -> Result<ScreenSnapshotV1, MigrationErr
             version: 1,
             source: e,
         }),
-        v if v > SCREEN_SNAPSHOT_SCHEMA_VERSION => {
-            Err(MigrationError::UnsupportedFutureVersion {
-                file_kind: "ScreenSnapshot",
-                found: v,
-                max_supported: SCREEN_SNAPSHOT_SCHEMA_VERSION,
-            })
-        }
+        v if v > SCREEN_SNAPSHOT_SCHEMA_VERSION => Err(MigrationError::UnsupportedFutureVersion {
+            file_kind: "ScreenSnapshot",
+            found: v,
+            max_supported: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+        }),
         v => Err(MigrationError::UnsupportedFutureVersion {
             file_kind: "ScreenSnapshot",
             found: v,
@@ -245,11 +226,7 @@ mod tests {
         let err = load_daemon_index(json).unwrap_err();
         assert!(matches!(
             err,
-            MigrationError::UnsupportedFutureVersion {
-                file_kind: "DaemonIndex",
-                found: 99,
-                ..
-            }
+            MigrationError::UnsupportedFutureVersion { file_kind: "DaemonIndex", found: 99, .. }
         ));
     }
 
@@ -259,11 +236,7 @@ mod tests {
         let err = load_runtime_file(json).unwrap_err();
         assert!(matches!(
             err,
-            MigrationError::UnsupportedFutureVersion {
-                file_kind: "RuntimeFile",
-                found: 42,
-                ..
-            }
+            MigrationError::UnsupportedFutureVersion { file_kind: "RuntimeFile", found: 42, .. }
         ));
     }
 
@@ -302,11 +275,7 @@ mod tests {
         let err = load_daemon_index(json).unwrap_err();
         assert!(matches!(
             err,
-            MigrationError::DeserializationFailed {
-                file_kind: "DaemonIndex",
-                version: 1,
-                ..
-            }
+            MigrationError::DeserializationFailed { file_kind: "DaemonIndex", version: 1, .. }
         ));
     }
 

--- a/services/rttx-server/src/state/mod.rs
+++ b/services/rttx-server/src/state/mod.rs
@@ -5,3 +5,5 @@
 //! [`crate::serialization`] until the migration is complete.
 
 pub mod layout;
+pub mod migrations;
+pub mod types;

--- a/services/rttx-server/src/state/types.rs
+++ b/services/rttx-server/src/state/types.rs
@@ -1,0 +1,484 @@
+//! V2 persisted structs with explicit `schema_version` (RFC-022 §2–§4).
+//!
+//! Every struct carries a top-level `schema_version: u32` field. Loading
+//! dispatches on this field to select the correct deserialization path and
+//! migration chain.
+
+use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
+use uuid::Uuid;
+
+use crate::runtime::RuntimePolicy;
+
+// ── Schema version constants ────────────────────────────────────────
+
+/// Current schema version for [`DaemonIndexV1`].
+pub const DAEMON_INDEX_SCHEMA_VERSION: u32 = 1;
+
+/// Current schema version for [`RuntimeFileV1`].
+pub const RUNTIME_FILE_SCHEMA_VERSION: u32 = 1;
+
+/// Current schema version for [`ScreenSnapshotV1`].
+pub const SCREEN_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+// ── Top-level daemon index ──────────────────────────────────────────
+
+/// Server-level index listing all known runtime IDs (RFC-022 §1–§2).
+///
+/// Stored at `<state_dir>/daemon.json`. Rewritten only when the set of
+/// runtime IDs changes, not on every serialization tick.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DaemonIndexV1 {
+    /// Must be [`DAEMON_INDEX_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Informational server version that last wrote this file.
+    pub server_version: String,
+    /// IDs of all runtimes managed by this daemon.
+    pub runtime_ids: Vec<Uuid>,
+    /// When this daemon index was first created.
+    pub created_at: SystemTime,
+    /// When this file was last written.
+    pub last_serialized_at: SystemTime,
+}
+
+// ── Per-runtime file ────────────────────────────────────────────────
+
+/// Top-level wrapper stored in `<runtime_dir>/runtime.json` (RFC-022 §3).
+///
+/// Combines the durable spec with the semi-durable instance data.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeFileV1 {
+    /// Must be [`RUNTIME_FILE_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Durable runtime specification.
+    pub spec: RuntimeSpecV1,
+    /// Semi-durable instance data (bounded age, rebuilt on restart).
+    pub instance: RuntimeInstanceV1,
+}
+
+/// Durable runtime specification — identity, policy, panes, history.
+///
+/// These fields survive daemon restarts and are the source of truth for
+/// runtime reconstruction.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeSpecV1 {
+    /// Unique runtime identifier.
+    pub id: Uuid,
+    /// Human-readable runtime name.
+    pub name: String,
+    /// Retention policy.
+    pub policy: RuntimePolicy,
+    /// When this runtime was created.
+    pub created_at: SystemTime,
+    /// Pane specifications.
+    pub panes: Vec<PaneSpecV1>,
+    /// Active pane ID within this runtime.
+    pub active_pane_id: Option<Uuid>,
+    /// Per-runtime command history.
+    pub command_history: Vec<HistoryEntryV1>,
+}
+
+/// Semi-durable instance data — revision counters and timestamps.
+///
+/// Written alongside the spec but considered bounded-age: the daemon
+/// rebuilds these on restart from the live process state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeInstanceV1 {
+    /// Monotonic mutation counter.
+    pub revision: u64,
+    /// When the runtime was last active (had attached clients or I/O).
+    pub last_active_at: SystemTime,
+    /// When screen snapshots were last flushed to disk.
+    pub last_snapshot_at: SystemTime,
+}
+
+// ── Pane spec ───────────────────────────────────────────────────────
+
+/// Durable pane specification (RFC-022 §3).
+///
+/// Captures the identity and last-known terminal state of a single pane.
+/// Scrollback and screen data live in separate files; this struct holds
+/// only the metadata needed to reconstruct the pane.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PaneSpecV1 {
+    /// Unique pane identifier.
+    pub id: Uuid,
+    /// Last known working directory.
+    pub cwd: Option<String>,
+    /// Pane title.
+    pub title: Option<String>,
+    /// Exit status if the pane's process exited.
+    pub exit_status: Option<i32>,
+    /// Terminal columns.
+    pub cols: u16,
+    /// Terminal rows.
+    pub rows: u16,
+}
+
+/// Per-runtime command history entry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HistoryEntryV1 {
+    /// The command text.
+    pub command: String,
+    /// Working directory when the command was run.
+    pub cwd: String,
+    /// When the command was executed.
+    pub timestamp: SystemTime,
+    /// Which pane the command was run in.
+    pub pane_id: Uuid,
+}
+
+// ── Screen snapshot ─────────────────────────────────────────────────
+
+/// Deterministic screen snapshot for a single pane (RFC-022 §4).
+///
+/// Stored at `<runtime_dir>/screen/<pane_id>.snap`. Consumed on
+/// resurrection to restore the visible screen without replaying raw
+/// scrollback bytes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScreenSnapshotV1 {
+    /// Must be [`SCREEN_SNAPSHOT_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Pane this snapshot belongs to.
+    pub pane_id: Uuid,
+    /// Terminal columns at snapshot time.
+    pub cols: u16,
+    /// Terminal rows at snapshot time.
+    pub rows: u16,
+    /// Cursor row (0-based).
+    pub cursor_row: u16,
+    /// Cursor column (0-based).
+    pub cursor_col: u16,
+    /// Whether the cursor was visible.
+    pub cursor_visible: bool,
+    /// Terminal title (OSC 2).
+    pub title: Option<String>,
+    /// Working directory (OSC 7).
+    pub cwd: Option<String>,
+    /// Monotonic output counter for delta ordering.
+    pub pane_output_seq: u64,
+    /// Terminal mode flags at snapshot time.
+    pub modes: TerminalModeSnapshot,
+    /// Raw bytes representing the visible screen content.
+    ///
+    /// Bounded by the visible viewport size, not the full scrollback.
+    /// Future iterations may replace this with a cell-grid model.
+    pub screen_bytes: Vec<u8>,
+}
+
+/// Terminal mode flags captured at snapshot time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TerminalModeSnapshot {
+    /// Bracketed paste mode (DECSET 2004).
+    pub bracketed_paste: bool,
+    /// Application cursor keys mode (DECSET 1).
+    pub application_cursor_keys: bool,
+    /// Application keypad mode (DECKPAM).
+    pub application_keypad: bool,
+    /// Mouse tracking mode: 0=off, 1000/1002/1003.
+    pub mouse_tracking_mode: u16,
+    /// SGR mouse mode (DECSET 1006).
+    pub sgr_mouse: bool,
+    /// Focus event reporting (DECSET 1004).
+    pub focus_reporting: bool,
+}
+
+// ── Version envelope for dispatch ───────────────────────────────────
+
+/// Minimal envelope used to peek at `schema_version` before full
+/// deserialization. Allows the loader to select the correct struct
+/// version and migration path.
+#[derive(Debug, Deserialize)]
+pub struct SchemaVersionEnvelope {
+    /// The schema version declared in the file.
+    pub schema_version: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::SystemTime;
+
+    fn sample_pane_spec() -> PaneSpecV1 {
+        PaneSpecV1 {
+            id: Uuid::new_v4(),
+            cwd: Some("/home/user".into()),
+            title: Some("bash".into()),
+            exit_status: None,
+            cols: 80,
+            rows: 24,
+        }
+    }
+
+    fn sample_history_entry() -> HistoryEntryV1 {
+        HistoryEntryV1 {
+            command: "ls -la".into(),
+            cwd: "/home/user".into(),
+            timestamp: SystemTime::now(),
+            pane_id: Uuid::new_v4(),
+        }
+    }
+
+    fn sample_runtime_spec() -> RuntimeSpecV1 {
+        RuntimeSpecV1 {
+            id: Uuid::new_v4(),
+            name: "dev".into(),
+            policy: RuntimePolicy::Persistent,
+            created_at: SystemTime::now(),
+            panes: vec![sample_pane_spec()],
+            active_pane_id: None,
+            command_history: vec![sample_history_entry()],
+        }
+    }
+
+    fn sample_runtime_instance() -> RuntimeInstanceV1 {
+        RuntimeInstanceV1 {
+            revision: 42,
+            last_active_at: SystemTime::now(),
+            last_snapshot_at: SystemTime::now(),
+        }
+    }
+
+    fn sample_daemon_index() -> DaemonIndexV1 {
+        DaemonIndexV1 {
+            schema_version: DAEMON_INDEX_SCHEMA_VERSION,
+            server_version: "0.4.0".into(),
+            runtime_ids: vec![Uuid::new_v4()],
+            created_at: SystemTime::now(),
+            last_serialized_at: SystemTime::now(),
+        }
+    }
+
+    fn sample_runtime_file() -> RuntimeFileV1 {
+        RuntimeFileV1 {
+            schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+            spec: sample_runtime_spec(),
+            instance: sample_runtime_instance(),
+        }
+    }
+
+    fn sample_screen_snapshot() -> ScreenSnapshotV1 {
+        ScreenSnapshotV1 {
+            schema_version: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+            pane_id: Uuid::new_v4(),
+            cols: 80,
+            rows: 24,
+            cursor_row: 10,
+            cursor_col: 5,
+            cursor_visible: true,
+            title: Some("vim".into()),
+            cwd: Some("/home/user/project".into()),
+            pane_output_seq: 100,
+            modes: TerminalModeSnapshot {
+                bracketed_paste: true,
+                application_cursor_keys: false,
+                application_keypad: false,
+                mouse_tracking_mode: 0,
+                sgr_mouse: false,
+                focus_reporting: false,
+            },
+            screen_bytes: b"hello world\r\n".to_vec(),
+        }
+    }
+
+    // ── Round-trip serialization ────────────────────────────────────
+
+    #[test]
+    fn daemon_index_round_trip() {
+        let original = sample_daemon_index();
+        let json = serde_json::to_string_pretty(&original).unwrap();
+        let recovered: DaemonIndexV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn runtime_file_round_trip() {
+        let original = sample_runtime_file();
+        let json = serde_json::to_string_pretty(&original).unwrap();
+        let recovered: RuntimeFileV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn screen_snapshot_round_trip() {
+        let original = sample_screen_snapshot();
+        let json = serde_json::to_string_pretty(&original).unwrap();
+        let recovered: ScreenSnapshotV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn pane_spec_round_trip() {
+        let original = sample_pane_spec();
+        let json = serde_json::to_string_pretty(&original).unwrap();
+        let recovered: PaneSpecV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn history_entry_round_trip() {
+        let original = sample_history_entry();
+        let json = serde_json::to_string_pretty(&original).unwrap();
+        let recovered: HistoryEntryV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    // ── Schema version field presence ───────────────────────────────
+
+    #[test]
+    fn daemon_index_json_contains_schema_version() {
+        let index = sample_daemon_index();
+        let json = serde_json::to_string(&index).unwrap();
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(raw["schema_version"], DAEMON_INDEX_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn runtime_file_json_contains_schema_version() {
+        let file = sample_runtime_file();
+        let json = serde_json::to_string(&file).unwrap();
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(raw["schema_version"], RUNTIME_FILE_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn screen_snapshot_json_contains_schema_version() {
+        let snap = sample_screen_snapshot();
+        let json = serde_json::to_string(&snap).unwrap();
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(raw["schema_version"], SCREEN_SNAPSHOT_SCHEMA_VERSION);
+    }
+
+    // ── Envelope dispatch ───────────────────────────────────────────
+
+    #[test]
+    fn schema_version_envelope_extracts_version() {
+        let index = sample_daemon_index();
+        let json = serde_json::to_string(&index).unwrap();
+        let envelope: SchemaVersionEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(envelope.schema_version, DAEMON_INDEX_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn schema_version_envelope_works_for_runtime_file() {
+        let file = sample_runtime_file();
+        let json = serde_json::to_string(&file).unwrap();
+        let envelope: SchemaVersionEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(envelope.schema_version, RUNTIME_FILE_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn schema_version_envelope_works_for_screen_snapshot() {
+        let snap = sample_screen_snapshot();
+        let json = serde_json::to_string(&snap).unwrap();
+        let envelope: SchemaVersionEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(envelope.schema_version, SCREEN_SNAPSHOT_SCHEMA_VERSION);
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────
+
+    #[test]
+    fn daemon_index_with_no_runtimes() {
+        let index = DaemonIndexV1 {
+            schema_version: DAEMON_INDEX_SCHEMA_VERSION,
+            server_version: "0.4.0".into(),
+            runtime_ids: vec![],
+            created_at: SystemTime::now(),
+            last_serialized_at: SystemTime::now(),
+        };
+        let json = serde_json::to_string_pretty(&index).unwrap();
+        let recovered: DaemonIndexV1 = serde_json::from_str(&json).unwrap();
+        assert!(recovered.runtime_ids.is_empty());
+    }
+
+    #[test]
+    fn runtime_spec_with_no_panes_or_history() {
+        let spec = RuntimeSpecV1 {
+            id: Uuid::new_v4(),
+            name: "empty".into(),
+            policy: RuntimePolicy::Ephemeral,
+            created_at: SystemTime::now(),
+            panes: vec![],
+            active_pane_id: None,
+            command_history: vec![],
+        };
+        let json = serde_json::to_string_pretty(&spec).unwrap();
+        let recovered: RuntimeSpecV1 = serde_json::from_str(&json).unwrap();
+        assert!(recovered.panes.is_empty());
+        assert!(recovered.command_history.is_empty());
+        assert_eq!(recovered.policy, RuntimePolicy::Ephemeral);
+    }
+
+    #[test]
+    fn pane_spec_with_all_optional_fields_none() {
+        let pane = PaneSpecV1 {
+            id: Uuid::new_v4(),
+            cwd: None,
+            title: None,
+            exit_status: None,
+            cols: 120,
+            rows: 40,
+        };
+        let json = serde_json::to_string_pretty(&pane).unwrap();
+        let recovered: PaneSpecV1 = serde_json::from_str(&json).unwrap();
+        assert!(recovered.cwd.is_none());
+        assert!(recovered.title.is_none());
+        assert!(recovered.exit_status.is_none());
+    }
+
+    #[test]
+    fn screen_snapshot_with_empty_bytes() {
+        let snap = ScreenSnapshotV1 {
+            schema_version: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+            pane_id: Uuid::new_v4(),
+            cols: 80,
+            rows: 24,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_visible: true,
+            title: None,
+            cwd: None,
+            pane_output_seq: 0,
+            modes: TerminalModeSnapshot {
+                bracketed_paste: false,
+                application_cursor_keys: false,
+                application_keypad: false,
+                mouse_tracking_mode: 0,
+                sgr_mouse: false,
+                focus_reporting: false,
+            },
+            screen_bytes: vec![],
+        };
+        let json = serde_json::to_string_pretty(&snap).unwrap();
+        let recovered: ScreenSnapshotV1 = serde_json::from_str(&json).unwrap();
+        assert!(recovered.screen_bytes.is_empty());
+    }
+
+    #[test]
+    fn screen_snapshot_all_modes_active() {
+        let snap = ScreenSnapshotV1 {
+            schema_version: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+            pane_id: Uuid::new_v4(),
+            cols: 80,
+            rows: 24,
+            cursor_row: 23,
+            cursor_col: 79,
+            cursor_visible: false,
+            title: Some("htop".into()),
+            cwd: Some("/".into()),
+            pane_output_seq: u64::MAX,
+            modes: TerminalModeSnapshot {
+                bracketed_paste: true,
+                application_cursor_keys: true,
+                application_keypad: true,
+                mouse_tracking_mode: 1003,
+                sgr_mouse: true,
+                focus_reporting: true,
+            },
+            screen_bytes: vec![0x1b, b'[', b'H'],
+        };
+        let json = serde_json::to_string_pretty(&snap).unwrap();
+        let recovered: ScreenSnapshotV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(snap.modes, recovered.modes);
+    }
+}

--- a/services/rttx-server/tests/v2_persisted_structs.rs
+++ b/services/rttx-server/tests/v2_persisted_structs.rs
@@ -1,0 +1,146 @@
+//! Integration test for v2 persisted structs and migration chain (RFC-022 §2–§4).
+//!
+//! Verifies that structs serialize to disk and load back through the
+//! migration chain, including future-version rejection and forward
+//! compatibility with unknown fields.
+
+use rttx_server::runtime::RuntimePolicy;
+use rttx_server::state::migrations::{
+    load_daemon_index, load_runtime_file, load_screen_snapshot, peek_schema_version,
+};
+use rttx_server::state::types::*;
+use std::time::SystemTime;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+fn write_and_load_daemon_index(index: &DaemonIndexV1) -> DaemonIndexV1 {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("daemon.json");
+    let json = serde_json::to_string_pretty(index).unwrap();
+    std::fs::write(&path, &json).unwrap();
+    let loaded = std::fs::read_to_string(&path).unwrap();
+    load_daemon_index(&loaded).unwrap()
+}
+
+fn write_and_load_runtime_file(file: &RuntimeFileV1) -> RuntimeFileV1 {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("runtime.json");
+    let json = serde_json::to_string_pretty(file).unwrap();
+    std::fs::write(&path, &json).unwrap();
+    let loaded = std::fs::read_to_string(&path).unwrap();
+    load_runtime_file(&loaded).unwrap()
+}
+
+fn write_and_load_screen_snapshot(snap: &ScreenSnapshotV1) -> ScreenSnapshotV1 {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("screen.snap");
+    let json = serde_json::to_string_pretty(snap).unwrap();
+    std::fs::write(&path, &json).unwrap();
+    let loaded = std::fs::read_to_string(&path).unwrap();
+    load_screen_snapshot(&loaded).unwrap()
+}
+
+#[test]
+fn daemon_index_persists_and_loads_via_migration_chain() {
+    let original = DaemonIndexV1 {
+        schema_version: DAEMON_INDEX_SCHEMA_VERSION,
+        server_version: "0.4.0".into(),
+        runtime_ids: vec![Uuid::new_v4(), Uuid::new_v4()],
+        created_at: SystemTime::now(),
+        last_serialized_at: SystemTime::now(),
+    };
+    let recovered = write_and_load_daemon_index(&original);
+    assert_eq!(original, recovered);
+}
+
+#[test]
+fn runtime_file_persists_and_loads_via_migration_chain() {
+    let pane = PaneSpecV1 {
+        id: Uuid::new_v4(),
+        cwd: Some("/home/user/project".into()),
+        title: Some("nvim".into()),
+        exit_status: None,
+        cols: 120,
+        rows: 40,
+    };
+    let original = RuntimeFileV1 {
+        schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+        spec: RuntimeSpecV1 {
+            id: Uuid::new_v4(),
+            name: "workspace-1".into(),
+            policy: RuntimePolicy::Persistent,
+            created_at: SystemTime::now(),
+            panes: vec![pane],
+            active_pane_id: None,
+            command_history: vec![HistoryEntryV1 {
+                command: "cargo build".into(),
+                cwd: "/home/user/project".into(),
+                timestamp: SystemTime::now(),
+                pane_id: Uuid::new_v4(),
+            }],
+        },
+        instance: RuntimeInstanceV1 {
+            revision: 7,
+            last_active_at: SystemTime::now(),
+            last_snapshot_at: SystemTime::now(),
+        },
+    };
+    let recovered = write_and_load_runtime_file(&original);
+    assert_eq!(original, recovered);
+}
+
+#[test]
+fn screen_snapshot_persists_and_loads_via_migration_chain() {
+    let original = ScreenSnapshotV1 {
+        schema_version: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+        pane_id: Uuid::new_v4(),
+        cols: 80,
+        rows: 24,
+        cursor_row: 12,
+        cursor_col: 40,
+        cursor_visible: true,
+        title: Some("bash".into()),
+        cwd: Some("/tmp".into()),
+        pane_output_seq: 500,
+        modes: TerminalModeSnapshot {
+            bracketed_paste: true,
+            application_cursor_keys: false,
+            application_keypad: false,
+            mouse_tracking_mode: 1000,
+            sgr_mouse: true,
+            focus_reporting: false,
+        },
+        screen_bytes: vec![0x1b, b'[', b'2', b'J'],
+    };
+    let recovered = write_and_load_screen_snapshot(&original);
+    assert_eq!(original, recovered);
+}
+
+#[test]
+fn forward_compatible_ignores_unknown_fields() {
+    // Simulate a future writer adding an extra field — serde should ignore it.
+    let json = r#"{
+        "schema_version": 1,
+        "server_version": "0.5.0",
+        "runtime_ids": [],
+        "created_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
+        "last_serialized_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
+        "future_field": "should be ignored"
+    }"#;
+    let version = peek_schema_version(json).unwrap();
+    assert_eq!(version, 1);
+    // Should load successfully despite the unknown field.
+    let result = load_daemon_index(json);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn future_version_rejected_from_disk() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("daemon.json");
+    let json = r#"{"schema_version": 99, "server_version": "9.0.0", "runtime_ids": []}"#;
+    std::fs::write(&path, json).unwrap();
+    let loaded = std::fs::read_to_string(&path).unwrap();
+    let result = load_daemon_index(&loaded);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## What changed and why

RFC-022 Step 2: Define the v2 persisted structs with explicit `schema_version` fields and a typed migration chain.

### New modules

- **`state::types`** — `DaemonIndexV1`, `RuntimeFileV1` (`RuntimeSpecV1` + `RuntimeInstanceV1`), `PaneSpecV1`, `ScreenSnapshotV1`, `HistoryEntryV1`, `TerminalModeSnapshot`, and `SchemaVersionEnvelope`. Every top-level file struct carries `schema_version: u32` for version dispatch.
- **`state::migrations`** — `peek_schema_version()` helper, per-file-type loaders (`load_daemon_index`, `load_runtime_file`, `load_screen_snapshot`) that dispatch on schema version, and `MigrationError` for future/corrupt/invalid cases.

### Manual verification

```bash
cargo build -p rttx-server
cargo test -p rttx-server --lib state::types
cargo test -p rttx-server --lib state::migrations
```

### Tests added

28 unit tests covering:
- Round-trip serialization for all structs (5 tests)
- `schema_version` field presence in JSON output (3 tests)
- `SchemaVersionEnvelope` dispatch (3 tests)
- Edge cases: empty collections, all-None optionals, all-active modes (5 tests)
- Migration happy path: current version loads directly (3 tests)
- Future version rejection (3 tests)
- Invalid/corrupt JSON handling (3 tests)
- Error display formatting (2 tests)
- Peek helper (1 test)

### Tests run

- `cargo test -p rttx-server --lib` — 318 passed
- `cargo test -p rttx-server --tests` — all integration tests passed
- `cargo test -p rttx-proto` — 333 passed
- `bash .github/scripts/run-clippy.sh` — passed
- `bash .github/scripts/run-quality-tests.sh` — passed

Fixes #718