### PR TITLE
feat(server): swap serialization to per-runtime files with symlink .bak backup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.0',
+  version: '0.4.1',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -1,5 +1,5 @@
 Name:           rttx
-Version:        0.4.0
+Version:        0.4.1
 Release:        1%{?dist}
 Summary:        A tiling terminal emulator for GNOME
 

--- a/services/rttx-server/src/runtime.rs
+++ b/services/rttx-server/src/runtime.rs
@@ -489,6 +489,110 @@ impl Runtime {
             last_active_at: self.last_active_at,
         }
     }
+
+    /// Build a v2 `RuntimeFileV1` for per-runtime persistence.
+    #[must_use]
+    pub fn to_runtime_file(&self) -> crate::state::types::RuntimeFileV1 {
+        use crate::state::types::{
+            HistoryEntryV1, PaneSpecV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1,
+            RuntimeInstanceV1, RuntimeSpecV1,
+        };
+
+        let panes = self
+            .panes
+            .values()
+            .map(|p| {
+                let cwd = p.cwd.clone().or_else(|| p.read_proc_cwd());
+                PaneSpecV1 {
+                    id: p.id,
+                    cwd,
+                    title: p.title.clone(),
+                    exit_status: p.exit_status,
+                    cols: p.cols,
+                    rows: p.rows,
+                }
+            })
+            .collect();
+
+        let command_history = self
+            .command_history
+            .iter()
+            .map(|h| HistoryEntryV1 {
+                command: h.command.clone(),
+                cwd: h.cwd.clone(),
+                timestamp: h.timestamp,
+                pane_id: h.pane_id,
+            })
+            .collect();
+
+        RuntimeFileV1 {
+            schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+            spec: RuntimeSpecV1 {
+                id: self.id,
+                name: self.name.clone(),
+                policy: self.policy,
+                created_at: self.created_at,
+                panes,
+                active_pane_id: self.active_pane_id,
+                command_history,
+            },
+            instance: RuntimeInstanceV1 {
+                revision: self.revision,
+                last_active_at: self.last_active_at,
+                last_snapshot_at: SystemTime::now(),
+            },
+        }
+    }
+
+    /// Resurrect a runtime from a v2 `RuntimeFileV1`.
+    #[must_use]
+    pub fn from_runtime_file(rf: &crate::state::types::RuntimeFileV1) -> Self {
+        let panes: HashMap<Uuid, Pane> = rf
+            .spec
+            .panes
+            .iter()
+            .map(|ps| {
+                let mut pane = Pane::new(ps.id, ps.cols, ps.rows);
+                pane.cwd.clone_from(&ps.cwd);
+                pane.title.clone_from(&ps.title);
+                pane.exit_status = ps.exit_status;
+                pane.reconstructed = true;
+                (ps.id, pane)
+            })
+            .collect();
+
+        let command_history: Vec<HistoryEntry> = rf
+            .spec
+            .command_history
+            .iter()
+            .map(|h| HistoryEntry {
+                command: h.command.clone(),
+                cwd: h.cwd.clone(),
+                timestamp: h.timestamp,
+                pane_id: h.pane_id,
+            })
+            .collect();
+
+        let command_history = if command_history.len() > MAX_COMMAND_HISTORY {
+            command_history[command_history.len() - MAX_COMMAND_HISTORY..].to_vec()
+        } else {
+            command_history
+        };
+
+        Self {
+            id: rf.spec.id,
+            name: rf.spec.name.clone(),
+            active_pane_id: rf.spec.active_pane_id,
+            command_history,
+            policy: rf.spec.policy,
+            reconstructed: true,
+            revision: rf.instance.revision.max(default_runtime_revision()),
+            created_at: rf.spec.created_at,
+            last_active_at: rf.instance.last_active_at,
+            attached_clients: HashMap::new(),
+            panes,
+        }
+    }
 }
 
 /// Serializable runtime state for disk persistence.
@@ -789,5 +893,51 @@ mod tests {
             restored.command_history[0].command, "cmd-200",
             "oldest entries should be dropped on load"
         );
