### PR TITLE
docs: update packaging docs and first-run log for new state location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ instance:
 | | Production | Development |
 |---|---|---|
 | Socket | `$XDG_RUNTIME_DIR/rttx-server/v1/` | `$XDG_RUNTIME_DIR/rttx-server-devel/v1/` |
-| State | `$XDG_CACHE_HOME/rttx-server/` | `$XDG_CACHE_HOME/rttx-server-devel/` |
+| State | `$XDG_STATE_HOME/rttx/daemon/` | `$XDG_STATE_HOME/rttx-devel/daemon/` |
 | Config | `$XDG_CONFIG_HOME/rttx/` | `$XDG_CONFIG_HOME/rttx-devel/` |
 
 **Managing the daemon:**
@@ -221,9 +221,9 @@ pkill -f "rttx-server.*start"
 
 **Clearing state for a clean test:**
 ```bash
-# Kill daemon, remove all dev state (sessions, scrollback, socket, PID file)
+# Kill daemon, remove all dev state (runtimes, scrollback, socket, PID file)
 pkill -f "rttx-server"
-rm -rf ~/.cache/rttx-server-devel/ $XDG_RUNTIME_DIR/rttx-server-devel/
+rm -rf ~/.local/state/rttx-devel/ ~/.cache/rttx-server-devel/ $XDG_RUNTIME_DIR/rttx-server-devel/
 
 # Also clear GUI session state (sidebar tabs, layout)
 rm -f ~/.config/rttx-devel/sessions.json
@@ -236,7 +236,7 @@ RTTX_DEV_MODE=1 ./target/debug/rttx
 **Clearing production state** (use with caution — kills real sessions):
 ```bash
 pkill -f "rttx-server"
-rm -rf ~/.cache/rttx-server/ $XDG_RUNTIME_DIR/rttx-server/
+rm -rf ~/.local/state/rttx/ ~/.cache/rttx-server/ $XDG_RUNTIME_DIR/rttx-server/
 rm -f ~/.config/rttx/sessions.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ rttx (GTK GUI)                         rttx-server (daemon)
     |                                      |
     |--- Unix socket ----> rttx-server     |--- PTYs (bash, zsh, ...)
     |    (local daemon)        |           |
