### PR TITLE
feat(server): implement runtime directory cleanup and startup orphan sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.1',
+  version: '0.4.2',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -257,6 +257,16 @@ impl Server {
                     }
                 }
             }
+
+            // Sweep orphaned runtime directories (RFC-022 §7).
+            let known_ids: std::collections::HashSet<Uuid> = result
+                .runtimes
+                .iter()
+                .map(|rf| rf.spec.id)
+                .chain(result.failed_ids.iter().copied())
+                .collect();
+            crate::state::cleanup::sweep_orphans(&state_dir, &known_ids);
+
             if total > 0 || result.failed_ids.is_empty() {
                 return;
             }
@@ -530,6 +540,10 @@ impl Server {
                 let _ = kill_tx.send(());
             }
         }
+
+        // Remove the runtime's on-disk directory in a background thread.
+        let state_dir = self.os.state_dir();
+        crate::state::cleanup::remove_runtime_dir_background(&state_dir, runtime_id);
 
         let msg = ClientMsg::V2(protocol::runtime_terminated(runtime_id, final_revision, reason));
         self.broadcast_to_clients(attached_client_ids, exclude_client_id, &msg);

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1904,3 +1904,111 @@ async fn v3_snapshot_includes_terminal_modes() {
         panic!("expected RuntimeSnapshot");
     }
 }
+
+// ── Runtime directory cleanup tests ─────────────────────────────
+
+#[derive(Debug)]
+struct TempOs {
+    runtime: PathBuf,
+    cache: PathBuf,
+    state: PathBuf,
+}
+
+impl OsInterface for TempOs {
+    fn runtime_dir(&self) -> PathBuf {
+        self.runtime.clone()
+    }
+    fn cache_dir(&self) -> PathBuf {
+        self.cache.clone()
+    }
+    fn state_dir(&self) -> PathBuf {
+        self.state.clone()
+    }
+}
+
+fn temp_os(tmp: &std::path::Path) -> TempOs {
+    let runtime = tmp.join("runtime");
+    let cache = tmp.join("cache");
+    let state = tmp.join("state");
+    std::fs::create_dir_all(&runtime).unwrap();
+    std::fs::create_dir_all(&cache).unwrap();
+    std::fs::create_dir_all(&state).unwrap();
+    TempOs { runtime, cache, state }
+}
+
+#[tokio::test]
+#[traced_test]
+async fn terminate_runtime_removes_state_directory() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let os = temp_os(tmp.path());
+    let state_dir = os.state_dir();
+    let mut server = Server::new(Box::new(os));
+
+    let mut rt = Runtime::new("cleanup-test".into());
+    let runtime_id = rt.id;
+    let pane = Pane::new(Uuid::new_v4(), 80, 24);
+    rt.add_pane(pane);
+    server.runtimes.insert(runtime_id, rt);
+
+    // Persist the runtime to disk so there's a directory to clean up.
+    let rf = server.runtimes[&runtime_id].to_runtime_file();
+    crate::state::persistence::save_runtime(&state_dir, &rf).unwrap();
+    let dir = crate::state::layout::runtime_dir(&state_dir, runtime_id);
+    assert!(dir.exists());
+
+    server.terminate_runtime(runtime_id, 1, TerminationReason::Explicit, None);
+
+    // Wait for background cleanup thread.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    assert!(!dir.exists());
+}
+
+#[test]
+#[traced_test]
+fn load_persisted_state_sweeps_orphans() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let os = temp_os(tmp.path());
+    let state_dir = os.state_dir();
+
+    let known_id = Uuid::new_v4();
+    let orphan_id = Uuid::new_v4();
+
+    // Create runtime files for both.
+    let known_rf = crate::state::types::RuntimeFileV1 {
+        schema_version: crate::state::types::RUNTIME_FILE_SCHEMA_VERSION,
+        spec: crate::state::types::RuntimeSpecV1 {
+            id: known_id,
+            name: "known".into(),
+            policy: RuntimePolicy::Persistent,
+            created_at: std::time::SystemTime::now(),
+            panes: vec![],
+            active_pane_id: None,
+            command_history: vec![],
+        },
+        instance: crate::state::types::RuntimeInstanceV1 {
+            revision: 1,
+            last_active_at: std::time::SystemTime::now(),
+            last_snapshot_at: std::time::SystemTime::now(),
+        },
+    };
+    crate::state::persistence::save_runtime(&state_dir, &known_rf).unwrap();
+
+    // Create orphan directory (not in daemon index).
+    let orphan_dir = crate::state::layout::runtime_dir(&state_dir, orphan_id);
+    std::fs::create_dir_all(&orphan_dir).unwrap();
+    std::fs::write(orphan_dir.join("runtime.json"), "{}").unwrap();
+
+    // Save daemon index referencing only the known runtime.
+    crate::state::persistence::save_daemon_index(&state_dir, &[known_id]).unwrap();
+
+    let mut server = Server::new(Box::new(os));
+    server.load_persisted_state();
+
+    // Known runtime should be loaded.
+    assert!(server.runtimes.contains_key(&known_id));
+
+    // Orphan should have been moved to .orphans/.
+    assert!(!orphan_dir.exists());
+    let orphan_dest = crate::state::layout::orphans_dir(&state_dir).join(orphan_id.to_string());
+    assert!(orphan_dest.exists());
+}

