### PR TITLE
refactor(client): remove legacy persistence code and old file paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.8"
+version = "0.4.9"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
-
-use crate::config;
+use std::path::Path;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -87,21 +85,6 @@ pub fn migrate_legacy(commands: &mut [SavedCommand]) {
             command.host_tags.push(crate::host::LOCAL_KEY.into());
         }
     }
-}
-
-fn commands_path() -> PathBuf {
-    let mut path = config::config_dir_path();
-    path.push("commands.json");
-    path
-}
-
-#[must_use]
-pub fn load() -> Vec<SavedCommand> {
-    load_from(&commands_path())
-}
-
-pub fn save(commands: &[SavedCommand]) -> Result<(), Box<dyn std::error::Error>> {
-    save_to(commands, &commands_path())
 }
 
 #[must_use]

--- a/clients/rttx/src/host.rs
+++ b/clients/rttx/src/host.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
-
-use crate::config;
+use std::path::Path;
 
 /// Reserved host key for the local machine.
 pub const LOCAL_KEY: &str = "local";
@@ -94,21 +92,6 @@ fn strip_ssh_user(target: &str) -> &str {
 }
 
 // ── Persistence ─────────────────────────────────────────────────
-
-fn hosts_path() -> PathBuf {
-    let mut path = config::config_dir_path();
-    path.push("hosts.json");
-    path
-}
-
-#[must_use]
-pub fn load() -> Vec<Host> {
-    load_from(&hosts_path())
-}
-
-pub fn save(hosts: &[Host]) -> Result<(), Box<dyn std::error::Error>> {
-    save_to(hosts, &hosts_path())
-}
 
 #[must_use]
 pub fn load_from(path: &Path) -> Vec<Host> {

--- a/clients/rttx/src/places.rs
+++ b/clients/rttx/src/places.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
-
-use crate::config;
+use std::path::Path;
 
 /// A saved navigation target — a directory path scoped to one or more hosts.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -95,21 +93,6 @@ pub fn matches_query(place: &Place, query: &str) -> bool {
 }
 
 // ── Persistence ─────────────────────────────────────────────────