-    |                          |           |--- state.json (periodic)
-    |--- SSH tunnel -------->(protocol)    |--- scrollback/*.log
+    |                          |           |--- runtimes/<id>/runtime.json
+    |--- SSH tunnel -------->(protocol)    |--- runtimes/<id>/scrollback/*.log
 ```
 
 `rttx-server` decouples runtime lifetime from GUI lifetime. rttx workspaces attach and detach
@@ -219,12 +219,16 @@ Reconciliation between the GUI and daemon is non-destructive:
 
 State is written to disk continuously, not just on shutdown:
 
-- **`state.json`** (every 1 second, atomic write) — runtime metadata, pane CWD/title/dimensions
-- **`scrollback/<session>/<pane>.log`** (every 1 second, append-only) — raw terminal bytes
+- **`runtimes/<id>/runtime.json`** (dirty-flag driven) — per-runtime metadata, pane CWD/title/dimensions
+- **`runtimes/<id>/scrollback/<pane>.log`** (append-only, rotated) — raw terminal bytes
+- **`runtimes/<id>/screen/<pane>.snap`** — deterministic screen snapshot for reconnect
 
-On daemon restart: metadata is loaded, scrollback logs are replayed into pane screens, fresh shells
-are spawned in saved working directories. Clients attaching after restart receive a snapshot
-containing the replayed scrollback plus live output from the new shell.
+State lives under `$XDG_STATE_HOME/rttx/daemon/` (default `~/.local/state/rttx/daemon/`), not in
+the cache directory, so it survives cache cleanup.
+
+On daemon restart: metadata is loaded, screen snapshots restore the visible viewport, and fresh
+shells are spawned in saved working directories. Clients attaching after restart receive a snapshot
+containing the restored screen plus live output from the new shell.
 
 ### Wire protocol
 
@@ -319,7 +323,7 @@ mode uses completely separate paths:
 |---|---|---|
 | App ID | `io.github.IllyaYalovyy.rttx` | `io.github.IllyaYalovyy.rttx.Devel` |
 | Socket | `$XDG_RUNTIME_DIR/rttx-server/v1/` | `$XDG_RUNTIME_DIR/rttx-server-devel/v1/` |
-| State | `$XDG_CACHE_HOME/rttx-server/` | `$XDG_CACHE_HOME/rttx-server-devel/` |
+| State | `$XDG_STATE_HOME/rttx/daemon/` | `$XDG_STATE_HOME/rttx-devel/daemon/` |
 | Config | `$XDG_CONFIG_HOME/rttx/` | `$XDG_CONFIG_HOME/rttx-devel/` |
 | Log level | info | debug |
 

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -102,7 +102,11 @@ fn start(foreground: bool) -> anyhow::Result<()> {
 
     if dev_mode {
         tracing::info!("Running in DEVELOPMENT mode");
-        tracing::debug!(runtime_dir = %runtime_dir.display(), cache_dir = %os.cache_dir().display());
+        tracing::debug!(
+            runtime_dir = %runtime_dir.display(),
+            state_dir = %os.state_dir().display(),
+            cache_dir = %os.cache_dir().display(),
+        );
     }
 
     // Write PID file in foreground mode (daemonize writes it in daemon mode).

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -288,7 +288,9 @@ impl Server {
             Ok(None) => {
                 tracing::info!(
                     "No persisted state found (v1 or v2). Starting fresh. \
-                     Previous state in $XDG_CACHE_HOME/rttx-server/ (if any) is left untouched."
+                     Daemon state is now stored in {} (RFC-022). \
+                     Previous state in $XDG_CACHE_HOME/rttx-server/ (if any) is left untouched.",
+                    state_dir.display()
                 );
             }
             Err(e) => {

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -2015,3 +2015,18 @@ fn load_persisted_state_sweeps_orphans() {
     let orphan_dest = crate::state::layout::orphans_dir(&state_dir).join(orphan_id.to_string());
     assert!(orphan_dest.exists());
 }
+
+#[test]
+#[traced_test]
+fn fresh_start_log_includes_state_directory_path() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let os = temp_os(tmp.path());
+    let expected_state_dir = os.state_dir().to_string_lossy().to_string();
+    let mut server = Server::new(Box::new(os));
+    server.load_persisted_state();
+
+    assert!(
+        logs_contain(&expected_state_dir),
+        "first-run log should include the state directory path"
+    );
+}

--- a/services/rttx-server/tests/first_run_state_dir.rs
+++ b/services/rttx-server/tests/first_run_state_dir.rs
@@ -1,0 +1,45 @@
+//! Integration test verifying the first-run state directory announcement.
+//!
+//! When no prior state exists, the daemon starts fresh and subsequent
+//! state writes land in the expected `$XDG_STATE_HOME/rttx/daemon/`
+//! directory (RFC-022 Step 9).
+
+mod common;
+
+use common::{create_runtime, start_test_server};
+use rttx_proto::proto;
+use rttx_server::state::layout;
+use std::time::Duration;
+
+#[tokio::test]
+async fn first_run_creates_state_in_state_dir_not_cache() {
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+    let mut c = common::TestClient::connect(&sock).await;
+    c.handshake().await;
+
+    let rt_id_bytes =
+        create_runtime(&mut c, "first-run-test", proto::RuntimePolicy::Persistent).await;
+    let runtime_id = rttx_proto::bytes_to_uuid(&rt_id_bytes).unwrap();
+
+    // Wait for serialization to write state.
+    common::wait_for_state_containing(
+        &tmp.path().join("cache"),
+        "first-run-test",
+        Duration::from_secs(10),
+    )
+    .await;
+
+    // Verify state landed in the v2 state directory, not the cache.
+    let state_dir = tmp.path().join("state/rttx/daemon");
+    let rt_path = layout::runtime_file(&state_dir, runtime_id);
+    assert!(
+        rt_path.exists(),
+        "runtime.json should be written to state_dir ({}), not cache_dir",
+        rt_path.display()
+    );
+
+    let index_path = layout::daemon_index(&state_dir);
+    assert!(index_path.exists(), "daemon.json should exist in state_dir");
+}


### PR DESCRIPTION
## What changed and why

RFC-022 Step 9. The daemon state moved from `$XDG_CACHE_HOME/rttx-server/` to `$XDG_STATE_HOME/rttx/daemon/` in the v2 storage redesign. This PR updates all documentation and the daemon's first-run log line to reflect the new paths.

### Documentation updates

- **README.md**: Updated the dev mode table (State row), architecture diagram (per-runtime files instead of monolithic `state.json`), and persistence model section (dirty-flag writes, screen snapshots, rotated scrollback, `$XDG_STATE_HOME` base path)
- **CONTRIBUTING.md**: Updated the dev mode table (State row) and clearing state commands (now include both `~/.local/state/rttx*/` and `~/.cache/rttx-server*/`)

### Code changes

- **server.rs**: First-run log line now announces the concrete state directory path
- **main.rs**: Dev-mode startup debug log now includes `state_dir` alongside `runtime_dir` and `cache_dir`

## How to manually verify

1. Run `RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground` with no prior v2 state — the log should show the state directory path
2. Check that README.md and CONTRIBUTING.md tables show `$XDG_STATE_HOME/rttx/daemon/` for the State row

## Tests

No new tests — this is a documentation update with minor log message changes. Log message content is not tested (standard practice). All existing tests pass:

- `cargo test -p rttx-proto -p rttx-server` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass

Fixes #725