### PR TITLE
feat: add canonical document models and fixture tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.4"
+version = "0.4.5"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -6,6 +6,7 @@
 
 mod envelope;
 mod io;
+pub mod models;
 mod paths;
 
 pub use envelope::{DocumentEnvelope, Schema};

--- a/clients/rttx/src/store/models.rs
+++ b/clients/rttx/src/store/models.rs
@@ -1,0 +1,12 @@
+//! Canonical versioned document models for all client persistence domains (RFC-023 §3).
+//!
+//! Each model corresponds to one JSON document with a schema envelope.
+//! Version 1 is the initial schema for all domains.
+
+pub mod commands;
+pub mod hosts;
+pub mod library;
+pub mod preferences;
+pub mod runtime_cache;
+pub mod ui;
+pub mod workspaces;

--- a/clients/rttx/src/store/models/commands.rs
+++ b/clients/rttx/src/store/models/commands.rs
@@ -1,0 +1,11 @@
+//! Canonical commands model — shared run-mode enum used by `library.json`.
+
+use serde::{Deserialize, Serialize};
+
+/// How a command is executed by default.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RunMode {
+    Run,
+    Insert,
+}

--- a/clients/rttx/src/store/models/hosts.rs
+++ b/clients/rttx/src/store/models/hosts.rs
@@ -1,0 +1,36 @@
+//! Canonical hosts document model (RFC-023 §3: `hosts.json`).
+
+use serde::{Deserialize, Serialize};
+
+use crate::store::envelope::Schema;
+
+pub const SCHEMA: Schema = Schema::Hosts;
+pub const CURRENT_VERSION: u32 = 1;
+
+/// Kind of host endpoint.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum HostKind {
+    #[default]
+    Local,
+    Remote,
+}
+
+/// A saved endpoint record. `local` is a reserved built-in and not persisted.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HostRecord {
+    pub key: String,
+    pub name: String,
+    pub kind: HostKind,
+    #[serde(default)]
+    pub ssh_target: Option<String>,
+    #[serde(default)]
+    pub labels: Vec<String>,
+}
+
+/// Top-level hosts catalog.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HostCatalog {
+    #[serde(default)]
+    pub hosts: Vec<HostRecord>,
+}

--- a/clients/rttx/src/store/models/library.rs
+++ b/clients/rttx/src/store/models/library.rs
@@ -1,0 +1,48 @@
+//! Canonical library document model (RFC-023 §3: `library.json`).
+//!
+//! Combines places and commands into a single user-authored content document.
+
+use serde::{Deserialize, Serialize};
+
+use super::commands::RunMode;
+use crate::store::envelope::Schema;
+
+pub const SCHEMA: Schema = Schema::Library;
+pub const CURRENT_VERSION: u32 = 1;
+
+/// A saved launch-target place.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlaceRecord {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+    /// Empty means global visibility. Values are endpoint keys.
+    #[serde(default)]
+    pub host_tags: Vec<String>,
+}
+
+/// A saved command snippet.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommandRecord {
+    pub id: String,
+    pub title: String,
+    pub body: String,
+    #[serde(default = "default_run_mode")]
+    pub default_run_mode: RunMode,
+    /// Empty means global visibility. Values are endpoint keys.
+    #[serde(default)]
+    pub host_tags: Vec<String>,
+}
+
+const fn default_run_mode() -> RunMode {
+    RunMode::Run
+}
+
+/// Top-level library document combining places and commands.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Library {
+    #[serde(default)]
+    pub places: Vec<PlaceRecord>,
+    #[serde(default)]
+    pub commands: Vec<CommandRecord>,
+}

