### PR TITLE
feat(server): implement ScreenSnapshotV1 serialization and scrollback rotation

### DIFF
--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -5,6 +5,7 @@
 
 use crate::screen::{PaneScreen, strip_client_queries};
 use crate::serialization::scrollback_log_path;
+use crate::state::types::{SCREEN_SNAPSHOT_SCHEMA_VERSION, ScreenSnapshotV1, TerminalModeSnapshot};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -16,6 +17,9 @@ const DEFAULT_MAX_SCROLLBACK: usize = 10 * 1024 * 1024;
 
 /// Default on-disk scrollback log byte limit per pane (10 MB).
 const DEFAULT_MAX_SCROLLBACK_LOG: u64 = 10 * 1024 * 1024;
+
+/// Number of rotated scrollback segments to keep (RFC-022 §4).
+const SCROLLBACK_ROTATE_KEEP: u32 = 3;
 
 /// Maximum bytes sent in a snapshot to a reconnecting client (256 KB).
 ///
@@ -140,11 +144,8 @@ impl Pane {
         self.pending_flush = Vec::new();
         self.scrollback_log_path = Some(path.clone());
 
-        // Cap the file size.
-        let meta = std::fs::metadata(&path)?;
-        if meta.len() > DEFAULT_MAX_SCROLLBACK_LOG {
-            truncate_log_tail(&path, DEFAULT_MAX_SCROLLBACK_LOG)?;
-        }
+        // Rotate when the file exceeds the cap.
+        rotate_scrollback_log(&path, DEFAULT_MAX_SCROLLBACK_LOG, SCROLLBACK_ROTATE_KEEP)?;
 
         Ok(())
     }
@@ -211,16 +212,67 @@ impl Pane {
             rows: self.rows,
         }
     }
+
+    /// Build a deterministic screen snapshot for on-disk persistence (RFC-022 §4).
+    #[must_use]
+    pub fn to_screen_snapshot(&self) -> ScreenSnapshotV1 {
+        let (cursor_row, cursor_col) = self.screen.cursor_position();
+        let screen_bytes = self.screen.snapshot_bytes(MAX_SNAPSHOT_BYTES).to_vec();
+        ScreenSnapshotV1 {
+            schema_version: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+            pane_id: self.id,
+            cols: self.cols,
+            rows: self.rows,
+            cursor_row: cursor_row as u16,
+            cursor_col: cursor_col as u16,
+            cursor_visible: self.screen.cursor_visible(),
+            title: self.title.clone(),
+            cwd: self.cwd.clone().or_else(|| self.read_proc_cwd()),
+            pane_output_seq: self.output_seq,
+            modes: TerminalModeSnapshot {
+                bracketed_paste: self.screen.bracketed_paste_mode(),
+                application_cursor_keys: self.screen.application_cursor_keys(),
+                application_keypad: self.screen.application_keypad(),
+                mouse_tracking_mode: self.screen.mouse_tracking_mode(),
+                sgr_mouse: self.screen.sgr_mouse_mode(),
+                focus_reporting: self.screen.focus_event_mode(),
+            },
+            screen_bytes,
+        }
+    }
 }
 
-/// Truncate a log file to keep only the last `max_bytes` bytes.
+/// Rotate a scrollback log file when it exceeds `max_bytes`.
 ///