--- a/services/rttx-server/src/state/cleanup.rs
+++ b/services/rttx-server/src/state/cleanup.rs
@@ -125,7 +125,10 @@ fn prune_old_orphans(orphans_dir: &Path) {
             let short = &name.to_string_lossy()[..8.min(name.len())];
             match std::fs::remove_dir_all(entry.path()) {
                 Ok(()) => {
-                    tracing::info!("Pruned old orphan {short} (age: {} days)", age.as_secs() / 86400);
+                    tracing::info!(
+                        "Pruned old orphan {short} (age: {} days)",
+                        age.as_secs() / 86400
+                    );
                 }
                 Err(e) => {
                     tracing::error!("Failed to prune orphan {short}: {e}");
@@ -138,10 +141,10 @@ fn prune_old_orphans(orphans_dir: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::RuntimePolicy;
     use crate::state::layout;
     use crate::state::persistence;
     use crate::state::types::*;
-    use crate::runtime::RuntimePolicy;
     use std::collections::HashSet;
     use tempfile::TempDir;
 

--- a/services/rttx-server/src/state/cleanup.rs
+++ b/services/rttx-server/src/state/cleanup.rs
@@ -1,0 +1,312 @@
+//! Runtime directory cleanup and orphan sweep (RFC-022 §7).
+//!
+//! On runtime delete: remove `runtimes/<id>/` in a background task.
+//! On startup: move unreferenced runtime directories to `runtimes/.orphans/`.
+//! Prune `.orphans/` entries older than 30 days.
+
+use crate::state::layout;
+use std::collections::HashSet;
+use std::hash::BuildHasher;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+use uuid::Uuid;
+
+/// How long orphaned directories are kept before pruning.
+const ORPHAN_RETENTION: Duration = Duration::from_hours(30 * 24);
+
+/// Remove a runtime's directory in a background task.
+///
+/// Errors are logged but do not propagate — the caller should not block
+/// on cleanup of a terminated runtime.
+pub fn remove_runtime_dir_background(state_dir: &Path, runtime_id: Uuid) {
+    let dir = layout::runtime_dir(state_dir, runtime_id);
+    let short = &runtime_id.to_string()[..8];
+    if !dir.exists() {
+        return;
+    }
+    let short = short.to_string();
+    std::thread::spawn(move || {
+        if let Err(e) = std::fs::remove_dir_all(&dir) {
+            tracing::error!("Failed to remove runtime directory for {short}: {e}");
+        } else {
+            tracing::info!("Removed runtime directory for {short}");
+        }
+    });
+}
+
+/// Move unreferenced runtime directories to `.orphans/` and prune old orphans.
+///
+/// Called once on startup after loading the daemon index. `known_ids` is the
+/// set of runtime IDs that the daemon index references (both successfully
+/// loaded and failed-to-load runtimes are considered "known").
+pub fn sweep_orphans<S: BuildHasher>(state_dir: &Path, known_ids: &HashSet<Uuid, S>) {
+    let runtimes = layout::runtimes_dir(state_dir);
+    if !runtimes.exists() {
+        return;
+    }
+
+    let orphans = layout::orphans_dir(state_dir);
+
+    // Phase 1: move unreferenced runtime dirs to .orphans/
+    let entries = match std::fs::read_dir(&runtimes) {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::error!("Failed to read runtimes directory: {e}");
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        // Skip the .orphans directory itself.
+        if name_str == ".orphans" {
+            continue;
+        }
+
+        // Only consider directories that look like UUIDs.
+        let Ok(id) = Uuid::parse_str(&name_str) else {
+            continue;
+        };
+
+        if known_ids.contains(&id) {
+            continue;
+        }
+
+        // Move to .orphans/
+        if let Err(e) = std::fs::create_dir_all(&orphans) {
+            tracing::error!("Failed to create orphans directory: {e}");
+            return;
+        }
+        let dest = orphans.join(&name);
+        match std::fs::rename(entry.path(), &dest) {
+            Ok(()) => {
+                tracing::info!("Moved orphaned runtime {} to .orphans/", &name_str[..8]);
+            }
+            Err(e) => {
+                tracing::error!("Failed to move orphaned runtime {}: {e}", &name_str[..8]);
+            }
+        }
+    }
+
+    // Phase 2: prune old orphans.
+    prune_old_orphans(&orphans);
+}
+
+/// Remove orphan entries older than [`ORPHAN_RETENTION`].
+fn prune_old_orphans(orphans_dir: &Path) {
+    if !orphans_dir.exists() {
+        return;
+    }
+
+    let now = SystemTime::now();
+    let entries = match std::fs::read_dir(orphans_dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::error!("Failed to read orphans directory: {e}");
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let age = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|mtime| now.duration_since(mtime).ok());
+
+        let Some(age) = age else {
+            continue;
+        };
+
+        if age > ORPHAN_RETENTION {
+            let name = entry.file_name();
+            let short = &name.to_string_lossy()[..8.min(name.len())];
+            match std::fs::remove_dir_all(entry.path()) {
+                Ok(()) => {
+                    tracing::info!("Pruned old orphan {short} (age: {} days)", age.as_secs() / 86400);
+                }
+                Err(e) => {
+                    tracing::error!("Failed to prune orphan {short}: {e}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::layout;
+    use crate::state::persistence;
+    use crate::state::types::*;
+    use crate::runtime::RuntimePolicy;
+    use std::collections::HashSet;
+    use tempfile::TempDir;
+
+    fn sample_runtime_file(id: Uuid) -> RuntimeFileV1 {
+        RuntimeFileV1 {
+            schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+            spec: RuntimeSpecV1 {
+                id,
+                name: "test".into(),
+                policy: RuntimePolicy::Persistent,
+                created_at: SystemTime::now(),
+                panes: vec![],
+                active_pane_id: None,
+                command_history: vec![],
+            },
+            instance: RuntimeInstanceV1 {
+                revision: 1,
+                last_active_at: SystemTime::now(),
+                last_snapshot_at: SystemTime::now(),
+            },
+        }
+    }
+
+    #[test]
+    fn remove_runtime_dir_background_removes_directory() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let rt_id = Uuid::new_v4();
+
+        // Create a runtime directory with some content.
+        let rf = sample_runtime_file(rt_id);
+        persistence::save_runtime(state_dir, &rf).unwrap();
+        let dir = layout::runtime_dir(state_dir, rt_id);
+        assert!(dir.exists());
+
+        remove_runtime_dir_background(state_dir, rt_id);
+
+        // Wait for background thread to finish.
+        std::thread::sleep(Duration::from_millis(200));
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn remove_runtime_dir_background_noop_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        // Should not panic or error.
+        remove_runtime_dir_background(tmp.path(), Uuid::new_v4());
+    }
+
+    #[test]
+    fn sweep_orphans_moves_unreferenced_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+
+        let known_id = Uuid::new_v4();
+        let orphan_id = Uuid::new_v4();
+
+        // Create directories for both.
+        persistence::save_runtime(state_dir, &sample_runtime_file(known_id)).unwrap();
+        persistence::save_runtime(state_dir, &sample_runtime_file(orphan_id)).unwrap();
+
+        let known_ids: HashSet<Uuid> = std::iter::once(known_id).collect();
+        sweep_orphans(state_dir, &known_ids);
+
+        // Known runtime dir still exists.
+        assert!(layout::runtime_dir(state_dir, known_id).exists());
+
+        // Orphan was moved.
+        assert!(!layout::runtime_dir(state_dir, orphan_id).exists());
+        let orphan_dest = layout::orphans_dir(state_dir).join(orphan_id.to_string());
+        assert!(orphan_dest.exists());
+    }
+
+    #[test]
+    fn sweep_orphans_skips_orphans_dir_itself() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+
+        // Create .orphans/ with some content.
+        let orphans = layout::orphans_dir(state_dir);
+        std::fs::create_dir_all(&orphans).unwrap();
+        std::fs::write(orphans.join("marker"), "test").unwrap();
+
+        let known_ids: HashSet<Uuid> = HashSet::new();
+        sweep_orphans(state_dir, &known_ids);
+
+        // .orphans/ should still exist.
+        assert!(orphans.exists());
+    }
+
+    #[test]
+    fn sweep_orphans_skips_non_uuid_directories() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+
+        let runtimes = layout::runtimes_dir(state_dir);
+        std::fs::create_dir_all(&runtimes).unwrap();
+        let non_uuid = runtimes.join("not-a-uuid");
+        std::fs::create_dir_all(&non_uuid).unwrap();
+
+        let known_ids: HashSet<Uuid> = HashSet::new();
+        sweep_orphans(state_dir, &known_ids);
+
+        // Non-UUID directory should be left alone.
+        assert!(non_uuid.exists());
+    }
+
+    #[test]
+    fn sweep_orphans_prunes_old_entries() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+
+        let orphans = layout::orphans_dir(state_dir);
+        std::fs::create_dir_all(&orphans).unwrap();
+
+        // Create an old orphan (set mtime to 31 days ago).
+        let old_id = Uuid::new_v4();
+        let old_dir = orphans.join(old_id.to_string());
+        std::fs::create_dir_all(&old_dir).unwrap();
+        std::fs::write(old_dir.join("runtime.json"), "{}").unwrap();
+
+        let old_time = SystemTime::now() - Duration::from_hours(31 * 24);
+        let old_filetime = std::fs::FileTimes::new().set_modified(old_time);
+        std::fs::File::open(&old_dir).unwrap().set_times(old_filetime).unwrap();
+
+        // Create a recent orphan.
+        let recent_id = Uuid::new_v4();
+        let recent_dir = orphans.join(recent_id.to_string());
+        std::fs::create_dir_all(&recent_dir).unwrap();
+
+        let known_ids: HashSet<Uuid> = HashSet::new();
+        sweep_orphans(state_dir, &known_ids);
+
+        // Old orphan should be pruned.
+        assert!(!old_dir.exists());
+        // Recent orphan should remain.
+        assert!(recent_dir.exists());
+    }
+
+    #[test]
+    fn sweep_orphans_noop_when_no_runtimes_dir() {
+        let tmp = TempDir::new().unwrap();
+        let known_ids: HashSet<Uuid> = HashSet::new();
+        // Should not panic.
+        sweep_orphans(tmp.path(), &known_ids);
+    }
+
+    #[test]
+    fn sweep_orphans_with_empty_known_ids_moves_all() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        persistence::save_runtime(state_dir, &sample_runtime_file(id1)).unwrap();
+        persistence::save_runtime(state_dir, &sample_runtime_file(id2)).unwrap();
+
+        let known_ids: HashSet<Uuid> = HashSet::new();
+        sweep_orphans(state_dir, &known_ids);
+
+        assert!(!layout::runtime_dir(state_dir, id1).exists());
+        assert!(!layout::runtime_dir(state_dir, id2).exists());
+
+        let orphans = layout::orphans_dir(state_dir);
+        assert!(orphans.join(id1.to_string()).exists());
+        assert!(orphans.join(id2.to_string()).exists());
+    }
+}

--- a/services/rttx-server/src/state/layout.rs
+++ b/services/rttx-server/src/state/layout.rs
@@ -35,6 +35,9 @@ const SCROLLBACK_DIR: &str = "scrollback";
 /// Subdirectory for per-pane shell history.
 const HISTORY_DIR: &str = "history";
 
+/// Subdirectory for orphaned runtime directories awaiting pruning.
+const ORPHANS_DIR: &str = ".orphans";
+
 /// Path to the top-level daemon index file.
 #[must_use]
 pub fn daemon_index(state_dir: &Path) -> PathBuf {
@@ -75,6 +78,12 @@ pub fn scrollback_log(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) -> Path
 #[must_use]
 pub fn history_file(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) -> PathBuf {
     runtime_dir(state_dir, runtime_id).join(HISTORY_DIR).join(format!("{pane_id}.hist"))
+}
+
+/// Path to the `.orphans/` directory inside `runtimes/`.
+#[must_use]
+pub fn orphans_dir(state_dir: &Path) -> PathBuf {
+    runtimes_dir(state_dir).join(ORPHANS_DIR)
 }
 
 #[cfg(test)]
@@ -145,6 +154,12 @@ mod tests {
         assert!(p.to_string_lossy().contains("/history/"));
         assert!(p.to_string_lossy().ends_with(".hist"));
         assert!(p.starts_with(runtime_dir(Path::new(STATE), rt)));
+    }
+
+    #[test]
+    fn orphans_dir_path() {
+        let p = orphans_dir(Path::new(STATE));
+        assert_eq!(p, Path::new("/xdg/state/rttx/daemon/runtimes/.orphans"));
     }
 
     #[test]

--- a/services/rttx-server/src/state/mod.rs
+++ b/services/rttx-server/src/state/mod.rs
@@ -4,6 +4,7 @@
 //! RFC-022. The v1 monolithic `state.json` path helpers remain in
 //! [`crate::serialization`] until the migration is complete.
 
+pub mod cleanup;
 pub mod io;
 pub mod layout;
 pub mod migrations;

--- a/services/rttx-server/tests/runtime_cleanup.rs
+++ b/services/rttx-server/tests/runtime_cleanup.rs
@@ -1,0 +1,132 @@
+//! Integration tests for runtime directory cleanup and orphan sweep.
+
+mod common;
+
+use common::{TestClient, start_test_server, wait_for_state_file};
+use rttx_proto::{bytes_to_uuid, proto, uuid_to_bytes};
+use std::time::Duration;
+
+/// After terminating a runtime, its v2 state directory should be removed.
+#[tokio::test]
+async fn terminate_runtime_cleans_up_v2_directory() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let state_dir = tmp.path().join("state/rttx/daemon");
+
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    // Create a persistent runtime.
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "cleanup-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let resp = client.recv_or_timeout().await;
+    let runtime_id = match resp.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(rc)) => {
+            bytes_to_uuid(&rc.runtime_id).unwrap()
+        }
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+
+    // Wait for serialization to write the runtime directory.
+    wait_for_state_file(&tmp.path().join("cache"), Duration::from_secs(5)).await;
+    // Give the v2 serialization loop time to write.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let runtime_dir = state_dir.join("runtimes").join(runtime_id.to_string());
+    assert!(runtime_dir.exists(), "runtime directory should exist after creation");
+
+    // Attach so we can terminate.
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
+            runtime_id: uuid_to_bytes(runtime_id),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    let _snap = client.recv_or_timeout().await;
+
+    // Terminate the runtime.
+    let terminate = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::TerminateRuntime(proto::TerminateRuntime {
+            runtime_id: uuid_to_bytes(runtime_id),
+        })),
+    };
+    client.send(&terminate).await;
+    let resp = client.recv_or_timeout().await;
+    assert!(
+        matches!(resp.msg, Some(proto::server_message::Msg::RuntimeTerminated(_))),
+        "expected RuntimeTerminated"
+    );
+
+    // Wait for background cleanup thread.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(
+        !runtime_dir.exists(),
+        "runtime directory should be removed after termination"
+    );
+}
+
+/// On startup, unreferenced runtime directories are moved to .orphans/.
+#[tokio::test]
+async fn startup_quarantines_orphaned_runtime_directories() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state/rttx/daemon");
+    std::fs::create_dir_all(&state_dir).unwrap();
+
+    let known_id = uuid::Uuid::new_v4();
+    let orphan_id = uuid::Uuid::new_v4();
+
+    // Create a valid runtime file for the known runtime.
+    let runtimes_dir = state_dir.join("runtimes");
+    let known_dir = runtimes_dir.join(known_id.to_string());
+    std::fs::create_dir_all(&known_dir).unwrap();
+    let known_rf = serde_json::json!({
+        "schema_version": 1,
+        "spec": {
+            "id": known_id.to_string(),
+            "name": "known",
+            "policy": "persistent",
+            "created_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 },
+            "panes": [],
+            "active_pane_id": null,
+            "command_history": []
+        },
+        "instance": {
+            "revision": 1,
+            "last_active_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 },
+            "last_snapshot_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 }
+        }
+    });
+    std::fs::write(known_dir.join("runtime.json"), serde_json::to_string_pretty(&known_rf).unwrap()).unwrap();
+
+    // Create an orphan directory (not in daemon index).
+    let orphan_dir = runtimes_dir.join(orphan_id.to_string());
+    std::fs::create_dir_all(&orphan_dir).unwrap();
+    std::fs::write(orphan_dir.join("runtime.json"), "{}").unwrap();
+
+    // Write daemon index referencing only the known runtime.
+    let index = serde_json::json!({
+        "schema_version": 1,
+        "server_version": "0.4.2",
+        "runtime_ids": [known_id.to_string()],
+        "created_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 },
+        "last_serialized_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 }
+    });
+    std::fs::write(state_dir.join("daemon.json"), serde_json::to_string_pretty(&index).unwrap()).unwrap();
+
+    // Start the server — it should sweep orphans during load.
+    let (_socket_path, _handle) = start_test_server(tmp.path()).await;
+
+    // Orphan should have been moved to .orphans/.
+    assert!(!orphan_dir.exists(), "orphan directory should be moved");
+    let orphan_dest = runtimes_dir.join(".orphans").join(orphan_id.to_string());
+    assert!(orphan_dest.exists(), "orphan should be in .orphans/");
+
+    // Known runtime directory should still exist.
+    assert!(known_dir.exists(), "known runtime directory should remain");
+}

