### PR TITLE
refactor(client): remove canonical writes of legacy SessionMode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.7"
+version = "0.4.8"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/store/models/workspaces.rs
+++ b/clients/rttx/src/store/models/workspaces.rs
@@ -447,7 +447,6 @@ impl WorkspaceRecord {
             zoomed_terminal_uuid: self.zoomed_pane_id.clone(),
             user_renamed: self.user_renamed,
         };
-        ws.sync_legacy_mode_from_runtime();
         ws.normalize_active_terminal();
         ws
     }

--- a/clients/rttx/src/test_helpers.rs
+++ b/clients/rttx/src/test_helpers.rs
@@ -131,7 +131,6 @@ pub fn managed_session_with_runtime(
         user_renamed: false,
     };
     session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
-    session.sync_legacy_mode_from_runtime();
     session
 }
 

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -407,7 +407,8 @@ impl Window {
             crate::runtime::workspace_menu_items(&crate::runtime::WorkspaceMenuContext {
                 is_remote: matches!(session.runtime.endpoint, RuntimeEndpoint::Remote { .. }),
                 is_managed: session.uses_managed_runtime(),
-                is_persistent: session.mode.is_persistent(),
+                is_persistent: session.runtime.is_managed()
+                    && matches!(session.runtime.policy, WorkspacePolicy::Persistent),
                 is_attached: session.runtime.runtime_id.is_some(),
                 is_disconnected: disconnected,
             })

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -484,7 +484,6 @@ impl Window {
             }
             session.prune_recovery();
             session.normalize_active_terminal();
-            session.sync_legacy_mode_from_runtime();
             session.zoomed_terminal_uuid = None;
         }
 

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -1023,7 +1023,6 @@ impl Window {
             };
             let previous_endpoint = session.runtime.endpoint.clone();
             session.runtime.endpoint = RuntimeEndpoint::Remote { host };
-            session.sync_legacy_mode_from_runtime();
             (session.clone(), previous_endpoint)
         };
 

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -2961,10 +2961,7 @@ fn save_state_persists_terminated_workspace_without_runtime_id() {
     );
     assert_eq!(saved_session.runtime.policy, WorkspacePolicy::Persistent);
     assert_eq!(saved_session.runtime.runtime_id, None);