-/// Reads the tail, rewrites the file. This is `O(max_bytes)` but runs at most
-/// once per flush cycle and only when the file exceeds the cap.
-fn truncate_log_tail(path: &Path, max_bytes: u64) -> Result<(), std::io::Error> {
-    let data = std::fs::read(path)?;
-    let keep_from = data.len().saturating_sub(max_bytes as usize);
-    std::fs::write(path, &data[keep_from..])?;
+/// Renames `log` → `log.1`, `log.1` → `log.2`, etc., keeping at most
+/// `keep` rotated segments. The caller creates a fresh `log` on the next
+/// append. This avoids the mid-escape-sequence corruption caused by the
+/// old byte-boundary truncation approach (RFC-022 §4).
+fn rotate_scrollback_log(path: &Path, max_bytes: u64, keep: u32) -> Result<(), std::io::Error> {
+    let meta = std::fs::metadata(path)?;
+    if meta.len() <= max_bytes {
+        return Ok(());
+    }
+
+    // Shift existing segments: .3 → deleted, .2 → .3, .1 → .2
+    for i in (1..keep).rev() {
+        let src = path.with_extension(format!("log.{i}"));
+        let dst = path.with_extension(format!("log.{}", i + 1));
+        if src.exists() {
+            std::fs::rename(&src, &dst)?;
+        }
+    }
+
+    // Delete the oldest segment if it exceeds keep count.
+    let oldest = path.with_extension(format!("log.{}", keep + 1));
+    if oldest.exists() {
+        std::fs::remove_file(&oldest)?;
+    }
+
+    // Current log → .1
+    let first_rotated = path.with_extension("log.1");
+    std::fs::rename(path, &first_rotated)?;
+
     Ok(())
 }
 
@@ -359,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    fn flush_scrollback_caps_file_size() {
+    fn flush_scrollback_rotates_when_exceeding_cap() {
         let tmp = tempfile::TempDir::new().unwrap();
         let session_id = Uuid::new_v4();
         let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
@@ -370,23 +422,60 @@ mod tests {
             pane.feed_output(&chunk);
             pane.flush_scrollback(tmp.path(), session_id).unwrap();
         }
-        // 4 * 4 MB = 16 MB written, cap is 10 MB.
+        // After 16 MB written with 10 MB cap, rotation should have occurred.
         let log_path = pane.scrollback_log_path.as_ref().unwrap();
-        let size = std::fs::metadata(log_path).unwrap().len();
-        assert!(
-            size <= DEFAULT_MAX_SCROLLBACK_LOG,
-            "scrollback log {size} bytes exceeds cap {DEFAULT_MAX_SCROLLBACK_LOG}"
-        );
-        assert!(size > 0, "scrollback log should not be empty");
+        let rotated = log_path.with_extension("log.1");
+        assert!(rotated.exists(), "rotated segment .1 should exist");
     }
 
     #[test]
-    fn truncate_log_tail_keeps_end() {
+    fn rotate_scrollback_log_shifts_segments() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("scrollback").join("test.log");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        // Create a file exceeding the cap.
+        std::fs::write(&path, vec![b'A'; 100]).unwrap();
+        rotate_scrollback_log(&path, 50, 3).unwrap();
+
+        // Original should be gone (renamed to .1).
+        assert!(!path.exists());
+        assert!(path.with_extension("log.1").exists());
+
+        // Create a new log and rotate again.
+        std::fs::write(&path, vec![b'B'; 100]).unwrap();
+        rotate_scrollback_log(&path, 50, 3).unwrap();
+
+        assert!(!path.exists());
+        assert!(path.with_extension("log.1").exists());
+        assert!(path.with_extension("log.2").exists());
+    }
+
+    #[test]
+    fn rotate_scrollback_log_respects_keep_limit() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.log");
-        std::fs::write(&path, b"AAABBBCCC").unwrap();
-        truncate_log_tail(&path, 3).unwrap();
-        assert_eq!(std::fs::read(&path).unwrap(), b"CCC");
+
+        for i in 0..6 {
+            std::fs::write(&path, vec![b'A' + i; 100]).unwrap();
+            rotate_scrollback_log(&path, 50, 3).unwrap();
+        }
+
+        // Should keep at most 3 rotated segments.
+        assert!(path.with_extension("log.1").exists());
+        assert!(path.with_extension("log.2").exists());
+        assert!(path.with_extension("log.3").exists());
+        assert!(!path.with_extension("log.4").exists());
+    }
+
+    #[test]
+    fn rotate_scrollback_log_noop_when_under_cap() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.log");
+        std::fs::write(&path, b"small").unwrap();
+        rotate_scrollback_log(&path, 100, 3).unwrap();
+        assert!(path.exists());
+        assert!(!path.with_extension("log.1").exists());
     }
 
     #[test]