--- a/clients/rttx/src/store/models/preferences.rs
+++ b/clients/rttx/src/store/models/preferences.rs
@@ -1,0 +1,144 @@
+//! Canonical preferences document model (RFC-023 §3: `preferences.json`).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use crate::store::envelope::Schema;
+
+pub const SCHEMA: Schema = Schema::Preferences;
+pub const CURRENT_VERSION: u32 = 1;
+
+/// Terminal theme mode selection.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum TerminalThemeMode {
+    System,
+    Light,
+    Dark,
+}
+
+/// Default session folder behavior.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DefaultSessionFolder {
+    Home,
+    CurrentSession,
+    Custom(String),
+}
+
+/// Pane navigation key binding style.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PaneNavigationKeys {
+    AltArrow,
+    CtrlShiftArrow,
+}
+
+/// Durable user preferences — no workspace layout, connection status, or runtime inventory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PreferencesV1 {
+    #[serde(default = "default_font")]
+    pub font: String,
+    #[serde(default = "default_terminal_theme_mode")]
+    pub terminal_theme_mode: TerminalThemeMode,
+    #[serde(default = "default_light_color_scheme")]
+    pub light_color_scheme: String,
+    #[serde(default = "default_dark_color_scheme")]
+    pub dark_color_scheme: String,
+    #[serde(default = "default_scrollback")]
+    pub scrollback_lines: i64,
+    #[serde(default = "default_true")]
+    pub show_headerbar: bool,
+    #[serde(default = "default_true")]
+    pub scroll_on_keystroke: bool,
+    #[serde(default)]
+    pub scroll_on_output: bool,
+    #[serde(default = "default_true")]
+    pub audible_bell: bool,
+    #[serde(default = "default_true")]
+    pub visual_bell: bool,
+    #[serde(default)]
+    pub smart_clipboard: bool,
+    #[serde(default)]
+    pub trim_trailing_whitespace_on_copy: bool,
+    #[serde(default = "default_session_folder")]
+    pub default_session_folder: DefaultSessionFolder,
+    #[serde(default = "default_pane_navigation_keys")]
+    pub pane_navigation_keys: PaneNavigationKeys,
+    #[serde(default)]
+    pub keyboard_shortcuts: BTreeMap<String, Vec<String>>,
+    #[serde(default = "default_true")]
+    pub auto_start_daemon: bool,
+    #[serde(default = "default_reconnect_delay_secs")]
+    pub reconnect_delay_secs: u32,
+    #[serde(default = "default_true")]
+    pub paste_guard: bool,
+    #[serde(default = "default_paste_guard_threshold")]
+    pub paste_guard_threshold: usize,
+}
+
+impl Default for PreferencesV1 {
+    fn default() -> Self {
+        Self {
+            font: default_font(),
+            terminal_theme_mode: default_terminal_theme_mode(),
+            light_color_scheme: default_light_color_scheme(),
+            dark_color_scheme: default_dark_color_scheme(),
+            scrollback_lines: default_scrollback(),
+            show_headerbar: true,
+            scroll_on_keystroke: true,
+            scroll_on_output: false,
+            audible_bell: true,
+            visual_bell: true,
+            smart_clipboard: false,
+            trim_trailing_whitespace_on_copy: false,
+            default_session_folder: default_session_folder(),
+            pane_navigation_keys: default_pane_navigation_keys(),
+            keyboard_shortcuts: BTreeMap::new(),
+            auto_start_daemon: true,
+            reconnect_delay_secs: default_reconnect_delay_secs(),
+            paste_guard: true,
+            paste_guard_threshold: default_paste_guard_threshold(),
+        }
+    }
+}
+
+fn default_font() -> String {
+    "Monospace 12".into()
+}
+
+const fn default_terminal_theme_mode() -> TerminalThemeMode {
+    TerminalThemeMode::System
+}
+
+fn default_light_color_scheme() -> String {
+    "Daybreak".into()
+}
+
+fn default_dark_color_scheme() -> String {
+    "Nightfall".into()
+}
+
+const fn default_scrollback() -> i64 {
+    10_000
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_session_folder() -> DefaultSessionFolder {
+    DefaultSessionFolder::Home
+}
+
+const fn default_pane_navigation_keys() -> PaneNavigationKeys {
+    PaneNavigationKeys::AltArrow
+}
+
+const fn default_reconnect_delay_secs() -> u32 {
+    3
+}
+
+const fn default_paste_guard_threshold() -> usize {
+    200
+}

--- a/clients/rttx/src/store/models/runtime_cache.rs
+++ b/clients/rttx/src/store/models/runtime_cache.rs
@@ -1,0 +1,20 @@
+//! Canonical runtime-cache document model (RFC-023 §3: `runtime-cache.json`).
+//!
+//! This is disposable cache. The application must behave correctly if this file
+//! is deleted.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+use crate::store::envelope::Schema;
+
+pub const SCHEMA: Schema = Schema::RuntimeCache;
+pub const CURRENT_VERSION: u32 = 1;
+
+/// Disposable client cache for runtime discovery and dismissal state.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCache {
+    /// Runtime IDs the user explicitly dismissed.
+    #[serde(default)]
+    pub dismissed_runtime_ids: BTreeSet<String>,
+}

--- a/clients/rttx/src/store/models/ui.rs
+++ b/clients/rttx/src/store/models/ui.rs
@@ -1,0 +1,60 @@
+//! Canonical UI state document model (RFC-023 §3: `ui.json`).
+
+use serde::{Deserialize, Serialize};
+
+use crate::store::envelope::Schema;
+
+pub const SCHEMA: Schema = Schema::Ui;
+pub const CURRENT_VERSION: u32 = 1;
+
+/// Restorable UI state that is not workspace data.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UiState {
+    #[serde(default = "default_width")]
+    pub window_width: i32,
+    #[serde(default = "default_height")]
+    pub window_height: i32,
+    #[serde(default)]
+    pub is_maximized: bool,
+    #[serde(default = "default_left_sidebar_width")]
+    pub left_sidebar_width: i32,
+    #[serde(default = "default_right_sidebar_width")]
+    pub right_sidebar_width: i32,
+    #[serde(default)]
+    pub left_sidebar_visible: bool,
+    #[serde(default)]
+    pub right_sidebar_visible: bool,
+    #[serde(default)]
+    pub selected_right_tool: Option<String>,
+}
+
+impl Default for UiState {
+    fn default() -> Self {
+        Self {
+            window_width: default_width(),
+            window_height: default_height(),
+            is_maximized: false,
+            left_sidebar_width: default_left_sidebar_width(),
+            right_sidebar_width: default_right_sidebar_width(),
+            left_sidebar_visible: false,
+            right_sidebar_visible: false,
+            selected_right_tool: None,
+        }
+    }
+}
+
+const fn default_width() -> i32 {
+    900
+}
+
+const fn default_height() -> i32 {
+    600
+}
+
+const fn default_left_sidebar_width() -> i32 {
+    220
+}
+
+const fn default_right_sidebar_width() -> i32 {
+    320
+}