+    }
+
+    #[test]
+    fn runtime_file_v2_round_trip() {
+        let mut runtime = Runtime::new("v2-test".into());
+        runtime.policy = RuntimePolicy::Persistent;
+        let pane = Pane::new(Uuid::new_v4(), 100, 30);
+        let pane_id = pane.id;
+        runtime.add_pane(pane);
+        runtime.add_history_entry(HistoryEntry {
+            command: "cargo build".into(),
+            cwd: "/project".into(),
+            timestamp: std::time::SystemTime::now(),
+            pane_id,
+        });
+
+        let rf = runtime.to_runtime_file();
+        assert_eq!(rf.spec.id, runtime.id);
+        assert_eq!(rf.spec.name, "v2-test");
+        assert_eq!(rf.spec.panes.len(), 1);
+        assert_eq!(rf.spec.panes[0].id, pane_id);
+        assert_eq!(rf.spec.panes[0].cols, 100);
+        assert_eq!(rf.spec.command_history.len(), 1);
+        assert_eq!(rf.instance.revision, runtime.revision());
+
+        let restored = Runtime::from_runtime_file(&rf);
+        assert_eq!(restored.id, runtime.id);
+        assert_eq!(restored.name, "v2-test");
+        assert_eq!(restored.policy, RuntimePolicy::Persistent);
+        assert!(restored.reconstructed);
+        assert_eq!(restored.revision(), runtime.revision());
+        assert!(restored.panes.contains_key(&pane_id));
+        assert_eq!(restored.panes[&pane_id].cols, 100);
+        assert_eq!(restored.panes[&pane_id].rows, 30);
+        assert_eq!(restored.command_history.len(), 1);
+        assert_eq!(restored.command_history[0].command, "cargo build");
+    }
+
+    #[test]
+    fn from_runtime_file_truncates_oversized_history() {
+        let mut runtime = Runtime::new("hist-test".into());
+        runtime.command_history = (0..MAX_COMMAND_HISTORY + 50).map(make_history_entry).collect();
+
+        let rf = runtime.to_runtime_file();
+        let restored = Runtime::from_runtime_file(&rf);
+        assert_eq!(restored.command_history.len(), MAX_COMMAND_HISTORY);
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -228,21 +228,62 @@ impl Server {
     }
 
     /// Load persisted state and resurrect runtimes.
+    ///
+    /// Tries v2 per-runtime files first. If no v2 state exists, falls back
+    /// to the v1 monolithic `state.json`. On first v2 startup with neither
+    /// present, starts clean with a loud log line.
     pub fn load_persisted_state(&mut self) {
+        let state_dir = self.os.state_dir();
+
+        // Try v2 per-runtime layout first.
+        if let Some(result) = crate::state::persistence::load_all(&state_dir) {
+            let total = result.runtimes.len() + result.failed_ids.len();
+            tracing::info!(
+                "Loaded {} persisted runtimes from v2 state ({} failed)",
+                result.runtimes.len(),
+                result.failed_ids.len()
+            );
+            let cache_dir = self.os.cache_dir();
+            for rf in &result.runtimes {
+                let rt = Runtime::from_runtime_file(rf);
+                let runtime_id = rt.id;
+                self.runtimes.insert(rt.id, rt);
+                // Set scrollback log paths (still in cache_dir for now).
+                if let Some(rt) = self.runtimes.get_mut(&runtime_id) {
+                    for pane in rt.panes.values_mut() {
+                        pane.scrollback_log_path = Some(serialization::scrollback_log_path(
+                            &cache_dir, runtime_id, pane.id,
+                        ));
+                    }
+                }
+            }
+            if total > 0 || result.failed_ids.is_empty() {
+                return;
+            }
+        }
+
+        // Fall back to v1 monolithic state.json.
         let state_path = default_state_path(&self.os.cache_dir());
         match load_state(&state_path) {
             Ok(Some(state)) => {
-                tracing::info!("Loaded {} persisted runtimes", state.runtimes.len());
+                tracing::info!(
+                    "No v2 state found; loaded {} runtimes from v1 state.json",
+                    state.runtimes.len()
+                );
                 for ps in &state.runtimes {
                     let rt = Runtime::from_persisted(ps);
                     self.runtimes.insert(rt.id, rt);
                 }
             }
             Ok(None) => {
-                tracing::info!("No persisted state found, starting fresh");
+                tracing::info!(
+                    "No persisted state found (v1 or v2). Starting fresh. \
+                     Previous state in $XDG_CACHE_HOME/rttx-server/ (if any) is left untouched."
+                );
             }
             Err(e) => {
-                tracing::error!("Failed to load persisted state: {e}");
+                tracing::error!("Failed to load v1 persisted state: {e}");
+                tracing::info!("Starting fresh due to load failure");
             }
         }
     }
@@ -2042,6 +2083,9 @@ fn spawn_pty_read_loop(
 
 /// Run the serialization loop, writing state to disk every `interval`.
 ///
+/// Uses v2 per-runtime files with symlink-based backup. Also writes the
+/// v1 monolithic `state.json` for backward compatibility during transition.
+///
 /// Stops when the shutdown signal fires.
 pub async fn serialization_loop(
     server: Arc<Mutex<Server>>,
@@ -2061,6 +2105,7 @@ pub async fn serialization_loop(
 
         let mut s = server.lock().await;
         let cache_dir = s.os.cache_dir();
+        let state_dir = s.os.state_dir();
 
         let runtime_ids: Vec<_> = s.runtimes.keys().copied().collect();
         for runtime_id in runtime_ids {
@@ -2083,12 +2128,33 @@ pub async fn serialization_loop(
             s.log_diagnostics();
         }
 
+        // Collect v2 runtime files for persistent runtimes.
+        let runtime_files: Vec<_> = s
+            .runtimes
+            .values()
+            .filter(|rt| rt.policy == RuntimePolicy::Persistent)
+            .map(Runtime::to_runtime_file)
+            .collect();
+
+        // Also write v1 for backward compat during transition.
         let snapshot = s.build_snapshot();
-        let state_path = default_state_path(&cache_dir);
+        let v1_path = default_state_path(&cache_dir);
         drop(s);
 
-        if let Err(e) = write_state_atomic(&snapshot, &state_path) {
-            tracing::error!("Failed to serialize state: {e}");
+        // Write v2 per-runtime files.
+        let ids: Vec<_> = runtime_files.iter().map(|rf| rf.spec.id).collect();
+        if let Err(e) = crate::state::persistence::save_daemon_index(&state_dir, &ids) {
+            tracing::error!("Failed to write v2 daemon index: {e}");
+        }
+        for rf in &runtime_files {
+            if let Err(e) = crate::state::persistence::save_runtime(&state_dir, rf) {
+                tracing::error!("Failed to write v2 runtime {}: {e}", short_id(rf.spec.id));
+            }
+        }
+
+        // Write v1 monolithic state.json.
+        if let Err(e) = write_state_atomic(&snapshot, &v1_path) {
+            tracing::error!("Failed to serialize v1 state: {e}");
         }
     }
 }
@@ -2097,6 +2163,7 @@ pub async fn serialization_loop(
 pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
     let mut s = server.lock().await;
     let cache_dir = s.os.cache_dir();
+    let state_dir = s.os.state_dir();
 
     for rt in s.runtimes.values_mut() {
         let label = format!("\"{}\" ({})", rt.name, short_id(rt.id));
@@ -2110,14 +2177,33 @@ pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
         }
     }
 
+    // Write v2 per-runtime files.
+    let runtime_files: Vec<_> = s
+        .runtimes
+        .values()
+        .filter(|rt| rt.policy == RuntimePolicy::Persistent)
+        .map(Runtime::to_runtime_file)
+        .collect();
+
+    let ids: Vec<_> = runtime_files.iter().map(|rf| rf.spec.id).collect();
+    if let Err(e) = crate::state::persistence::save_daemon_index(&state_dir, &ids) {
+        tracing::error!("Failed to write v2 daemon index on shutdown: {e}");
+    }
+    for rf in &runtime_files {
+        if let Err(e) = crate::state::persistence::save_runtime(&state_dir, rf) {
+            tracing::error!("Failed to write v2 runtime {} on shutdown: {e}", short_id(rf.spec.id));
+        }
+    }
+
+    // Also write v1 for backward compat.
     let snapshot = s.build_snapshot();
     let state_path = default_state_path(&cache_dir);
     drop(s);
 
     if let Err(e) = write_state_atomic(&snapshot, &state_path) {
-        tracing::error!("Failed to persist final state: {e}");
+        tracing::error!("Failed to persist final v1 state: {e}");
     } else {
-        tracing::info!("Final state persisted");
+        tracing::info!("Final state persisted (v1 + v2)");
     }
 }
 

--- a/services/rttx-server/src/state/io.rs
+++ b/services/rttx-server/src/state/io.rs
@@ -1,0 +1,265 @@
+//! Atomic file I/O with symlink-based `.bak` backup (RFC-022 §6).
+//!
+//! Write protocol:
+//! 1. Write content to `<path>.tmp`
+//! 2. If `<path>` exists, copy it to `<path>.prev`
+//! 3. Update `<path>.bak` symlink to point to `<path>.prev`
+//! 4. Rename `<path>.tmp` → `<path>`
+//!
+//! On crash at any point, at least one of `<path>` or `<path>.prev`
+//! (reachable via `.bak`) contains a valid copy.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Write `content` to `path` with symlink-based backup.
+///
+/// Creates parent directories as needed.
+pub fn write_with_backup(path: &Path, content: &str) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let tmp_path = path.with_extension("tmp");
+    let prev_path = path.with_extension("prev");
+    let bak_path = path.with_extension("bak");
+
+    // 1. Write to tmp
+    fs::write(&tmp_path, content)?;
+
+    // 2. If the live file exists, copy to .prev
+    if path.exists() {
+        fs::copy(path, &prev_path)?;
+    }
+
+    // 3. Update .bak symlink (remove + create)
+    let _ = fs::remove_file(&bak_path);
+    if let Some(prev_name) = prev_path.file_name() {
+        std::os::unix::fs::symlink(prev_name, &bak_path)?;
+    }
+
+    // 4. Rename tmp → live (atomic on same filesystem)
+    fs::rename(&tmp_path, path)?;
+
+    Ok(())
+}
+
+/// Resolve the backup path for a given primary path.
+///
+/// Follows the `.bak` symlink if it exists, otherwise falls back to `.prev`.
+fn resolve_backup_path(path: &Path) -> PathBuf {
+    let bak_path = path.with_extension("bak");
+    fs::read_link(&bak_path).map_or_else(
+        |_| path.with_extension("prev"),
+        |target| {
+            if target.is_relative() {
+                path.parent().map_or_else(|| target.clone(), |p| p.join(&target))
+            } else {
+                target
+            }
+        },
+    )
+}
+
+/// Read `path`, falling back to the `.bak` symlink target on failure.
+///
+/// Returns `None` only if neither the primary nor backup file is readable
+/// and non-empty.
+pub fn read_with_fallback(path: &Path) -> Option<String> {
+    // Try primary
+    match fs::read_to_string(path) {
+        Ok(content) if !content.is_empty() => return Some(content),
+        Ok(_) => {
+            tracing::warn!("Primary file is empty: {}", path.display());
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            // Primary missing — fall through to backup
+        }
+        Err(e) => {
+            tracing::warn!("Failed to read primary file {}: {e}", path.display());
+        }
+    }
+
+    // Try backup
+    let prev_path = resolve_backup_path(path);
+    match fs::read_to_string(&prev_path) {
+        Ok(content) if !content.is_empty() => {
+            tracing::info!("Recovered from backup: {}", prev_path.display());
+            Some(content)
+        }
+        Ok(_) => {
+            tracing::warn!("Backup file is empty: {}", prev_path.display());
+            None
+        }
+        Err(_) => None,
+    }
+}
+
+/// Read the primary file only (no fallback). Returns `None` if missing.
+#[must_use]
+pub fn read_primary(path: &Path) -> Option<String> {
+    match fs::read_to_string(path) {
+        Ok(content) if !content.is_empty() => Some(content),
+        _ => None,
+    }
+}
+
+/// Read the backup file only. Returns `None` if missing or empty.
+#[must_use]
+pub fn read_backup(path: &Path) -> Option<String> {
+    let prev_path = resolve_backup_path(path);
+    match fs::read_to_string(&prev_path) {
+        Ok(content) if !content.is_empty() => Some(content),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn write_creates_file_and_backup_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("test.json");
+
+        write_with_backup(&path, "first").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "first");
+
+        write_with_backup(&path, "second").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "second");
+
+        let prev = path.with_extension("prev");
+        assert_eq!(fs::read_to_string(&prev).unwrap(), "first");
+
+        let bak = path.with_extension("bak");
+        assert!(bak.is_symlink());
+    }
+
+    #[test]
+    fn read_with_fallback_returns_primary() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("data.json");
+        fs::write(&path, "content").unwrap();
+
+        let result = read_with_fallback(&path);
+        assert_eq!(result.as_deref(), Some("content"));
+    }
+
+    #[test]
+    fn read_with_fallback_returns_none_when_both_missing() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("missing.json");
+
+        let result = read_with_fallback(&path);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn read_with_fallback_uses_prev_when_primary_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("data.json");
+        let prev = path.with_extension("prev");
+        let bak = path.with_extension("bak");
+
+        fs::write(&path, "").unwrap();
+        fs::write(&prev, "backup content").unwrap();
+        std::os::unix::fs::symlink("data.prev", &bak).unwrap();
+
+        let result = read_with_fallback(&path);
+        assert_eq!(result.as_deref(), Some("backup content"));
+    }
+
+    #[test]
+    fn read_with_fallback_uses_prev_when_primary_unreadable() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("sub").join("data.json");
+        let prev = path.with_extension("prev");
+        let bak = path.with_extension("bak");
+
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Make primary unreadable by making it a directory
+        fs::create_dir_all(&path).unwrap();
+        fs::write(&prev, "recovered").unwrap();
+        std::os::unix::fs::symlink("data.prev", &bak).unwrap();
+
+        let result = read_with_fallback(&path);
+        assert_eq!(result.as_deref(), Some("recovered"));
+    }
+
+    #[test]
+    fn write_creates_parent_directories() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("deep").join("nested").join("file.json");
+
+        write_with_backup(&path, "nested").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "nested");
+    }
+
+    #[test]
+    fn multiple_writes_keep_only_one_prev() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("data.json");
+
+        write_with_backup(&path, "v1").unwrap();
+        write_with_backup(&path, "v2").unwrap();
+        write_with_backup(&path, "v3").unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "v3");
+        let prev = path.with_extension("prev");
+        assert_eq!(fs::read_to_string(&prev).unwrap(), "v2");
+    }
+
+    #[test]
+    fn crash_after_tmp_write_leaves_original_intact() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("data.json");
+
+        // First write succeeds
+        write_with_backup(&path, "original").unwrap();
+
+        // Simulate crash: only .tmp exists from a second write attempt
+        let tmp_path = path.with_extension("tmp");
+        fs::write(&tmp_path, "partial").unwrap();
+
+        let result = read_with_fallback(&path);
+        assert_eq!(result.as_deref(), Some("original"));
+    }
+
+    #[test]
+    fn crash_after_prev_copy_recovers_from_backup() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("data.json");
+        let prev = path.with_extension("prev");
+        let bak = path.with_extension("bak");
+
+        // Simulate: primary is gone (crash during rename), but prev exists
+        fs::write(&prev, "safe copy").unwrap();
+        std::os::unix::fs::symlink("data.prev", &bak).unwrap();
+
+        let result = read_with_fallback(&path);
+        assert_eq!(result.as_deref(), Some("safe copy"));
+    }
+
+    #[test]
+    fn read_primary_returns_none_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("missing.json");
+        assert!(read_primary(&path).is_none());
+    }
+
+    #[test]
+    fn read_backup_returns_content_from_prev() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("data.json");
+        let prev = path.with_extension("prev");
+        let bak = path.with_extension("bak");
+
+        fs::write(&prev, "backup").unwrap();
+        std::os::unix::fs::symlink("data.prev", &bak).unwrap();
+
+        assert_eq!(read_backup(&path).as_deref(), Some("backup"));
+    }
+}

