### PR TITLE
feat(store): move workspace, UI, and runtime-cache state behind ClientStore API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.6"
+version = "0.4.7"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -181,6 +181,96 @@ impl ClientStore {
         let places = self.load_places();
         self.save_library(&places, commands)
     }
+
+    // ── Workspaces ──────────────────────────────────────────
+
+    /// Load workspaces through the envelope-aware loader with malformed-file recovery.
+    #[must_use]
+    pub fn load_workspaces(&self) -> LoadOutcome<models::workspaces::WorkspaceStore> {
+        let path = self.paths.state().join("workspaces.json");
+        atomic_load(
+            &path,
+            models::workspaces::SCHEMA,
+            models::workspaces::CURRENT_VERSION,
+            &self.paths.backups(),
+        )
+    }
+
+    /// Save workspaces atomically with an envelope wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the atomic write fails.
+    pub fn save_workspaces(
+        &self,
+        store: &models::workspaces::WorkspaceStore,
+    ) -> std::io::Result<()> {
+        let path = self.paths.state().join("workspaces.json");
+        let envelope = DocumentEnvelope::new(
+            models::workspaces::SCHEMA,
+            models::workspaces::CURRENT_VERSION,
+            store.clone(),
+        );
+        atomic_save(&path, &envelope)
+    }
+
+    // ── UI State ────────────────────────────────────────────
+
+    /// Load UI state through the envelope-aware loader with malformed-file recovery.
+    #[must_use]
+    pub fn load_ui_state(&self) -> LoadOutcome<models::ui::UiState> {
+        let path = self.paths.state().join("ui.json");
+        atomic_load(
+            &path,
+            models::ui::SCHEMA,
+            models::ui::CURRENT_VERSION,
+            &self.paths.backups(),
+        )
+    }
+
+    /// Save UI state atomically with an envelope wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the atomic write fails.
+    pub fn save_ui_state(&self, ui: &models::ui::UiState) -> std::io::Result<()> {
+        let path = self.paths.state().join("ui.json");
+        let envelope =
+            DocumentEnvelope::new(models::ui::SCHEMA, models::ui::CURRENT_VERSION, ui.clone());
+        atomic_save(&path, &envelope)
+    }
+
+    // ── Runtime Cache ───────────────────────────────────────
+
+    /// Load runtime cache through the envelope-aware loader with malformed-file recovery.
+    #[must_use]
+    pub fn load_runtime_cache(&self) -> LoadOutcome<models::runtime_cache::RuntimeCache> {
+        let path = self.paths.cache().join("runtime-cache.json");
+        atomic_load(
+            &path,
+            models::runtime_cache::SCHEMA,
+            models::runtime_cache::CURRENT_VERSION,
+            &self.paths.backups(),
+        )
+    }
+
+    /// Save runtime cache atomically with an envelope wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the atomic write fails.
+    pub fn save_runtime_cache(
+        &self,
+        cache: &models::runtime_cache::RuntimeCache,
+    ) -> std::io::Result<()> {
+        let path = self.paths.cache().join("runtime-cache.json");
+        let envelope = DocumentEnvelope::new(
+            models::runtime_cache::SCHEMA,
+            models::runtime_cache::CURRENT_VERSION,
+            cache.clone(),
+        );
+        atomic_save(&path, &envelope)
+    }
 }
 
 impl<T> LoadOutcome<T> {
@@ -374,5 +464,261 @@ mod tests {
             LoadOutcome::UnsupportedVersion { found: 5, max_supported: 1 };
         let mapped = unsupported.map(|v| v + 1);
         assert!(matches!(mapped, LoadOutcome::UnsupportedVersion { found: 5, max_supported: 1 }));
+    }
+
+    // ── Workspaces ──────────────────────────────────────────
+
+    #[test]
+    fn workspaces_round_trip_through_store() {
+        let (_tmp, store) = test_store();
+        let ws = models::workspaces::WorkspaceStore {
+            active_workspace_id: Some("ws-1".into()),
+            workspaces: vec![models::workspaces::WorkspaceRecord {
+                id: "ws-1".into(),
+                name: "Editor".into(),
+                user_renamed: true,
+                endpoint_key: "local".into(),
+                policy: models::workspaces::WorkspacePolicy::Persistent,
+                runtime_ref: Some(models::workspaces::RuntimeRef {
+                    runtime_id: "rt-1".into(),
+                    attachment_kind: models::workspaces::RuntimeAttachmentKind::Created,
+                }),
+                layout: models::workspaces::LayoutNode::Terminal {
+                    uuid: "t-1".into(),
+                    profile: None,
+                    cwd: Some("/home/user".into()),
+                    custom_title: Some("vim".into()),
+                },
+                active_pane_id: Some("t-1".into()),
+                zoomed_pane_id: None,
+                input_sync: models::workspaces::InputSyncState::Off,
+                color: models::workspaces::WorkspaceColor::Green,
+                pane_recovery: std::collections::BTreeMap::new(),
+            }],
+        };
+        store.save_workspaces(&ws).unwrap();
+        let loaded = store.load_workspaces().into_value().unwrap();
+        assert_eq!(loaded.active_workspace_id, Some("ws-1".into()));
+        assert_eq!(loaded.workspaces.len(), 1);
+        assert_eq!(loaded.workspaces[0].name, "Editor");
+        assert!(loaded.workspaces[0].user_renamed);
+        assert_eq!(loaded.workspaces[0].runtime_ref.as_ref().unwrap().runtime_id, "rt-1");
+    }
+
+    #[test]
+    fn workspaces_missing_file_returns_default() {
+        let (_tmp, store) = test_store();
+        let outcome = store.load_workspaces();
+        assert!(matches!(outcome, LoadOutcome::Default(_)));
+        let ws = outcome.into_value().unwrap();
+        assert!(ws.workspaces.is_empty());
+    }
+
+    #[test]
+    fn workspaces_malformed_file_recovers_to_default() {
+        let (_tmp, store) = test_store();
+        let path = store.paths.state().join("workspaces.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "bad json").unwrap();
+        let outcome = store.load_workspaces();
+        assert!(matches!(outcome, LoadOutcome::DefaultAfterFailure(_)));
+    }
+
+    // ── UI State ────────────────────────────────────────────
+
+    #[test]
+    fn ui_state_round_trip_through_store() {
+        let (_tmp, store) = test_store();
+        let ui = models::ui::UiState {
+            window_width: 1920,
+            window_height: 1080,
+            is_maximized: true,
+            left_sidebar_width: 300,
+            right_sidebar_width: 400,
+            ..models::ui::UiState::default()
+        };
+        store.save_ui_state(&ui).unwrap();
+        let loaded = store.load_ui_state().into_value().unwrap();
+        assert_eq!(loaded.window_width, 1920);
+        assert_eq!(loaded.window_height, 1080);
+        assert!(loaded.is_maximized);
+        assert_eq!(loaded.left_sidebar_width, 300);
+        assert_eq!(loaded.right_sidebar_width, 400);
+    }
+
+    #[test]
+    fn ui_state_missing_file_returns_default() {
+        let (_tmp, store) = test_store();
+        let outcome = store.load_ui_state();
+        assert!(matches!(outcome, LoadOutcome::Default(_)));
+        let ui = outcome.into_value().unwrap();
+        assert_eq!(ui.window_width, 900);
+        assert_eq!(ui.window_height, 600);
+    }
+
+    #[test]
+    fn ui_state_malformed_file_recovers_to_default() {
+        let (_tmp, store) = test_store();
+        let path = store.paths.state().join("ui.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "not json").unwrap();
+        let outcome = store.load_ui_state();
+        assert!(matches!(outcome, LoadOutcome::DefaultAfterFailure(_)));
+    }
+
+    // ── Runtime Cache ───────────────────────────────────────
+
+    #[test]
+    fn runtime_cache_round_trip_through_store() {
+        let (_tmp, store) = test_store();
+        let cache = models::runtime_cache::RuntimeCache {
+            dismissed_runtime_ids: ["rt-1".into(), "rt-2".into()].into_iter().collect(),
+        };
+        store.save_runtime_cache(&cache).unwrap();
+        let loaded = store.load_runtime_cache().into_value().unwrap();
+        assert_eq!(loaded.dismissed_runtime_ids.len(), 2);
+        assert!(loaded.dismissed_runtime_ids.contains("rt-1"));
+        assert!(loaded.dismissed_runtime_ids.contains("rt-2"));
+    }
+
+    #[test]
+    fn runtime_cache_missing_file_returns_default() {
+        let (_tmp, store) = test_store();
+        let outcome = store.load_runtime_cache();
+        assert!(matches!(outcome, LoadOutcome::Default(_)));
+        assert!(outcome.into_value().unwrap().dismissed_runtime_ids.is_empty());
+    }
+
+    #[test]
+    fn runtime_cache_deletion_is_non_fatal() {
+        let (_tmp, store) = test_store();
+        let cache = models::runtime_cache::RuntimeCache {
+            dismissed_runtime_ids: std::iter::once("rt-1".into()).collect(),
+        };
+        store.save_runtime_cache(&cache).unwrap();
+        // Delete the file
+        let path = store.paths.cache().join("runtime-cache.json");
+        std::fs::remove_file(&path).unwrap();
+        // Load should return default, not error
+        let outcome = store.load_runtime_cache();
+        assert!(matches!(outcome, LoadOutcome::Default(_)));
+        assert!(outcome.into_value().unwrap().dismissed_runtime_ids.is_empty());
+    }
+
+    // ── Domain conversion round-trips ───────────────────────
+
+    #[test]
+    fn workspace_state_round_trips_through_store_model() {
+        use crate::workspace::state::WorkspaceState;
+
+        let ws = WorkspaceState::new("Editor".into());
+        let record: models::workspaces::WorkspaceRecord = (&ws).into();
+        let restored = record.to_workspace_state();
+
+        assert_eq!(restored.uuid, ws.uuid);
+        assert_eq!(restored.name, ws.name);
+        assert_eq!(restored.layout.terminal_uuids(), ws.layout.terminal_uuids());
+    }
+
+    #[test]
+    fn managed_workspace_round_trips_through_store_model() {
+        use crate::runtime::{RuntimeEndpoint, WorkspacePolicy};
+        use crate::workspace::state::WorkspaceState;
+
+        let ws = WorkspaceState::new_managed_remote(
+            "Remote".into(),
+            "deploy@example.com",
+            WorkspacePolicy::Persistent,
+            Some("/srv/app".into()),
+        );
+        let record: models::workspaces::WorkspaceRecord = (&ws).into();
+
+        assert_eq!(record.endpoint_key, "example.com");
+        assert!(record.runtime_ref.is_none()); // no runtime_id yet
+        assert_eq!(record.policy, models::workspaces::WorkspacePolicy::Persistent);
+
+        let restored = record.to_workspace_state();
+        assert!(restored.runtime.is_managed());
+        assert_eq!(
+            restored.runtime.endpoint,
+            RuntimeEndpoint::Remote { host: "example.com".into() }
+        );
+    }
+
+    #[test]
+    fn window_state_splits_into_three_store_documents() {
+        use crate::workspace::state::WindowState;
+
+        let mut state = WindowState {
+            width: 1920,
+            height: 1080,
+            is_maximized: true,
+            left_sidebar_width: 250,
+            right_sidebar_width: 350,
+            ..WindowState::default()
+        };
+        state.dismissed_runtime_ids.insert("dismissed-1".into());
+
+        let ws_store: models::workspaces::WorkspaceStore = (&state).into();
+        let ui: models::ui::UiState = (&state).into();
+        let cache: models::runtime_cache::RuntimeCache = (&state).into();
+
+        assert_eq!(ws_store.workspaces.len(), 1);
+        assert_eq!(ui.window_width, 1920);
+        assert_eq!(ui.window_height, 1080);
+        assert!(ui.is_maximized);
+        assert_eq!(ui.left_sidebar_width, 250);
+        assert_eq!(ui.right_sidebar_width, 350);
+        assert!(cache.dismissed_runtime_ids.contains("dismissed-1"));
+    }
+
+    #[test]
+    fn workspace_with_recovery_round_trips_through_store() {
+        use crate::workspace::recovery::{PaneRecovery, PaneSource, PaneTarget, StartupStep};
+        use crate::workspace::state::WorkspaceState;
+
+        let mut ws = WorkspaceState::new("Ops".into());
+        let terminal_uuid = ws.layout.terminal_uuids().into_iter().next().unwrap();
+        ws.set_recovery(
+            &terminal_uuid,
+            PaneRecovery {
+                source: PaneSource::Command { title: "Deploy".into() },
+                target: Some(PaneTarget::RemoteShell {
+                    ssh_target: "deploy@prod".into(),
+                    remote_folder: Some("/srv/app".into()),
+                }),
+                startup: vec![StartupStep::SendText {
+                    text: "make deploy".into(),
+                    execute: true,
+                }],
+            },
+        );
+
+        let record: models::workspaces::WorkspaceRecord = (&ws).into();
+        let restored = record.to_workspace_state();
+
+        let recovery = restored.recovery_for(&terminal_uuid).unwrap();
+        assert!(matches!(recovery.source, PaneSource::Command { ref title } if title == "Deploy"));
+        assert!(matches!(
+            recovery.target,
+            Some(PaneTarget::RemoteShell { ref ssh_target, .. }) if ssh_target == "deploy@prod"
+        ));
+        assert_eq!(recovery.startup.len(), 1);
+    }
+
+    #[test]
+    fn split_layout_round_trips_through_store_model() {
+        use crate::test_helpers::{hsplit, term};
+        use crate::workspace::state::WorkspaceState;
+
+        let mut ws = WorkspaceState::new("Split".into());
+        ws.layout = hsplit(term("t1"), term("t2"));
+
+        let record: models::workspaces::WorkspaceRecord = (&ws).into();
+        let restored = record.to_workspace_state();
+
+        assert_eq!(restored.layout.terminal_count(), 2);
+        assert!(restored.layout.contains_terminal("t1"));
+        assert!(restored.layout.contains_terminal("t2"));
     }
 }

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -220,12 +220,7 @@ impl ClientStore {
     #[must_use]
     pub fn load_ui_state(&self) -> LoadOutcome<models::ui::UiState> {
         let path = self.paths.state().join("ui.json");
-        atomic_load(
-            &path,
-            models::ui::SCHEMA,
-            models::ui::CURRENT_VERSION,
-            &self.paths.backups(),
-        )
+        atomic_load(&path, models::ui::SCHEMA, models::ui::CURRENT_VERSION, &self.paths.backups())
     }
 
     /// Save UI state atomically with an envelope wrapper.
@@ -687,10 +682,7 @@ mod tests {
                     ssh_target: "deploy@prod".into(),
                     remote_folder: Some("/srv/app".into()),
                 }),
-                startup: vec![StartupStep::SendText {
-                    text: "make deploy".into(),
-                    execute: true,
-                }],
+                startup: vec![StartupStep::SendText { text: "make deploy".into(), execute: true }],
             },
         );
 