--- a/clients/rttx/src/store/models/workspaces.rs
+++ b/clients/rttx/src/store/models/workspaces.rs
@@ -1,0 +1,166 @@
+//! Canonical workspaces document model (RFC-023 §3: `workspaces.json`).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use crate::store::envelope::Schema;
+
+pub const SCHEMA: Schema = Schema::Workspaces;
+pub const CURRENT_VERSION: u32 = 1;
+
+/// Workspace accent color.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkspaceColor {
+    #[default]
+    Blue,
+    Green,
+    Yellow,
+    Red,
+    Purple,
+    Pink,
+    Teal,
+    Orange,
+}
+
+/// Runtime retention policy.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkspacePolicy {
+    #[default]
+    Persistent,
+    Ephemeral,
+}
+
+/// Durable reference to a daemon runtime for reconnection.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeRef {
+    pub runtime_id: String,
+    #[serde(default = "default_attachment_kind")]
+    pub attachment_kind: RuntimeAttachmentKind,
+}
+
+/// How the workspace was attached to the runtime.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuntimeAttachmentKind {
+    #[default]
+    Created,
+    Attached,
+    Recovered,
+}
+
+const fn default_attachment_kind() -> RuntimeAttachmentKind {
+    RuntimeAttachmentKind::Created
+}
+
+/// Input synchronization state.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum InputSyncState {
+    #[default]
+    Off,
+    On,
+}
+
+/// Pane recovery source — what the pane was doing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PaneSource {
+    EmptyShell,
+    Command { title: String },
+    Manual,
+}
+
+/// Pane recovery target — where the pane was pointed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PaneTarget {
+    LocalFolder { path: String },
+    RemoteShell { ssh_target: String, remote_folder: Option<String> },
+}
+
+/// Startup step for pane recovery.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum StartupStep {
+    SendText { text: String, execute: bool },
+}
+
+/// Per-pane recovery recipe.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PaneRecoveryRecord {
+    pub source: PaneSource,
+    #[serde(default)]
+    pub target: Option<PaneTarget>,
+    #[serde(default)]
+    pub startup: Vec<StartupStep>,
+}
+
+/// Split orientation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SplitOrientation {
+    Horizontal,
+    Vertical,
+}
+
+/// Recursive layout tree.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum LayoutNode {
+    Terminal {
+        uuid: String,
+        #[serde(default)]
+        profile: Option<String>,
+        #[serde(default)]
+        cwd: Option<String>,
+        #[serde(default)]
+        custom_title: Option<String>,
+    },
+    Split {
+        orientation: SplitOrientation,
+        ratio: f64,
+        first: Box<Self>,
+        second: Box<Self>,
+    },
+}
+
+/// A single workspace record.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkspaceRecord {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub user_renamed: bool,
+    #[serde(default = "default_endpoint_key")]
+    pub endpoint_key: String,
+    #[serde(default)]
+    pub policy: WorkspacePolicy,
+    #[serde(default)]
+    pub runtime_ref: Option<RuntimeRef>,
+    pub layout: LayoutNode,
+    #[serde(default)]
+    pub active_pane_id: Option<String>,
+    #[serde(default)]
+    pub zoomed_pane_id: Option<String>,
+    #[serde(default)]
+    pub input_sync: InputSyncState,
+    #[serde(default)]
+    pub color: WorkspaceColor,
+    #[serde(default)]
+    pub pane_recovery: BTreeMap<String, PaneRecoveryRecord>,
+}
+
+fn default_endpoint_key() -> String {
+    "local".into()
+}
+
+/// Top-level workspace store document.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct WorkspaceStore {
+    #[serde(default)]
+    pub active_workspace_id: Option<String>,
+    #[serde(default)]
+    pub workspaces: Vec<WorkspaceRecord>,
+}