--- a/services/rttx-server/src/state/mod.rs
+++ b/services/rttx-server/src/state/mod.rs
@@ -4,6 +4,8 @@
 //! RFC-022. The v1 monolithic `state.json` path helpers remain in
 //! [`crate::serialization`] until the migration is complete.
 
+pub mod io;
 pub mod layout;
 pub mod migrations;
+pub mod persistence;
 pub mod types;

--- a/services/rttx-server/src/state/persistence.rs
+++ b/services/rttx-server/src/state/persistence.rs
@@ -1,0 +1,344 @@
+//! High-level persistence operations for v2 per-runtime state (RFC-022 §3, §6).
+//!
+//! Provides `load_all` and `save_runtime` / `save_daemon_index` that use
+//! the layout paths, typed structs, migration chain, and atomic I/O.
+
+use crate::state::io::write_with_backup;
+use crate::state::layout;
+use crate::state::migrations::{self, MigrationError};
+use crate::state::types::{DAEMON_INDEX_SCHEMA_VERSION, DaemonIndexV1, RuntimeFileV1};
+use std::path::Path;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+/// Result of loading all persisted v2 state on startup.
+#[derive(Debug)]
+pub struct LoadResult {
+    /// Successfully loaded runtime files.
+    pub runtimes: Vec<RuntimeFileV1>,
+    /// Runtime IDs that failed to load (corrupt or unreadable).
+    pub failed_ids: Vec<Uuid>,
+}
+
+/// Load all v2 state from the daemon state directory.
+///
+/// Returns `None` if no `daemon.json` exists (first v2 startup).
+/// Individual corrupt runtimes are logged and skipped, not fatal.
+pub fn load_all(state_dir: &Path) -> Option<LoadResult> {
+    let index_path = layout::daemon_index(state_dir);
+
+    // Try primary, then backup on parse failure.
+    let index = load_daemon_index_with_fallback(&index_path)?;
+
+    let mut runtimes = Vec::new();
+    let mut failed_ids = Vec::new();
+
+    for &runtime_id in &index.runtime_ids {
+        match load_runtime(state_dir, runtime_id) {
+            Ok(rf) => runtimes.push(rf),
+            Err(e) => {
+                tracing::error!(
+                    "Failed to load runtime {}: {e} — skipping",
+                    &runtime_id.to_string()[..8]
+                );
+                failed_ids.push(runtime_id);
+            }
+        }
+    }
+
+    Some(LoadResult { runtimes, failed_ids })
+}
+
+/// Load daemon index, trying backup on parse failure.
+fn load_daemon_index_with_fallback(path: &Path) -> Option<DaemonIndexV1> {
+    use crate::state::io::{read_backup, read_primary};
+
+    if let Some(json) = read_primary(path) {
+        match migrations::load_daemon_index(&json) {
+            Ok(idx) => return Some(idx),
+            Err(e) => {
+                tracing::warn!("Primary daemon index corrupt: {e} — trying backup");
+            }
+        }
+    }
+
+    if let Some(json) = read_backup(path) {
+        match migrations::load_daemon_index(&json) {
+            Ok(idx) => {
+                tracing::info!("Recovered daemon index from backup");
+                return Some(idx);
+            }
+            Err(e) => {
+                tracing::error!("Backup daemon index also corrupt: {e}");
+            }
+        }
+    }
+
+    // Check if the file simply doesn't exist (first startup)
+    if !path.exists() && !path.with_extension("prev").exists() {
+        return None;
+    }
+
+    tracing::error!("Daemon index unreadable from both primary and backup");
+    None
+}
+
+/// Load a single runtime file, trying backup on parse failure.
+fn load_runtime(state_dir: &Path, runtime_id: Uuid) -> Result<RuntimeFileV1, LoadError> {
+    let path = layout::runtime_file(state_dir, runtime_id);
+
+    // Try primary first
+    if let Some(json) = crate::state::io::read_primary(&path) {
+        match migrations::load_runtime_file(&json) {
+            Ok(rf) => return Ok(rf),
+            Err(e) => {
+                tracing::warn!(
+                    "Primary runtime file corrupt for {}: {e} — trying backup",
+                    &runtime_id.to_string()[..8]
+                );
+            }
+        }
+    }
+
+    // Try backup
+    if let Some(json) = crate::state::io::read_backup(&path) {
+        match migrations::load_runtime_file(&json) {
+            Ok(rf) => {
+                tracing::info!("Recovered runtime {} from backup", &runtime_id.to_string()[..8]);
+                return Ok(rf);
+            }
+            Err(e) => {
+                return Err(LoadError::Migration(e));
+            }
+        }
+    }
+
+    Err(LoadError::NotFound(runtime_id))
+}
+
+/// Save the daemon index to disk with backup.
+pub fn save_daemon_index(state_dir: &Path, runtime_ids: &[Uuid]) -> std::io::Result<()> {
+    let index = DaemonIndexV1 {
+        schema_version: DAEMON_INDEX_SCHEMA_VERSION,
+        server_version: env!("CARGO_PKG_VERSION").to_string(),
+        runtime_ids: runtime_ids.to_vec(),
+        created_at: SystemTime::now(),
+        last_serialized_at: SystemTime::now(),
+    };
+    let json = serde_json::to_string_pretty(&index).map_err(std::io::Error::other)?;
+    write_with_backup(&layout::daemon_index(state_dir), &json)
+}
+
+/// Save a single runtime file to disk with backup.
+pub fn save_runtime(state_dir: &Path, runtime_file: &RuntimeFileV1) -> std::io::Result<()> {
+    let path = layout::runtime_file(state_dir, runtime_file.spec.id);
+    let json = serde_json::to_string_pretty(runtime_file).map_err(std::io::Error::other)?;
+    write_with_backup(&path, &json)
+}
+
+/// Remove a runtime's directory from disk.
+pub fn remove_runtime_dir(state_dir: &Path, runtime_id: Uuid) -> std::io::Result<()> {
+    let dir = layout::runtime_dir(state_dir, runtime_id);
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir)?;
+    }
+    Ok(())
+}
+
+/// Errors that can occur when loading a single runtime.
+#[derive(Debug)]
+enum LoadError {
+    NotFound(Uuid),
+    Migration(MigrationError),
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(id) => write!(f, "runtime file not found for {id}"),
+            Self::Migration(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::RuntimePolicy;
+    use crate::state::types::{
+        HistoryEntryV1, PaneSpecV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1, RuntimeInstanceV1,
+        RuntimeSpecV1,
+    };
+    use tempfile::TempDir;
+
+    fn sample_runtime_file(id: Uuid) -> RuntimeFileV1 {
+        RuntimeFileV1 {
+            schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+            spec: RuntimeSpecV1 {
+                id,
+                name: "test-rt".into(),
+                policy: RuntimePolicy::Persistent,
+                created_at: SystemTime::now(),
+                panes: vec![PaneSpecV1 {
+                    id: Uuid::new_v4(),
+                    cwd: Some("/home/user".into()),
+                    title: Some("bash".into()),
+                    exit_status: None,
+                    cols: 80,
+                    rows: 24,
+                }],
+                active_pane_id: None,
+                command_history: vec![HistoryEntryV1 {
+                    command: "ls".into(),
+                    cwd: "/".into(),
+                    timestamp: SystemTime::now(),
+                    pane_id: Uuid::new_v4(),
+                }],
+            },
+            instance: RuntimeInstanceV1 {
+                revision: 5,
+                last_active_at: SystemTime::now(),
+                last_snapshot_at: SystemTime::now(),
+            },
+        }
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let rt_id = Uuid::new_v4();
+        let rf = sample_runtime_file(rt_id);
+
+        save_daemon_index(state_dir, &[rt_id]).unwrap();
+        save_runtime(state_dir, &rf).unwrap();
+
+        let result = load_all(state_dir).unwrap();
+        assert!(result.failed_ids.is_empty());
+        assert_eq!(result.runtimes.len(), 1);
+        assert_eq!(result.runtimes[0].spec.id, rt_id);
+        assert_eq!(result.runtimes[0].spec.name, "test-rt");
+    }
+
+    #[test]
+    fn load_all_returns_none_when_no_index() {
+        let tmp = TempDir::new().unwrap();
+        let result = load_all(tmp.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn corrupt_runtime_is_skipped_not_fatal() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let good_id = Uuid::new_v4();
+        let bad_id = Uuid::new_v4();
+
+        // Save good runtime
+        let rf = sample_runtime_file(good_id);
+        save_runtime(state_dir, &rf).unwrap();
+
+        // Write corrupt runtime file
+        let bad_dir = layout::runtime_dir(state_dir, bad_id);
+        std::fs::create_dir_all(&bad_dir).unwrap();
+        std::fs::write(layout::runtime_file(state_dir, bad_id), "not valid json").unwrap();
+
+        // Save index referencing both
+        save_daemon_index(state_dir, &[good_id, bad_id]).unwrap();
+
+        let result = load_all(state_dir).unwrap();
+        assert_eq!(result.runtimes.len(), 1);
+        assert_eq!(result.runtimes[0].spec.id, good_id);
+        assert_eq!(result.failed_ids, vec![bad_id]);
+    }
+
+    #[test]
+    fn multiple_runtimes_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let ids: Vec<Uuid> = (0..3).map(|_| Uuid::new_v4()).collect();
+
+        for &id in &ids {
+            save_runtime(state_dir, &sample_runtime_file(id)).unwrap();
+        }
+        save_daemon_index(state_dir, &ids).unwrap();
+
+        let result = load_all(state_dir).unwrap();
+        assert_eq!(result.runtimes.len(), 3);
+        assert!(result.failed_ids.is_empty());
+    }
+
+    #[test]
+    fn remove_runtime_dir_cleans_up() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let rt_id = Uuid::new_v4();
+
+        save_runtime(state_dir, &sample_runtime_file(rt_id)).unwrap();
+        let dir = layout::runtime_dir(state_dir, rt_id);
+        assert!(dir.exists());
+
+        remove_runtime_dir(state_dir, rt_id).unwrap();
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn remove_nonexistent_runtime_dir_is_ok() {
+        let tmp = TempDir::new().unwrap();
+        let result = remove_runtime_dir(tmp.path(), Uuid::new_v4());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn save_runtime_overwrites_with_backup() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let rt_id = Uuid::new_v4();
+
+        let mut rf = sample_runtime_file(rt_id);
+        rf.spec.name = "version-1".into();
+        save_runtime(state_dir, &rf).unwrap();
+
+        rf.spec.name = "version-2".into();
+        save_runtime(state_dir, &rf).unwrap();
+
+        // Primary has v2
+        let path = layout::runtime_file(state_dir, rt_id);
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("version-2"));
+
+        // Backup has v1
+        let prev = path.with_extension("prev");
+        let backup_content = std::fs::read_to_string(&prev).unwrap();
+        assert!(backup_content.contains("version-1"));
+    }
+
+    #[test]
+    fn load_recovers_from_backup_when_primary_corrupt() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let rt_id = Uuid::new_v4();
+
+        // Write a good version first
+        let rf = sample_runtime_file(rt_id);
+        save_runtime(state_dir, &rf).unwrap();
+
+        // Corrupt the primary
+        let path = layout::runtime_file(state_dir, rt_id);
+        let prev = path.with_extension("prev");
+        let bak = path.with_extension("bak");
+
+        // Copy good to prev, corrupt primary
+        std::fs::copy(&path, &prev).unwrap();
+        let _ = std::fs::remove_file(&bak);
+        std::os::unix::fs::symlink("runtime.prev", &bak).unwrap();
+        std::fs::write(&path, "corrupted!").unwrap();
+
+        // Save index
+        save_daemon_index(state_dir, &[rt_id]).unwrap();
+
+        let result = load_all(state_dir).unwrap();
+        assert_eq!(result.runtimes.len(), 1);
+        assert_eq!(result.runtimes[0].spec.id, rt_id);
+    }
+}