-    assert_eq!(
-        saved_session.mode,
-        crate::workspace::WorkspaceMode::Direct,
-    );
+    assert_eq!(saved_session.mode, crate::workspace::WorkspaceMode::Direct,);
     assert_eq!(
         saved_session.runtime.pane_bindings.get("managed-pane").map(String::as_str),
         Some("managed-pane")

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -2963,10 +2963,7 @@ fn save_state_persists_terminated_workspace_without_runtime_id() {
     assert_eq!(saved_session.runtime.runtime_id, None);
     assert_eq!(
         saved_session.mode,
-        crate::workspace::WorkspaceMode::RemotePersistent {
-            host: "builder.example".into(),
-            daemon_runtime_id: String::new(),
-        }
+        crate::workspace::WorkspaceMode::Direct,
     );
     assert_eq!(
         saved_session.runtime.pane_bindings.get("managed-pane").map(String::as_str),

--- a/clients/rttx/src/workspace/state.rs
+++ b/clients/rttx/src/workspace/state.rs
@@ -107,7 +107,7 @@ pub struct WorkspaceState {
     pub active_terminal_uuid: Option<String>,
     #[serde(default)]
     pub input_sync: bool,
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     pub mode: WorkspaceMode,
     #[serde(default)]
     pub runtime: WorkspaceRuntime,
@@ -162,7 +162,6 @@ impl WorkspaceState {
         let mut session = Self::new_with_initial_cwd(name, initial_cwd);
         let layout_terminal_uuids = session.layout.terminal_uuids();
         session.runtime = WorkspaceRuntime::managed_local(policy, &layout_terminal_uuids);
-        session.sync_legacy_mode_from_runtime();
         session
     }
 
@@ -176,7 +175,6 @@ impl WorkspaceState {
         let mut session = Self::new_with_initial_cwd(name, initial_cwd);
         let layout_terminal_uuids = session.layout.terminal_uuids();
         session.runtime = WorkspaceRuntime::managed_remote(host, policy, &layout_terminal_uuids);
-        session.sync_legacy_mode_from_runtime();
         session
     }
 
@@ -236,21 +234,6 @@ impl WorkspaceState {
         }
 
         self.runtime.ensure_placeholder_bindings(&self.layout.terminal_uuids());
-        self.sync_legacy_mode_from_runtime();
-    }
-
-    pub fn sync_legacy_mode_from_runtime(&mut self) {
-        self.mode = if self.runtime.is_managed() {
-            let daemon_runtime_id = self.runtime.runtime_id.clone().unwrap_or_default();
-            match &self.runtime.endpoint {
-                RuntimeEndpoint::Local => WorkspaceMode::Persistent { daemon_runtime_id },
-                RuntimeEndpoint::Remote { host } => {
-                    WorkspaceMode::RemotePersistent { host: host.clone(), daemon_runtime_id }
-                }
-            }
-        } else {
-            WorkspaceMode::Direct
-        };
     }
 
     pub fn set_recovery(&mut self, terminal_uuid: &str, recovery: PaneRecovery) {
@@ -465,50 +448,28 @@ mod tests {
     }
 
     #[test]
-    fn session_mode_default_is_direct() {
-        let session = WorkspaceState::new("Test".into());
-        assert_eq!(session.mode, WorkspaceMode::Direct);
-        assert!(!session.mode.is_persistent());
-        assert!(session.mode.daemon_runtime_id().is_none());
-        assert!(session.mode.host().is_none());
-        assert!(!session.uses_managed_runtime());
+    fn mode_is_not_written_to_json() {
+        let session =
+            WorkspaceState::new_managed_local("Test".into(), WorkspacePolicy::Persistent, None);
+        assert!(session.runtime.is_managed());
+        let json = serde_json::to_string(&session).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            value.get("mode").is_none(),
+            "mode must not be serialized — it is import-only for legacy files"
+        );
     }
 
     #[test]
-    fn session_mode_persistent_accessors() {
-        let mode = WorkspaceMode::Persistent { daemon_runtime_id: "ds1".into() };
-        assert!(mode.is_persistent());
-        assert_eq!(mode.daemon_runtime_id(), Some("ds1"));
-        assert!(mode.host().is_none());
-    }
-
-    #[test]
-    fn session_mode_remote_persistent_accessors() {
-        let mode = WorkspaceMode::RemotePersistent {
-            host: "user@devbox".into(),
-            daemon_runtime_id: "ds2".into(),
-        };
-        assert!(mode.is_persistent());
-        assert_eq!(mode.daemon_runtime_id(), Some("ds2"));
-        assert_eq!(mode.host(), Some("user@devbox"));
-    }
-
-    #[test]
-    fn session_mode_roundtrips_through_json() {
-        for mode in [
-            WorkspaceMode::Direct,
-            WorkspaceMode::Persistent { daemon_runtime_id: "abc-123".into() },
-            WorkspaceMode::RemotePersistent {
-                host: "admin@prod".into(),
-                daemon_runtime_id: "def-456".into(),
-            },
-        ] {
-            let mut session = WorkspaceState::new("Test".into());
-            session.mode = mode.clone();
-            let json = serde_json::to_string(&session).unwrap();
-            let restored: WorkspaceState = serde_json::from_str(&json).unwrap();
-            assert_eq!(restored.mode, mode);
-        }
+    fn legacy_mode_still_deserializes_for_import() {
+        let json = r#"{
+            "uuid": "s1",
+            "name": "Legacy",
+            "layout": {"Terminal": {"uuid": "t1"}},
+            "mode": {"persistent": {"daemon_runtime_id": "rt-1"}}
+        }"#;
+        let session: WorkspaceState = serde_json::from_str(json).unwrap();
+        assert_eq!(session.mode, WorkspaceMode::Persistent { daemon_runtime_id: "rt-1".into() });
     }
 
     #[test]
@@ -526,7 +487,7 @@ mod tests {
     }
 
     #[test]
-    fn persistent_session_in_window_state_roundtrips() {
+    fn persistent_session_in_window_state_roundtrips_via_runtime() {
         let mut session = WorkspaceState::new("Persistent".into());
         session.mode = WorkspaceMode::Persistent { daemon_runtime_id: "ds-1".into() };
         session.normalize_runtime_metadata();
@@ -541,10 +502,15 @@ mod tests {
         };
         let json = serde_json::to_string(&state).unwrap();
         let restored: WindowState = serde_json::from_str(&json).unwrap();
-        assert_eq!(restored.workspaces[0].mode, WorkspaceMode::Direct);
+        assert_eq!(
+            restored.workspaces[0].mode,
+            WorkspaceMode::Direct,
+            "mode is no longer serialized"
+        );
         assert_eq!(
             restored.workspaces[1].mode,
-            WorkspaceMode::Persistent { daemon_runtime_id: "ds-1".into() }
+            WorkspaceMode::Direct,
+            "mode is no longer serialized"
         );
         assert!(restored.workspaces[1].runtime.is_managed());
         assert_eq!(restored.workspaces[1].runtime.runtime_id.as_deref(), Some("ds-1"));
@@ -824,7 +790,7 @@ mod module_boundary_tests {
     }
 
     #[test]
-    fn new_managed_remote_sets_endpoint_and_mode() {
+    fn new_managed_remote_sets_endpoint_and_runtime() {
         let session = WorkspaceState::new_managed_remote(
             "Work".into(),
             "server.example.com",
@@ -837,13 +803,7 @@ mod module_boundary_tests {
             RuntimeEndpoint::Remote { host: "server.example.com".into() }
         );
         assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
-        assert_eq!(
-            session.mode,
-            WorkspaceMode::RemotePersistent {
-                host: "server.example.com".into(),
-                daemon_runtime_id: String::new(),
-            }
-        );
+        assert_eq!(session.mode, WorkspaceMode::Direct, "mode is no longer written");
         assert_eq!(
             session.layout.terminal_cwd(&session.layout.terminal_uuids()[0]).as_deref(),
             Some("/home/user")

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1933,8 +1933,7 @@ mod tests {
     fn runtime_operations_do_not_write_legacy_mode() {
         use crate::workspace::WorkspaceMode;
 
-        let mut state =
-            window_state(vec![managed_session("ws-1", "Workspace", term("pane-1"))]);
+        let mut state = window_state(vec![managed_session("ws-1", "Workspace", term("pane-1"))]);
 
         // Simulate pane creation — mode must stay Direct.
         state.apply_managed_pane_created("ws-1", "pane-1", "rt-1", "daemon-pane-1");

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -188,7 +188,6 @@ impl WindowState {
                     self.workspaces.iter_mut().find(|session| session.uuid == *workspace_id)
                 {
                     session.runtime.runtime_id = None;
-                    session.sync_legacy_mode_from_runtime();
                 }
                 transition.connection_status_updates.push(ConnectionStatusUpdate {
                     workspace_id: workspace_id.clone(),
@@ -371,7 +370,6 @@ impl WindowState {
 
         session.runtime.runtime_id = Some(runtime_id.to_string());
         session.runtime.bind_runtime_pane(layout_terminal_uuid, runtime_pane_id);
-        session.sync_legacy_mode_from_runtime();
         true
     }
 
@@ -403,7 +401,6 @@ impl WindowState {
 
         let had_runtime_id = session.runtime.runtime_id.is_some();
         session.runtime.runtime_id = Some(runtime_id.to_string());
-        session.sync_legacy_mode_from_runtime();
 
         let layout_terminal_uuids = session.layout.terminal_uuids();
         let runtime_pane_uuids =
@@ -555,7 +552,6 @@ fn recovered_managed_workspace(
         session.runtime.pending_layout_panes.clear();
     }
 
-    session.sync_legacy_mode_from_runtime();
     Some(session)
 }
 
@@ -744,7 +740,10 @@ mod tests {
             Some("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
         );
         assert!(!session.runtime.is_layout_pane_pending("pane-1"));
-        assert_eq!(session.mode.daemon_runtime_id(), Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),);
+        assert_eq!(
+            session.runtime.runtime_id.as_deref(),
+            Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
+        );
     }
 
     #[test]

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1928,4 +1928,24 @@ mod tests {
         assert!(round_tripped.smart_clipboard);
         assert_eq!(round_tripped.paste_guard_threshold, 512);
     }
+
+    #[test]
+    fn runtime_operations_do_not_write_legacy_mode() {
+        use crate::workspace::WorkspaceMode;
+
+        let mut state =
+            window_state(vec![managed_session("ws-1", "Workspace", term("pane-1"))]);
+
+        // Simulate pane creation — mode must stay Direct.
+        state.apply_managed_pane_created("ws-1", "pane-1", "rt-1", "daemon-pane-1");
+        assert_eq!(state.workspaces[0].mode, WorkspaceMode::Direct);
+
+        // Simulate runtime termination — mode must stay Direct.
+        let _ = state.reconcile_endpoint_event(&EndpointEvent::RuntimeTerminated {
+            workspace_id: "ws-1".into(),
+            runtime_id: "rt-1".into(),
+            reason: rttx_proto::v3::RuntimeTerminationReason::Explicit,
+        });
+        assert_eq!(state.workspaces[0].mode, WorkspaceMode::Direct);
+    }
 }

--- a/clients/rttx/tests/reconnect_layout_stability.rs
+++ b/clients/rttx/tests/reconnect_layout_stability.rs
@@ -62,7 +62,6 @@ fn layout_stays_stable_across_reconnect_cycles_with_fresh_pane_ids() {
         &session.layout.terminal_uuids(),
     );
     session.runtime.runtime_id = Some(runtime_id.into());
-    session.sync_legacy_mode_from_runtime();
 
     let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };
 

--- a/clients/rttx/tests/stale_terminal_cleanup.rs
+++ b/clients/rttx/tests/stale_terminal_cleanup.rs
@@ -57,7 +57,6 @@ fn managed_session(layout: LayoutNode, runtime_id: &str) -> WorkspaceState {
         &session.layout.terminal_uuids(),
     );
     session.runtime.runtime_id = Some(runtime_id.into());
-    session.sync_legacy_mode_from_runtime();
     session
 }
 

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -558,7 +558,7 @@ fn remote_managed_session_persists_and_restores() {
         restored.runtime.endpoint,
         RuntimeEndpoint::Remote { host: "dev@build-host".into() }
     );
-    assert!(matches!(restored.mode, WorkspaceMode::RemotePersistent { .. }));
+    assert_eq!(restored.mode, WorkspaceMode::Direct, "mode is no longer serialized");
     assert_eq!(
         restored.layout.terminal_cwd(&restored.layout.terminal_uuids()[0]).as_deref(),
         Some("/home/dev/project")
@@ -588,9 +588,9 @@ fn remote_host_creates_managed_remote_session() {
 
 /// Updating a remote workspace endpoint must change the host and sync mode.
 #[test]
-fn update_remote_endpoint_changes_host_and_mode() {
+fn update_remote_endpoint_changes_host() {
     use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
-    use rttx::workspace::{WorkspaceMode, WorkspaceState};
+    use rttx::workspace::WorkspaceState;
 
     let mut session = WorkspaceState::new_managed_remote(
         "Remote".into(),
@@ -600,16 +600,12 @@ fn update_remote_endpoint_changes_host_and_mode() {
     );
 
     session.runtime.endpoint = RuntimeEndpoint::Remote { host: "new-host.example.com".into() };
-    session.sync_legacy_mode_from_runtime();
 
     assert_eq!(
         session.runtime.endpoint,
         RuntimeEndpoint::Remote { host: "new-host.example.com".into() }
     );
-    assert!(matches!(
-        session.mode,
-        WorkspaceMode::RemotePersistent { ref host, .. } if host == "new-host.example.com"
-    ));
+    assert!(session.runtime.is_managed());
 }
 
 /// Splitting a pane in a remote managed session must preserve the remote
@@ -1215,7 +1211,6 @@ fn input_sync_fan_out_targets_all_bound_managed_siblings() {
     session.runtime.bind_runtime_pane("pane-1", "daemon-1");
     session.runtime.bind_runtime_pane("pane-2", "daemon-2");
     session.runtime.bind_runtime_pane("pane-3", "daemon-3");
-    session.sync_legacy_mode_from_runtime();
 
     let state = WindowState {
         active_workspace_index: 0,

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -1391,3 +1391,28 @@ fn v3_snapshot_terminal_modes_propagate_through_reconciliation() {
     assert_eq!(modes.mouse_mode, rttx_proto::v3::MouseMode::Normal as i32);
     assert!(modes.sgr_mouse);
 }
+
+/// Serialized workspace state must not contain the legacy `mode` field.
+/// The `runtime` struct carries endpoint and policy; `mode` is import-only.
+#[test]
+fn serialized_managed_workspace_omits_legacy_mode_field() {
+    use rttx::runtime::WorkspacePolicy;
+    use rttx::workspace::{WindowState, WorkspaceState};
+
+    let session = WorkspaceState::new_managed_remote(
+        "Remote".into(),
+        "build-host",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+    let state = WindowState {
+        workspaces: vec![session],
+        active_workspace_index: 0,
+        ..WindowState::default()
+    };
+    let json = serde_json::to_string(&state).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let ws = &value["workspaces"][0];
+    assert!(ws.get("mode").is_none(), "mode must not appear in serialized state");
+    assert!(ws.get("runtime").is_some(), "runtime must be present in serialized state");
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.7',
+  version: '0.4.8',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

RFC-023 Step 6. Remove `SessionMode` (`WorkspaceMode`) from the canonical persistence path. The `mode` field on `WorkspaceState` becomes import-only for backward compatibility with pre-v1 files.

### Changes

- **Removed `sync_legacy_mode_from_runtime()`** method and all 10 call sites across production code (`window/mod.rs`, `window/runtime.rs`, `workspace_state.rs`, `test_helpers.rs`, `store/models/workspaces.rs`)
- **Added `skip_serializing`** to the `mode` field on `WorkspaceState` — it still deserializes for legacy import via `normalize_runtime_metadata()`
- **Replaced `mode.is_persistent()`** in `window/dialogs.rs` with a runtime-based check (`runtime.is_managed() && runtime.policy == Persistent`)
- **Bumped version** to 0.4.8 (change spans >3 source files)

### How to verify

1. Start rttx, create a managed workspace, close and reopen — workspace should restore correctly via `runtime` metadata
2. Load a legacy `sessions.json` with a `mode: {"persistent": {...}}` field — it should normalize to runtime metadata via `normalize_runtime_metadata()`
3. Save state and inspect the JSON — no `mode` field should be present

### Tests added

- `mode_is_not_written_to_json` — verifies `mode` is absent from serialized JSON
- `legacy_mode_still_deserializes_for_import` — verifies legacy JSON with `mode` field still deserializes correctly

### Tests updated

- `persistent_session_in_window_state_roundtrips_via_runtime` — mode defaults to Direct after roundtrip, runtime carries the data
- `new_managed_remote_sets_endpoint_and_runtime` — mode no longer set by constructor
- `update_remote_endpoint_changes_host` — no longer asserts mode sync
- `save_state_persists_terminated_workspace_without_runtime_id` (GTK test) — mode is Direct after save

### Tests run

- `cargo build --workspace` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` — 666 passed, 0 failed
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass)

Fixes #743