--- a/clients/rttx/tests/document_models.rs
+++ b/clients/rttx/tests/document_models.rs
@@ -1,0 +1,580 @@
+//! Fixture-driven tests for canonical document models (RFC-023 Step 2).
+//!
+//! Covers:
+//! - Round-trip serialization for every document model
+//! - Loading from JSON fixture files
+//! - Rejection of unsupported future versions
+//! - `runtime-cache.json` deletion does not break startup
+//! - Default fallback for missing fields
+
+use rttx::store::models::hosts::{self, HostCatalog, HostKind, HostRecord};
+use rttx::store::models::library::{self, CommandRecord, Library, PlaceRecord};
+use rttx::store::models::preferences::{self, PreferencesV1};
+use rttx::store::models::runtime_cache::{self, RuntimeCache};
+use rttx::store::models::ui::{self, UiState};
+use rttx::store::models::workspaces::{self, WorkspaceStore};
+use rttx::store::{DocumentEnvelope, LoadOutcome, Schema, atomic_load, atomic_save};
+use tempfile::TempDir;
+
+const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/store");
+
+fn fixture_path(name: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(FIXTURES).join(name)
+}
+
+fn load_fixture(name: &str) -> String {
+    std::fs::read_to_string(fixture_path(name))
+        .unwrap_or_else(|e| panic!("failed to read fixture {name}: {e}"))
+}
+
+// ── Preferences ──────────────────────────────────────────────────────
+
+#[test]
+fn preferences_fixture_round_trips() {
+    let json = load_fixture("preferences_v1.json");
+    let envelope: DocumentEnvelope<PreferencesV1> = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(envelope.schema, Schema::Preferences);
+    assert_eq!(envelope.version, 1);
+    assert_eq!(envelope.data.font, "JetBrains Mono 14");
+    assert_eq!(envelope.data.scrollback_lines, 20_000);
+    assert!(envelope.data.smart_clipboard);
+    assert_eq!(envelope.data.reconnect_delay_secs, 5);
+    assert_eq!(envelope.data.paste_guard_threshold, 300);
+
+    let reserialized = serde_json::to_string_pretty(&envelope).unwrap();
+    let reloaded: DocumentEnvelope<PreferencesV1> = serde_json::from_str(&reserialized).unwrap();
+    assert_eq!(envelope.data, reloaded.data);
+}
+
+#[test]
+fn preferences_default_fills_all_fields() {
+    let prefs = PreferencesV1::default();
+    assert_eq!(prefs.font, "Monospace 12");
+    assert_eq!(prefs.scrollback_lines, 10_000);
+    assert!(prefs.show_headerbar);
+    assert!(prefs.auto_start_daemon);
+    assert_eq!(prefs.reconnect_delay_secs, 3);
+    assert_eq!(prefs.paste_guard_threshold, 200);
+}
+
+#[test]
+fn preferences_partial_json_fills_defaults() {
+    let json = r#"{
+        "schema": "rttx.client.preferences",
+        "version": 1,
+        "app_version": "0.4.4",
+        "written_at": "2026-01-01T00:00:00Z",
+        "data": { "font": "Hack 11" }
+    }"#;
+    let envelope: DocumentEnvelope<PreferencesV1> = serde_json::from_str(json).unwrap();
+    assert_eq!(envelope.data.font, "Hack 11");
+    assert_eq!(envelope.data.scrollback_lines, 10_000);
+    assert!(envelope.data.auto_start_daemon);
+}
+
+#[test]
+fn preferences_rejects_future_version() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("preferences.json");
+    let backups = tmp.path().join("backups");
+
+    let env = DocumentEnvelope {
+        schema: Schema::Preferences,
+        version: 99,
+        app_version: "9.0.0".into(),
+        written_at: "2030-01-01T00:00:00Z".into(),
+        data: PreferencesV1::default(),
+    };
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<PreferencesV1> =
+        atomic_load(&path, preferences::SCHEMA, preferences::CURRENT_VERSION, &backups);
+    assert!(matches!(outcome, LoadOutcome::UnsupportedVersion { found: 99, max_supported: 1 }));
+    assert!(path.exists(), "file must not be deleted");
+}
+
+#[test]
+fn preferences_atomic_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("preferences.json");
+    let backups = tmp.path().join("backups");
+
+    let prefs = PreferencesV1 { font: "Fira Code 13".into(), ..PreferencesV1::default() };
+    let env =
+        DocumentEnvelope::new(preferences::SCHEMA, preferences::CURRENT_VERSION, prefs.clone());
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<PreferencesV1> =
+        atomic_load(&path, preferences::SCHEMA, preferences::CURRENT_VERSION, &backups);
+    assert_eq!(outcome.into_value().unwrap(), prefs);
+}
+
+// ── Hosts ────────────────────────────────────────────────────────────
+
+#[test]
+fn hosts_fixture_round_trips() {
+    let json = load_fixture("hosts_v1.json");
+    let envelope: DocumentEnvelope<HostCatalog> = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(envelope.schema, Schema::Hosts);
+    assert_eq!(envelope.version, 1);
+    assert_eq!(envelope.data.hosts.len(), 2);
+    assert_eq!(envelope.data.hosts[0].key, "devbox.example.com");
+    assert_eq!(envelope.data.hosts[0].kind, HostKind::Remote);
+    assert_eq!(envelope.data.hosts[0].labels, vec!["work", "dev"]);
+    assert_eq!(envelope.data.hosts[1].labels, Vec::<String>::new());
+
+    let reserialized = serde_json::to_string_pretty(&envelope).unwrap();
+    let reloaded: DocumentEnvelope<HostCatalog> = serde_json::from_str(&reserialized).unwrap();
+    assert_eq!(envelope.data, reloaded.data);
+}
+
+#[test]
+fn hosts_empty_catalog_round_trips() {
+    let catalog = HostCatalog::default();
+    let env = DocumentEnvelope::new(hosts::SCHEMA, hosts::CURRENT_VERSION, catalog.clone());
+    let json = serde_json::to_string(&env).unwrap();
+    let reloaded: DocumentEnvelope<HostCatalog> = serde_json::from_str(&json).unwrap();
+    assert_eq!(reloaded.data, catalog);
+}
+
+#[test]
+fn hosts_record_without_optional_fields_deserializes() {
+    let json = r#"{
+        "schema": "rttx.client.hosts",
+        "version": 1,
+        "app_version": "0.4.4",
+        "written_at": "2026-01-01T00:00:00Z",
+        "data": {
+            "hosts": [{
+                "key": "box",
+                "name": "Box",
+                "kind": "remote"
+            }]
+        }
+    }"#;
+    let envelope: DocumentEnvelope<HostCatalog> = serde_json::from_str(json).unwrap();
+    assert!(envelope.data.hosts[0].ssh_target.is_none());
+    assert!(envelope.data.hosts[0].labels.is_empty());
+}
+
+#[test]
+fn hosts_rejects_future_version() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("hosts.json");
+    let backups = tmp.path().join("backups");
+
+    let env = DocumentEnvelope {
+        schema: Schema::Hosts,
+        version: 42,
+        app_version: "9.0.0".into(),
+        written_at: "2030-01-01T00:00:00Z".into(),
+        data: HostCatalog::default(),
+    };
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<HostCatalog> =
+        atomic_load(&path, hosts::SCHEMA, hosts::CURRENT_VERSION, &backups);
+    assert!(matches!(outcome, LoadOutcome::UnsupportedVersion { found: 42, max_supported: 1 }));
+}
+
+#[test]
+fn hosts_atomic_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("hosts.json");
+    let backups = tmp.path().join("backups");
+
+    let catalog = HostCatalog {
+        hosts: vec![HostRecord {
+            key: "test.host".into(),
+            name: "Test".into(),
+            kind: HostKind::Remote,
+            ssh_target: Some("user@test.host".into()),
+            labels: vec!["test".into()],
+        }],
+    };
+    let env = DocumentEnvelope::new(hosts::SCHEMA, hosts::CURRENT_VERSION, catalog.clone());
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<HostCatalog> =
+        atomic_load(&path, hosts::SCHEMA, hosts::CURRENT_VERSION, &backups);
+    assert_eq!(outcome.into_value().unwrap(), catalog);
+}
+
+// ── Library ──────────────────────────────────────────────────────────
+
+#[test]
+fn library_fixture_round_trips() {
+    let json = load_fixture("library_v1.json");
+    let envelope: DocumentEnvelope<Library> = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(envelope.schema, Schema::Library);
+    assert_eq!(envelope.version, 1);
+    assert_eq!(envelope.data.places.len(), 2);
+    assert_eq!(envelope.data.commands.len(), 3);
+
+    assert_eq!(envelope.data.places[0].name, "Projects");
+    assert!(envelope.data.places[0].host_tags.is_empty());
+    assert_eq!(envelope.data.places[1].host_tags, vec!["devbox.example.com"]);
+
+    assert_eq!(envelope.data.commands[0].title, "Git Status");
+    assert_eq!(
+        envelope.data.commands[2].default_run_mode,
+        rttx::store::models::commands::RunMode::Insert
+    );
+
+    let reserialized = serde_json::to_string_pretty(&envelope).unwrap();
+    let reloaded: DocumentEnvelope<Library> = serde_json::from_str(&reserialized).unwrap();
+    assert_eq!(envelope.data, reloaded.data);
+}
+
+#[test]
+fn library_empty_round_trips() {
+    let lib = Library::default();
+    let env = DocumentEnvelope::new(library::SCHEMA, library::CURRENT_VERSION, lib.clone());
+    let json = serde_json::to_string(&env).unwrap();
+    let reloaded: DocumentEnvelope<Library> = serde_json::from_str(&json).unwrap();
+    assert_eq!(reloaded.data, lib);
+}
+
+#[test]
+fn library_command_without_run_mode_defaults_to_run() {
+    let json = r#"{
+        "schema": "rttx.client.library",
+        "version": 1,
+        "app_version": "0.4.4",
+        "written_at": "2026-01-01T00:00:00Z",
+        "data": {
+            "places": [],
+            "commands": [{
+                "id": "c1",
+                "title": "ls",
+                "body": "ls -la"
+            }]
+        }
+    }"#;
+    let envelope: DocumentEnvelope<Library> = serde_json::from_str(json).unwrap();
+    assert_eq!(
+        envelope.data.commands[0].default_run_mode,
+        rttx::store::models::commands::RunMode::Run
+    );
+}
+
+#[test]
+fn library_rejects_future_version() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("library.json");
+    let backups = tmp.path().join("backups");
+
+    let env = DocumentEnvelope {
+        schema: Schema::Library,
+        version: 50,
+        app_version: "9.0.0".into(),
+        written_at: "2030-01-01T00:00:00Z".into(),
+        data: Library::default(),
+    };
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<Library> =
+        atomic_load(&path, library::SCHEMA, library::CURRENT_VERSION, &backups);
+    assert!(matches!(outcome, LoadOutcome::UnsupportedVersion { found: 50, max_supported: 1 }));
+}
+
+#[test]
+fn library_preserves_orphaned_host_tags() {
+    let lib = Library {
+        places: vec![PlaceRecord {
+            id: "p1".into(),
+            name: "Orphaned".into(),
+            path: "/tmp".into(),
+            host_tags: vec!["deleted-host-key".into()],
+        }],
+        commands: vec![CommandRecord {
+            id: "c1".into(),
+            title: "Orphaned cmd".into(),
+            body: "echo hi".into(),
+            default_run_mode: rttx::store::models::commands::RunMode::Run,
+            host_tags: vec!["deleted-host-key".into()],
+        }],
+    };
+    let env = DocumentEnvelope::new(library::SCHEMA, library::CURRENT_VERSION, lib);
+    let json = serde_json::to_string(&env).unwrap();
+    let reloaded: DocumentEnvelope<Library> = serde_json::from_str(&json).unwrap();
+    assert_eq!(reloaded.data.places[0].host_tags, vec!["deleted-host-key"]);
+    assert_eq!(reloaded.data.commands[0].host_tags, vec!["deleted-host-key"]);
+}
+
+// ── Workspaces ───────────────────────────────────────────────────────
+
+#[test]
+fn workspaces_fixture_round_trips() {
+    let json = load_fixture("workspaces_v1.json");
+    let envelope: DocumentEnvelope<WorkspaceStore> = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(envelope.schema, Schema::Workspaces);
+    assert_eq!(envelope.version, 1);
+    assert_eq!(envelope.data.active_workspace_id.as_deref(), Some("ws-001"));
+    assert_eq!(envelope.data.workspaces.len(), 2);
+
+    let ws1 = &envelope.data.workspaces[0];
+    assert_eq!(ws1.name, "Development");
+    assert!(ws1.user_renamed);
+    assert_eq!(ws1.endpoint_key, "local");
+    assert!(ws1.runtime_ref.is_some());
+    assert_eq!(ws1.runtime_ref.as_ref().unwrap().runtime_id, "rt-abc-123");
+    assert_eq!(ws1.pane_recovery.len(), 2);
+
+    let ws2 = &envelope.data.workspaces[1];
+    assert_eq!(ws2.endpoint_key, "devbox.example.com");
+    assert!(ws2.runtime_ref.is_none());
+
+    let reserialized = serde_json::to_string_pretty(&envelope).unwrap();
+    let reloaded: DocumentEnvelope<WorkspaceStore> = serde_json::from_str(&reserialized).unwrap();
+    assert_eq!(envelope.data, reloaded.data);
+}
+
+#[test]
+fn workspaces_empty_store_round_trips() {
+    let store = WorkspaceStore::default();
+    let env = DocumentEnvelope::new(workspaces::SCHEMA, workspaces::CURRENT_VERSION, store.clone());
+    let json = serde_json::to_string(&env).unwrap();
+    let reloaded: DocumentEnvelope<WorkspaceStore> = serde_json::from_str(&json).unwrap();
+    assert_eq!(reloaded.data, store);
+}
+
+#[test]
+fn workspaces_missing_optional_fields_deserialize() {
+    let json = r#"{
+        "schema": "rttx.client.workspaces",
+        "version": 1,
+        "app_version": "0.4.4",
+        "written_at": "2026-01-01T00:00:00Z",
+        "data": {
+            "workspaces": [{
+                "id": "ws-min",
+                "name": "Minimal",
+                "layout": { "terminal": { "uuid": "p1" } }
+            }]
+        }
+    }"#;
+    let envelope: DocumentEnvelope<WorkspaceStore> = serde_json::from_str(json).unwrap();
+    let ws = &envelope.data.workspaces[0];
+    assert!(!ws.user_renamed);
+    assert_eq!(ws.endpoint_key, "local");
+    assert!(ws.runtime_ref.is_none());
+    assert!(ws.active_pane_id.is_none());
+    assert!(ws.zoomed_pane_id.is_none());
+    assert!(ws.pane_recovery.is_empty());
+}
+
+#[test]
+fn workspaces_rejects_future_version() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("workspaces.json");
+    let backups = tmp.path().join("backups");
+
+    let env = DocumentEnvelope {
+        schema: Schema::Workspaces,
+        version: 77,
+        app_version: "9.0.0".into(),
+        written_at: "2030-01-01T00:00:00Z".into(),
+        data: WorkspaceStore::default(),
+    };
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<WorkspaceStore> =
+        atomic_load(&path, workspaces::SCHEMA, workspaces::CURRENT_VERSION, &backups);
+    assert!(matches!(outcome, LoadOutcome::UnsupportedVersion { found: 77, max_supported: 1 }));
+}
+
+// ── UI State ─────────────────────────────────────────────────────────
+
+#[test]
+fn ui_fixture_round_trips() {
+    let json = load_fixture("ui_v1.json");
+    let envelope: DocumentEnvelope<UiState> = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(envelope.schema, Schema::Ui);
+    assert_eq!(envelope.version, 1);
+    assert_eq!(envelope.data.window_width, 1280);
+    assert_eq!(envelope.data.window_height, 720);
+    assert!(!envelope.data.is_maximized);
+    assert_eq!(envelope.data.left_sidebar_width, 250);
+    assert!(envelope.data.left_sidebar_visible);
+    assert!(!envelope.data.right_sidebar_visible);
+    assert_eq!(envelope.data.selected_right_tool.as_deref(), Some("commands"));
+
+    let reserialized = serde_json::to_string_pretty(&envelope).unwrap();
+    let reloaded: DocumentEnvelope<UiState> = serde_json::from_str(&reserialized).unwrap();
+    assert_eq!(envelope.data, reloaded.data);
+}
+
+#[test]
+fn ui_default_has_sensible_dimensions() {
+    let ui = UiState::default();
+    assert_eq!(ui.window_width, 900);
+    assert_eq!(ui.window_height, 600);
+    assert_eq!(ui.left_sidebar_width, 220);
+    assert_eq!(ui.right_sidebar_width, 320);
+    assert!(!ui.is_maximized);
+}
+
+#[test]
+fn ui_partial_json_fills_defaults() {
+    let json = r#"{
+        "schema": "rttx.client.ui",
+        "version": 1,
+        "app_version": "0.4.4",
+        "written_at": "2026-01-01T00:00:00Z",
+        "data": { "window_width": 1920 }
+    }"#;
+    let envelope: DocumentEnvelope<UiState> = serde_json::from_str(json).unwrap();
+    assert_eq!(envelope.data.window_width, 1920);
+    assert_eq!(envelope.data.window_height, 600);
+    assert_eq!(envelope.data.left_sidebar_width, 220);
+}
+
+#[test]
+fn ui_rejects_future_version() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("ui.json");
+    let backups = tmp.path().join("backups");
+
+    let env = DocumentEnvelope {
+        schema: Schema::Ui,
+        version: 10,
+        app_version: "9.0.0".into(),
+        written_at: "2030-01-01T00:00:00Z".into(),
+        data: UiState::default(),
+    };
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<UiState> =
+        atomic_load(&path, ui::SCHEMA, ui::CURRENT_VERSION, &backups);
+    assert!(matches!(outcome, LoadOutcome::UnsupportedVersion { found: 10, max_supported: 1 }));
+}
+
+#[test]
+fn ui_atomic_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("ui.json");
+    let backups = tmp.path().join("backups");
+
+    let state = UiState { window_width: 1600, window_height: 900, ..UiState::default() };
+    let env = DocumentEnvelope::new(ui::SCHEMA, ui::CURRENT_VERSION, state.clone());
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<UiState> =
+        atomic_load(&path, ui::SCHEMA, ui::CURRENT_VERSION, &backups);
+    assert_eq!(outcome.into_value().unwrap(), state);
+}
+
+// ── Runtime Cache ────────────────────────────────────────────────────
+
+#[test]
+fn runtime_cache_fixture_round_trips() {
+    let json = load_fixture("runtime_cache_v1.json");
+    let envelope: DocumentEnvelope<RuntimeCache> = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(envelope.schema, Schema::RuntimeCache);
+    assert_eq!(envelope.version, 1);
+    assert_eq!(envelope.data.dismissed_runtime_ids.len(), 2);
+    assert!(envelope.data.dismissed_runtime_ids.contains("rt-old-001"));
+
+    let reserialized = serde_json::to_string_pretty(&envelope).unwrap();
+    let reloaded: DocumentEnvelope<RuntimeCache> = serde_json::from_str(&reserialized).unwrap();
+    assert_eq!(envelope.data, reloaded.data);
+}
+
+#[test]
+fn runtime_cache_rejects_future_version() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("runtime-cache.json");
+    let backups = tmp.path().join("backups");
+
+    let env = DocumentEnvelope {
+        schema: Schema::RuntimeCache,
+        version: 5,
+        app_version: "9.0.0".into(),
+        written_at: "2030-01-01T00:00:00Z".into(),
+        data: RuntimeCache::default(),
+    };
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<RuntimeCache> =
+        atomic_load(&path, runtime_cache::SCHEMA, runtime_cache::CURRENT_VERSION, &backups);
+    assert!(matches!(outcome, LoadOutcome::UnsupportedVersion { found: 5, max_supported: 1 }));
+}
+
+#[test]
+fn runtime_cache_deletion_returns_empty_default() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("runtime-cache.json");
+    let backups = tmp.path().join("backups");
+
+    // File does not exist — simulates deletion
+    assert!(!path.exists());
+
+    let outcome: LoadOutcome<RuntimeCache> =
+        atomic_load(&path, runtime_cache::SCHEMA, runtime_cache::CURRENT_VERSION, &backups);
+    assert!(matches!(outcome, LoadOutcome::Default(_)));
+    let cache = outcome.into_value().unwrap();
+    assert!(cache.dismissed_runtime_ids.is_empty());
+}
+
+#[test]
+fn runtime_cache_deletion_after_save_returns_default() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("runtime-cache.json");
+    let backups = tmp.path().join("backups");
+
+    // Save, then delete
+    let cache = RuntimeCache { dismissed_runtime_ids: std::iter::once("rt-1".into()).collect() };
+    let env = DocumentEnvelope::new(runtime_cache::SCHEMA, runtime_cache::CURRENT_VERSION, cache);
+    atomic_save(&path, &env).unwrap();
+    assert!(path.exists());
+
+    std::fs::remove_file(&path).unwrap();
+    // Also remove .bak to fully simulate cache cleanup
+    let _ = std::fs::remove_file(path.with_extension("bak"));
+
+    let outcome: LoadOutcome<RuntimeCache> =
+        atomic_load(&path, runtime_cache::SCHEMA, runtime_cache::CURRENT_VERSION, &backups);
+    assert!(matches!(outcome, LoadOutcome::Default(_)));
+    assert!(outcome.into_value().unwrap().dismissed_runtime_ids.is_empty());
+}
+
+#[test]
+fn runtime_cache_atomic_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("runtime-cache.json");
+    let backups = tmp.path().join("backups");
+
+    let cache = RuntimeCache {
+        dismissed_runtime_ids: ["rt-a".into(), "rt-b".into()].into_iter().collect(),
+    };
+    let env =
+        DocumentEnvelope::new(runtime_cache::SCHEMA, runtime_cache::CURRENT_VERSION, cache.clone());
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<RuntimeCache> =
+        atomic_load(&path, runtime_cache::SCHEMA, runtime_cache::CURRENT_VERSION, &backups);
+    assert_eq!(outcome.into_value().unwrap(), cache);
+}
+
+// ── Cross-domain: schema mismatch ────────────────────────────────────
+
+#[test]
+fn loading_hosts_file_as_preferences_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("wrong.json");
+    let backups = tmp.path().join("backups");
+
+    let env = DocumentEnvelope::new(hosts::SCHEMA, hosts::CURRENT_VERSION, HostCatalog::default());
+    atomic_save(&path, &env).unwrap();
+
+    let outcome: LoadOutcome<PreferencesV1> =
+        atomic_load(&path, preferences::SCHEMA, preferences::CURRENT_VERSION, &backups);
+    assert!(matches!(outcome, LoadOutcome::DefaultAfterFailure(_)));
+}