--- a/clients/rttx/src/store/models/runtime_cache.rs
+++ b/clients/rttx/src/store/models/runtime_cache.rs
@@ -18,3 +18,13 @@ pub struct RuntimeCache {
     #[serde(default)]
     pub dismissed_runtime_ids: BTreeSet<String>,
 }
+
+// ── Conversions from domain types ───────────────────────────────
+
+use crate::workspace::state;
+
+impl From<&state::WindowState> for RuntimeCache {
+    fn from(ws: &state::WindowState) -> Self {
+        Self { dismissed_runtime_ids: ws.dismissed_runtime_ids.clone() }
+    }
+}

--- a/clients/rttx/src/store/models/ui.rs
+++ b/clients/rttx/src/store/models/ui.rs
@@ -58,3 +58,22 @@ const fn default_left_sidebar_width() -> i32 {
 const fn default_right_sidebar_width() -> i32 {
     320
 }
+
+// ── Conversions from domain types ───────────────────────────────
+
+use crate::workspace::state;
+
+impl From<&state::WindowState> for UiState {
+    fn from(ws: &state::WindowState) -> Self {
+        Self {
+            window_width: ws.width,
+            window_height: ws.height,
+            is_maximized: ws.is_maximized,
+            left_sidebar_width: ws.left_sidebar_width,
+            right_sidebar_width: ws.right_sidebar_width,
+            left_sidebar_visible: false,
+            right_sidebar_visible: false,
+            selected_right_tool: None,
+        }
+    }
+}

--- a/clients/rttx/src/store/models/workspaces.rs
+++ b/clients/rttx/src/store/models/workspaces.rs
@@ -455,13 +455,8 @@ impl WorkspaceRecord {
 
 impl From<&state::WindowState> for WorkspaceStore {
     fn from(ws: &state::WindowState) -> Self {
-        let active_workspace_id = ws
-            .workspaces
-            .get(ws.active_workspace_index)
-            .map(|s| s.uuid.clone());
-        Self {
-            active_workspace_id,
-            workspaces: ws.workspaces.iter().map(Into::into).collect(),
-        }
+        let active_workspace_id =
+            ws.workspaces.get(ws.active_workspace_index).map(|s| s.uuid.clone());
+        Self { active_workspace_id, workspaces: ws.workspaces.iter().map(Into::into).collect() }
     }
 }

--- a/clients/rttx/src/store/models/workspaces.rs
+++ b/clients/rttx/src/store/models/workspaces.rs
@@ -164,3 +164,304 @@ pub struct WorkspaceStore {
     #[serde(default)]
     pub workspaces: Vec<WorkspaceRecord>,
 }
+
+// ── Conversions from domain types ───────────────────────────────
+
+use crate::runtime::{RuntimeEndpoint, WorkspaceRuntime};
+use crate::workspace::recovery;
+use crate::workspace::state;
+
+impl From<&state::WorkspaceColor> for WorkspaceColor {
+    fn from(c: &state::WorkspaceColor) -> Self {
+        match c {
+            state::WorkspaceColor::Blue => Self::Blue,
+            state::WorkspaceColor::Green => Self::Green,
+            state::WorkspaceColor::Yellow => Self::Yellow,
+            state::WorkspaceColor::Red => Self::Red,
+            state::WorkspaceColor::Purple => Self::Purple,
+            state::WorkspaceColor::Pink => Self::Pink,
+            state::WorkspaceColor::Teal => Self::Teal,
+            state::WorkspaceColor::Orange => Self::Orange,
+        }
+    }
+}
+
+impl From<&WorkspaceColor> for state::WorkspaceColor {
+    fn from(c: &WorkspaceColor) -> Self {
+        match c {
+            WorkspaceColor::Blue => Self::Blue,
+            WorkspaceColor::Green => Self::Green,
+            WorkspaceColor::Yellow => Self::Yellow,
+            WorkspaceColor::Red => Self::Red,
+            WorkspaceColor::Purple => Self::Purple,
+            WorkspaceColor::Pink => Self::Pink,
+            WorkspaceColor::Teal => Self::Teal,
+            WorkspaceColor::Orange => Self::Orange,
+        }
+    }
+}
+
+impl From<&crate::runtime::WorkspacePolicy> for WorkspacePolicy {
+    fn from(p: &crate::runtime::WorkspacePolicy) -> Self {
+        match p {
+            crate::runtime::WorkspacePolicy::Persistent => Self::Persistent,
+            crate::runtime::WorkspacePolicy::Ephemeral => Self::Ephemeral,
+        }
+    }
+}
+
+impl From<&WorkspacePolicy> for crate::runtime::WorkspacePolicy {
+    fn from(p: &WorkspacePolicy) -> Self {
+        match p {
+            WorkspacePolicy::Persistent => Self::Persistent,
+            WorkspacePolicy::Ephemeral => Self::Ephemeral,
+        }
+    }
+}
+
+impl From<&recovery::PaneSource> for PaneSource {
+    fn from(s: &recovery::PaneSource) -> Self {
+        match s {
+            recovery::PaneSource::EmptyShell => Self::EmptyShell,
+            recovery::PaneSource::Command { title } => Self::Command { title: title.clone() },
+            recovery::PaneSource::Manual => Self::Manual,
+        }
+    }
+}
+
+impl From<&PaneSource> for recovery::PaneSource {
+    fn from(s: &PaneSource) -> Self {
+        match s {
+            PaneSource::EmptyShell => Self::EmptyShell,
+            PaneSource::Command { title } => Self::Command { title: title.clone() },
+            PaneSource::Manual => Self::Manual,
+        }
+    }
+}
+
+impl From<&recovery::PaneTarget> for PaneTarget {
+    fn from(t: &recovery::PaneTarget) -> Self {
+        match t {
+            recovery::PaneTarget::LocalFolder { path } => Self::LocalFolder { path: path.clone() },
+            recovery::PaneTarget::RemoteShell { ssh_target, remote_folder } => Self::RemoteShell {
+                ssh_target: ssh_target.clone(),
+                remote_folder: remote_folder.clone(),
+            },
+        }
+    }
+}
+
+impl From<&PaneTarget> for recovery::PaneTarget {
+    fn from(t: &PaneTarget) -> Self {
+        match t {
+            PaneTarget::LocalFolder { path } => Self::LocalFolder { path: path.clone() },
+            PaneTarget::RemoteShell { ssh_target, remote_folder } => Self::RemoteShell {
+                ssh_target: ssh_target.clone(),
+                remote_folder: remote_folder.clone(),
+            },
+        }
+    }
+}
+
+impl From<&recovery::StartupStep> for StartupStep {
+    fn from(s: &recovery::StartupStep) -> Self {
+        match s {
+            recovery::StartupStep::SendText { text, execute } => {
+                Self::SendText { text: text.clone(), execute: *execute }
+            }
+        }
+    }
+}
+
+impl From<&StartupStep> for recovery::StartupStep {
+    fn from(s: &StartupStep) -> Self {
+        match s {
+            StartupStep::SendText { text, execute } => {
+                Self::SendText { text: text.clone(), execute: *execute }
+            }
+        }
+    }
+}
+
+impl From<&recovery::PaneRecovery> for PaneRecoveryRecord {
+    fn from(r: &recovery::PaneRecovery) -> Self {
+        Self {
+            source: (&r.source).into(),
+            target: r.target.as_ref().map(Into::into),
+            startup: r.startup.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<&PaneRecoveryRecord> for recovery::PaneRecovery {
+    fn from(r: &PaneRecoveryRecord) -> Self {
+        Self {
+            source: (&r.source).into(),
+            target: r.target.as_ref().map(Into::into),
+            startup: r.startup.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<&crate::workspace::layout::SplitOrientation> for SplitOrientation {
+    fn from(o: &crate::workspace::layout::SplitOrientation) -> Self {
+        match o {
+            crate::workspace::layout::SplitOrientation::Horizontal => Self::Horizontal,
+            crate::workspace::layout::SplitOrientation::Vertical => Self::Vertical,
+        }
+    }
+}
+
+impl From<&SplitOrientation> for crate::workspace::layout::SplitOrientation {
+    fn from(o: &SplitOrientation) -> Self {
+        match o {
+            SplitOrientation::Horizontal => Self::Horizontal,
+            SplitOrientation::Vertical => Self::Vertical,
+        }
+    }
+}
+
+impl From<&crate::workspace::layout::LayoutNode> for LayoutNode {
+    fn from(n: &crate::workspace::layout::LayoutNode) -> Self {
+        match n {
+            crate::workspace::layout::LayoutNode::Terminal { uuid, profile, cwd, custom_title } => {
+                Self::Terminal {
+                    uuid: uuid.clone(),
+                    profile: profile.clone(),
+                    cwd: cwd.clone(),
+                    custom_title: custom_title.clone(),
+                }
+            }
+            crate::workspace::layout::LayoutNode::Split { orientation, ratio, first, second } => {
+                Self::Split {
+                    orientation: orientation.into(),
+                    ratio: *ratio,
+                    first: Box::new(first.as_ref().into()),
+                    second: Box::new(second.as_ref().into()),
+                }
+            }
+        }
+    }
+}
+
+impl From<&LayoutNode> for crate::workspace::layout::LayoutNode {
+    fn from(n: &LayoutNode) -> Self {
+        match n {
+            LayoutNode::Terminal { uuid, profile, cwd, custom_title } => Self::Terminal {
+                uuid: uuid.clone(),
+                profile: profile.clone(),
+                cwd: cwd.clone(),
+                custom_title: custom_title.clone(),
+            },
+            LayoutNode::Split { orientation, ratio, first, second } => Self::Split {
+                orientation: orientation.into(),
+                ratio: *ratio,
+                first: Box::new(first.as_ref().into()),
+                second: Box::new(second.as_ref().into()),
+            },
+        }
+    }
+}
+
+fn endpoint_key_from_runtime(runtime: &WorkspaceRuntime) -> String {
+    match &runtime.endpoint {
+        RuntimeEndpoint::Local => "local".into(),
+        RuntimeEndpoint::Remote { host } => crate::host::normalize_ssh_key(host),
+    }
+}
+
+fn runtime_ref_from_workspace(runtime: &WorkspaceRuntime) -> Option<RuntimeRef> {
+    runtime.runtime_id.as_ref().map(|id| RuntimeRef {
+        runtime_id: id.clone(),
+        attachment_kind: RuntimeAttachmentKind::Created,
+    })
+}
+
+impl From<&state::WorkspaceState> for WorkspaceRecord {
+    fn from(ws: &state::WorkspaceState) -> Self {
+        Self {
+            id: ws.uuid.clone(),
+            name: ws.name.clone(),
+            user_renamed: ws.user_renamed,
+            endpoint_key: if ws.runtime.is_managed() {
+                endpoint_key_from_runtime(&ws.runtime)
+            } else {
+                "local".into()
+            },
+            policy: (&ws.runtime.policy).into(),
+            runtime_ref: runtime_ref_from_workspace(&ws.runtime),
+            layout: (&ws.layout).into(),
+            active_pane_id: ws.active_terminal_uuid.clone(),
+            zoomed_pane_id: ws.zoomed_terminal_uuid.clone(),
+            input_sync: if ws.input_sync { InputSyncState::On } else { InputSyncState::Off },
+            color: (&ws.color).into(),
+            pane_recovery: ws
+                .terminal_recovery
+                .iter()
+                .map(|(k, v)| (k.clone(), v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl WorkspaceRecord {
+    /// Convert back to the domain `WorkspaceState`, reconstructing runtime metadata.
+    #[must_use]
+    pub fn to_workspace_state(&self) -> state::WorkspaceState {
+        let endpoint = if self.endpoint_key == "local" {
+            RuntimeEndpoint::Local
+        } else {
+            RuntimeEndpoint::Remote { host: self.endpoint_key.clone() }
+        };
+
+        let layout: crate::workspace::layout::LayoutNode = (&self.layout).into();
+        let layout_terminal_uuids = layout.terminal_uuids();
+
+        let managed = self.endpoint_key != "local" || self.runtime_ref.is_some();
+
+        let mut runtime = WorkspaceRuntime {
+            managed,
+            endpoint,
+            policy: (&self.policy).into(),
+            runtime_id: self.runtime_ref.as_ref().map(|r| r.runtime_id.clone()),
+            ..WorkspaceRuntime::default()
+        };
+        if managed {
+            runtime.ensure_placeholder_bindings(&layout_terminal_uuids);
+        }
+
+        let mut ws = state::WorkspaceState {
+            uuid: self.id.clone(),
+            name: self.name.clone(),
+            layout,
+            terminal_recovery: self
+                .pane_recovery
+                .iter()
+                .map(|(k, v)| (k.clone(), v.into()))
+                .collect(),
+            active_terminal_uuid: self.active_pane_id.clone(),
+            input_sync: matches!(self.input_sync, InputSyncState::On),
+            mode: state::WorkspaceMode::default(),
+            runtime,
+            color: (&self.color).into(),
+            zoomed_terminal_uuid: self.zoomed_pane_id.clone(),
+            user_renamed: self.user_renamed,
+        };
+        ws.sync_legacy_mode_from_runtime();
+        ws.normalize_active_terminal();
+        ws
+    }
+}
+
+impl From<&state::WindowState> for WorkspaceStore {
+    fn from(ws: &state::WindowState) -> Self {
+        let active_workspace_id = ws
+            .workspaces
+            .get(ws.active_workspace_index)
+            .map(|s| s.uuid.clone());
+        Self {
+            active_workspace_id,
+            workspaces: ws.workspaces.iter().map(Into::into).collect(),
+        }
+    }
+}

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -377,8 +377,11 @@ impl Window {
             legacy.dismissed_runtime_ids.extend(cache.dismissed_runtime_ids);
             legacy
         } else {
-            let mut workspaces: Vec<_> =
-                ws_store.workspaces.iter().map(crate::store::models::workspaces::WorkspaceRecord::to_workspace_state).collect();
+            let mut workspaces: Vec<_> = ws_store
+                .workspaces
+                .iter()
+                .map(crate::store::models::workspaces::WorkspaceRecord::to_workspace_state)
+                .collect();
             for ws in &mut workspaces {
                 ws.normalize_runtime_metadata();
             }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -363,7 +363,42 @@ impl Window {
     }
 
     fn load_state(&self) {
-        let state = workspace::load_window_state();
+        let store = crate::store::default_store();
+
+        // Load workspace state from the new store, falling back to legacy.
+        let ws_store = store.load_workspaces().into_value().unwrap_or_default();
+        let ui = store.load_ui_state().into_value().unwrap_or_default();
+        let cache = store.load_runtime_cache().into_value().unwrap_or_default();
+
+        let state = if ws_store.workspaces.is_empty() {
+            // No new-format workspaces — try legacy sessions.json
+            let mut legacy = workspace::load_window_state();
+            // Merge any cache data from the new store
+            legacy.dismissed_runtime_ids.extend(cache.dismissed_runtime_ids);
+            legacy
+        } else {
+            let mut workspaces: Vec<_> =
+                ws_store.workspaces.iter().map(crate::store::models::workspaces::WorkspaceRecord::to_workspace_state).collect();
+            for ws in &mut workspaces {
+                ws.normalize_runtime_metadata();
+            }
+            let active_workspace_index = ws_store
+                .active_workspace_id
+                .as_ref()
+                .and_then(|id| workspaces.iter().position(|ws| ws.uuid == *id))
+                .unwrap_or(0);
+            WindowState {
+                workspaces,
+                active_workspace_index,
+                width: ui.window_width,
+                height: ui.window_height,
+                is_maximized: ui.is_maximized,
+                left_sidebar_width: ui.left_sidebar_width,
+                right_sidebar_width: ui.right_sidebar_width,
+                dismissed_runtime_ids: cache.dismissed_runtime_ids,
+            }
+        };
+
         let active_index =
             state.active_workspace_index.min(state.workspaces.len().saturating_sub(1));
         let is_maximized = state.is_maximized;
@@ -478,6 +513,21 @@ impl Window {
 
         if let Err(e) = workspace::save_window_state(&state) {
             tracing::error!("Failed to save window state: {e}");
+        }
+
+        // Also save to the new store documents.
+        let store = crate::store::default_store();
+        let ws_store: crate::store::models::workspaces::WorkspaceStore = (&state).into();
+        let ui: crate::store::models::ui::UiState = (&state).into();
+        let cache: crate::store::models::runtime_cache::RuntimeCache = (&state).into();
+        if let Err(e) = store.save_workspaces(&ws_store) {
+            tracing::error!("Failed to save workspaces: {e}");
+        }
+        if let Err(e) = store.save_ui_state(&ui) {
+            tracing::error!("Failed to save UI state: {e}");
+        }
+        if let Err(e) = store.save_runtime_cache(&cache) {
+            tracing::error!("Failed to save runtime cache: {e}");
         }
     }
 

--- a/clients/rttx/tests/ui/common.py
+++ b/clients/rttx/tests/ui/common.py
@@ -255,10 +255,12 @@ class TestEnvironment:
         self.runtime_dir = os.path.join(self.root_dir, "run")
         self.config_home = os.path.join(self.root_dir, "config")
         self.cache_home = os.path.join(self.root_dir, "cache")
+        self.state_home = os.path.join(self.root_dir, "state")
         self.extra_env = extra_env or {}
         os.makedirs(self.runtime_dir, mode=0o700, exist_ok=True)
         os.makedirs(self.config_home, exist_ok=True)
         os.makedirs(self.cache_home, exist_ok=True)
+        os.makedirs(self.state_home, exist_ok=True)
         self.wayland_socket = f"{WAYLAND_SOCKET}-{uuid.uuid4().hex[:8]}"
         self._weston: subprocess.Popen | None = None
         self._daemon: subprocess.Popen | None = None
@@ -299,6 +301,7 @@ class TestEnvironment:
         env["XDG_RUNTIME_DIR"] = self.runtime_dir
         env["XDG_CONFIG_HOME"] = self.config_home
         env["XDG_CACHE_HOME"] = self.cache_home
+        env["XDG_STATE_HOME"] = self.state_home
         env["NO_AT_BRIDGE"] = "0"
         env["PATH"] = os.path.join(TARGET_DIR, "debug") + os.pathsep + env["PATH"]
         env.pop("GTK_A11Y", None)
@@ -425,11 +428,17 @@ class TestEnvironment:
         self.start_daemon()
 
     def clear_saved_state(self) -> None:
-        """Remove the GUI sessions file so startup recovery uses daemon inventory."""
-        try:
-            os.remove(self.sessions_file)
-        except FileNotFoundError:
-            pass
+        """Remove the GUI sessions file and new store documents so startup uses defaults."""
+        for path in [
+            self.sessions_file,
+            os.path.join(self.state_home, DEV_CONFIG_DIR, "client", "workspaces.json"),
+            os.path.join(self.state_home, DEV_CONFIG_DIR, "client", "ui.json"),
+            os.path.join(self.cache_home, DEV_CONFIG_DIR, "runtime-cache.json"),
+        ]:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
 
     def cleanup(self) -> None:
         """Stop all managed processes and remove the private temp roots."""

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.6',
+  version: '0.4.7',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

RFC-023 Step 5: Split `WindowState` into three separate `ClientStore` documents:

- **`workspaces.json`** — workspace/tab state (`WorkspaceRecord` with endpoint, policy, layout, pane recovery)
- **`ui.json`** — window geometry, sidebar widths, visibility, selected tool
- **`runtime-cache.json`** — dismissed runtime IDs (disposable cache)

### Changes

- **`ClientStore` methods**: Added `load_workspaces()`/`save_workspaces()`, `load_ui_state()`/`save_ui_state()`, `load_runtime_cache()`/`save_runtime_cache()`
- **Type conversions**: `From` impls between store model types (`WorkspaceRecord`, `WorkspaceStore`, `UiState`, `RuntimeCache`) and domain types (`WorkspaceState`, `WindowState`)
- **`load_state()`**: Reads from new store documents with legacy `sessions.json` fallback
- **`save_state()`**: Writes both legacy and new store documents for backward compatibility during migration
- **Version bump** to 0.4.7 (change spans 5+ source files)

### How to verify

1. Build: `cargo build -p rttx --no-default-features --features vte-0_76`
2. Run: `RTTX_DEV_MODE=1 cargo run -p rttx`
3. Create workspaces, split panes, rename
4. Close and reopen — state should restore from new store documents
5. Delete `$XDG_STATE_HOME/rttx-devel/client/workspaces.json` — should fall back to legacy `sessions.json`
6. Delete `$XDG_CACHE_HOME/rttx-devel/runtime-cache.json` — app should start normally

### Tests added

#### Store method tests (6)
- `workspaces_round_trip_through_store` — full round-trip through ClientStore
- `workspaces_missing_file_returns_default` — missing file returns default
- `workspaces_malformed_file_recovers_to_default` — malformed file recovery
- `ui_state_round_trip_through_store` — full round-trip through ClientStore
- `ui_state_missing_file_returns_default` — missing file returns default
- `ui_state_malformed_file_recovers_to_default` — malformed file recovery

#### Runtime cache tests (3)
- `runtime_cache_round_trip_through_store` — full round-trip through ClientStore
- `runtime_cache_missing_file_returns_default` — missing file returns default
- `runtime_cache_deletion_is_non_fatal` — deleted cache file is non-fatal

#### Domain conversion tests (5)
- `workspace_state_round_trips_through_store_model` — WorkspaceState ↔ WorkspaceRecord
- `managed_workspace_round_trips_through_store_model` — managed remote workspace conversion
- `window_state_splits_into_three_store_documents` — WindowState → WorkspaceStore + UiState + RuntimeCache
- `workspace_with_recovery_round_trips_through_store` — pane recovery recipes preserved
- `split_layout_round_trips_through_store_model` — nested split layout preserved

### Tests run

- `cargo build --workspace` (with VTE 0.76 flags for client) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` — 668 passed, 0 failed ✅
- `cargo test -p rttx-proto -p rttx-server` — all passed ✅
- `bash .github/scripts/run-clippy.sh` — clean ✅
- `bash .github/scripts/run-quality-tests.sh` — all new tests visible and passing ✅

### Limitations / follow-ups

- Legacy `sessions.json` is still written alongside new documents for backward compatibility
- `runtime_ref` location (Q2 in RFC-023) may need revisiting when RFC-021 lands
- Live connection state stays in memory only, not persisted (as specified in #742)

Fixes #742