--- a/services/rttx-server/tests/v2_serialization.rs
+++ b/services/rttx-server/tests/v2_serialization.rs
@@ -1,0 +1,289 @@
+//! Integration tests for v2 per-runtime serialization (RFC-022 Step 3).
+//!
+//! Verifies that the daemon writes per-runtime files with symlink backup,
+//! loads from v2 on restart, and falls back to v1 when no v2 state exists.
+
+mod common;
+
+use common::{TestClient, start_test_server, wait_for_state_containing};
+use rttx_proto::proto;
+use rttx_server::state::{layout, persistence, types::RUNTIME_FILE_SCHEMA_VERSION};
+use std::time::Duration;
+
+/// After creating a persistent runtime, the daemon writes both v1 state.json
+/// and v2 per-runtime files.
+#[tokio::test]
+async fn serialization_writes_v2_runtime_files() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut c = TestClient::connect(&sock).await;
+    c.handshake().await;
+
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "v2-write-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    })
+    .await;
+    let _runtime_id = match c.recv().await.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+
+    // Wait for serialization tick to write state.
+    wait_for_state_containing(&tmp.path().join("cache"), "v2-write-test", Duration::from_secs(10))
+        .await;
+
+    // Verify v2 daemon index exists.
+    let state_dir = tmp.path().join("state/rttx/daemon");
+    let index_path = layout::daemon_index(&state_dir);
+    assert!(index_path.exists(), "daemon.json should exist at {}", index_path.display());
+
+    // Verify daemon index content.
+    let result = persistence::load_all(&state_dir).expect("v2 state should be loadable");
+    assert_eq!(result.runtimes.len(), 1);
+    assert_eq!(result.runtimes[0].spec.name, "v2-write-test");
+    assert_eq!(result.runtimes[0].schema_version, RUNTIME_FILE_SCHEMA_VERSION);
+    assert!(result.failed_ids.is_empty());
+}
+
+/// After two serialization ticks, the .bak symlink and .prev file exist.
+#[tokio::test]
+async fn serialization_creates_backup_symlink() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut c = TestClient::connect(&sock).await;
+    c.handshake().await;
+
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "bak-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    })
+    .await;
+    let _runtime_id = match c.recv().await.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+
+    // Wait for at least 2 serialization ticks (1s interval in tests).
+    wait_for_state_containing(&tmp.path().join("cache"), "bak-test", Duration::from_secs(10)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let state_dir = tmp.path().join("state/rttx/daemon");
+    let index_path = layout::daemon_index(&state_dir);
+    let bak_path = index_path.with_extension("bak");
+    let prev_path = index_path.with_extension("prev");
+
+    assert!(bak_path.is_symlink(), ".bak symlink should exist");
+    assert!(prev_path.exists(), ".prev file should exist");
+}
+
+/// Restart loads from v2 state (not v1) when both exist.
+#[tokio::test]
+async fn restart_prefers_v2_over_v1() {
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    // Phase 1: create runtime, let serialization write both v1 and v2.
+    let runtime_id;
+    {
+        let (sock, handle) = start_test_server(tmp.path()).await;
+        let mut c = TestClient::connect(&sock).await;
+        c.handshake().await;
+
+        c.send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+                name: "v2-preferred".into(),
+                policy: proto::RuntimePolicy::Persistent as i32,
+            })),
+        })
+        .await;
+        runtime_id = match c.recv().await.msg {
+            Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+            other => panic!("expected RuntimeCreated, got {other:?}"),
+        };
+
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "v2-preferred",
+            Duration::from_secs(10),
+        )
+        .await;
+        handle.abort();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Corrupt v1 state.json to prove v2 is used.
+    let v1_path = tmp.path().join("cache/state.json");
+    std::fs::write(&v1_path, "corrupted v1").unwrap();
+
+    // Phase 2: restart — should load from v2 successfully.
+    {
+        let (sock, _handle) = start_test_server(tmp.path()).await;
+        let mut c = TestClient::connect(&sock).await;
+        c.handshake().await;
+
+        c.send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::ListRuntimes(proto::ListRuntimes {})),
+        })
+        .await;
+        let runtimes = match c.recv().await.msg {
+            Some(proto::server_message::Msg::RuntimeList(sl)) => sl.runtimes,
+            other => panic!("expected RuntimeList, got {other:?}"),
+        };
+        assert_eq!(runtimes.len(), 1);
+        assert_eq!(runtimes[0].id, runtime_id);
+        assert_eq!(runtimes[0].name, "v2-preferred");
+    }
+}
+
+/// When no v2 state exists but v1 does, the daemon falls back to v1.
+#[tokio::test]
+async fn fallback_to_v1_when_no_v2_state() {
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    // Phase 1: create runtime, let serialization write.
+    {
+        let (sock, handle) = start_test_server(tmp.path()).await;
+        let mut c = TestClient::connect(&sock).await;
+        c.handshake().await;
+
+        c.send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+                name: "v1-fallback".into(),
+                policy: proto::RuntimePolicy::Persistent as i32,
+            })),
+        })
+        .await;
+        let _ = c.recv().await; // RuntimeCreated
+
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "v1-fallback",
+            Duration::from_secs(10),
+        )
+        .await;
+        handle.abort();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Remove v2 state directory entirely.
+    let state_dir = tmp.path().join("state");
+    if state_dir.exists() {
+        std::fs::remove_dir_all(&state_dir).unwrap();
+    }
+
+    // Phase 2: restart — should fall back to v1.
+    {
+        let (sock, _handle) = start_test_server(tmp.path()).await;
+        let mut c = TestClient::connect(&sock).await;
+        c.handshake().await;
+
+        c.send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::ListRuntimes(proto::ListRuntimes {})),
+        })
+        .await;
+        let runtimes = match c.recv().await.msg {
+            Some(proto::server_message::Msg::RuntimeList(sl)) => sl.runtimes,
+            other => panic!("expected RuntimeList, got {other:?}"),
+        };
+        assert_eq!(runtimes.len(), 1);
+        assert_eq!(runtimes[0].name, "v1-fallback");
+    }
+}
+
+/// When neither v1 nor v2 state exists, the daemon starts fresh.
+#[tokio::test]
+async fn fresh_start_when_no_state() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut c = TestClient::connect(&sock).await;
+    c.handshake().await;
+
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::ListRuntimes(proto::ListRuntimes {})),
+    })
+    .await;
+    let runtimes = match c.recv().await.msg {
+        Some(proto::server_message::Msg::RuntimeList(sl)) => sl.runtimes,
+        other => panic!("expected RuntimeList, got {other:?}"),
+    };
+    assert!(runtimes.is_empty(), "fresh start should have no runtimes");
+}
+
+/// Corrupt v2 runtime file is skipped; other runtimes still load.
+#[tokio::test]
+async fn corrupt_v2_runtime_skipped_not_fatal() {
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    // Phase 1: create two runtimes.
+    let rt1_id;
+    {
+        let (sock, handle) = start_test_server(tmp.path()).await;
+        let mut c = TestClient::connect(&sock).await;
+        c.handshake().await;
+
+        c.send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+                name: "good-runtime".into(),
+                policy: proto::RuntimePolicy::Persistent as i32,
+            })),
+        })
+        .await;
+        rt1_id = match c.recv().await.msg {
+            Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+            other => panic!("expected RuntimeCreated, got {other:?}"),
+        };
+
+        c.send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+                name: "bad-runtime".into(),
+                policy: proto::RuntimePolicy::Persistent as i32,
+            })),
+        })
+        .await;
+        let _ = c.recv().await; // RuntimeCreated
+
+        wait_for_state_containing(
+            &tmp.path().join("cache"),
+            "bad-runtime",
+            Duration::from_secs(10),
+        )
+        .await;
+        handle.abort();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Corrupt the second runtime's file.
+    let state_dir = tmp.path().join("state/rttx/daemon");
+    let result = persistence::load_all(&state_dir).unwrap();
+    let bad_rt = result.runtimes.iter().find(|r| r.spec.name == "bad-runtime").unwrap();
+    let bad_path = layout::runtime_file(&state_dir, bad_rt.spec.id);
+    std::fs::write(&bad_path, "not valid json").unwrap();
+    // Also remove .prev so backup can't save it
+    let _ = std::fs::remove_file(bad_path.with_extension("prev"));
+
+    // Phase 2: restart — good runtime should survive.
+    {
+        let (sock, _handle) = start_test_server(tmp.path()).await;
+        let mut c = TestClient::connect(&sock).await;
+        c.handshake().await;
+
+        c.send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::ListRuntimes(proto::ListRuntimes {})),
+        })
+        .await;
+        let runtimes = match c.recv().await.msg {
+            Some(proto::server_message::Msg::RuntimeList(sl)) => sl.runtimes,
+            other => panic!("expected RuntimeList, got {other:?}"),
+        };
+        assert_eq!(runtimes.len(), 1, "only the good runtime should survive");
+        assert_eq!(runtimes[0].id, rt1_id);
+        assert_eq!(runtimes[0].name, "good-runtime");
+    }
+}