--- a/services/rttx-server/tests/runtime_cleanup.rs
+++ b/services/rttx-server/tests/runtime_cleanup.rs
@@ -65,10 +65,7 @@ async fn terminate_runtime_cleans_up_v2_directory() {
 
     // Wait for background cleanup thread.
     tokio::time::sleep(Duration::from_millis(500)).await;
-    assert!(
-        !runtime_dir.exists(),
-        "runtime directory should be removed after termination"
-    );
+    assert!(!runtime_dir.exists(), "runtime directory should be removed after termination");
 }
 
 /// On startup, unreferenced runtime directories are moved to .orphans/.
@@ -102,7 +99,11 @@ async fn startup_quarantines_orphaned_runtime_directories() {
             "last_snapshot_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 }
         }
     });
-    std::fs::write(known_dir.join("runtime.json"), serde_json::to_string_pretty(&known_rf).unwrap()).unwrap();
+    std::fs::write(
+        known_dir.join("runtime.json"),
+        serde_json::to_string_pretty(&known_rf).unwrap(),
+    )
+    .unwrap();
 
     // Create an orphan directory (not in daemon index).
     let orphan_dir = runtimes_dir.join(orphan_id.to_string());
@@ -117,7 +118,8 @@ async fn startup_quarantines_orphaned_runtime_directories() {
         "created_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 },
         "last_serialized_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 }
     });