-
-fn places_path() -> PathBuf {
-    let mut path = config::config_dir_path();
-    path.push("places.json");
-    path
-}
-
-#[must_use]
-pub fn load() -> Vec<Place> {
-    load_from(&places_path())
-}
-
-pub fn save(places: &[Place]) -> Result<(), Box<dyn std::error::Error>> {
-    save_to(places, &places_path())
-}
 
 #[must_use]
 pub fn load_from(path: &Path) -> Vec<Place> {

--- a/clients/rttx/src/preferences.rs
+++ b/clients/rttx/src/preferences.rs
@@ -1,10 +1,8 @@
 /// User preferences, persisted as JSON in `XDG_CONFIG_HOME/rttx/preferences.json`.
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 
 use crate::color_scheme;
-use crate::config;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -255,29 +253,6 @@ impl From<PreferencesDisk> for Preferences {
 
 fn parse_preferences_json(data: &str) -> Preferences {
     serde_json::from_str::<PreferencesDisk>(data).map(Into::into).unwrap_or_default()
-}
-
-fn prefs_path() -> PathBuf {
-    let mut path = config::config_dir_path();
-    path.push("preferences.json");
-    path
-}
-
-#[must_use]
-pub fn load() -> Preferences {
-    let path = prefs_path();
-    std::fs::read_to_string(path)
-        .map_or_else(|_| Preferences::default(), |data| parse_preferences_json(&data))
-}
-
-pub fn save(prefs: &Preferences) -> Result<(), Box<dyn std::error::Error>> {
-    let path = prefs_path();
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let json = serde_json::to_string_pretty(prefs)?;
-    std::fs::write(&path, json)?;
-    Ok(())
 }
 
 #[must_use]

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -641,7 +641,7 @@ mod tests {
     }
 
     #[test]
-    fn window_state_splits_into_three_store_documents() {
+    fn window_state_fields_map_to_store_documents() {
         use crate::workspace::state::WindowState;
 
         let mut state = WindowState {
@@ -654,9 +654,23 @@ mod tests {
         };
         state.dismissed_runtime_ids.insert("dismissed-1".into());
 
-        let ws_store: models::workspaces::WorkspaceStore = (&state).into();
-        let ui: models::ui::UiState = (&state).into();
-        let cache: models::runtime_cache::RuntimeCache = (&state).into();
+        let active_workspace_id =
+            state.workspaces.get(state.active_workspace_index).map(|s| s.uuid.clone());
+        let ws_store = models::workspaces::WorkspaceStore {
+            active_workspace_id,
+            workspaces: state.workspaces.iter().map(Into::into).collect(),
+        };
+        let ui = models::ui::UiState {
+            window_width: state.width,
+            window_height: state.height,
+            is_maximized: state.is_maximized,
+            left_sidebar_width: state.left_sidebar_width,
+            right_sidebar_width: state.right_sidebar_width,
+            ..Default::default()
+        };
+        let cache = models::runtime_cache::RuntimeCache {
+            dismissed_runtime_ids: state.dismissed_runtime_ids.clone(),
+        };
 
         assert_eq!(ws_store.workspaces.len(), 1);
         assert_eq!(ui.window_width, 1920);

--- a/clients/rttx/src/store/models/runtime_cache.rs
+++ b/clients/rttx/src/store/models/runtime_cache.rs
@@ -18,5 +18,3 @@ pub struct RuntimeCache {
     #[serde(default)]
     pub dismissed_runtime_ids: BTreeSet<String>,
 }
-
-

--- a/clients/rttx/src/store/models/runtime_cache.rs
+++ b/clients/rttx/src/store/models/runtime_cache.rs
@@ -19,12 +19,4 @@ pub struct RuntimeCache {
     pub dismissed_runtime_ids: BTreeSet<String>,
 }
 
-// ── Conversions from domain types ───────────────────────────────
 
-use crate::workspace::state;
-
-impl From<&state::WindowState> for RuntimeCache {
-    fn from(ws: &state::WindowState) -> Self {
-        Self { dismissed_runtime_ids: ws.dismissed_runtime_ids.clone() }
-    }
-}

--- a/clients/rttx/src/store/models/ui.rs
+++ b/clients/rttx/src/store/models/ui.rs
@@ -58,5 +58,3 @@ const fn default_left_sidebar_width() -> i32 {
 const fn default_right_sidebar_width() -> i32 {
     320
 }
-
-

--- a/clients/rttx/src/store/models/ui.rs
+++ b/clients/rttx/src/store/models/ui.rs
@@ -59,21 +59,4 @@ const fn default_right_sidebar_width() -> i32 {
     320
 }
 
-// ── Conversions from domain types ───────────────────────────────
 
-use crate::workspace::state;
-
-impl From<&state::WindowState> for UiState {
-    fn from(ws: &state::WindowState) -> Self {
-        Self {
-            window_width: ws.width,
-            window_height: ws.height,
-            is_maximized: ws.is_maximized,
-            left_sidebar_width: ws.left_sidebar_width,
-            right_sidebar_width: ws.right_sidebar_width,
-            left_sidebar_visible: false,
-            right_sidebar_visible: false,
-            selected_right_tool: None,
-        }
-    }
-}

--- a/clients/rttx/src/store/models/workspaces.rs
+++ b/clients/rttx/src/store/models/workspaces.rs
@@ -452,10 +452,4 @@ impl WorkspaceRecord {
     }
 }
 
-impl From<&state::WindowState> for WorkspaceStore {
-    fn from(ws: &state::WindowState) -> Self {
-        let active_workspace_id =
-            ws.workspaces.get(ws.active_workspace_index).map(|s| s.uuid.clone());
-        Self { active_workspace_id, workspaces: ws.workspaces.iter().map(Into::into).collect() }
-    }
-}
+

--- a/clients/rttx/src/store/models/workspaces.rs
+++ b/clients/rttx/src/store/models/workspaces.rs
@@ -451,5 +451,3 @@ impl WorkspaceRecord {
         ws
     }
 }
-
-

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -371,20 +371,17 @@ impl Window {
         let cache = store.load_runtime_cache().into_value().unwrap_or_default();
 
         let state = if ws_store.workspaces.is_empty() {
-            // No new-format workspaces — try legacy sessions.json
+            // One-time legacy import: read sessions.json and migrate
+            // WorkspaceMode into WorkspaceRuntime.
             let mut legacy = workspace::load_window_state();
-            // Merge any cache data from the new store
             legacy.dismissed_runtime_ids.extend(cache.dismissed_runtime_ids);
             legacy
         } else {
-            let mut workspaces: Vec<_> = ws_store
+            let workspaces: Vec<_> = ws_store
                 .workspaces
                 .iter()
                 .map(crate::store::models::workspaces::WorkspaceRecord::to_workspace_state)
                 .collect();
-            for ws in &mut workspaces {
-                ws.normalize_runtime_metadata();
-            }
             let active_workspace_index = ws_store
                 .active_workspace_id
                 .as_ref()
@@ -513,15 +510,24 @@ impl Window {
             }
         }
 
-        if let Err(e) = workspace::save_window_state(&state) {
-            tracing::error!("Failed to save window state: {e}");
-        }
-
-        // Also save to the new store documents.
         let store = crate::store::default_store();
-        let ws_store: crate::store::models::workspaces::WorkspaceStore = (&state).into();
-        let ui: crate::store::models::ui::UiState = (&state).into();
-        let cache: crate::store::models::runtime_cache::RuntimeCache = (&state).into();
+        let active_workspace_id =
+            state.workspaces.get(state.active_workspace_index).map(|s| s.uuid.clone());
+        let ws_store = crate::store::models::workspaces::WorkspaceStore {
+            active_workspace_id,
+            workspaces: state.workspaces.iter().map(Into::into).collect(),
+        };
+        let ui = crate::store::models::ui::UiState {
+            window_width: state.width,
+            window_height: state.height,
+            is_maximized: state.is_maximized,
+            left_sidebar_width: state.left_sidebar_width,
+            right_sidebar_width: state.right_sidebar_width,
+            ..Default::default()
+        };
+        let cache = crate::store::models::runtime_cache::RuntimeCache {
+            dismissed_runtime_ids: state.dismissed_runtime_ids.clone(),
+        };
         if let Err(e) = store.save_workspaces(&ws_store) {
             tracing::error!("Failed to save workspaces: {e}");
         }

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3894,7 +3894,11 @@ fn command_sidebar_filters_by_selected_host() {
     let mut remote_cmd = crate::commands::SavedCommand::new("Remote cmd", "echo remote");
     remote_cmd.host_tags = vec!["example.com".into()];
     let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
-    crate::commands::save_to(&[local_cmd, remote_cmd, global_cmd], &config_dir().join("commands.json")).unwrap();
+    crate::commands::save_to(
+        &[local_cmd, remote_cmd, global_cmd],
+        &config_dir().join("commands.json"),
+    )
+    .unwrap();
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.command-host-filter-tests")
@@ -3933,7 +3937,11 @@ fn command_sidebar_groups_by_host_in_all_hosts_view() {
     let mut remote_cmd = crate::commands::SavedCommand::new("Remote cmd", "echo remote");
     remote_cmd.host_tags = vec!["example.com".into()];
     let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
-    crate::commands::save_to(&[local_cmd, remote_cmd, global_cmd], &config_dir.join("commands.json")).unwrap();
+    crate::commands::save_to(
+        &[local_cmd, remote_cmd, global_cmd],
+        &config_dir.join("commands.json"),
+    )
+    .unwrap();
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.command-all-hosts-sections-test")
@@ -3974,7 +3982,8 @@ fn command_sidebar_shows_sections_for_specific_host() {
     let mut local_cmd = crate::commands::SavedCommand::new("Local cmd", "echo local");
     local_cmd.host_tags = vec!["local".into()];
     let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
-    crate::commands::save_to(&[local_cmd, global_cmd], &config_dir().join("commands.json")).unwrap();
+    crate::commands::save_to(&[local_cmd, global_cmd], &config_dir().join("commands.json"))
+        .unwrap();
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.command-host-sections-test")

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -2,6 +2,67 @@ use super::*;
 use crate::workspace::PaneTarget;
 use std::time::{Duration, Instant};
 
+fn config_dir() -> std::path::PathBuf {
+    crate::config::config_dir_path()
+}
+
+fn store() -> crate::store::ClientStore {
+    crate::store::default_store()
+}
+
+/// Load workspace state from the new store, reconstructing `WindowState`.
+fn load_saved_window_state() -> WindowState {
+    let store = store();
+    let ws_store = store.load_workspaces().into_value().unwrap_or_default();
+    let ui = store.load_ui_state().into_value().unwrap_or_default();
+    let cache = store.load_runtime_cache().into_value().unwrap_or_default();
+    let workspaces: Vec<_> = ws_store
+        .workspaces
+        .iter()
+        .map(crate::store::models::workspaces::WorkspaceRecord::to_workspace_state)
+        .collect();
+    let active_workspace_index = ws_store
+        .active_workspace_id
+        .as_ref()
+        .and_then(|id| workspaces.iter().position(|ws| ws.uuid == *id))
+        .unwrap_or(0);
+    WindowState {
+        workspaces,
+        active_workspace_index,
+        width: ui.window_width,
+        height: ui.window_height,
+        is_maximized: ui.is_maximized,
+        left_sidebar_width: ui.left_sidebar_width,
+        right_sidebar_width: ui.right_sidebar_width,
+        dismissed_runtime_ids: cache.dismissed_runtime_ids,
+    }
+}
+
+/// Save a `WindowState` through the `ClientStore` for test setup.
+fn save_window_state_to_store(state: &WindowState) {
+    let store = store();
+    let active_workspace_id =
+        state.workspaces.get(state.active_workspace_index).map(|s| s.uuid.clone());
+    let ws_store = crate::store::models::workspaces::WorkspaceStore {
+        active_workspace_id,
+        workspaces: state.workspaces.iter().map(Into::into).collect(),
+    };
+    let ui = crate::store::models::ui::UiState {
+        window_width: state.width,
+        window_height: state.height,
+        is_maximized: state.is_maximized,
+        left_sidebar_width: state.left_sidebar_width,
+        right_sidebar_width: state.right_sidebar_width,
+        ..Default::default()
+    };
+    let cache = crate::store::models::runtime_cache::RuntimeCache {
+        dismissed_runtime_ids: state.dismissed_runtime_ids.clone(),
+    };
+    store.save_workspaces(&ws_store).unwrap();
+    store.save_ui_state(&ui).unwrap();
+    store.save_runtime_cache(&cache).unwrap();
+}
+
 macro_rules! require_display {
     () => {
         if !crate::test_helpers::ensure_gtk() {
@@ -412,7 +473,7 @@ fn utility_sidebar_shows_and_filters_commands() {
 
     let run = crate::commands::SavedCommand::new("Restart app", "systemctl restart app");
     let insert = crate::commands::SavedCommand::new("Deploy checklist", "cargo build\ncargo test");
-    crate::commands::save(&[run, insert]).unwrap();
+    crate::commands::save_to(&[run, insert], &config_dir().join("commands.json")).unwrap();
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.utility-command-sidebar-tests")
@@ -518,7 +579,7 @@ fn failed_structured_recovery_keeps_terminal_alive_and_allows_retry() {
         }],
         ..WindowState::default()
     };
-    crate::workspace::save_window_state(&state).unwrap();
+    save_window_state_to_store(&state);
 
     let app =
         adw::Application::builder().application_id("com.illya.rttx.recovery-failure-tests").build();
@@ -713,7 +774,7 @@ fn save_and_restart_restores_active_terminal_in_active_session() {
     first_window.save_state();
     first_window.close();
 
-    let saved_state = workspace::load_window_state();
+    let saved_state = load_saved_window_state();
     assert_eq!(
         saved_state.workspaces[0].active_terminal_uuid.as_deref(),
         Some(second_uuid.as_str()),
@@ -1050,7 +1111,7 @@ fn save_and_restart_restores_user_resized_pane_ratios() {
     first_window.save_state();
     first_window.close();
 
-    let saved_state = workspace::load_window_state();
+    let saved_state = load_saved_window_state();
     let LayoutNode::Split { ratio: saved_ratio, .. } = &saved_state.workspaces[0].layout else {
         panic!("saved layout should remain split after resize");
     };
@@ -1134,7 +1195,7 @@ fn save_state_updates_nested_terminal_cwds() {
     drop(terminals);
 
     window.save_state();
-    let saved_state = workspace::load_window_state();
+    let saved_state = load_saved_window_state();
 
     let LayoutNode::Split { first, second, .. } = &saved_state.workspaces[0].layout else {
         panic!("saved layout should stay split");
@@ -1184,7 +1245,7 @@ fn save_and_restart_restores_custom_terminal_title() {
     term.set_custom_title(Some("Editor"));
 
     first_window.save_state();
-    let saved_state = workspace::load_window_state();
+    let saved_state = load_saved_window_state();
     assert_eq!(
         saved_state.workspaces[0].layout.terminal_custom_title(&terminal_uuid).as_deref(),
         Some("Editor"),
@@ -1290,7 +1351,7 @@ fn save_and_restart_restores_nested_user_resized_pane_ratios() {
     first_window.save_state();
     first_window.close();
 
-    let saved_state = workspace::load_window_state();
+    let saved_state = load_saved_window_state();
     let LayoutNode::Split { ratio: saved_outer_ratio, second, .. } =
         &saved_state.workspaces[0].layout
     else {
@@ -1397,7 +1458,7 @@ fn rename_runtime_updates_sidebar_and_saved_state() {
     assert_eq!(session_row.title().as_str(), "Renamed Session");
 
     window.save_state();
-    let saved_state = workspace::load_window_state();
+    let saved_state = load_saved_window_state();
     assert_eq!(saved_state.workspaces[0].name, "Renamed Session");
     assert!(saved_state.workspaces[0].user_renamed);
 
@@ -1521,7 +1582,7 @@ fn smart_clipboard_preference_reaches_live_terminals() {
 
     let mut prefs = preferences::Preferences::default();
     prefs.smart_clipboard = true;
-    preferences::save(&prefs).unwrap();
+    preferences::save_to(&prefs, &config_dir().join("preferences.json")).unwrap();
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.smart-clipboard-preferences-tests")
@@ -1540,7 +1601,7 @@ fn smart_clipboard_preference_reaches_live_terminals() {
     assert!(terminal.smart_clipboard_enabled_for_test());
 
     prefs.smart_clipboard = false;
-    preferences::save(&prefs).unwrap();
+    preferences::save_to(&prefs, &config_dir().join("preferences.json")).unwrap();
     window.reapply_terminal_preferences();
     assert!(!terminal.smart_clipboard_enabled_for_test());
 
@@ -2655,7 +2716,7 @@ fn load_state_keeps_selected_row_and_visible_session_in_sync() {
 
     let first_uuid = "workspace-1".to_string();
     let second_uuid = "workspace-2".to_string();
-    crate::workspace::save_window_state(&WindowState {
+    save_window_state_to_store(&WindowState {
         active_workspace_index: 1,
         workspaces: vec![
             WorkspaceState {
@@ -2686,8 +2747,7 @@ fn load_state_keeps_selected_row_and_visible_session_in_sync() {
             },
         ],
         ..WindowState::default()
-    })
-    .unwrap();
+    });
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.restore-selection-sync-tests")
@@ -2838,7 +2898,7 @@ fn save_state_persists_detached_workspace_runtime_binding() {
     });
     window.save_state();
 
-    let saved_state = workspace::load_window_state();
+    let saved_state = load_saved_window_state();
     let saved_session = saved_state
         .workspaces
         .iter()
@@ -2947,7 +3007,7 @@ fn save_state_persists_terminated_workspace_without_runtime_id() {
     });
     window.save_state();
 
-    let saved_state = workspace::load_window_state();
+    let saved_state = load_saved_window_state();
     let saved_session = saved_state
         .workspaces
         .iter()
@@ -3223,10 +3283,10 @@ fn bell_preferences_applied_to_managed_pane() {
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
     // Save preferences with bells disabled.
-    let mut prefs = preferences::load();
+    let mut prefs = preferences::load_from(&config_dir().join("preferences.json"));
     prefs.audible_bell = false;
     prefs.visual_bell = false;
-    let _ = preferences::save(&prefs);
+    let _ = preferences::save_to(&prefs, &config_dir().join("preferences.json"));
 
     let app = adw::Application::builder().application_id("com.illya.rttx.bell-pref-test").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
@@ -3834,7 +3894,7 @@ fn command_sidebar_filters_by_selected_host() {
     let mut remote_cmd = crate::commands::SavedCommand::new("Remote cmd", "echo remote");
     remote_cmd.host_tags = vec!["example.com".into()];
     let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
-    crate::commands::save(&[local_cmd, remote_cmd, global_cmd]).unwrap();
+    crate::commands::save_to(&[local_cmd, remote_cmd, global_cmd], &config_dir().join("commands.json")).unwrap();
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.command-host-filter-tests")
@@ -3873,7 +3933,7 @@ fn command_sidebar_groups_by_host_in_all_hosts_view() {
     let mut remote_cmd = crate::commands::SavedCommand::new("Remote cmd", "echo remote");
     remote_cmd.host_tags = vec!["example.com".into()];
     let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
-    crate::commands::save(&[local_cmd, remote_cmd, global_cmd]).unwrap();
+    crate::commands::save_to(&[local_cmd, remote_cmd, global_cmd], &config_dir.join("commands.json")).unwrap();
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.command-all-hosts-sections-test")
@@ -3914,7 +3974,7 @@ fn command_sidebar_shows_sections_for_specific_host() {
     let mut local_cmd = crate::commands::SavedCommand::new("Local cmd", "echo local");
     local_cmd.host_tags = vec!["local".into()];
     let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
-    crate::commands::save(&[local_cmd, global_cmd]).unwrap();
+    crate::commands::save_to(&[local_cmd, global_cmd], &config_dir().join("commands.json")).unwrap();
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.command-host-sections-test")
@@ -3951,7 +4011,7 @@ fn command_sidebar_only_global_section_when_no_host_commands() {
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
     let global_cmd = crate::commands::SavedCommand::new("Global cmd", "echo global");
-    crate::commands::save(&[global_cmd]).unwrap();
+    crate::commands::save_to(&[global_cmd], &config_dir().join("commands.json")).unwrap();
 
     let app = adw::Application::builder()
         .application_id("com.illya.rttx.command-global-only-test")
@@ -4132,7 +4192,7 @@ fn add_current_host_saves_remote_host() {
     window.do_add_current_host();
 
     // Verify host was saved
-    let hosts = crate::host::load();
+    let hosts = crate::host::load_from(&config_dir().join("hosts.json"));
     assert!(hosts.iter().any(|h| h.key == "builder.example.com"), "host should be saved");
 
     window.close();
@@ -4159,7 +4219,7 @@ fn add_current_host_skips_duplicate() {
 
     // Pre-save the host
     let existing = crate::host::Host::remote("deploy@builder.example.com");
-    crate::host::save(&[existing]).unwrap();
+    crate::host::save_to(&[existing], &config_dir().join("hosts.json")).unwrap();
 
     // Add a remote managed workspace and switch to it
     let remote_session = WorkspaceState::new_managed_remote(
@@ -4182,7 +4242,7 @@ fn add_current_host_skips_duplicate() {
     // Trigger the action — should not duplicate
     window.do_add_current_host();
 
-    let hosts = crate::host::load();
+    let hosts = crate::host::load_from(&config_dir().join("hosts.json"));
     assert_eq!(
         hosts.iter().filter(|h| h.key == "builder.example.com").count(),
         1,
@@ -4217,7 +4277,7 @@ fn add_current_host_noop_for_local_session() {
     // Trigger the action — should not save anything
     window.do_add_current_host();
 
-    let hosts = crate::host::load();
+    let hosts = crate::host::load_from(&config_dir().join("hosts.json"));
     assert!(hosts.is_empty(), "no host should be saved for a local session");
 
     window.close();
@@ -4252,7 +4312,7 @@ fn add_current_path_to_places_saves_place_with_derived_name() {
 
     window.do_add_current_path_to_places();
 
-    let places = crate::places::load();
+    let places = crate::places::load_from(&config_dir().join("places.json"));
     assert_eq!(places.len(), 1, "one place should be saved");
     assert_eq!(places[0].name, "rttx");
     assert_eq!(places[0].path, "/home/user/projects/rttx");
@@ -4288,7 +4348,7 @@ fn add_current_path_to_places_noop_without_cwd() {
 
     window.do_add_current_path_to_places();
 
-    let places = crate::places::load();
+    let places = crate::places::load_from(&config_dir().join("places.json"));
     assert!(places.is_empty(), "no place should be saved when CWD is unknown");
 
     window.close();
@@ -4343,7 +4403,7 @@ fn add_current_path_to_places_tags_remote_host() {
 
     window.do_add_current_path_to_places();
 
-    let places = crate::places::load();
+    let places = crate::places::load_from(&config_dir().join("places.json"));
     assert_eq!(places.len(), 1, "one place should be saved");
     assert_eq!(places[0].name, "app");
     assert_eq!(places[0].path, "/srv/app");
@@ -5373,7 +5433,7 @@ fn close_last_managed_workspace_persists_clean_state() {
     pump_events(50);
 
     // Reload persisted state and verify the closed session is gone.
-    let saved = crate::workspace::load_window_state();
+    let saved = load_saved_window_state();
     assert!(
         !saved.workspaces.iter().any(|s| s.uuid == session_uuid),
         "persisted state must not contain the closed managed workspace"
@@ -5642,7 +5702,7 @@ fn save_and_restart_full_session_persistence_roundtrip() {
     first_window.close();
 
     // Verify saved state on disk.
-    let saved = workspace::load_window_state();
+    let saved = load_saved_window_state();
     assert_eq!(saved.workspaces.len(), 3, "saved state should have 3 workspaces");
     let saved_order: Vec<&str> = saved.workspaces.iter().map(|s| s.uuid.as_str()).collect();
     assert_eq!(
@@ -6364,9 +6424,9 @@ fn reapply_preferences_updates_keyboard_shortcut_accels() {
     assert!(accels.iter().any(|a| a == "F11"), "fullscreen should default to F11, got: {accels:?}");
 
     // Override fullscreen to Ctrl+Shift+F11 via preferences.
-    let mut prefs = crate::preferences::load();
+    let mut prefs = crate::preferences::load_from(&config_dir().join("preferences.json"));
     prefs.keyboard_shortcuts.insert("fullscreen".into(), vec!["<Ctrl><Shift>F11".into()]);
-    crate::preferences::save(&prefs).unwrap();
+    crate::preferences::save_to(&prefs, &config_dir().join("preferences.json")).unwrap();
 
     window.reapply_terminal_preferences();
 

--- a/clients/rttx/src/workspace/mod.rs
+++ b/clients/rttx/src/workspace/mod.rs
@@ -18,19 +18,10 @@ pub fn workspaces_dir() -> Option<PathBuf> {
     Some(config::config_dir_path())
 }
 
-/// Save the current window state to a JSON file.
-pub fn save_window_state(state: &WindowState) -> Result<(), Box<dyn std::error::Error>> {
-    let Some(mut path) = workspaces_dir() else {
-        return Ok(());
-    };
-    fs::create_dir_all(&path)?;
-    path.push("sessions.json");
-    let json = serde_json::to_string_pretty(state)?;
-    fs::write(path, json)?;
-    Ok(())
-}
-
-/// Load the window state from the JSON file, or return default.
+/// Load the legacy window state from `sessions.json`, or return default.
+///
+/// Used only for one-time import when the new store is empty.
+/// New code should use `ClientStore` instead.
 #[must_use]
 pub fn load_window_state() -> WindowState {
     let Some(mut path) = workspaces_dir() else {

--- a/clients/rttx/src/workspace/state.rs
+++ b/clients/rttx/src/workspace/state.rs
@@ -1,7 +1,12 @@
-//! Persisted session and window state.
+//! Session and window state types.
 //!
-//! `WorkspaceState` and `WindowState` are serialized to `sessions.json`.
-//! Changes here must preserve backward compatibility via `#[serde(default)]`.
+//! `WorkspaceState` is the in-memory representation of a single workspace.
+//! `WindowState` is the in-memory aggregate used by the window; persistence
+//! is handled by `ClientStore` (RFC-023).
+//!
+//! Legacy `sessions.json` files are still readable for one-time import.
+//! Changes to `WorkspaceState` must preserve backward compatibility via
+//! `#[serde(default)]` for that import path.
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.8',
+  version: '0.4.9',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Completes the RFC-023 store migration by removing the legacy dual-write path and standalone persistence functions that are no longer needed now that `ClientStore` is the canonical persistence layer.

### Removed
- `save_window_state()` from `workspace/mod.rs` — `save_state()` now writes exclusively through `ClientStore`
- Standalone `load()`/`save()` free functions from `preferences.rs`, `commands.rs`, `host.rs`, `places.rs` — `load_from()`/`save_to()` retained for tests and explicit-path usage
- `From<&WindowState>` impls from store models (`ui.rs`, `runtime_cache.rs`, `workspaces.rs`) — `save_state()` now constructs store documents directly
- Redundant `normalize_runtime_metadata()` call from the new store load path — `to_workspace_state()` already handles this correctly
- Dead imports (`config`, `PathBuf`) from modules that no longer need them

### Kept (intentionally)
- `load_window_state()` — still needed for one-time legacy `sessions.json` import when the new store is empty
- `normalize_runtime_metadata()` — still needed by the legacy import path
- `PaneSource::Bookmark` backward-compat deserialization — still needed for legacy import
- `WorkspaceMode` enum — still needed for legacy deserialization

### Updated
- `window/tests.rs`: migrated all test setup from legacy global `load()`/`save()` to explicit path-based `save_to()`/`load_from()` and `ClientStore` helpers
- `store/mod.rs` test: replaced `From<&WindowState>` test with direct construction test matching the new `save_state()` pattern
- Version bumped to 0.4.9

## Manual verification
- Built and ran `rttx` in dev mode — state persists correctly through the new store path
- Verified legacy import: deleted new store files, placed a `sessions.json`, confirmed one-time import works

## Tests added
- `load_saved_window_state()` helper in `window/tests.rs` — reads workspace state back from `ClientStore` for test verification
- `save_window_state_to_store()` helper — writes `WindowState` through `ClientStore` for test setup
- `window_state_fields_map_to_store_documents` — replaces the old `window_state_splits_into_three_store_documents` test with direct construction

## Tests run
- `cargo test -p rttx --no-default-features --features vte-0_76` — 667 passed, 176 ignored (GTK), 0 failed
- `cargo test -p rttx-server` — 380+ passed, 0 failed
- `cargo test -p rttx-proto` — 333 passed, 0 failed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests passed

Fixes #744