### PR TITLE
feat(client): add ClientStore path and document-envelope infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -14,6 +14,7 @@ pub mod places_window;
 pub mod preferences;
 pub mod runtime;
 pub mod shortcuts;
+pub mod store;
 pub mod workspace;
 pub mod workspace_state;
 

--- a/clients/rttx/src/store/envelope.rs
+++ b/clients/rttx/src/store/envelope.rs
@@ -1,0 +1,263 @@
+//! Document envelope with schema identity and version (RFC-023 §2).
+
+use serde::{Deserialize, Serialize};
+
+/// Known document schemas. Unknown values are rejected on load.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Schema {
+    #[serde(rename = "rttx.client.preferences")]
+    Preferences,
+    #[serde(rename = "rttx.client.hosts")]
+    Hosts,
+    #[serde(rename = "rttx.client.library")]
+    Library,
+    #[serde(rename = "rttx.client.workspaces")]
+    Workspaces,
+    #[serde(rename = "rttx.client.ui")]
+    Ui,
+    #[serde(rename = "rttx.client.runtime_cache")]
+    RuntimeCache,
+    #[serde(rename = "rttx.client.migrations")]
+    Migrations,
+}
+
+/// Self-describing envelope wrapping every persisted client document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentEnvelope<T> {
+    pub schema: Schema,
+    pub version: u32,
+    pub app_version: String,
+    pub written_at: String,
+    pub data: T,
+}
+
+impl<T> DocumentEnvelope<T> {
+    /// Create a new envelope stamped with the current app version and time.
+    pub fn new(schema: Schema, version: u32, data: T) -> Self {
+        Self {
+            schema,
+            version,
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+            written_at: now_iso8601(),
+            data,
+        }
+    }
+}
+
+/// Minimal envelope for peeking at schema and version without deserializing data.
+#[derive(Debug, Deserialize)]
+pub struct EnvelopeHeader {
+    pub schema: Schema,
+    pub version: u32,
+}
+
+/// Peek at the envelope header without deserializing the `data` payload.
+///
+/// # Errors
+///
+/// Returns an error if the JSON is malformed or the `schema` value is unknown.
+pub fn peek_header(json: &str) -> Result<EnvelopeHeader, EnvelopeError> {
+    serde_json::from_str(json).map_err(EnvelopeError::Parse)
+}
+
+/// Validate that a header matches the expected schema and a supported version range.
+///
+/// # Errors
+///
+/// - `SchemaMismatch` if the header schema differs from `expected`.
+/// - `UnsupportedVersion` if the header version exceeds `max_supported`.
+pub fn validate_header(
+    header: &EnvelopeHeader,
+    expected: Schema,
+    max_supported: u32,
+) -> Result<(), EnvelopeError> {
+    if header.schema != expected {
+        return Err(EnvelopeError::SchemaMismatch { expected, found: header.schema });
+    }
+    if header.version > max_supported {
+        return Err(EnvelopeError::UnsupportedVersion {
+            schema: expected,
+            found: header.version,
+            max_supported,
+        });
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum EnvelopeError {
+    Parse(serde_json::Error),
+    SchemaMismatch { expected: Schema, found: Schema },
+    UnsupportedVersion { schema: Schema, found: u32, max_supported: u32 },
+}
+
+impl std::fmt::Display for EnvelopeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parse(e) => write!(f, "envelope parse error: {e}"),
+            Self::SchemaMismatch { expected, found } => {
+                write!(f, "schema mismatch: expected {expected:?}, found {found:?}")
+            }
+            Self::UnsupportedVersion { schema, found, max_supported } => {
+                write!(f, "{schema:?}: version {found} is newer than max supported {max_supported}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EnvelopeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(e) => Some(e),
+            Self::SchemaMismatch { .. } | Self::UnsupportedVersion { .. } => None,
+        }
+    }
+}
+
+fn now_iso8601() -> String {
+    // Use SystemTime for a simple UTC timestamp without adding chrono.
+    use std::time::SystemTime;
+    let duration = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default();
+    let secs = duration.as_secs();
+
+    // Manual UTC formatting: good enough for a diagnostic timestamp.
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let hours = time_secs / 3600;
+    let minutes = (time_secs % 3600) / 60;
+    let seconds = time_secs % 60;
+
+    // Days since epoch to Y-M-D (simplified Gregorian).
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
+const fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
+    // Algorithm from Howard Hinnant's `civil_from_days`.
+    days += 719_468;
+    let era = days / 146_097;
+    let doe = days % 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn envelope_round_trips_through_json() {
+        let env = DocumentEnvelope::new(Schema::Preferences, 1, json!({"font_size": 14}));
+        let json = serde_json::to_string(&env).unwrap();
+        let loaded: DocumentEnvelope<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.schema, Schema::Preferences);
+        assert_eq!(loaded.version, 1);
+        assert_eq!(loaded.data["font_size"], 14);
+    }
+
+    #[test]
+    fn peek_header_extracts_schema_and_version() {
+        let json = r#"{"schema":"rttx.client.hosts","version":3,"app_version":"0.4.0","written_at":"2026-01-01T00:00:00Z","data":{}}"#;
+        let header = peek_header(json).unwrap();
+        assert_eq!(header.schema, Schema::Hosts);
+        assert_eq!(header.version, 3);
+    }
+
+    #[test]
+    fn peek_header_rejects_unknown_schema() {
+        let json = r#"{"schema":"rttx.client.unknown","version":1,"app_version":"0.4.0","written_at":"2026-01-01T00:00:00Z","data":{}}"#;
+        let err = peek_header(json).unwrap_err();
+        assert!(matches!(err, EnvelopeError::Parse(_)));
+    }
+
+    #[test]
+    fn peek_header_rejects_malformed_json() {
+        let err = peek_header("not json").unwrap_err();
+        assert!(matches!(err, EnvelopeError::Parse(_)));
+    }
+
+    #[test]
+    fn validate_header_accepts_current_version() {
+        let header = EnvelopeHeader { schema: Schema::Preferences, version: 1 };
+        assert!(validate_header(&header, Schema::Preferences, 1).is_ok());
+    }
+
+    #[test]
+    fn validate_header_accepts_older_version() {
+        let header = EnvelopeHeader { schema: Schema::Preferences, version: 1 };
+        assert!(validate_header(&header, Schema::Preferences, 3).is_ok());
+    }
+
+    #[test]
+    fn validate_header_rejects_future_version() {
+        let header = EnvelopeHeader { schema: Schema::Preferences, version: 5 };
+        let err = validate_header(&header, Schema::Preferences, 2).unwrap_err();
+        assert!(matches!(
+            err,
+            EnvelopeError::UnsupportedVersion { found: 5, max_supported: 2, .. }
+        ));
+    }
+
+    #[test]
+    fn validate_header_rejects_schema_mismatch() {
+        let header = EnvelopeHeader { schema: Schema::Hosts, version: 1 };
+        let err = validate_header(&header, Schema::Preferences, 1).unwrap_err();
+        assert!(matches!(err, EnvelopeError::SchemaMismatch { .. }));
+    }
+
+    #[test]
+    fn schema_serializes_to_dotted_string() {
+        let json = serde_json::to_string(&Schema::Preferences).unwrap();
+        assert_eq!(json, r#""rttx.client.preferences""#);
+    }
+
+    #[test]
+    fn all_schemas_round_trip() {
+        let schemas = [
+            Schema::Preferences,
+            Schema::Hosts,
+            Schema::Library,
+            Schema::Workspaces,
+            Schema::Ui,
+            Schema::RuntimeCache,
+            Schema::Migrations,
+        ];
+        for schema in schemas {
+            let json = serde_json::to_string(&schema).unwrap();
+            let loaded: Schema = serde_json::from_str(&json).unwrap();
+            assert_eq!(loaded, schema);
+        }
+    }
+
+    #[test]
+    fn envelope_new_stamps_app_version() {
+        let env = DocumentEnvelope::new(Schema::Ui, 1, ());
+        assert_eq!(env.app_version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn envelope_new_stamps_written_at_as_iso8601() {
+        let env = DocumentEnvelope::new(Schema::Ui, 1, ());
+        // Should look like YYYY-MM-DDTHH:MM:SSZ
+        assert!(env.written_at.ends_with('Z'), "timestamp should end with Z");
+        assert_eq!(env.written_at.len(), 20, "ISO 8601 UTC should be 20 chars");
+    }
+
+    #[test]
+    fn days_to_ymd_epoch() {
+        assert_eq!(super::days_to_ymd(0), (1970, 1, 1));
+    }
+
+    #[test]
+    fn days_to_ymd_known_date() {
+        // 2026-04-13 is day 20_556 since epoch
+        assert_eq!(super::days_to_ymd(20_556), (2026, 4, 13));
+    }
+}

--- a/clients/rttx/src/store/io.rs
+++ b/clients/rttx/src/store/io.rs
@@ -1,0 +1,428 @@
+//! Atomic file I/O with backup recovery for client documents (RFC-023 §4).
+//!
+//! Write protocol:
+//! 1. Serialize to `<path>.tmp` in the same directory.
+//! 2. Flush and fsync the temporary file.
+//! 3. Rename the current file to `<path>.bak` (last-good backup).
+//! 4. Rename `<path>.tmp` into place.
+//! 5. Fsync the parent directory.
+//!
+//! Load protocol:
+//! - Missing file → return default.
+//! - Malformed primary → move to `backups/`, try `.bak`, report recovery.
+//! - Malformed primary and no usable backup → preserve bad file, return default.
+//! - Unsupported future version → refuse (do not overwrite).
+
+use crate::store::envelope::{
+    DocumentEnvelope, EnvelopeError, Schema, peek_header, validate_header,
+};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+
+/// Outcome of loading a document.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LoadOutcome<T> {
+    /// Loaded successfully from the primary file.
+    Loaded(T),
+    /// Primary was malformed; recovered from backup.
+    Recovered(T),
+    /// File did not exist; returned the default.
+    Default(T),
+    /// Both primary and backup were unusable; returned the default.
+    /// The malformed file was preserved in `backups/`.
+    DefaultAfterFailure(T),
+    /// The document version is newer than this client supports.
+    /// The file was not modified.
+    UnsupportedVersion { found: u32, max_supported: u32 },
+}
+
+impl<T> LoadOutcome<T> {
+    /// Extract the loaded value, if any.
+    #[must_use]
+    pub fn into_value(self) -> Option<T> {
+        match self {
+            Self::Loaded(v)
+            | Self::Recovered(v)
+            | Self::Default(v)
+            | Self::DefaultAfterFailure(v) => Some(v),
+            Self::UnsupportedVersion { .. } => None,
+        }
+    }
+}
+
+/// Write a document envelope atomically.
+///
+/// Creates parent directories as needed.
+///
+/// # Errors
+///
+/// Returns an I/O error if the write, fsync, or rename fails.
+pub fn atomic_save<T: Serialize>(path: &Path, envelope: &DocumentEnvelope<T>) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let tmp_path = path.with_extension("tmp");
+    let bak_path = path.with_extension("bak");
+
+    write_and_sync(&tmp_path, envelope)?;
+
+    if path.exists() {
+        fs::rename(path, &bak_path)?;
+    }
+
+    fs::rename(&tmp_path, path)?;
+    fsync_dir(path);
+
+    Ok(())
+}
+
+/// Load a document with envelope validation and backup recovery.
+///
+/// `backups_dir` is the directory where malformed files are preserved.
+#[must_use]
+pub fn atomic_load<T: for<'de> Deserialize<'de> + Default>(
+    path: &Path,
+    expected_schema: Schema,
+    max_version: u32,
+    backups_dir: &Path,
+) -> LoadOutcome<T> {
+    let Ok(primary_json) = fs::read_to_string(path) else {
+        // Distinguish "not found" (normal first run) from other read errors.
+        return if path.exists() {
+            try_backup_or_default(path, expected_schema, max_version)
+        } else {
+            LoadOutcome::Default(T::default())
+        };
+    };
+
+    match try_parse::<T>(&primary_json, expected_schema, max_version) {
+        ParseResult::Ok(data) => LoadOutcome::Loaded(data),
+        ParseResult::UnsupportedVersion { found, max_supported } => {
+            LoadOutcome::UnsupportedVersion { found, max_supported }
+        }
+        ParseResult::Malformed => {
+            preserve_malformed(path, backups_dir);
+            try_backup_or_default(path, expected_schema, max_version)
+        }
+    }
+}
+
+enum ParseResult<T> {
+    Ok(T),
+    UnsupportedVersion { found: u32, max_supported: u32 },
+    Malformed,
+}
+
+fn try_parse<T: for<'de> Deserialize<'de>>(
+    json: &str,
+    expected_schema: Schema,
+    max_version: u32,
+) -> ParseResult<T> {
+    let Ok(header) = peek_header(json) else {
+        return ParseResult::Malformed;
+    };
+
+    if let Err(e) = validate_header(&header, expected_schema, max_version) {
+        return match e {
+            EnvelopeError::UnsupportedVersion { found, max_supported, .. } => {
+                ParseResult::UnsupportedVersion { found, max_supported }
+            }
+            _ => ParseResult::Malformed,
+        };
+    }
+
+    match serde_json::from_str::<DocumentEnvelope<T>>(json) {
+        Ok(env) => ParseResult::Ok(env.data),
+        Err(_) => ParseResult::Malformed,
+    }
+}
+
+fn try_backup_or_default<T: for<'de> Deserialize<'de> + Default>(
+    path: &Path,
+    expected_schema: Schema,
+    max_version: u32,
+) -> LoadOutcome<T> {
+    if let Ok(bak_json) = fs::read_to_string(path.with_extension("bak"))
+        && let ParseResult::Ok(data) = try_parse::<T>(&bak_json, expected_schema, max_version)
+    {
+        return LoadOutcome::Recovered(data);
+    }
+    LoadOutcome::DefaultAfterFailure(T::default())
+}
+
+/// Move a malformed primary file into the backups directory.
+fn preserve_malformed(path: &Path, backups_dir: &Path) {
+    let file_name =
+        path.file_name().map_or_else(|| "unknown".into(), |n| n.to_string_lossy().into_owned());
+
+    if fs::create_dir_all(backups_dir).is_err() {
+        tracing::error!("Failed to create backups directory: {}", backups_dir.display());
+        return;
+    }
+
+    if let Err(e) = fs::rename(path, backups_dir.join(&file_name)) {
+        tracing::error!("Failed to move malformed file to backups: {e}");
+    } else {
+        tracing::warn!("Moved malformed {file_name} to {}", backups_dir.display());
+    }
+}
+
+fn write_and_sync<T: Serialize>(path: &Path, envelope: &DocumentEnvelope<T>) -> io::Result<()> {
+    let json = serde_json::to_string_pretty(envelope).map_err(io::Error::other)?;
+    let mut file = fs::File::create(path)?;
+    file.write_all(json.as_bytes())?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn fsync_dir(file_path: &Path) {
+    if let Some(parent) = file_path.parent()
+        && let Ok(dir) = fs::File::open(parent)
+    {
+        let _ = dir.sync_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::envelope::DocumentEnvelope;
+    use serde::{Deserialize, Serialize};
+    use tempfile::TempDir;
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestData {
+        #[serde(default)]
+        value: String,
+    }
+
+    fn make_envelope(schema: Schema, version: u32, data: TestData) -> DocumentEnvelope<TestData> {
+        DocumentEnvelope {
+            schema,
+            version,
+            app_version: "0.4.0".into(),
+            written_at: "2026-01-01T00:00:00Z".into(),
+            data,
+        }
+    }
+
+    #[test]
+    fn save_creates_file_with_valid_envelope() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("prefs.json");
+        let env = make_envelope(Schema::Preferences, 1, TestData { value: "hello".into() });
+
+        atomic_save(&path, &env).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let loaded: DocumentEnvelope<TestData> = serde_json::from_str(&content).unwrap();
+        assert_eq!(loaded.schema, Schema::Preferences);
+        assert_eq!(loaded.data.value, "hello");
+    }
+
+    #[test]
+    fn save_creates_parent_directories() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("deep").join("nested").join("doc.json");
+        let env = make_envelope(Schema::Hosts, 1, TestData::default());
+
+        atomic_save(&path, &env).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn save_creates_bak_on_overwrite() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+
+        let v1 = make_envelope(Schema::Preferences, 1, TestData { value: "v1".into() });
+        atomic_save(&path, &v1).unwrap();
+
+        let v2 = make_envelope(Schema::Preferences, 1, TestData { value: "v2".into() });
+        atomic_save(&path, &v2).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("v2"));
+
+        let bak_content = fs::read_to_string(path.with_extension("bak")).unwrap();
+        assert!(bak_content.contains("v1"));
+    }
+
+    #[test]
+    fn save_no_tmp_file_left_behind() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+        let env = make_envelope(Schema::Preferences, 1, TestData::default());
+
+        atomic_save(&path, &env).unwrap();
+        assert!(!path.with_extension("tmp").exists());
+    }
+
+    #[test]
+    fn load_missing_file_returns_default() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("missing.json");
+        let backups = tmp.path().join("backups");
+
+        let outcome: LoadOutcome<TestData> = atomic_load(&path, Schema::Preferences, 1, &backups);
+        assert!(matches!(outcome, LoadOutcome::Default(_)));
+        assert_eq!(outcome.into_value().unwrap(), TestData::default());
+    }
+
+    #[test]
+    fn load_valid_file_returns_loaded() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("prefs.json");
+        let backups = tmp.path().join("backups");
+        let env = make_envelope(Schema::Preferences, 1, TestData { value: "loaded".into() });
+        atomic_save(&path, &env).unwrap();
+
+        let outcome: LoadOutcome<TestData> = atomic_load(&path, Schema::Preferences, 1, &backups);
+        assert!(matches!(outcome, LoadOutcome::Loaded(_)));
+        assert_eq!(outcome.into_value().unwrap().value, "loaded");
+    }
+
+    #[test]
+    fn load_malformed_primary_recovers_from_backup() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+        let backups = tmp.path().join("backups");
+
+        let good = make_envelope(Schema::Preferences, 1, TestData { value: "backup".into() });
+        fs::write(path.with_extension("bak"), serde_json::to_string_pretty(&good).unwrap())
+            .unwrap();
+
+        fs::write(&path, "not valid json").unwrap();
+
+        let outcome: LoadOutcome<TestData> = atomic_load(&path, Schema::Preferences, 1, &backups);
+        assert!(matches!(outcome, LoadOutcome::Recovered(_)));
+        assert_eq!(outcome.into_value().unwrap().value, "backup");
+    }
+
+    #[test]
+    fn load_malformed_primary_preserves_bad_file_in_backups() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+        let backups = tmp.path().join("backups");
+
+        fs::write(&path, "corrupted content").unwrap();
+
+        let _: LoadOutcome<TestData> = atomic_load(&path, Schema::Preferences, 1, &backups);
+
+        let preserved = backups.join("doc.json");
+        assert!(preserved.exists());
+        assert_eq!(fs::read_to_string(&preserved).unwrap(), "corrupted content");
+    }
+
+    #[test]
+    fn load_malformed_primary_and_backup_returns_default_after_failure() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+        let backups = tmp.path().join("backups");
+
+        fs::write(&path, "bad primary").unwrap();
+        fs::write(path.with_extension("bak"), "bad backup").unwrap();
+
+        let outcome: LoadOutcome<TestData> = atomic_load(&path, Schema::Preferences, 1, &backups);
+        assert!(matches!(outcome, LoadOutcome::DefaultAfterFailure(_)));
+    }
+
+    #[test]
+    fn load_unsupported_future_version_refuses() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+        let backups = tmp.path().join("backups");
+
+        let env = make_envelope(Schema::Preferences, 99, TestData { value: "future".into() });
+        atomic_save(&path, &env).unwrap();
+
+        let outcome: LoadOutcome<TestData> = atomic_load(&path, Schema::Preferences, 1, &backups);
+        assert!(matches!(outcome, LoadOutcome::UnsupportedVersion { found: 99, max_supported: 1 }));
+
+        // File must NOT be modified or deleted
+        assert!(path.exists());
+        assert!(fs::read_to_string(&path).unwrap().contains("future"));
+    }
+
+    #[test]
+    fn load_wrong_schema_treats_as_malformed() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+        let backups = tmp.path().join("backups");
+
+        let env = make_envelope(Schema::Hosts, 1, TestData { value: "hosts".into() });
+        atomic_save(&path, &env).unwrap();
+
+        let outcome: LoadOutcome<TestData> = atomic_load(&path, Schema::Preferences, 1, &backups);
+        assert!(matches!(outcome, LoadOutcome::DefaultAfterFailure(_)));
+    }
+
+    #[test]
+    fn load_older_version_succeeds() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+        let backups = tmp.path().join("backups");
+
+        let env = make_envelope(Schema::Preferences, 1, TestData { value: "old".into() });
+        atomic_save(&path, &env).unwrap();
+
+        let outcome: LoadOutcome<TestData> = atomic_load(&path, Schema::Preferences, 3, &backups);
+        assert!(matches!(outcome, LoadOutcome::Loaded(_)));
+        assert_eq!(outcome.into_value().unwrap().value, "old");
+    }
+
+    #[test]
+    fn save_then_load_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("round.json");
+        let backups = tmp.path().join("backups");
+
+        let data = TestData { value: "round-trip".into() };
+        let env = DocumentEnvelope::new(Schema::Library, 1, data.clone());
+        atomic_save(&path, &env).unwrap();
+
+        let outcome: LoadOutcome<TestData> = atomic_load(&path, Schema::Library, 1, &backups);
+        assert_eq!(outcome.into_value().unwrap(), data);
+    }
+
+    #[test]
+    fn load_outcome_into_value_returns_none_for_unsupported() {
+        let outcome: LoadOutcome<TestData> =
+            LoadOutcome::UnsupportedVersion { found: 5, max_supported: 1 };
+        assert!(outcome.into_value().is_none());
+    }
+
+    #[test]
+    fn multiple_saves_keep_only_one_bak() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+
+        for i in 1..=3 {
+            let env = make_envelope(Schema::Preferences, 1, TestData { value: format!("v{i}") });
+            atomic_save(&path, &env).unwrap();
+        }
+
+        assert!(fs::read_to_string(&path).unwrap().contains("v3"));
+        assert!(fs::read_to_string(path.with_extension("bak")).unwrap().contains("v2"));
+    }
+
+    #[test]
+    fn crash_after_tmp_write_leaves_original_intact() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+        let backups = tmp.path().join("backups");
+
+        let env = make_envelope(Schema::Preferences, 1, TestData { value: "original".into() });
+        atomic_save(&path, &env).unwrap();
+
+        // Simulate crash: only .tmp exists from a second write attempt
+        fs::write(path.with_extension("tmp"), "partial write").unwrap();
+
+        let outcome: LoadOutcome<TestData> = atomic_load(&path, Schema::Preferences, 1, &backups);
+        assert!(matches!(outcome, LoadOutcome::Loaded(_)));
+        assert_eq!(outcome.into_value().unwrap().value, "original");
+    }
+}

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -1,0 +1,31 @@
+//! Client-side document store with versioned envelopes and atomic writes (RFC-023 §2, §4, §6).
+//!
+//! Every persisted JSON document uses a self-describing envelope with `schema`,
+//! `version`, and diagnostic fields. Writes are atomic (temp + fsync + rename).
+//! Loads recover from malformed files by falling back to the last-good backup.
+
+mod envelope;
+mod io;
+mod paths;
+
+pub use envelope::{DocumentEnvelope, Schema};
+pub use io::{LoadOutcome, atomic_load, atomic_save};
+pub use paths::StorePaths;
+
+/// Client store providing typed document persistence with atomic I/O.
+#[derive(Debug, Clone)]
+pub struct ClientStore {
+    paths: StorePaths,
+}
+
+impl ClientStore {
+    #[must_use]
+    pub const fn new(paths: StorePaths) -> Self {
+        Self { paths }
+    }
+
+    #[must_use]
+    pub const fn paths(&self) -> &StorePaths {
+        &self.paths
+    }
+}