### PR DESCRIPTION
## What changed and why

RFC-022 Step 3. Replaces the monolithic `state.json` rewrite with per-runtime `runtime.json` files under `$XDG_STATE_HOME/rttx/daemon/`. Uses symlink-based `.bak` backup for crash safety.

### Key behaviors:
- On startup: tries v2 per-runtime files first, falls back to v1 `state.json`
- On first v2 startup with no state: starts clean, logs loudly
- Old `$XDG_CACHE_HOME/rttx-server/` left untouched
- Both v1 and v2 written during transition for backward compatibility
- Corrupt individual runtime files are skipped (not fatal to the whole daemon)

### Write protocol (RFC-022 §6):
1. Write to `<path>.tmp`
2. Copy live file to `<path>.prev`
3. Update `<path>.bak` symlink → `<path>.prev`
4. Rename `<path>.tmp` → `<path>`

## Manual verification steps

1. Start daemon with `RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground`
2. Create a workspace in the GUI
3. Verify `$XDG_STATE_HOME/rttx-devel/daemon/daemon.json` exists
4. Verify `runtimes/<id>/runtime.json` exists with `.bak` symlink
5. Kill daemon, restart — workspace should be restored from v2 state
6. Delete v2 state dir, restart — should fall back to v1 `state.json`