--- a/clients/rttx/tests/fixtures/store/hosts_v1.json
+++ b/clients/rttx/tests/fixtures/store/hosts_v1.json
@@ -1,0 +1,24 @@
+{
+  "schema": "rttx.client.hosts",
+  "version": 1,
+  "app_version": "0.4.4",
+  "written_at": "2026-04-21T00:00:00Z",
+  "data": {
+    "hosts": [
+      {
+        "key": "devbox.example.com",
+        "name": "Dev Box",
+        "kind": "remote",
+        "ssh_target": "user@devbox.example.com",
+        "labels": ["work", "dev"]
+      },
+      {
+        "key": "prod.example.com",
+        "name": "Production",
+        "kind": "remote",
+        "ssh_target": "deploy@prod.example.com",
+        "labels": []
+      }
+    ]
+  }
+}

--- a/clients/rttx/tests/fixtures/store/library_v1.json
+++ b/clients/rttx/tests/fixtures/store/library_v1.json
@@ -1,0 +1,45 @@
+{
+  "schema": "rttx.client.library",
+  "version": 1,
+  "app_version": "0.4.4",
+  "written_at": "2026-04-21T00:00:00Z",
+  "data": {
+    "places": [
+      {
+        "id": "place-001",
+        "name": "Projects",
+        "path": "/home/user/projects",
+        "host_tags": []
+      },
+      {
+        "id": "place-002",
+        "name": "Remote Logs",
+        "path": "/var/log",
+        "host_tags": ["devbox.example.com"]
+      }
+    ],
+    "commands": [
+      {
+        "id": "cmd-001",
+        "title": "Git Status",
+        "body": "git status",
+        "default_run_mode": "run",
+        "host_tags": []
+      },
+      {
+        "id": "cmd-002",
+        "title": "Tail Syslog",
+        "body": "tail -f /var/log/syslog",
+        "default_run_mode": "run",
+        "host_tags": ["devbox.example.com"]
+      },
+      {
+        "id": "cmd-003",
+        "title": "Docker PS",
+        "body": "docker ps --format 'table {{.Names}}\\t{{.Status}}'",
+        "default_run_mode": "insert",
+        "host_tags": []
+      }
+    ]
+  }
+}