--- a/clients/rttx/src/store/paths.rs
+++ b/clients/rttx/src/store/paths.rs
@@ -1,0 +1,61 @@
+//! Injectable path roots for the client store (RFC-023 §1).
+
+use std::path::{Path, PathBuf};
+
+/// Root directories for the three XDG-based storage locations.
+///
+/// Config holds durable user choices, state holds restorable application state,
+/// and cache holds disposable runtime data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorePaths {
+    config: PathBuf,
+    state: PathBuf,
+    cache: PathBuf,
+}
+
+impl StorePaths {
+    #[must_use]
+    pub const fn new(config: PathBuf, state: PathBuf, cache: PathBuf) -> Self {
+        Self { config, state, cache }
+    }
+
+    #[must_use]
+    pub fn config(&self) -> &Path {
+        &self.config
+    }
+
+    #[must_use]
+    pub fn state(&self) -> &Path {
+        &self.state
+    }
+
+    #[must_use]
+    pub fn cache(&self) -> &Path {
+        &self.cache
+    }
+
+    /// Path to the `backups/` directory under the state root.
+    #[must_use]
+    pub fn backups(&self) -> PathBuf {
+        self.state.join("backups")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paths_expose_injected_roots() {
+        let paths = StorePaths::new("/c".into(), "/s".into(), "/k".into());
+        assert_eq!(paths.config(), Path::new("/c"));
+        assert_eq!(paths.state(), Path::new("/s"));
+        assert_eq!(paths.cache(), Path::new("/k"));
+    }
+
+    #[test]
+    fn backups_dir_is_under_state() {
+        let paths = StorePaths::new("/c".into(), "/s/client".into(), "/k".into());
+        assert_eq!(paths.backups(), PathBuf::from("/s/client/backups"));
+    }
+}

--- a/designs/RFC-023-client-configuration-state-store.md
+++ b/designs/RFC-023-client-configuration-state-store.md
@@ -2,7 +2,7 @@
 
 | Field         | Value  |
 |---------------|--------|
-| Status        | Review |
+| Status        | Accepted |
 | Author(s)     | jd2023 |
 | Supersedes    | -      |
 | Superseded by | -      |

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.3',
+  version: '0.4.4',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

RFC-023 Step 1. Adds the `store` module to the client with the foundational infrastructure for the new versioned document persistence layer.

### New types

- **`StorePaths`** — injectable config/state/cache root directories following XDG conventions (RFC-023 §1)
- **`DocumentEnvelope<T>`** — self-describing JSON wrapper with `schema`, `version`, `app_version`, `written_at`, and `data` fields (RFC-023 §2)
- **`Schema`** enum — all seven planned client document schemas (`preferences`, `hosts`, `library`, `workspaces`, `ui`, `runtime_cache`, `migrations`)
- **`EnvelopeHeader`** — lightweight peek type for validating schema and version without deserializing the full payload
- **`EnvelopeError`** — typed errors for parse failures, schema mismatches, and unsupported future versions
- **`LoadOutcome<T>`** — discriminated result type: `Loaded`, `Recovered`, `Default`, `DefaultAfterFailure`, `UnsupportedVersion`
- **`ClientStore`** — top-level struct tying `StorePaths` to the I/O helpers

### Atomic I/O (RFC-023 §4)

- **`atomic_save`**: temp file → fsync → rename current to `.bak` → rename temp into place → fsync parent dir
- **`atomic_load`**: missing → default, malformed → preserve in `backups/` + try `.bak` backup, unsupported future version → refuse without modifying file

### Also

- RFC-023 status moved from Review to Accepted
- Version bumped to 0.4.4 (>3 source files changed)

## How to manually verify

```bash
cargo test -p rttx --no-default-features --features vte-0_76 -- store
```

All 32 store tests exercise the envelope, I/O, and path infrastructure.

## Tests added

### Envelope tests (14)
- `envelope_round_trips_through_json`
- `peek_header_extracts_schema_and_version`
- `peek_header_rejects_unknown_schema`
- `peek_header_rejects_malformed_json`
- `validate_header_accepts_current_version`
- `validate_header_accepts_older_version`
- `validate_header_rejects_future_version`
- `validate_header_rejects_schema_mismatch`
- `schema_serializes_to_dotted_string`
- `all_schemas_round_trip`
- `envelope_new_stamps_app_version`
- `envelope_new_stamps_written_at_as_iso8601`
- `days_to_ymd_epoch`
- `days_to_ymd_known_date`

### I/O tests (16)
- `save_creates_file_with_valid_envelope`
- `save_creates_parent_directories`
- `save_creates_bak_on_overwrite`
- `save_no_tmp_file_left_behind`
- `load_missing_file_returns_default`
- `load_valid_file_returns_loaded`
- `load_malformed_primary_recovers_from_backup`
- `load_malformed_primary_preserves_bad_file_in_backups`
- `load_malformed_primary_and_backup_returns_default_after_failure`
- `load_unsupported_future_version_refuses`
- `load_wrong_schema_treats_as_malformed`
- `load_older_version_succeeds`
- `save_then_load_round_trip`
- `load_outcome_into_value_returns_none_for_unsupported`
- `multiple_saves_keep_only_one_bak`
- `crash_after_tmp_write_leaves_original_intact`

### Path tests (2)
- `paths_expose_injected_roots`
- `backups_dir_is_under_state`

## Tests run

- `cargo build --workspace` (with VTE 0.76 flags for client) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 32 store tests visible and passing)

## Limitations / follow-ups

- This is infrastructure only — no existing persistence code is migrated yet (Steps 2–7 of RFC-023)
- `ClientStore` currently exposes `paths()` but no domain-specific load/save methods; those come in Step 2

Fixes #738