## Tests added

### Unit tests (in `runtime.rs`):
- `runtime_file_v2_round_trip` — `to_runtime_file`/`from_runtime_file` preserves all fields
- `from_runtime_file_truncates_oversized_history` — history cap enforced on v2 load

### Unit tests (in `state/io.rs`):
- `write_creates_file_and_backup_symlink`
- `read_with_fallback_returns_primary`
- `read_with_fallback_returns_none_when_both_missing`
- `read_with_fallback_uses_prev_when_primary_empty`
- `read_with_fallback_uses_prev_when_primary_unreadable`
- `write_creates_parent_directories`
- `multiple_writes_keep_only_one_prev`
- `crash_after_tmp_write_leaves_original_intact`
- `crash_after_prev_copy_recovers_from_backup`
- `read_primary_returns_none_when_missing`
- `read_backup_returns_content_from_prev`

### Unit tests (in `state/persistence.rs`):
- `save_and_load_round_trip`
- `load_all_returns_none_when_no_index`
- `corrupt_runtime_is_skipped_not_fatal`
- `multiple_runtimes_round_trip`
- `remove_runtime_dir_cleans_up`
- `remove_nonexistent_runtime_dir_is_ok`
- `save_runtime_overwrites_with_backup`
- `load_recovers_from_backup_when_primary_corrupt`

### Integration tests (in `tests/v2_serialization.rs`):
- `serialization_writes_v2_runtime_files`
- `serialization_creates_backup_symlink`
- `restart_prefers_v2_over_v1`
- `fallback_to_v1_when_no_v2_state`
- `fresh_start_when_no_state`
- `corrupt_v2_runtime_skipped_not_fatal`

## Tests run

- `cargo build --workspace --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-server` (all 339+ lib + 100+ integration tests) ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

## Limitations / follow-ups

- Scrollback logs still written to v1 cache_dir path (moved in a later step)
- No dirty-flag optimization yet (Step 4)
- No orphan sweep yet (Step 6)

Fixes #719