-    std::fs::write(state_dir.join("daemon.json"), serde_json::to_string_pretty(&index).unwrap()).unwrap();
+    std::fs::write(state_dir.join("daemon.json"), serde_json::to_string_pretty(&index).unwrap())
+        .unwrap();
 
     // Start the server — it should sweep orphans during load.
     let (_socket_path, _handle) = start_test_server(tmp.path()).await;

--- a/services/rttx-server/tests/stdio_transport.rs
+++ b/services/rttx-server/tests/stdio_transport.rs
@@ -17,12 +17,14 @@ async fn start_daemon(
     bin: &str,
     runtime_dir: &std::path::Path,
     cache_dir: &std::path::Path,
+    state_dir: &std::path::Path,
 ) -> tokio::process::Child {
     let child = Command::new(bin)
         .arg("start")
         .arg("--foreground")
         .env("XDG_RUNTIME_DIR", runtime_dir)
         .env("XDG_CACHE_HOME", cache_dir)
+        .env("XDG_STATE_HOME", state_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -63,15 +65,18 @@ async fn attach_stdio_hello_and_create_runtime() {
     let tmp = TempDir::new().unwrap();
     let runtime_dir = tmp.path().join("runtime");
     let cache_dir = tmp.path().join("cache");
+    let state_dir = tmp.path().join("state");
     tokio::fs::create_dir_all(&runtime_dir).await.unwrap();
     tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+    tokio::fs::create_dir_all(&state_dir).await.unwrap();
 
-    let mut daemon = start_daemon(bin, &runtime_dir, &cache_dir).await;
+    let mut daemon = start_daemon(bin, &runtime_dir, &cache_dir, &state_dir).await;
 
     let mut child = Command::new(bin)
         .arg("attach-stdio")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
         .env("XDG_CACHE_HOME", &cache_dir)
+        .env("XDG_STATE_HOME", &state_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())


### PR DESCRIPTION
## What changed and why

Implements RFC-022 §7 (runtime directory cleanup and startup orphan sweep), resolving #722 and subsuming #689.

### Runtime directory removal on delete

When a runtime is terminated via `terminate_runtime`, its on-disk directory (`runtimes/<id>/`) is now removed in a background thread. This prevents unbounded growth of orphaned scrollback, screen snapshot, and history files.

### Startup orphan sweep

On daemon startup, after loading the v2 daemon index, any runtime directory not referenced by the index is moved to `runtimes/.orphans/` for manual recovery. Orphan entries older than 30 days are pruned automatically.

### Pre-existing test fix

The `attach_stdio_hello_and_create_runtime` test was loading real v2 persisted runtimes because `XDG_STATE_HOME` was not overridden. Fixed by isolating the test's state directory.

## How to manually verify

1. Start the daemon, create a persistent runtime, stop the daemon
2. Manually create a fake runtime directory in `runtimes/` with a random UUID name
3. Restart the daemon — the fake directory should be moved to `runtimes/.orphans/`
4. Create and terminate a runtime — its directory should be removed

## Tests added

### Unit tests (state::cleanup)
- `remove_runtime_dir_background_removes_directory` — verifies background removal
- `remove_runtime_dir_background_noop_when_missing` — no-op for missing dirs
- `sweep_orphans_moves_unreferenced_dirs` — moves orphans, keeps known
- `sweep_orphans_skips_orphans_dir_itself` — .orphans/ not treated as orphan
- `sweep_orphans_skips_non_uuid_directories` — non-UUID dirs left alone
- `sweep_orphans_prunes_old_entries` — entries >30 days are pruned
- `sweep_orphans_noop_when_no_runtimes_dir` — no-op when dir missing
- `sweep_orphans_with_empty_known_ids_moves_all` — all dirs moved when no known IDs

### Integration tests (server::tests)
- `terminate_runtime_removes_state_directory` — end-to-end: terminate → dir removed
- `load_persisted_state_sweeps_orphans` — end-to-end: startup → orphans quarantined

### Layout test
- `orphans_dir_path` — path helper produces correct path

### Pre-existing fix
- `attach_stdio_hello_and_create_runtime` — now passes with isolated XDG_STATE_HOME

## Tests run

- `cargo test -p rttx-server -p rttx-proto` — all pass (0 failures)
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all server tests pass; GTK tests skip (expected: server-only change, VTE 0.76 system)

## Limitations

- The background thread for directory removal is fire-and-forget. If it fails, the error is logged but the directory remains. The next startup orphan sweep will quarantine it.
- Orphan sweep runs only on startup, not periodically. This matches the RFC design since the daemon restarts infrequently.