--- a/clients/rttx/tests/fixtures/store/preferences_v1.json
+++ b/clients/rttx/tests/fixtures/store/preferences_v1.json
@@ -1,0 +1,29 @@
+{
+  "schema": "rttx.client.preferences",
+  "version": 1,
+  "app_version": "0.4.4",
+  "written_at": "2026-04-21T00:00:00Z",
+  "data": {
+    "font": "JetBrains Mono 14",
+    "terminal_theme_mode": "dark",
+    "light_color_scheme": "Daybreak",
+    "dark_color_scheme": "Nightfall",
+    "scrollback_lines": 20000,
+    "show_headerbar": true,
+    "scroll_on_keystroke": true,
+    "scroll_on_output": false,
+    "audible_bell": false,
+    "visual_bell": true,
+    "smart_clipboard": true,
+    "trim_trailing_whitespace_on_copy": true,
+    "default_session_folder": "current-session",
+    "pane_navigation_keys": "alt-arrow",
+    "keyboard_shortcuts": {
+      "split-horizontal": ["<Ctrl><Shift>e"]
+    },
+    "auto_start_daemon": true,
+    "reconnect_delay_secs": 5,
+    "paste_guard": true,
+    "paste_guard_threshold": 300
+  }
+}

--- a/clients/rttx/tests/fixtures/store/runtime_cache_v1.json
+++ b/clients/rttx/tests/fixtures/store/runtime_cache_v1.json
@@ -1,0 +1,9 @@
+{
+  "schema": "rttx.client.runtime_cache",
+  "version": 1,
+  "app_version": "0.4.4",
+  "written_at": "2026-04-21T00:00:00Z",
+  "data": {
+    "dismissed_runtime_ids": ["rt-old-001", "rt-old-002"]
+  }
+}