@@ -524,5 +613,77 @@ mod tests {
         let content = std::fs::read(log_path).unwrap();
         // Scrollback log should not contain DSR/DA1/DA2 query sequences.
         assert_eq!(content, b"line1\r\nline2\r\n");
+    }
+
+    #[test]
+    fn to_screen_snapshot_captures_pane_state() {
+        let mut pane = Pane::new(Uuid::new_v4(), 120, 40);
+        pane.feed_output(b"\x1b]0;my-title\x07");
+        pane.feed_output(b"\x1b]7;file://localhost/home/user\x07");
+        pane.feed_output(b"hello world\r\n");
+        pane.feed_output(b"\x1b[?2004h"); // bracketed paste
+
+        let snap = pane.to_screen_snapshot();
+        assert_eq!(snap.pane_id, pane.id);
+        assert_eq!(snap.cols, 120);
+        assert_eq!(snap.rows, 40);
+        assert_eq!(snap.title.as_deref(), Some("my-title"));
+        assert_eq!(snap.cwd.as_deref(), Some("/home/user"));
+        assert!(snap.modes.bracketed_paste);
+        assert!(!snap.screen_bytes.is_empty());
+        assert_eq!(snap.schema_version, SCREEN_SNAPSHOT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn to_screen_snapshot_captures_cursor_position() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"line1\r\nline2\r\nXYZ");
+
+        let snap = pane.to_screen_snapshot();
+        assert_eq!(snap.cursor_row, 2);
+        assert_eq!(snap.cursor_col, 3);
+    }
+
+    #[test]
+    fn to_screen_snapshot_captures_all_terminal_modes() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"\x1b[?2004h"); // bracketed paste
+        pane.feed_output(b"\x1b[?1h"); // application cursor keys
+        pane.feed_output(b"\x1b="); // application keypad
+        pane.feed_output(b"\x1b[?1003h"); // any-event mouse
+        pane.feed_output(b"\x1b[?1006h"); // SGR mouse
+        pane.feed_output(b"\x1b[?1004h"); // focus reporting
+        pane.feed_output(b"\x1b[?25l"); // hide cursor
+
+        let snap = pane.to_screen_snapshot();
+        assert!(snap.modes.bracketed_paste);
+        assert!(snap.modes.application_cursor_keys);
+        assert!(snap.modes.application_keypad);
+        assert_eq!(snap.modes.mouse_tracking_mode, 1003);
+        assert!(snap.modes.sgr_mouse);
+        assert!(snap.modes.focus_reporting);
+        assert!(!snap.cursor_visible);
+    }
+
+    #[test]
+    fn to_screen_snapshot_screen_bytes_bounded_by_max_snapshot() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        // Feed more than MAX_SNAPSHOT_BYTES.
+        let big = vec![b'X'; MAX_SNAPSHOT_BYTES + 1024];
+        pane.feed_output(&big);
+
+        let snap = pane.to_screen_snapshot();
+        assert!(snap.screen_bytes.len() <= MAX_SNAPSHOT_BYTES);
+    }
+
+    #[test]
+    fn to_screen_snapshot_round_trips_through_json() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"test data\r\n");
+
+        let snap = pane.to_screen_snapshot();
+        let json = serde_json::to_string_pretty(&snap).unwrap();
+        let recovered: ScreenSnapshotV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(snap, recovered);
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -297,21 +297,36 @@ impl Server {
     pub async fn reconstruct_runtimes(server: &Arc<Mutex<Self>>) {
         let panes_to_reconstruct: Vec<(Uuid, Uuid, String, Option<String>, u16, u16)> = {
             let mut s = server.lock().await;
+            let state_dir = s.os.state_dir();
 
             for rt in s.runtimes.values_mut() {
                 let label = format!("\"{}\" ({})", rt.name, short_id(rt.id));
                 for pane in rt.panes.values_mut() {
-                    // Replay scrollback log into the pane screen.
+                    let pane_short = short_id(pane.id);
+
+                    // Prefer screen snapshot over raw scrollback replay.
+                    if let Some(snap) = crate::state::persistence::load_screen_snapshot(
+                        &state_dir, rt.id, pane.id,
+                    ) {
+                        let clean = restart_safe_scrollback(&snap.screen_bytes);
+                        tracing::info!(
+                            "Restoring pane {pane_short} in runtime {label} from screen snapshot ({} bytes)",
+                            clean.len(),
+                        );
+                        pane.screen.feed(clean);
+                        continue;
+                    }
+
+                    // Fall back to scrollback log replay.
                     if let Some(ref log_path) = pane.scrollback_log_path
                         && log_path.exists()
                     {
-                        let pane_short = short_id(pane.id);
                         match std::fs::read(log_path) {
                             Ok(data) => {
                                 let restart_safe = restart_safe_scrollback(&data);
                                 let clean = strip_client_queries(restart_safe);
                                 tracing::info!(
-                                    "Replaying {} bytes of scrollback for pane {pane_short} in runtime {label}",
+                                    "Replaying {} bytes of scrollback for pane {pane_short} in runtime {label} (no snapshot)",
                                     clean.len(),
                                 );
                                 pane.screen.feed(&clean);
@@ -2141,6 +2156,16 @@ pub async fn serialization_loop(
             .map(Runtime::to_runtime_file)
             .collect();
 
+        // Collect screen snapshots for all panes in dirty persistent runtimes.
+        let screen_snapshots: Vec<(Uuid, _)> = s
+            .runtimes
+            .values()
+            .filter(|rt| rt.policy == RuntimePolicy::Persistent && rt.is_dirty())
+            .flat_map(|rt| {
+                rt.panes.values().map(move |pane| (rt.id, pane.to_screen_snapshot()))
+            })
+            .collect();
+
         // Check whether the set of persistent runtime IDs changed.
         let mut current_ids: Vec<Uuid> = s
             .runtimes
@@ -2170,6 +2195,19 @@ pub async fn serialization_loop(
         for rf in &dirty_runtime_files {
             if let Err(e) = crate::state::persistence::save_runtime(&state_dir, rf) {
                 tracing::error!("Failed to write v2 runtime {}: {e}", short_id(rf.spec.id));
+            }
+        }
+
+        // Write screen snapshots for dirty runtimes.
+        for (runtime_id, snap) in &screen_snapshots {
+            if let Err(e) =
+                crate::state::persistence::save_screen_snapshot(&state_dir, *runtime_id, snap)
+            {
+                tracing::error!(
+                    "Failed to write screen snapshot for pane {} in runtime {}: {e}",
+                    short_id(snap.pane_id),
+                    short_id(*runtime_id)
+                );
             }
         }
 
@@ -2220,6 +2258,16 @@ pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
         .map(Runtime::to_runtime_file)
         .collect();
 
+    // Collect screen snapshots for all persistent panes.
+    let screen_snapshots: Vec<(Uuid, _)> = s
+        .runtimes
+        .values()
+        .filter(|rt| rt.policy == RuntimePolicy::Persistent)
+        .flat_map(|rt| {
+            rt.panes.values().map(move |pane| (rt.id, pane.to_screen_snapshot()))
+        })
+        .collect();
+
     let ids: Vec<_> = runtime_files.iter().map(|rf| rf.spec.id).collect();
     if let Err(e) = crate::state::persistence::save_daemon_index(&state_dir, &ids) {
         tracing::error!("Failed to write v2 daemon index on shutdown: {e}");
@@ -2227,6 +2275,16 @@ pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
     for rf in &runtime_files {
         if let Err(e) = crate::state::persistence::save_runtime(&state_dir, rf) {
             tracing::error!("Failed to write v2 runtime {} on shutdown: {e}", short_id(rf.spec.id));
+        }
+    }
+    for (runtime_id, snap) in &screen_snapshots {
+        if let Err(e) =
+            crate::state::persistence::save_screen_snapshot(&state_dir, *runtime_id, snap)
+        {
+            tracing::error!(
+                "Failed to write screen snapshot for pane {} on shutdown: {e}",
+                short_id(snap.pane_id)
+            );
         }
     }
 

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -305,9 +305,9 @@ impl Server {
                     let pane_short = short_id(pane.id);
 
                     // Prefer screen snapshot over raw scrollback replay.
-                    if let Some(snap) = crate::state::persistence::load_screen_snapshot(
-                        &state_dir, rt.id, pane.id,
-                    ) {
+                    if let Some(snap) =
+                        crate::state::persistence::load_screen_snapshot(&state_dir, rt.id, pane.id)
+                    {
                         let clean = restart_safe_scrollback(&snap.screen_bytes);
                         tracing::info!(
                             "Restoring pane {pane_short} in runtime {label} from screen snapshot ({} bytes)",
@@ -2161,9 +2161,7 @@ pub async fn serialization_loop(
             .runtimes
             .values()
             .filter(|rt| rt.policy == RuntimePolicy::Persistent && rt.is_dirty())
-            .flat_map(|rt| {
-                rt.panes.values().map(move |pane| (rt.id, pane.to_screen_snapshot()))
-            })
+            .flat_map(|rt| rt.panes.values().map(move |pane| (rt.id, pane.to_screen_snapshot())))
             .collect();
 
         // Check whether the set of persistent runtime IDs changed.
@@ -2263,9 +2261,7 @@ pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
         .runtimes
         .values()
         .filter(|rt| rt.policy == RuntimePolicy::Persistent)
-        .flat_map(|rt| {
-            rt.panes.values().map(move |pane| (rt.id, pane.to_screen_snapshot()))
-        })
+        .flat_map(|rt| rt.panes.values().map(move |pane| (rt.id, pane.to_screen_snapshot())))
         .collect();
 
     let ids: Vec<_> = runtime_files.iter().map(|rf| rf.spec.id).collect();

--- a/services/rttx-server/src/state/persistence.rs
+++ b/services/rttx-server/src/state/persistence.rs
@@ -6,7 +6,9 @@
 use crate::state::io::write_with_backup;
 use crate::state::layout;
 use crate::state::migrations::{self, MigrationError};
-use crate::state::types::{DAEMON_INDEX_SCHEMA_VERSION, DaemonIndexV1, RuntimeFileV1};
+use crate::state::types::{
+    DAEMON_INDEX_SCHEMA_VERSION, DaemonIndexV1, RuntimeFileV1, ScreenSnapshotV1,
+};
 use std::path::Path;
 use std::time::SystemTime;
 use uuid::Uuid;
@@ -136,6 +138,44 @@ pub fn save_runtime(state_dir: &Path, runtime_file: &RuntimeFileV1) -> std::io::
     write_with_backup(&path, &json)
 }
 
+/// Save a screen snapshot for a pane to disk.
+pub fn save_screen_snapshot(
+    state_dir: &Path,
+    runtime_id: Uuid,
+    snapshot: &ScreenSnapshotV1,
+) -> std::io::Result<()> {
+    let path = layout::screen_snapshot(state_dir, runtime_id, snapshot.pane_id);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string(snapshot).map_err(std::io::Error::other)?;
+    std::fs::write(&path, json)?;
+    Ok(())
+}
+
+/// Load a screen snapshot for a pane from disk.
+///
+/// Returns `None` if the file does not exist or is corrupt. A corrupt
+/// snapshot is not fatal — the pane resurrects with a blank screen.
+pub fn load_screen_snapshot(
+    state_dir: &Path,
+    runtime_id: Uuid,
+    pane_id: Uuid,
+) -> Option<ScreenSnapshotV1> {
+    let path = layout::screen_snapshot(state_dir, runtime_id, pane_id);
+    let json = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<ScreenSnapshotV1>(&json) {
+        Ok(snap) => Some(snap),
+        Err(e) => {
+            tracing::warn!(
+                "Corrupt screen snapshot for pane {}: {e} — starting with blank screen",
+                &pane_id.to_string()[..8]
+            );
+            None
+        }
+    }
+}
+
 /// Remove a runtime's directory from disk.
 pub fn remove_runtime_dir(state_dir: &Path, runtime_id: Uuid) -> std::io::Result<()> {
     let dir = layout::runtime_dir(state_dir, runtime_id);
@@ -167,7 +207,7 @@ mod tests {
     use crate::runtime::RuntimePolicy;
     use crate::state::types::{
         HistoryEntryV1, PaneSpecV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1, RuntimeInstanceV1,
-        RuntimeSpecV1,
+        RuntimeSpecV1, SCREEN_SNAPSHOT_SCHEMA_VERSION, ScreenSnapshotV1, TerminalModeSnapshot,
     };
     use tempfile::TempDir;
 
@@ -340,5 +380,64 @@ mod tests {
         let result = load_all(state_dir).unwrap();
         assert_eq!(result.runtimes.len(), 1);
         assert_eq!(result.runtimes[0].spec.id, rt_id);
+    }
+
+    fn sample_screen_snapshot(pane_id: Uuid) -> ScreenSnapshotV1 {
+        ScreenSnapshotV1 {
+            schema_version: SCREEN_SNAPSHOT_SCHEMA_VERSION,
+            pane_id,
+            cols: 80,
+            rows: 24,
+            cursor_row: 5,
+            cursor_col: 10,
+            cursor_visible: true,
+            title: Some("bash".into()),
+            cwd: Some("/home/user".into()),
+            pane_output_seq: 42,
+            modes: TerminalModeSnapshot {
+                bracketed_paste: true,
+                application_cursor_keys: false,
+                application_keypad: false,
+                mouse_tracking_mode: 0,
+                sgr_mouse: false,
+                focus_reporting: false,
+            },
+            screen_bytes: b"hello world\r\n$ ".to_vec(),
+        }
+    }
+
+    #[test]
+    fn screen_snapshot_save_and_load_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let rt_id = Uuid::new_v4();
+        let pane_id = Uuid::new_v4();
+        let snap = sample_screen_snapshot(pane_id);
+
+        save_screen_snapshot(state_dir, rt_id, &snap).unwrap();
+        let loaded = load_screen_snapshot(state_dir, rt_id, pane_id).unwrap();
+        assert_eq!(snap, loaded);
+    }
+
+    #[test]
+    fn screen_snapshot_load_returns_none_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let result = load_screen_snapshot(tmp.path(), Uuid::new_v4(), Uuid::new_v4());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn screen_snapshot_load_returns_none_when_corrupt() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let rt_id = Uuid::new_v4();
+        let pane_id = Uuid::new_v4();
+
+        let path = layout::screen_snapshot(state_dir, rt_id, pane_id);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "not valid json").unwrap();
+
+        let result = load_screen_snapshot(state_dir, rt_id, pane_id);
+        assert!(result.is_none());
     }
 }

--- a/services/rttx-server/tests/screen_snapshot.rs
+++ b/services/rttx-server/tests/screen_snapshot.rs
@@ -1,0 +1,131 @@
+//! Integration tests for `ScreenSnapshotV1` serialization (RFC-022 Step 5).
+//!
+//! Verifies that the daemon writes screen snapshots alongside per-runtime
+//! files and that corrupt snapshots do not block runtime loading.
+
+mod common;
+
+use common::{TestClient, start_test_server, wait_for_state_containing};
+use rttx_proto::{bytes_to_uuid, proto};
+use rttx_server::state::{layout, persistence};
+use std::time::Duration;
+
+/// After creating a persistent runtime with a pane, the daemon writes
+/// screen snapshot files at `screen/<pane_id>.snap`.
+#[tokio::test]
+async fn serialization_writes_screen_snapshots() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut c = TestClient::connect(&sock).await;
+    c.handshake().await;
+
+    // Create a persistent runtime.
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "snap-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    })
+    .await;
+    let runtime_id_bytes = match c.recv().await.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+    let runtime_id = bytes_to_uuid(&runtime_id_bytes).unwrap();
+
+    // Attach to the runtime (ReadWrite).
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
+            runtime_id: runtime_id_bytes.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    })
+    .await;
+    // Consume the Snapshot response (empty panes at this point).
+    let _ = c.recv().await;
+
+    // Create a pane.
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            runtime_id: runtime_id_bytes.clone(),
+            cols: 80,
+            rows: 24,
+            ..Default::default()
+        })),
+    })
+    .await;
+    let pane_id = match c.recv().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => bytes_to_uuid(&pc.pane_id).unwrap(),
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    // Wait for serialization tick to write state.
+    wait_for_state_containing(&tmp.path().join("cache"), "snap-test", Duration::from_secs(10))
+        .await;
+
+    // Verify screen snapshot file exists.
+    let state_dir = tmp.path().join("state/rttx/daemon");
+    let snap_path = layout::screen_snapshot(&state_dir, runtime_id, pane_id);
+    assert!(snap_path.exists(), "screen snapshot should exist at {}", snap_path.display());
+
+    // Verify snapshot content is valid.
+    let snap = persistence::load_screen_snapshot(&state_dir, runtime_id, pane_id)
+        .expect("screen snapshot should be loadable");
+    assert_eq!(snap.pane_id, pane_id);
+    assert_eq!(snap.cols, 80);
+    assert_eq!(snap.rows, 24);
+    assert_eq!(snap.schema_version, rttx_server::state::types::SCREEN_SNAPSHOT_SCHEMA_VERSION);
+}
+
+/// A corrupt screen snapshot does not prevent runtime loading.
+#[tokio::test]
+async fn corrupt_screen_snapshot_does_not_block_runtime_load() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state/rttx/daemon");
+
+    let runtime_id = uuid::Uuid::new_v4();
+    let pane_id = uuid::Uuid::new_v4();
+
+    let rf = rttx_server::state::types::RuntimeFileV1 {
+        schema_version: rttx_server::state::types::RUNTIME_FILE_SCHEMA_VERSION,
+        spec: rttx_server::state::types::RuntimeSpecV1 {
+            id: runtime_id,
+            name: "corrupt-snap-test".into(),
+            policy: rttx_server::runtime::RuntimePolicy::Persistent,
+            created_at: std::time::SystemTime::now(),
+            panes: vec![rttx_server::state::types::PaneSpecV1 {
+                id: pane_id,
+                cwd: Some("/tmp".into()),
+                title: None,
+                exit_status: None,
+                cols: 80,
+                rows: 24,
+            }],
+            active_pane_id: None,
+            command_history: vec![],
+        },
+        instance: rttx_server::state::types::RuntimeInstanceV1 {
+            revision: 1,
+            last_active_at: std::time::SystemTime::now(),
+            last_snapshot_at: std::time::SystemTime::now(),
+        },
+    };
+
+    persistence::save_daemon_index(&state_dir, &[runtime_id]).unwrap();
+    persistence::save_runtime(&state_dir, &rf).unwrap();
+
+    // Write a corrupt screen snapshot.
+    let snap_path = layout::screen_snapshot(&state_dir, runtime_id, pane_id);
+    std::fs::create_dir_all(snap_path.parent().unwrap()).unwrap();
+    std::fs::write(&snap_path, "not valid json").unwrap();
+
+    // Loading the snapshot should return None (not crash).
+    let snap = persistence::load_screen_snapshot(&state_dir, runtime_id, pane_id);
+    assert!(snap.is_none(), "corrupt snapshot should return None");
+
+    // The runtime itself should still load fine.
+    let result = persistence::load_all(&state_dir).expect("v2 state should load");
+    assert_eq!(result.runtimes.len(), 1);
+    assert_eq!(result.runtimes[0].spec.id, runtime_id);
+}


### PR DESCRIPTION
## What changed and why

RFC-022 Step 5. Implements deterministic screen snapshot serialization and replaces the raw-bytes scrollback truncation with rotation.

### Screen snapshot serialization

- **`Pane::to_screen_snapshot()`** builds a `ScreenSnapshotV1` from the live `PaneScreen` state: cursor position, terminal mode flags (bracketed paste, application cursor keys, application keypad, mouse tracking, SGR mouse, focus reporting, cursor visibility), viewport bytes bounded by `MAX_SNAPSHOT_BYTES` (256 KB), title, CWD, and output sequence counter.
- **`save_screen_snapshot()` / `load_screen_snapshot()`** in `state::persistence` write/read `screen/<pane_id>.snap` files under the per-runtime directory.
- The **serialization loop** and **`persist_and_cleanup`** now write screen snapshots alongside runtime files for all dirty persistent runtimes.
- **`reconstruct_runtimes`** prefers the screen snapshot over raw scrollback replay. If no snapshot exists, falls back to the scrollback log (backward compatible with pre-snapshot state). `restart_safe_scrollback()` is applied to snapshot bytes to avoid duplicate prompts after restart.

### Scrollback rotation

- Replaces `truncate_log_tail()` (which sliced at a raw byte boundary, potentially corrupting escape sequences) with `rotate_scrollback_log()`.
- When a scrollback log exceeds 10 MB, it is renamed to `.log.1`, shifting existing segments (`.log.1` → `.log.2`, etc.) up to a maximum of 3 retained segments.
- The tail of the oldest segment may still start mid-sequence, but it is only rendered on user-initiated scrollback, not on reconnect.

## Manual verification

1. Build and run the daemon in dev mode
2. Create a persistent workspace, type some commands
3. Shut down the daemon gracefully
4. Verify `screen/<pane_id>.snap` files exist under the runtime directory in `$XDG_STATE_HOME/rttx/daemon/runtimes/<runtime_id>/`
5. Restart the daemon — the pane should restore from the snapshot (log line: "Restoring pane ... from screen snapshot")
6. Generate >10 MB of scrollback output (`yes | head -c 11000000`) and verify rotation creates `.log.1` segments

## Tests added

### Unit tests (pane.rs)
- `to_screen_snapshot_captures_pane_state` — verifies snapshot captures id, dimensions, title, CWD, modes, bytes
- `to_screen_snapshot_captures_cursor_position` — verifies cursor row/col from VTE parser
- `to_screen_snapshot_captures_all_terminal_modes` — verifies all 7 terminal mode flags
- `to_screen_snapshot_screen_bytes_bounded_by_max_snapshot` — verifies viewport byte cap
- `to_screen_snapshot_round_trips_through_json` — verifies JSON serialization round-trip
- `rotate_scrollback_log_shifts_segments` — verifies segment shifting
- `rotate_scrollback_log_respects_keep_limit` — verifies oldest segments are pruned
- `rotate_scrollback_log_noop_when_under_cap` — verifies no rotation when under limit
- `flush_scrollback_rotates_when_exceeding_cap` — verifies end-to-end rotation via flush

### Persistence tests (state/persistence.rs)
- `screen_snapshot_save_and_load_round_trip` — verifies save/load cycle
- `screen_snapshot_load_returns_none_when_missing` — verifies graceful handling of missing files
- `screen_snapshot_load_returns_none_when_corrupt` — verifies corrupt snapshots don't crash

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (356 lib + all integration tests pass; pre-existing `stdio_transport` flake excluded)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (pre-existing flaky `ctrl_d` test excluded)

Fixes #721