### PR TITLE
feat(store): move preferences, hosts, library behind ClientStore API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.5"
+version = "0.4.6"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/commands_window.rs
+++ b/clients/rttx/src/commands_window.rs
@@ -2,7 +2,7 @@ use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
 
-use crate::commands::{self, CommandRunMode, SavedCommand};
+use crate::commands::{CommandRunMode, SavedCommand};
 use crate::form_dialog::FormDialog;
 use crate::host_tag_picker::HostTagPicker;
 use crate::window::Window;
@@ -65,13 +65,13 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
             }
         };
 
-        let mut items = commands::load();
+        let mut items = crate::store::default_store().load_commands();
         if let Some(existing) = items.iter_mut().find(|i| i.uuid == cmd.uuid) {
             *existing = cmd;
         } else {
             items.push(cmd);
         }
-        if let Err(e) = commands::save(&items) {
+        if let Err(e) = crate::store::default_store().save_commands(&items) {
             status_label.set_text(&format!("Failed to save: {e}"));
             return;
         }

--- a/clients/rttx/src/host_tag_picker.rs
+++ b/clients/rttx/src/host_tag_picker.rs
@@ -27,10 +27,7 @@ impl HostTagPicker {
     /// Build a picker from saved hosts, pre-checking `selected_tags`.
     #[must_use]
     pub fn new(selected_tags: &[String]) -> Self {
-        let hosts = crate::store::default_store()
-            .load_hosts()
-            .into_value()
-            .unwrap_or_default();
+        let hosts = crate::store::default_store().load_hosts().into_value().unwrap_or_default();
         Self::with_hosts(&hosts, selected_tags)
     }
 

--- a/clients/rttx/src/host_tag_picker.rs
+++ b/clients/rttx/src/host_tag_picker.rs
@@ -27,7 +27,11 @@ impl HostTagPicker {
     /// Build a picker from saved hosts, pre-checking `selected_tags`.
     #[must_use]
     pub fn new(selected_tags: &[String]) -> Self {
-        Self::with_hosts(&host::load(), selected_tags)
+        let hosts = crate::store::default_store()
+            .load_hosts()
+            .into_value()
+            .unwrap_or_default();
+        Self::with_hosts(&hosts, selected_tags)
     }
 
     /// Build a picker from an explicit host list, pre-checking `selected_tags`.

--- a/clients/rttx/src/new_workspace_dialog.rs
+++ b/clients/rttx/src/new_workspace_dialog.rs
@@ -80,7 +80,7 @@ fn populate_places(
         container.remove(&child);
     }
 
-    let saved = places::load();
+    let saved = crate::store::default_store().load_places();
     let visible = places::visible_for_host(&saved, host_key);
 
     let mut has_builtin = false;

--- a/clients/rttx/src/places_window.rs
+++ b/clients/rttx/src/places_window.rs
@@ -4,7 +4,7 @@ use libadwaita::prelude::*;
 
 use crate::form_dialog::FormDialog;
 use crate::host_tag_picker::HostTagPicker;
-use crate::places::{self, Place};
+use crate::places::Place;
 use crate::window::Window;
 
 pub fn show_form(parent: &Window, place: Option<&Place>) {
@@ -43,13 +43,13 @@ pub fn show_form(parent: &Window, place: Option<&Place>) {
             }
         };
 
-        let mut items = places::load();
+        let mut items = crate::store::default_store().load_places();
         if let Some(existing) = items.iter_mut().find(|i| i.uuid == place.uuid) {
             *existing = place;
         } else {
             items.push(place);
         }
-        if let Err(e) = places::save(&items) {
+        if let Err(e) = crate::store::default_store().save_places(&items) {
             status_label.set_text(&format!("Failed to save: {e}"));
             return;
         }

--- a/clients/rttx/src/preferences_window.rs
+++ b/clients/rttx/src/preferences_window.rs
@@ -8,12 +8,12 @@ use libadwaita as adw;
 use libadwaita::prelude::*;
 
 use crate::color_scheme;
-use crate::preferences::{self, DefaultSessionFolder, Preferences, TerminalThemeMode};
+use crate::preferences::{DefaultSessionFolder, Preferences, TerminalThemeMode};
 use crate::shortcuts::{self, DEFAULT_SHORTCUTS};
 
 /// Build and present the preferences window.
 pub fn show(parent: &impl IsA<gtk4::Window>) {
-    let prefs = preferences::load();
+    let prefs = crate::store::default_store().load_preferences().into_value().unwrap_or_default();
     let window = adw::PreferencesWindow::new();
     window.set_transient_for(Some(parent.as_ref()));
     window.set_modal(true);
@@ -268,7 +268,7 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
             paste_guard: paste_guard_row.is_active(),
             paste_guard_threshold: prefs.paste_guard_threshold,
         };
-        if let Err(e) = preferences::save(&new_prefs) {
+        if let Err(e) = crate::store::default_store().save_preferences(&new_prefs) {
             tracing::error!("Failed to save preferences: {e}");
         }
         if let Ok(win) = parent_window.clone().downcast::<crate::window::Window>() {

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -147,6 +147,40 @@ impl ClientStore {
         );
         atomic_save(&path, &envelope)
     }
+
+    // ── Convenience: load/save just places or commands ──────
+
+    /// Load only the places from the library document.
+    #[must_use]
+    pub fn load_places(&self) -> Vec<Place> {
+        self.load_library().into_value().map_or_else(Vec::new, |(p, _)| p)
+    }
+
+    /// Load only the commands from the library document.
+    #[must_use]
+    pub fn load_commands(&self) -> Vec<SavedCommand> {
+        self.load_library().into_value().map_or_else(Vec::new, |(_, c)| c)
+    }
+
+    /// Save places, preserving the current commands.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the atomic write fails.
+    pub fn save_places(&self, places: &[Place]) -> std::io::Result<()> {
+        let commands = self.load_commands();
+        self.save_library(places, &commands)
+    }
+
+    /// Save commands, preserving the current places.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the atomic write fails.
+    pub fn save_commands(&self, commands: &[SavedCommand]) -> std::io::Result<()> {
+        let places = self.load_places();
+        self.save_library(&places, commands)
+    }
 }
 
 impl<T> LoadOutcome<T> {

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -13,6 +13,27 @@ pub use envelope::{DocumentEnvelope, Schema};
 pub use io::{LoadOutcome, atomic_load, atomic_save};
 pub use paths::StorePaths;
 
+use crate::commands::SavedCommand;
+use crate::host::Host;
+use crate::places::Place;
+use crate::preferences::Preferences;
+
+/// Build a `ClientStore` from the active application profile.
+///
+/// Uses `config_dir_path()` for config, `state_dir_path()` for state,
+/// and the XDG cache directory for cache.
+#[must_use]
+pub fn default_store() -> ClientStore {
+    let profile = crate::config::app_profile();
+    let config = crate::config::config_dir_path();
+    let state = crate::config::state_dir_path();
+    let cache_dir_name = if profile.is_development { "rttx-devel" } else { "rttx" };
+    let cache = gtk4::glib::user_cache_dir().join(cache_dir_name);
+    ClientStore::new(StorePaths::new(config, state, cache))
+}
+
+use gtk4;
+
 /// Client store providing typed document persistence with atomic I/O.
 #[derive(Debug, Clone)]
 pub struct ClientStore {
@@ -28,5 +49,296 @@ impl ClientStore {
     #[must_use]
     pub const fn paths(&self) -> &StorePaths {
         &self.paths
+    }
+
+    // ── Preferences ─────────────────────────────────────────
+
+    /// Load preferences through the envelope-aware loader with malformed-file recovery.
+    #[must_use]
+    pub fn load_preferences(&self) -> LoadOutcome<Preferences> {
+        let path = self.paths.config().join("preferences.json");
+        let outcome: LoadOutcome<models::preferences::PreferencesV1> = atomic_load(
+            &path,
+            models::preferences::SCHEMA,
+            models::preferences::CURRENT_VERSION,
+            &self.paths.backups(),
+        );
+        outcome.map(Into::into)
+    }
+
+    /// Save preferences atomically with an envelope wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the atomic write fails.
+    pub fn save_preferences(&self, prefs: &Preferences) -> std::io::Result<()> {
+        let path = self.paths.config().join("preferences.json");
+        let v1: models::preferences::PreferencesV1 = prefs.into();
+        let envelope = DocumentEnvelope::new(
+            models::preferences::SCHEMA,
+            models::preferences::CURRENT_VERSION,
+            v1,
+        );
+        atomic_save(&path, &envelope)
+    }
+
+    // ── Hosts ───────────────────────────────────────────────
+
+    /// Load hosts through the envelope-aware loader with malformed-file recovery.
+    #[must_use]
+    pub fn load_hosts(&self) -> LoadOutcome<Vec<Host>> {
+        let path = self.paths.config().join("hosts.json");
+        let outcome: LoadOutcome<models::hosts::HostCatalog> = atomic_load(
+            &path,
+            models::hosts::SCHEMA,
+            models::hosts::CURRENT_VERSION,
+            &self.paths.backups(),
+        );
+        outcome.map(|catalog| catalog.hosts.into_iter().map(Into::into).collect())
+    }
+
+    /// Save hosts atomically with an envelope wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the atomic write fails.
+    pub fn save_hosts(&self, hosts: &[Host]) -> std::io::Result<()> {
+        let path = self.paths.config().join("hosts.json");
+        let catalog = models::hosts::HostCatalog { hosts: hosts.iter().map(Into::into).collect() };
+        let envelope =
+            DocumentEnvelope::new(models::hosts::SCHEMA, models::hosts::CURRENT_VERSION, catalog);
+        atomic_save(&path, &envelope)
+    }
+
+    // ── Library (places + commands) ─────────────────────────
+
+    /// Load the combined library (places and commands) through the envelope-aware loader.
+    #[must_use]
+    pub fn load_library(&self) -> LoadOutcome<(Vec<Place>, Vec<SavedCommand>)> {
+        let path = self.paths.config().join("library.json");
+        let outcome: LoadOutcome<models::library::Library> = atomic_load(
+            &path,
+            models::library::SCHEMA,
+            models::library::CURRENT_VERSION,
+            &self.paths.backups(),
+        );
+        outcome.map(|lib| {
+            let places = lib.places.into_iter().map(Into::into).collect();
+            let commands = lib.commands.into_iter().map(Into::into).collect();
+            (places, commands)
+        })
+    }
+
+    /// Save places and commands as a single library document.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the atomic write fails.
+    pub fn save_library(&self, places: &[Place], commands: &[SavedCommand]) -> std::io::Result<()> {
+        let path = self.paths.config().join("library.json");
+        let library = models::library::Library {
+            places: places.iter().map(Into::into).collect(),
+            commands: commands.iter().map(Into::into).collect(),
+        };
+        let envelope = DocumentEnvelope::new(
+            models::library::SCHEMA,
+            models::library::CURRENT_VERSION,
+            library,
+        );
+        atomic_save(&path, &envelope)
+    }
+}
+
+impl<T> LoadOutcome<T> {
+    /// Transform the contained value, preserving the outcome variant.
+    #[must_use]
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> LoadOutcome<U> {
+        match self {
+            Self::Loaded(v) => LoadOutcome::Loaded(f(v)),
+            Self::Recovered(v) => LoadOutcome::Recovered(f(v)),
+            Self::Default(v) => LoadOutcome::Default(f(v)),
+            Self::DefaultAfterFailure(v) => LoadOutcome::DefaultAfterFailure(f(v)),
+            Self::UnsupportedVersion { found, max_supported } => {
+                LoadOutcome::UnsupportedVersion { found, max_supported }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_store() -> (TempDir, ClientStore) {
+        let tmp = TempDir::new().unwrap();
+        let paths = StorePaths::new(
+            tmp.path().join("config"),
+            tmp.path().join("state"),
+            tmp.path().join("cache"),
+        );
+        (tmp, ClientStore::new(paths))
+    }
+
+    // ── Preferences ─────────────────────────────────────────
+
+    #[test]
+    fn preferences_round_trip_through_store() {
+        let (_tmp, store) = test_store();
+        let prefs = Preferences {
+            font: "JetBrains Mono 14".into(),
+            scrollback_lines: 5000,
+            ..Default::default()
+        };
+        store.save_preferences(&prefs).unwrap();
+        let loaded = store.load_preferences().into_value().unwrap();
+        assert_eq!(loaded.font, "JetBrains Mono 14");
+        assert_eq!(loaded.scrollback_lines, 5000);
+    }
+
+    #[test]
+    fn preferences_missing_file_returns_default() {
+        let (_tmp, store) = test_store();
+        let outcome = store.load_preferences();
+        assert!(matches!(outcome, LoadOutcome::Default(_)));
+    }
+
+    #[test]
+    fn preferences_malformed_file_recovers_to_default() {
+        let (_tmp, store) = test_store();
+        let path = store.paths.config().join("preferences.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "not json").unwrap();
+        let outcome = store.load_preferences();
+        assert!(matches!(outcome, LoadOutcome::DefaultAfterFailure(_)));
+    }
+
+    #[test]
+    fn preferences_malformed_primary_recovers_from_backup() {
+        let (_tmp, store) = test_store();
+        // Save a good version first
+        let prefs = Preferences { font: "Backup Font 12".into(), ..Default::default() };
+        store.save_preferences(&prefs).unwrap();
+        // Save again to create .bak
+        let prefs2 = Preferences { font: "Current Font 12".into(), ..Default::default() };
+        store.save_preferences(&prefs2).unwrap();
+        // Corrupt the primary
+        let path = store.paths.config().join("preferences.json");
+        std::fs::write(&path, "corrupted").unwrap();
+        let outcome = store.load_preferences();
+        assert!(matches!(outcome, LoadOutcome::Recovered(_)));
+        assert_eq!(outcome.into_value().unwrap().font, "Backup Font 12");
+    }
+
+    // ── Hosts ───────────────────────────────────────────────
+
+    #[test]
+    fn hosts_round_trip_through_store() {
+        let (_tmp, store) = test_store();
+        let hosts = vec![Host::remote("deploy@example.com")];
+        store.save_hosts(&hosts).unwrap();
+        let loaded = store.load_hosts().into_value().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].key, "example.com");
+        assert_eq!(loaded[0].ssh_target.as_deref(), Some("deploy@example.com"));
+    }
+
+    #[test]
+    fn hosts_missing_file_returns_empty() {
+        let (_tmp, store) = test_store();
+        let outcome = store.load_hosts();
+        assert!(matches!(outcome, LoadOutcome::Default(_)));
+        assert!(outcome.into_value().unwrap().is_empty());
+    }
+
+    #[test]
+    fn hosts_malformed_file_recovers_to_default() {
+        let (_tmp, store) = test_store();
+        let path = store.paths.config().join("hosts.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "bad json").unwrap();
+        let outcome = store.load_hosts();
+        assert!(matches!(outcome, LoadOutcome::DefaultAfterFailure(_)));
+    }
+
+    // ── Library ─────────────────────────────────────────────
+
+    #[test]
+    fn library_round_trip_through_store() {
+        let (_tmp, store) = test_store();
+        let mut place = Place::new("rttx", "~/pro/rttx");
+        place.host_tags = vec!["local".into()];
+        let mut cmd = SavedCommand::new("Build", "cargo build");
+        cmd.host_tags = vec!["local".into(), "example.com".into()];
+
+        store.save_library(&[place], &[cmd]).unwrap();
+        let (places, commands) = store.load_library().into_value().unwrap();
+        assert_eq!(places.len(), 1);
+        assert_eq!(places[0].name, "rttx");
+        assert_eq!(places[0].host_tags, vec!["local"]);
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].title, "Build");
+        assert_eq!(commands[0].host_tags, vec!["local", "example.com"]);
+    }
+
+    #[test]
+    fn library_missing_file_returns_empty() {
+        let (_tmp, store) = test_store();
+        let outcome = store.load_library();
+        assert!(matches!(outcome, LoadOutcome::Default(_)));
+        let (places, commands) = outcome.into_value().unwrap();
+        assert!(places.is_empty());
+        assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn library_malformed_file_recovers_to_default() {
+        let (_tmp, store) = test_store();
+        let path = store.paths.config().join("library.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "garbage").unwrap();
+        let outcome = store.load_library();
+        assert!(matches!(outcome, LoadOutcome::DefaultAfterFailure(_)));
+    }
+
+    #[test]
+    fn library_preserves_uuid_and_run_mode() {
+        let (_tmp, store) = test_store();
+        let place = Place {
+            uuid: "fixed-uuid-1".into(),
+            name: "Test".into(),
+            path: "/test".into(),
+            host_tags: vec![],
+        };
+        let cmd = SavedCommand {
+            uuid: "fixed-uuid-2".into(),
+            title: "Insert".into(),
+            body: "echo hi".into(),
+            default_run_mode: crate::commands::CommandRunMode::Insert,
+            host_tags: vec![],
+        };
+        store.save_library(&[place], &[cmd]).unwrap();
+        let (places, commands) = store.load_library().into_value().unwrap();
+        assert_eq!(places[0].uuid, "fixed-uuid-1");
+        assert_eq!(commands[0].uuid, "fixed-uuid-2");
+        assert_eq!(commands[0].default_run_mode, crate::commands::CommandRunMode::Insert);
+    }
+
+    // ── LoadOutcome::map ────────────────────────────────────
+
+    #[test]
+    fn load_outcome_map_preserves_variant() {
+        let loaded: LoadOutcome<i32> = LoadOutcome::Loaded(42);
+        let mapped = loaded.map(|v| v.to_string());
+        assert!(matches!(mapped, LoadOutcome::Loaded(ref s) if s == "42"));
+
+        let recovered: LoadOutcome<i32> = LoadOutcome::Recovered(7);
+        let mapped = recovered.map(|v| v * 2);
+        assert!(matches!(mapped, LoadOutcome::Recovered(14)));
+
+        let unsupported: LoadOutcome<i32> =
+            LoadOutcome::UnsupportedVersion { found: 5, max_supported: 1 };
+        let mapped = unsupported.map(|v| v + 1);
+        assert!(matches!(mapped, LoadOutcome::UnsupportedVersion { found: 5, max_supported: 1 }));
     }
 }

--- a/clients/rttx/src/store/models/hosts.rs
+++ b/clients/rttx/src/store/models/hosts.rs
@@ -34,3 +34,34 @@ pub struct HostCatalog {
     #[serde(default)]
     pub hosts: Vec<HostRecord>,
 }
+
+// ── Conversions to/from the existing domain type ────────────
+
+impl From<HostRecord> for crate::host::Host {
+    fn from(rec: HostRecord) -> Self {
+        Self {
+            key: rec.key,
+            name: rec.name,
+            kind: match rec.kind {
+                HostKind::Local => crate::host::HostKind::Local,
+                HostKind::Remote => crate::host::HostKind::Remote,
+            },
+            ssh_target: rec.ssh_target,
+        }
+    }
+}
+
+impl From<&crate::host::Host> for HostRecord {
+    fn from(host: &crate::host::Host) -> Self {
+        Self {
+            key: host.key.clone(),
+            name: host.name.clone(),
+            kind: match host.kind {
+                crate::host::HostKind::Local => HostKind::Local,
+                crate::host::HostKind::Remote => HostKind::Remote,
+            },
+            ssh_target: host.ssh_target.clone(),
+            labels: Vec::new(),
+        }
+    }
+}

--- a/clients/rttx/src/store/models/library.rs
+++ b/clients/rttx/src/store/models/library.rs
@@ -46,3 +46,52 @@ pub struct Library {
     #[serde(default)]
     pub commands: Vec<CommandRecord>,
 }
+
+// ── Conversions to/from the existing domain types ───────────
+
+impl From<PlaceRecord> for crate::places::Place {
+    fn from(rec: PlaceRecord) -> Self {
+        Self { uuid: rec.id, name: rec.name, path: rec.path, host_tags: rec.host_tags }
+    }
+}
+
+impl From<&crate::places::Place> for PlaceRecord {
+    fn from(place: &crate::places::Place) -> Self {
+        Self {
+            id: place.uuid.clone(),
+            name: place.name.clone(),
+            path: place.path.clone(),
+            host_tags: place.host_tags.clone(),
+        }
+    }
+}
+
+impl From<CommandRecord> for crate::commands::SavedCommand {
+    fn from(rec: CommandRecord) -> Self {
+        Self {
+            uuid: rec.id,
+            title: rec.title,
+            body: rec.body,
+            default_run_mode: match rec.default_run_mode {
+                RunMode::Run => crate::commands::CommandRunMode::Run,
+                RunMode::Insert => crate::commands::CommandRunMode::Insert,
+            },
+            host_tags: rec.host_tags,
+        }
+    }
+}
+
+impl From<&crate::commands::SavedCommand> for CommandRecord {
+    fn from(cmd: &crate::commands::SavedCommand) -> Self {
+        Self {
+            id: cmd.uuid.clone(),
+            title: cmd.title.clone(),
+            body: cmd.body.clone(),
+            default_run_mode: match cmd.default_run_mode {
+                crate::commands::CommandRunMode::Run => RunMode::Run,
+                crate::commands::CommandRunMode::Insert => RunMode::Insert,
+            },
+            host_tags: cmd.host_tags.clone(),
+        }
+    }
+}

--- a/clients/rttx/src/store/models/preferences.rs
+++ b/clients/rttx/src/store/models/preferences.rs
@@ -142,3 +142,92 @@ const fn default_reconnect_delay_secs() -> u32 {
 const fn default_paste_guard_threshold() -> usize {
     200
 }
+
+// ── Conversions to/from the existing domain type ────────────
+
+impl From<PreferencesV1> for crate::preferences::Preferences {
+    fn from(v1: PreferencesV1) -> Self {
+        Self {
+            font: v1.font,
+            color_scheme: "default".into(),
+            terminal_theme_mode: match v1.terminal_theme_mode {
+                TerminalThemeMode::System => crate::preferences::TerminalThemeMode::System,
+                TerminalThemeMode::Light => crate::preferences::TerminalThemeMode::Light,
+                TerminalThemeMode::Dark => crate::preferences::TerminalThemeMode::Dark,
+            },
+            light_color_scheme: v1.light_color_scheme,
+            dark_color_scheme: v1.dark_color_scheme,
+            scrollback_lines: v1.scrollback_lines,
+            show_headerbar: v1.show_headerbar,
+            scroll_on_keystroke: v1.scroll_on_keystroke,
+            scroll_on_output: v1.scroll_on_output,
+            audible_bell: v1.audible_bell,
+            visual_bell: v1.visual_bell,
+            smart_clipboard: v1.smart_clipboard,
+            trim_trailing_whitespace_on_copy: v1.trim_trailing_whitespace_on_copy,
+            default_session_folder: match v1.default_session_folder {
+                DefaultSessionFolder::Home => crate::preferences::DefaultSessionFolder::Home,
+                DefaultSessionFolder::CurrentSession => {
+                    crate::preferences::DefaultSessionFolder::CurrentSession
+                }
+                DefaultSessionFolder::Custom(s) => {
+                    crate::preferences::DefaultSessionFolder::Custom(s)
+                }
+            },
+            pane_navigation_keys: match v1.pane_navigation_keys {
+                PaneNavigationKeys::AltArrow => crate::preferences::PaneNavigationKeys::AltArrow,
+                PaneNavigationKeys::CtrlShiftArrow => {
+                    crate::preferences::PaneNavigationKeys::CtrlShiftArrow
+                }
+            },
+            keyboard_shortcuts: v1.keyboard_shortcuts,
+            auto_start_daemon: v1.auto_start_daemon,
+            reconnect_delay_secs: v1.reconnect_delay_secs,
+            paste_guard: v1.paste_guard,
+            paste_guard_threshold: v1.paste_guard_threshold,
+        }
+    }
+}
+
+impl From<&crate::preferences::Preferences> for PreferencesV1 {
+    fn from(prefs: &crate::preferences::Preferences) -> Self {
+        Self {
+            font: prefs.font.clone(),
+            terminal_theme_mode: match prefs.terminal_theme_mode {
+                crate::preferences::TerminalThemeMode::System => TerminalThemeMode::System,
+                crate::preferences::TerminalThemeMode::Light => TerminalThemeMode::Light,
+                crate::preferences::TerminalThemeMode::Dark => TerminalThemeMode::Dark,
+            },
+            light_color_scheme: prefs.light_color_scheme.clone(),
+            dark_color_scheme: prefs.dark_color_scheme.clone(),
+            scrollback_lines: prefs.scrollback_lines,
+            show_headerbar: prefs.show_headerbar,
+            scroll_on_keystroke: prefs.scroll_on_keystroke,
+            scroll_on_output: prefs.scroll_on_output,
+            audible_bell: prefs.audible_bell,
+            visual_bell: prefs.visual_bell,
+            smart_clipboard: prefs.smart_clipboard,
+            trim_trailing_whitespace_on_copy: prefs.trim_trailing_whitespace_on_copy,
+            default_session_folder: match &prefs.default_session_folder {
+                crate::preferences::DefaultSessionFolder::Home => DefaultSessionFolder::Home,
+                crate::preferences::DefaultSessionFolder::CurrentSession => {
+                    DefaultSessionFolder::CurrentSession
+                }
+                crate::preferences::DefaultSessionFolder::Custom(s) => {
+                    DefaultSessionFolder::Custom(s.clone())
+                }
+            },
+            pane_navigation_keys: match prefs.pane_navigation_keys {
+                crate::preferences::PaneNavigationKeys::AltArrow => PaneNavigationKeys::AltArrow,
+                crate::preferences::PaneNavigationKeys::CtrlShiftArrow => {
+                    PaneNavigationKeys::CtrlShiftArrow
+                }
+            },
+            keyboard_shortcuts: prefs.keyboard_shortcuts.clone(),
+            auto_start_daemon: prefs.auto_start_daemon,
+            reconnect_delay_secs: prefs.reconnect_delay_secs,
+            paste_guard: prefs.paste_guard,
+            paste_guard_threshold: prefs.paste_guard_threshold,
+        }
+    }
+}

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -16,7 +16,10 @@ fn trim_trailing_whitespace(text: &str) -> String {
 /// Copy the terminal selection to the system clipboard, trimming trailing
 /// whitespace per line when the preference is enabled.
 pub(crate) fn copy_to_clipboard(vte: &vte4::Terminal) {
-    let prefs = crate::preferences::load();
+    let prefs = crate::store::default_store()
+        .load_preferences()
+        .into_value()
+        .unwrap_or_default();
     if !prefs.trim_trailing_whitespace_on_copy {
         vte.copy_clipboard_format(vte4::Format::Text);
         return;
@@ -48,7 +51,7 @@ pub const fn should_open_context_menu(mods: gtk4::gdk::ModifierType) -> bool {
 /// Each item triggers `win.open-place` with the place path as parameter.
 pub(crate) fn populate_places_submenu(menu: &gtk4::gio::Menu, host_key: &str) {
     menu.remove_all();
-    let saved = crate::places::load();
+    let saved = crate::store::default_store().load_places();
     let visible = crate::places::visible_for_host(&saved, host_key);
     for place in &visible {
         let item = gtk4::gio::MenuItem::new(Some(&place.display_label()), None);

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -16,10 +16,7 @@ fn trim_trailing_whitespace(text: &str) -> String {
 /// Copy the terminal selection to the system clipboard, trimming trailing
 /// whitespace per line when the preference is enabled.
 pub(crate) fn copy_to_clipboard(vte: &vte4::Terminal) {
-    let prefs = crate::store::default_store()
-        .load_preferences()
-        .into_value()
-        .unwrap_or_default();
+    let prefs = crate::store::default_store().load_preferences().into_value().unwrap_or_default();
     if !prefs.trim_trailing_whitespace_on_copy {
         vte.copy_clipboard_format(vte4::Format::Text);
         return;

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -6,7 +6,10 @@ type ActionCallback = fn(&Window);
 
 impl Window {
     pub(super) fn setup_actions(&self, app: &adw::Application) {
-        let prefs = crate::preferences::load();
+        let prefs = crate::store::default_store()
+            .load_preferences()
+            .into_value()
+            .unwrap_or_default();
         let overrides = &prefs.keyboard_shortcuts;
 
         let actions: &[(&str, ActionCallback)] = &[
@@ -114,7 +117,7 @@ impl Window {
         let win = self.clone();
         edit_command_action.connect_activate(move |_, param| {
             let uuid: String = param.and_then(glib::Variant::get).unwrap_or_default();
-            let all_commands = commands::load();
+            let all_commands = crate::store::default_store().load_commands();
             if let Some(command) = all_commands.iter().find(|c| c.uuid == uuid) {
                 crate::commands_window::show_form(&win, Some(command));
             }
@@ -137,7 +140,7 @@ impl Window {
         let win = self.clone();
         edit_place_action.connect_activate(move |_, param| {
             let uuid: String = param.and_then(glib::Variant::get).unwrap_or_default();
-            let all_places = places::load();
+            let all_places = crate::store::default_store().load_places();
             if let Some(place) = all_places.iter().find(|p| p.uuid == uuid) {
                 crate::places_window::show_form(&win, Some(place));
             }
@@ -358,7 +361,10 @@ impl Window {
         let Some(uuid) = self.focused_terminal_uuid() else { return };
         let Some(terminal) = self.terminal_handle(&uuid) else { return };
 
-        let prefs = crate::preferences::load();
+        let prefs = crate::store::default_store()
+            .load_preferences()
+            .into_value()
+            .unwrap_or_default();
         if !prefs.paste_guard {
             Self::execute_paste(&terminal, self, &uuid);
             return;
@@ -378,7 +384,11 @@ impl Window {
                 _ => None,
             };
 
-            let threshold = crate::preferences::load().paste_guard_threshold;
+            let threshold = crate::store::default_store()
+                .load_preferences()
+                .into_value()
+                .unwrap_or_default()
+                .paste_guard_threshold;
             match decide(clipboard_text, threshold, is_direct) {
                 PasteGuardDecision::Paste | PasteGuardDecision::FallThroughToVte => {
                     if let Some(terminal) = win.terminal_handle(&terminal_uuid) {

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -6,10 +6,8 @@ type ActionCallback = fn(&Window);
 
 impl Window {
     pub(super) fn setup_actions(&self, app: &adw::Application) {
-        let prefs = crate::store::default_store()
-            .load_preferences()
-            .into_value()
-            .unwrap_or_default();
+        let prefs =
+            crate::store::default_store().load_preferences().into_value().unwrap_or_default();
         let overrides = &prefs.keyboard_shortcuts;
 
         let actions: &[(&str, ActionCallback)] = &[
@@ -361,10 +359,8 @@ impl Window {
         let Some(uuid) = self.focused_terminal_uuid() else { return };
         let Some(terminal) = self.terminal_handle(&uuid) else { return };
 
-        let prefs = crate::store::default_store()
-            .load_preferences()
-            .into_value()
-            .unwrap_or_default();
+        let prefs =
+            crate::store::default_store().load_preferences().into_value().unwrap_or_default();
         if !prefs.paste_guard {
             Self::execute_paste(&terminal, self, &uuid);
             return;

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -119,9 +119,10 @@ impl Window {
             "Delete Command?",
             "The command will be permanently removed.",
             move || {
-                let mut items = commands::load();
+                let store = crate::store::default_store();
+                let mut items = store.load_commands();
                 items.retain(|c| c.uuid != uuid);
-                if let Err(e) = commands::save(&items) {
+                if let Err(e) = store.save_commands(&items) {
                     tracing::error!("Failed to delete command: {e}");
                 }
                 win.refresh_command_sidebar();
@@ -132,9 +133,10 @@ impl Window {
     pub(super) fn confirm_delete_place(&self, uuid: String) {
         let win = self.clone();
         self.confirm_delete("Delete Place?", "The place will be permanently removed.", move || {
-            let mut items = places::load();
+            let store = crate::store::default_store();
+            let mut items = store.load_places();
             items.retain(|p| p.uuid != uuid);
-            if let Err(e) = places::save(&items) {
+            if let Err(e) = store.save_places(&items) {
                 tracing::error!("Failed to delete place: {e}");
             }
             win.refresh_place_sidebar();
@@ -142,9 +144,10 @@ impl Window {
     }
 
     pub(super) fn confirm_delete_host(&self, host_key: String) {
-        let saved_hosts = host::load();
-        let saved_places = places::load();
-        let saved_commands = commands::load();
+        let store = crate::store::default_store();
+        let saved_hosts = store.load_hosts().into_value().unwrap_or_default();
+        let saved_places = store.load_places();
+        let saved_commands = store.load_commands();
         let affected = host::deletion_affected(&host_key, &saved_places, &saved_commands);
 
         if affected.is_empty() {
@@ -153,9 +156,10 @@ impl Window {
                 "Delete Host?",
                 "The host will be permanently removed.",
                 move || {
-                    let mut hosts = host::load();
+                    let store = crate::store::default_store();
+                    let mut hosts = store.load_hosts().into_value().unwrap_or_default();
                     hosts.retain(|h| h.key != host_key);
-                    if let Err(e) = host::save(&hosts) {
+                    if let Err(e) = store.save_hosts(&hosts) {
                         tracing::error!("Failed to delete host: {e}");
                     }
                     win.rebuild_host_selector_model(None);
@@ -266,9 +270,10 @@ impl Window {
                 .map(|(uuid, _)| uuid.clone())
                 .collect();
 
-            let hosts = host::load();
-            let places_data = places::load();
-            let commands_data = commands::load();
+            let store = crate::store::default_store();
+            let hosts = store.load_hosts().into_value().unwrap_or_default();
+            let places_data = store.load_places();
+            let commands_data = store.load_commands();
             let (new_hosts, new_places, new_commands) = host::apply_deletion_cleanup(
                 &host_key,
                 &hosts,
@@ -277,14 +282,11 @@ impl Window {
                 &place_uuids,
                 &command_uuids,
             );
-            if let Err(e) = host::save(&new_hosts) {
+            if let Err(e) = store.save_hosts(&new_hosts) {
                 tracing::error!("Failed to save hosts: {e}");
             }
-            if let Err(e) = places::save(&new_places) {
-                tracing::error!("Failed to save places: {e}");
-            }
-            if let Err(e) = commands::save(&new_commands) {
-                tracing::error!("Failed to save commands: {e}");
+            if let Err(e) = store.save_library(&new_places, &new_commands) {
+                tracing::error!("Failed to save library: {e}");
             }
             win.rebuild_host_selector_model(None);
             win.refresh_place_sidebar();
@@ -336,14 +338,15 @@ impl Window {
                 return;
             }
             let new_host = host::Host::remote(ssh_target);
-            let mut hosts = host::load();
+            let store = crate::store::default_store();
+            let mut hosts = store.load_hosts().into_value().unwrap_or_default();
             if hosts.iter().any(|h| h.key == new_host.key) {
                 win.show_toast(&format!("Host \"{}\" already exists", new_host.name));
                 dialog_ref.close();
                 return;
             }
             hosts.push(new_host.clone());
-            if let Err(e) = host::save(&hosts) {
+            if let Err(e) = store.save_hosts(&hosts) {
                 tracing::error!("Failed to save hosts: {e}");
                 win.show_toast("Failed to save host");
                 dialog_ref.close();
@@ -619,7 +622,8 @@ impl Window {
         };
 
         let new_host = host::Host::remote(&ssh_target);
-        let mut hosts = host::load();
+        let store = crate::store::default_store();
+        let mut hosts = store.load_hosts().into_value().unwrap_or_default();
 
         if hosts.iter().any(|h| h.key == new_host.key) {
             self.show_toast(&format!("Host \"{}\" is already saved", new_host.name));
@@ -627,7 +631,7 @@ impl Window {
         }
 
         hosts.push(new_host.clone());
-        if let Err(e) = host::save(&hosts) {
+        if let Err(e) = store.save_hosts(&hosts) {
             tracing::error!("Failed to save hosts: {e}");
             self.show_toast("Failed to save host");
             return;
@@ -657,9 +661,10 @@ impl Window {
 
         let place = crate::places::Place::from_cwd(&cwd, host_tags);
         let label = place.display_label();
-        let mut places = crate::places::load();
+        let store = crate::store::default_store();
+        let mut places = store.load_places();
         places.push(place);
-        if let Err(e) = crate::places::save(&places) {
+        if let Err(e) = store.save_places(&places) {
             tracing::error!("Failed to save places: {e}");
             self.show_toast("Failed to save place");
             return;

--- a/clients/rttx/src/window/input.rs
+++ b/clients/rttx/src/window/input.rs
@@ -50,10 +50,8 @@ impl Window {
     }
 
     pub(crate) fn reapply_terminal_preferences(&self) {
-        let prefs = crate::store::default_store()
-            .load_preferences()
-            .into_value()
-            .unwrap_or_default();
+        let prefs =
+            crate::store::default_store().load_preferences().into_value().unwrap_or_default();
 
         // Reapply all keyboard shortcuts from preferences.
         if let Some(app) = self.application().and_downcast::<adw::Application>() {
@@ -89,10 +87,8 @@ impl Window {
     }
 
     pub(super) fn apply_preferences_to_persistent_pane(&self, pane: &PersistentPaneView) {
-        let prefs = crate::store::default_store()
-            .load_preferences()
-            .into_value()
-            .unwrap_or_default();
+        let prefs =
+            crate::store::default_store().load_preferences().into_value().unwrap_or_default();
         let font_desc = gtk4::pango::FontDescription::from_string(&prefs.font);
         pane.vte().set_font(Some(&font_desc));
         pane.vte().set_scrollback_lines(prefs.scrollback_lines);

--- a/clients/rttx/src/window/input.rs
+++ b/clients/rttx/src/window/input.rs
@@ -50,7 +50,10 @@ impl Window {
     }
 
     pub(crate) fn reapply_terminal_preferences(&self) {
-        let prefs = preferences::load();
+        let prefs = crate::store::default_store()
+            .load_preferences()
+            .into_value()
+            .unwrap_or_default();
 
         // Reapply all keyboard shortcuts from preferences.
         if let Some(app) = self.application().and_downcast::<adw::Application>() {
@@ -86,7 +89,10 @@ impl Window {
     }
 
     pub(super) fn apply_preferences_to_persistent_pane(&self, pane: &PersistentPaneView) {
-        let prefs = preferences::load();
+        let prefs = crate::store::default_store()
+            .load_preferences()
+            .into_value()
+            .unwrap_or_default();
         let font_desc = gtk4::pango::FontDescription::from_string(&prefs.font);
         pane.vte().set_font(Some(&font_desc));
         pane.vte().set_scrollback_lines(prefs.scrollback_lines);

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -569,7 +569,10 @@ impl Window {
     }
 
     pub(super) fn refresh_host_menus(&self) {
-        let saved = host::load();
+        let saved = crate::store::default_store()
+            .load_hosts()
+            .into_value()
+            .unwrap_or_default();
 
         let mut keys: Vec<String> = vec![host::LOCAL_KEY.into()];
         for h in &saved {
@@ -618,12 +621,20 @@ impl Window {
     }
 
     fn new_workspace_for_host(&self, host_key: &str) {
-        let host = host::resolve(host_key, &host::load());
+        let hosts = crate::store::default_store()
+            .load_hosts()
+            .into_value()
+            .unwrap_or_default();
+        let host = host::resolve(host_key, &hosts);
         crate::new_workspace_dialog::show(self, &host);
     }
 
     fn connect_for_host(&self, host_key: &str) {
-        let host = host::resolve(host_key, &host::load());
+        let hosts = crate::store::default_store()
+            .load_hosts()
+            .into_value()
+            .unwrap_or_default();
+        let host = host::resolve(host_key, &hosts);
         self.request_connect_existing(&host);
     }
 
@@ -785,7 +796,10 @@ impl Window {
     }
 
     fn resolve_default_session_folder(&self) -> Option<String> {
-        let prefs = preferences::load();
+        let prefs = crate::store::default_store()
+            .load_preferences()
+            .into_value()
+            .unwrap_or_default();
         match prefs.default_session_folder {
             preferences::DefaultSessionFolder::Home => None,
             preferences::DefaultSessionFolder::CurrentSession => {

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -569,10 +569,7 @@ impl Window {
     }
 
     pub(super) fn refresh_host_menus(&self) {
-        let saved = crate::store::default_store()
-            .load_hosts()
-            .into_value()
-            .unwrap_or_default();
+        let saved = crate::store::default_store().load_hosts().into_value().unwrap_or_default();
 
         let mut keys: Vec<String> = vec![host::LOCAL_KEY.into()];
         for h in &saved {
@@ -621,19 +618,13 @@ impl Window {
     }
 
     fn new_workspace_for_host(&self, host_key: &str) {
-        let hosts = crate::store::default_store()
-            .load_hosts()
-            .into_value()
-            .unwrap_or_default();
+        let hosts = crate::store::default_store().load_hosts().into_value().unwrap_or_default();
         let host = host::resolve(host_key, &hosts);
         crate::new_workspace_dialog::show(self, &host);
     }
 
     fn connect_for_host(&self, host_key: &str) {
-        let hosts = crate::store::default_store()
-            .load_hosts()
-            .into_value()
-            .unwrap_or_default();
+        let hosts = crate::store::default_store().load_hosts().into_value().unwrap_or_default();
         let host = host::resolve(host_key, &hosts);
         self.request_connect_existing(&host);
     }
@@ -796,10 +787,8 @@ impl Window {
     }
 
     fn resolve_default_session_folder(&self) -> Option<String> {
-        let prefs = crate::store::default_store()
-            .load_preferences()
-            .into_value()
-            .unwrap_or_default();
+        let prefs =
+            crate::store::default_store().load_preferences().into_value().unwrap_or_default();
         match prefs.default_session_folder {
             preferences::DefaultSessionFolder::Home => None,
             preferences::DefaultSessionFolder::CurrentSession => {

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -252,7 +252,10 @@ impl Window {
             return true;
         }
 
-        let prefs = crate::preferences::load();
+        let prefs = crate::store::default_store()
+            .load_preferences()
+            .into_value()
+            .unwrap_or_default();
         match crate::daemon_bridge::EndpointConnectionManager::new(
             prefs.auto_start_daemon,
             prefs.reconnect_delay_secs,

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -252,10 +252,8 @@ impl Window {
             return true;
         }
 
-        let prefs = crate::store::default_store()
-            .load_preferences()
-            .into_value()
-            .unwrap_or_default();
+        let prefs =
+            crate::store::default_store().load_preferences().into_value().unwrap_or_default();
         match crate::daemon_bridge::EndpointConnectionManager::new(
             prefs.auto_start_daemon,
             prefs.reconnect_delay_secs,

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -34,7 +34,10 @@ impl Window {
 
     /// Rebuild the host selector dropdown model from saved hosts + workspace endpoints.
     pub(super) fn rebuild_host_selector_model(&self, select_key: Option<&str>) {
-        let saved_hosts = host::load();
+        let saved_hosts = crate::store::default_store()
+            .load_hosts()
+            .into_value()
+            .unwrap_or_default();
         let state = self.imp().state.borrow();
 
         let mut keys: Vec<String> = Vec::new();
@@ -81,8 +84,11 @@ impl Window {
         }
 
         let query = imp.sidebar_search_entry.text();
-        let saved = places::load();
-        let saved_hosts = host::load();
+        let saved = crate::store::default_store().load_places();
+        let saved_hosts = crate::store::default_store()
+            .load_hosts()
+            .into_value()
+            .unwrap_or_default();
         let selected_key = self.selected_host_key();
 
         let any_shown = selected_key.as_ref().map_or_else(
@@ -216,8 +222,11 @@ impl Window {
         }
 
         let query = imp.sidebar_search_entry.text();
-        let all_commands = commands::load();
-        let saved_hosts = host::load();
+        let all_commands = crate::store::default_store().load_commands();
+        let saved_hosts = crate::store::default_store()
+            .load_hosts()
+            .into_value()
+            .unwrap_or_default();
         let selected_key = self.selected_host_key();
 
         let any_shown = selected_key.as_ref().map_or_else(
@@ -374,14 +383,19 @@ impl Window {
                 keys.push(h.key.clone());
             }
         }
-        for p in places::load() {
+        let store = crate::store::default_store();
+        let (places, commands) = store
+            .load_library()
+            .into_value()
+            .unwrap_or_default();
+        for p in places {
             for tag in &p.host_tags {
                 if !keys.contains(tag) {
                     keys.push(tag.clone());
                 }
             }
         }
-        for c in commands::load() {
+        for c in commands {
             for tag in &c.host_tags {
                 if !keys.contains(tag) {
                     keys.push(tag.clone());
@@ -397,9 +411,9 @@ impl Window {
     }
 
     fn reorder_command(&self, source_uuid: &str, target_uuid: &str) {
-        let mut items = commands::load();
+        let mut items = crate::store::default_store().load_commands();
         commands::reorder(&mut items, source_uuid, target_uuid);
-        let _ = commands::save(&items);
+        let _ = crate::store::default_store().save_commands(&items);
         self.refresh_command_sidebar();
     }
 

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -34,10 +34,8 @@ impl Window {
 
     /// Rebuild the host selector dropdown model from saved hosts + workspace endpoints.
     pub(super) fn rebuild_host_selector_model(&self, select_key: Option<&str>) {
-        let saved_hosts = crate::store::default_store()
-            .load_hosts()
-            .into_value()
-            .unwrap_or_default();
+        let saved_hosts =
+            crate::store::default_store().load_hosts().into_value().unwrap_or_default();
         let state = self.imp().state.borrow();
 
         let mut keys: Vec<String> = Vec::new();
@@ -85,10 +83,8 @@ impl Window {
 
         let query = imp.sidebar_search_entry.text();
         let saved = crate::store::default_store().load_places();
-        let saved_hosts = crate::store::default_store()
-            .load_hosts()
-            .into_value()
-            .unwrap_or_default();
+        let saved_hosts =
+            crate::store::default_store().load_hosts().into_value().unwrap_or_default();
         let selected_key = self.selected_host_key();
 
         let any_shown = selected_key.as_ref().map_or_else(
@@ -223,10 +219,8 @@ impl Window {
 
         let query = imp.sidebar_search_entry.text();
         let all_commands = crate::store::default_store().load_commands();
-        let saved_hosts = crate::store::default_store()
-            .load_hosts()
-            .into_value()
-            .unwrap_or_default();
+        let saved_hosts =
+            crate::store::default_store().load_hosts().into_value().unwrap_or_default();
         let selected_key = self.selected_host_key();
 
         let any_shown = selected_key.as_ref().map_or_else(
@@ -384,10 +378,7 @@ impl Window {
             }
         }
         let store = crate::store::default_store();
-        let (places, commands) = store
-            .load_library()
-            .into_value()
-            .unwrap_or_default();
+        let (places, commands) = store.load_library().into_value().unwrap_or_default();
         for p in places {
             for tag in &p.host_tags {
                 if !keys.contains(tag) {

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -91,10 +91,8 @@ impl Window {
 
     fn connect_terminal_signals(&self, term: &TerminalWidget) {
         {
-            let prefs = crate::store::default_store()
-                .load_preferences()
-                .into_value()
-                .unwrap_or_default();
+            let prefs =
+                crate::store::default_store().load_preferences().into_value().unwrap_or_default();
             let font_desc = gtk4::pango::FontDescription::from_string(&prefs.font);
             let is_dark = adw::StyleManager::default().is_dark();
             let effective_name = prefs.effective_color_scheme_name(is_dark);

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -91,7 +91,10 @@ impl Window {
 
     fn connect_terminal_signals(&self, term: &TerminalWidget) {
         {
-            let prefs = preferences::load();
+            let prefs = crate::store::default_store()
+                .load_preferences()
+                .into_value()
+                .unwrap_or_default();
             let font_desc = gtk4::pango::FontDescription::from_string(&prefs.font);
             let is_dark = adw::StyleManager::default().is_dark();
             let effective_name = prefs.effective_color_scheme_name(is_dark);

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1910,4 +1910,23 @@ mod tests {
             "live dismissed ID should be retained"
         );
     }
+
+    #[test]
+    fn store_preferences_conversion_preserves_all_fields() {
+        use crate::store::models::preferences::PreferencesV1;
+
+        let prefs = crate::preferences::Preferences {
+            font: "Hack 11".into(),
+            scrollback_lines: 5000,
+            smart_clipboard: true,
+            paste_guard_threshold: 512,
+            ..Default::default()
+        };
+        let v1: PreferencesV1 = (&prefs).into();
+        let round_tripped: crate::preferences::Preferences = v1.into();
+        assert_eq!(round_tripped.font, "Hack 11");
+        assert_eq!(round_tripped.scrollback_lines, 5000);
+        assert!(round_tripped.smart_clipboard);
+        assert_eq!(round_tripped.paste_guard_threshold, 512);
+    }
 }

--- a/clients/rttx/tests/client_store_integration.rs
+++ b/clients/rttx/tests/client_store_integration.rs
@@ -1,0 +1,150 @@
+//! Integration tests for `ClientStore` API (RFC-023 Step 4).
+//!
+//! Verifies end-to-end round-trip through the store for preferences, hosts,
+//! and the merged library document, including malformed-file recovery.
+
+use rttx::commands::{CommandRunMode, SavedCommand};
+use rttx::host::Host;
+use rttx::places::Place;
+use rttx::preferences::Preferences;
+use rttx::store::{ClientStore, LoadOutcome, StorePaths};
+use tempfile::TempDir;
+
+fn test_store() -> (TempDir, ClientStore) {
+    let tmp = TempDir::new().unwrap();
+    let paths = StorePaths::new(
+        tmp.path().join("config"),
+        tmp.path().join("state"),
+        tmp.path().join("cache"),
+    );
+    (tmp, ClientStore::new(paths))
+}
+
+// ── Preferences ──────────────────────────────────────────────────────
+
+#[test]
+fn client_store_preferences_full_round_trip() {
+    let (_tmp, store) = test_store();
+    let prefs = Preferences {
+        font: "Fira Code 13".into(),
+        scrollback_lines: 20_000,
+        smart_clipboard: true,
+        paste_guard_threshold: 512,
+        ..Default::default()
+    };
+    store.save_preferences(&prefs).unwrap();
+    let loaded = store.load_preferences().into_value().unwrap();
+    assert_eq!(loaded.font, "Fira Code 13");
+    assert_eq!(loaded.scrollback_lines, 20_000);
+    assert!(loaded.smart_clipboard);
+    assert_eq!(loaded.paste_guard_threshold, 512);
+}
+
+#[test]
+fn client_store_preferences_malformed_recovery() {
+    let (_tmp, store) = test_store();
+    // Save a good version, then save again to create .bak
+    let good = Preferences { font: "Good Font 12".into(), ..Default::default() };
+    store.save_preferences(&good).unwrap();
+    let updated = Preferences { font: "Updated Font 12".into(), ..Default::default() };
+    store.save_preferences(&updated).unwrap();
+    // Corrupt the primary
+    let path = store.paths().config().join("preferences.json");
+    std::fs::write(&path, "corrupted data").unwrap();
+    let outcome = store.load_preferences();
+    assert!(matches!(outcome, LoadOutcome::Recovered(_)));
+    assert_eq!(outcome.into_value().unwrap().font, "Good Font 12");
+}
+
+// ── Hosts ────────────────────────────────────────────────────────────
+
+#[test]
+fn client_store_hosts_full_round_trip() {
+    let (_tmp, store) = test_store();
+    let hosts = vec![Host::remote("deploy@example.com"), Host::remote("admin@staging.example.com")];
+    store.save_hosts(&hosts).unwrap();
+    let loaded = store.load_hosts().into_value().unwrap();
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(loaded[0].key, "example.com");
+    assert_eq!(loaded[1].key, "staging.example.com");
+}
+
+// ── Library (places + commands merged) ───────────────────────────────
+
+#[test]
+fn client_store_library_merges_places_and_commands() {
+    let (_tmp, store) = test_store();
+    let mut place = Place::new("rttx", "~/pro/rttx");
+    place.host_tags = vec!["local".into()];
+    let mut cmd = SavedCommand::new("Build", "cargo build");
+    cmd.host_tags = vec!["local".into(), "example.com".into()];
+
+    store.save_library(&[place], &[cmd]).unwrap();
+
+    // Verify both are in the same file
+    let lib_path = store.paths().config().join("library.json");
+    let content = std::fs::read_to_string(&lib_path).unwrap();
+    assert!(content.contains("rttx.client.library"));
+    assert!(content.contains("rttx"));
+    assert!(content.contains("Build"));
+
+    let (places, commands) = store.load_library().into_value().unwrap();
+    assert_eq!(places.len(), 1);
+    assert_eq!(commands.len(), 1);
+    assert_eq!(places[0].name, "rttx");
+    assert_eq!(commands[0].title, "Build");
+}
+
+#[test]
+fn client_store_save_places_preserves_commands() {
+    let (_tmp, store) = test_store();
+    let cmd = SavedCommand::new("Deploy", "cargo deploy");
+    store.save_commands(&[cmd]).unwrap();
+
+    let place = Place::new("Home", "~");
+    store.save_places(&[place]).unwrap();
+
+    let (places, commands) = store.load_library().into_value().unwrap();
+    assert_eq!(places.len(), 1);
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].title, "Deploy");
+}
+
+#[test]
+fn client_store_save_commands_preserves_places() {
+    let (_tmp, store) = test_store();
+    let place = Place::new("Projects", "~/projects");
+    store.save_places(&[place]).unwrap();
+
+    let cmd = SavedCommand::new("Test", "cargo test");
+    store.save_commands(&[cmd]).unwrap();
+
+    let (places, commands) = store.load_library().into_value().unwrap();
+    assert_eq!(places.len(), 1);
+    assert_eq!(commands.len(), 1);
+    assert_eq!(places[0].name, "Projects");
+}
+
+#[test]
+fn client_store_library_preserves_command_run_mode() {
+    let (_tmp, store) = test_store();
+    let mut cmd = SavedCommand::new("Insert", "echo hi");
+    cmd.default_run_mode = CommandRunMode::Insert;
+    store.save_commands(&[cmd]).unwrap();
+
+    let commands = store.load_commands();
+    assert_eq!(commands[0].default_run_mode, CommandRunMode::Insert);
+}
+
+#[test]
+fn client_store_library_malformed_recovery() {
+    let (_tmp, store) = test_store();
+    let path = store.paths().config().join("library.json");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "not json").unwrap();
+    let outcome = store.load_library();
+    assert!(matches!(outcome, LoadOutcome::DefaultAfterFailure(_)));
+    let (places, commands) = outcome.into_value().unwrap();
+    assert!(places.is_empty());
+    assert!(commands.is_empty());
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.5',
+  version: '0.4.6',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

RFC-023 Step 4: Replace the independent `load()`/`save()` free functions in `preferences.rs`, `host.rs`, `places.rs`, and `commands.rs` with `ClientStore` methods.

### Changes

- **`ClientStore` methods**: Added `load_preferences()`/`save_preferences()`, `load_hosts()`/`save_hosts()`, `load_library()`/`save_library()` to `ClientStore`
- **Convenience methods**: Added `load_places()`, `load_commands()`, `save_places()`, `save_commands()` for call sites that only need one half of the library
- **Type conversions**: `From` impls between store model types (`PreferencesV1`, `HostCatalog`, `Library`) and existing domain types (`Preferences`, `Host`, `Place`, `SavedCommand`)
- **Factory function**: `default_store()` creates a `ClientStore` from the active app profile
- **All writes** now go through atomic I/O (temp + fsync + rename) with envelope wrappers
- **All loads** now go through the envelope-aware loader with malformed-file recovery
- **Places and commands** merge into a single `library.json` document
- **Version bump** to 0.4.6 (change spans 14+ source files)

### Call sites updated

All production code that previously called `preferences::load()`, `preferences::save()`, `host::load()`, `host::save()`, `places::load()`, `places::save()`, `commands::load()`, `commands::save()` now uses `ClientStore` methods:

- `preferences_window.rs` — load/save preferences
- `commands_window.rs` — load/save commands
- `places_window.rs` — load/save places
- `host_tag_picker.rs` — load hosts
- `new_workspace_dialog.rs` — load places
- `terminal/mod.rs` — load preferences, load places
- `window/actions.rs` — load preferences, load commands, load places
- `window/dialogs.rs` — load/save hosts, places, commands (deletion, add host, add place)
- `window/input.rs` — load preferences
- `window/mod.rs` — load hosts, load preferences
- `window/runtime.rs` — load preferences
- `window/sidebar.rs` — load hosts, places, commands; save commands (reorder)
- `window/terminal.rs` — load preferences

### How to verify

1. Build: `cargo build -p rttx --no-default-features --features vte-0_76`
2. Run: `RTTX_DEV_MODE=1 cargo run -p rttx`
3. Verify preferences save/load (change font, restart)
4. Verify host add/delete (add remote host, delete it)
5. Verify place add/delete (add current path, delete it)
6. Verify command add/edit/delete/reorder
7. Check that `library.json` is created in config dir with envelope wrapper

### Tests added

- `preferences_round_trip_through_store` — full round-trip through ClientStore
- `preferences_missing_file_returns_default` — missing file returns default
- `preferences_malformed_file_recovers_to_default` — malformed file recovery
- `preferences_malformed_primary_recovers_from_backup` — backup recovery
- `hosts_round_trip_through_store` — full round-trip through ClientStore
- `hosts_missing_file_returns_empty` — missing file returns empty
- `hosts_malformed_file_recovers_to_default` — malformed file recovery
- `library_round_trip_through_store` — places + commands round-trip
- `library_missing_file_returns_empty` — missing file returns empty
- `library_malformed_file_recovers_to_default` — malformed file recovery
- `library_preserves_uuid_and_run_mode` — UUID and run mode preservation
- `load_outcome_map_preserves_variant` — LoadOutcome::map correctness

### Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76` — 653 passed, 0 failed
- `cargo test -p rttx-proto -p rttx-server` — all passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed, 0 failures

Fixes #741