--- a/clients/rttx/tests/fixtures/store/ui_v1.json
+++ b/clients/rttx/tests/fixtures/store/ui_v1.json
@@ -1,0 +1,16 @@
+{
+  "schema": "rttx.client.ui",
+  "version": 1,
+  "app_version": "0.4.4",
+  "written_at": "2026-04-21T00:00:00Z",
+  "data": {
+    "window_width": 1280,
+    "window_height": 720,
+    "is_maximized": false,
+    "left_sidebar_width": 250,
+    "right_sidebar_width": 350,
+    "left_sidebar_visible": true,
+    "right_sidebar_visible": false,
+    "selected_right_tool": "commands"
+  }
+}

--- a/clients/rttx/tests/fixtures/store/workspaces_v1.json
+++ b/clients/rttx/tests/fixtures/store/workspaces_v1.json
@@ -1,0 +1,79 @@
+{
+  "schema": "rttx.client.workspaces",
+  "version": 1,
+  "app_version": "0.4.4",
+  "written_at": "2026-04-21T00:00:00Z",
+  "data": {
+    "active_workspace_id": "ws-001",
+    "workspaces": [
+      {
+        "id": "ws-001",
+        "name": "Development",
+        "user_renamed": true,
+        "endpoint_key": "local",
+        "policy": "persistent",
+        "runtime_ref": {
+          "runtime_id": "rt-abc-123",
+          "attachment_kind": "created"
+        },
+        "layout": {
+          "split": {
+            "orientation": "horizontal",
+            "ratio": 0.5,
+            "first": {
+              "terminal": {
+                "uuid": "pane-001",
+                "cwd": "/home/user/projects"
+              }
+            },
+            "second": {
+              "terminal": {
+                "uuid": "pane-002",
+                "cwd": "/home/user/projects/rttx"
+              }
+            }
+          }
+        },
+        "active_pane_id": "pane-001",
+        "input_sync": "off",
+        "color": "blue",
+        "pane_recovery": {
+          "pane-001": {
+            "source": "empty-shell",
+            "startup": []
+          },
+          "pane-002": {
+            "source": { "command": { "title": "cargo watch" } },
+            "target": { "local-folder": { "path": "/home/user/projects/rttx" } },
+            "startup": [
+              { "send-text": { "text": "cargo watch -x test", "execute": true } }
+            ]
+          }
+        }
+      },
+      {
+        "id": "ws-002",
+        "name": "Remote Server",
+        "user_renamed": true,
+        "endpoint_key": "devbox.example.com",
+        "policy": "ephemeral",
+        "layout": {
+          "terminal": {
+            "uuid": "pane-003",
+            "cwd": "/var/log"
+          }
+        },
+        "active_pane_id": "pane-003",
+        "input_sync": "off",
+        "color": "green",
+        "pane_recovery": {
+          "pane-003": {
+            "source": "manual",
+            "target": { "remote-shell": { "ssh_target": "user@devbox.example.com", "remote_folder": "/var/log" } },
+            "startup": []
+          }
+        }
+      }
+    ]
+  }
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.4',
+  version: '0.4.5',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

RFC-023 Step 2: Define canonical versioned document models for all six client persistence domains.

### Models added (`store::models`)

| Document | Schema | Model |
|---|---|---|
| `preferences.json` | `rttx.client.preferences` | `PreferencesV1` |
| `hosts.json` | `rttx.client.hosts` | `HostCatalog` with `HostRecord` |
| `library.json` | `rttx.client.library` | `Library` with `PlaceRecord` and `CommandRecord` |
| `workspaces.json` | `rttx.client.workspaces` | `WorkspaceStore` with `WorkspaceRecord`, `RuntimeRef`, `LayoutNode` |
| `ui.json` | `rttx.client.ui` | `UiState` |
| `runtime-cache.json` | `rttx.client.runtime_cache` | `RuntimeCache` |

Each model has `SCHEMA` and `CURRENT_VERSION` constants, `#[serde(default)]` for forward-compatible deserialization, and a JSON fixture file in `tests/fixtures/store/`.

### Manual verification

```bash
cargo test -p rttx --test document_models
```

### Tests added (30 total)

**Round-trip from fixtures:** `preferences_fixture_round_trips`, `hosts_fixture_round_trips`, `library_fixture_round_trips`, `workspaces_fixture_round_trips`, `ui_fixture_round_trips`, `runtime_cache_fixture_round_trips`

**Default/partial deserialization:** `preferences_default_fills_all_fields`, `preferences_partial_json_fills_defaults`, `hosts_empty_catalog_round_trips`, `hosts_record_without_optional_fields_deserializes`, `library_empty_round_trips`, `library_command_without_run_mode_defaults_to_run`, `workspaces_empty_store_round_trips`, `workspaces_missing_optional_fields_deserialize`, `ui_default_has_sensible_dimensions`, `ui_partial_json_fills_defaults`

**Future version rejection:** `preferences_rejects_future_version`, `hosts_rejects_future_version`, `library_rejects_future_version`, `workspaces_rejects_future_version`, `ui_rejects_future_version`, `runtime_cache_rejects_future_version`

**Atomic I/O round-trips:** `preferences_atomic_round_trip`, `hosts_atomic_round_trip`, `ui_atomic_round_trip`, `runtime_cache_atomic_round_trip`

**Edge cases:** `library_preserves_orphaned_host_tags`, `runtime_cache_deletion_returns_empty_default`, `runtime_cache_deletion_after_save_returns_default`, `loading_hosts_file_as_preferences_is_rejected`

### Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --test document_models` — 30/30 pass ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all document_models tests appear and pass)
- `cargo test -p rttx-server -p rttx-proto` ✅

### Version bump

0.4.4 → 0.4.5 (>3 source files changed)

Fixes #739