### PR TITLE
fix: scroll to bottom on keystroke in daemon-backed panes

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -869,6 +869,27 @@ mod tests {
         assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::c, ctrl), Some(vec![0x03]),);
         assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::d, ctrl), Some(vec![0x04]),);
     }
+
+    /// Keys that produce `ForwardToPty` in managed mode are the ones that
+    /// trigger scroll-to-bottom when the user types in a scrolled-up pane.
+    /// Regression for #753.
+    #[test]
+    fn managed_forward_to_pty_keys_trigger_scroll_on_keystroke() {
+        let typing_keys: &[(gtk4::gdk::Key, gtk4::gdk::ModifierType)] = &[
+            (gtk4::gdk::Key::a, gtk4::gdk::ModifierType::empty()),
+            (gtk4::gdk::Key::Return, gtk4::gdk::ModifierType::empty()),
+            (gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK),
+            (gtk4::gdk::Key::Up, gtk4::gdk::ModifierType::empty()),
+        ];
+        for (key, mods) in typing_keys {
+            let action =
+                terminal_key_action(TerminalInputBackend::Managed, *key, *mods, false, false);
+            assert!(
+                matches!(action, TerminalKeyAction::ForwardToPty(_)),
+                "{key:?}+{mods:?} must produce ForwardToPty (scroll-on-keystroke trigger)"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -747,6 +747,20 @@ impl PersistentPaneView {
         (vte.column_count() as u16, vte.row_count() as u16)
     }
 
+    /// Scroll VTE to the bottom of the scrollback buffer.
+    ///
+    /// Used to implement scroll-on-keystroke for managed panes, where VTE's
+    /// built-in `scroll_on_keystroke` property has no effect because keystrokes
+    /// are intercepted before reaching VTE's native input handler.
+    fn scroll_to_bottom_if_enabled(&self) {
+        if !self.imp().vte.is_scroll_on_keystroke() {
+            return;
+        }
+        if let Some(adj) = self.imp().vte.vadjustment() {
+            adj.set_value(adj.upper() - adj.page_size());
+        }
+    }
+
     /// Connect a callback for keyboard and mouse input.
     ///
     /// The callback receives the raw terminal bytes to send to the daemon.
@@ -795,6 +809,7 @@ impl PersistentPaneView {
             if let Some(pane) = im_pane_weak.upgrade()
                 && pane.imp().accepts_input.get()
             {
+                pane.scroll_to_bottom_if_enabled();
                 im_forward(text.as_bytes());
             }
         });
@@ -829,6 +844,7 @@ impl PersistentPaneView {
                 }
                 TerminalKeyAction::ForwardToPty(bytes) => {
                     if pane.imp().accepts_input.get() {
+                        pane.scroll_to_bottom_if_enabled();
                         forward_input(&bytes);
                     }
                     glib::Propagation::Stop
@@ -2205,6 +2221,122 @@ mod tests {
         assert!(
             (restored - saved).abs() < 1.0,
             "restored scroll position should be near saved {saved}, got {restored}"
+        );
+
+        window.close();
+    }
+
+    /// Regression for #753: typing in a scrolled-up managed pane must scroll
+    /// the viewport to the bottom so the user can see what they are typing.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn scroll_to_bottom_on_keystroke_in_managed_pane() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("scroll-key-1", "runtime-1");
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 480);
+        window.set_child(Some(&pane));
+        window.present();
+        pump_events(100);
+
+        let connected = present_connection_status(&ConnectionStatus::Connected);
+        pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
+
+        let forwarded = Rc::new(RefCell::new(Vec::new()));
+        let forwarded_clone = Rc::clone(&forwarded);
+        pane.connect_input(move |bytes| {
+            forwarded_clone.borrow_mut().push(bytes.to_vec());
+        });
+
+        // Feed enough lines to create scrollback.
+        let mut data = Vec::new();
+        for i in 0..200 {
+            data.extend_from_slice(format!("line {i}\r\n").as_bytes());
+        }
+        pane.feed_snapshot(&data);
+        pump_events(100);
+
+        // Scroll up from the bottom.
+        let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+        let bottom = adj.upper() - adj.page_size();
+        assert!(bottom > 0.0, "scrollback should be large enough to scroll");
+        adj.set_value(0.0);
+        pump_events(50);
+        assert!(
+            adj.value() < bottom - 1.0,
+            "viewport should be scrolled up, got {} expected near 0",
+            adj.value()
+        );
+
+        // Type a character — Ctrl+D sends ForwardToPty(0x04).
+        pane.emit_input_key_for_test(
+            gtk4::gdk::Key::d,
+            gtk4::gdk::ModifierType::CONTROL_MASK,
+        );
+        pump_events(50);
+
+        let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+        let bottom = adj.upper() - adj.page_size();
+        assert!(
+            (adj.value() - bottom).abs() < 1.0,
+            "typing should scroll to bottom; got {} expected ~{bottom}",
+            adj.value()
+        );
+
+        window.close();
+    }
+
+    /// Regression for #753: when `scroll_on_keystroke` is disabled, typing
+    /// must NOT scroll the viewport.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn no_scroll_on_keystroke_when_preference_disabled() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("scroll-key-2", "runtime-1");
+        pane.vte().set_scroll_on_keystroke(false);
+        let window = gtk4::Window::new();
+        window.set_default_size(640, 480);
+        window.set_child(Some(&pane));
+        window.present();
+        pump_events(100);
+
+        let connected = present_connection_status(&ConnectionStatus::Connected);
+        pane.set_connection_presentation(&ConnectionStatus::Connected, &connected);
+
+        let forwarded = Rc::new(RefCell::new(Vec::new()));
+        let forwarded_clone = Rc::clone(&forwarded);
+        pane.connect_input(move |bytes| {
+            forwarded_clone.borrow_mut().push(bytes.to_vec());
+        });
+
+        // Feed enough lines to create scrollback.
+        let mut data = Vec::new();
+        for i in 0..200 {
+            data.extend_from_slice(format!("line {i}\r\n").as_bytes());
+        }
+        pane.feed_snapshot(&data);
+        pump_events(100);
+
+        // Scroll up from the bottom.
+        let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+        adj.set_value(0.0);
+        pump_events(50);
+        let scrolled_pos = adj.value();
+
+        // Type a character.
+        pane.emit_input_key_for_test(
+            gtk4::gdk::Key::d,
+            gtk4::gdk::ModifierType::CONTROL_MASK,
+        );
+        pump_events(50);
+
+        let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+        assert!(
+            (adj.value() - scrolled_pos).abs() < 1.0,
+            "with scroll_on_keystroke disabled, viewport should stay at {scrolled_pos}; got {}",
+            adj.value()
         );
 
         window.close();

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -947,8 +947,9 @@ impl PersistentPaneView {
         self.imp().exited.get()
     }
 
-    #[cfg(test)]
-    pub(crate) fn emit_input_key_for_test(
+    #[doc(hidden)]
+    #[must_use]
+    pub fn emit_input_key_for_test(
         &self,
         key: gtk4::gdk::Key,
         modifiers: gtk4::gdk::ModifierType,
@@ -2270,7 +2271,8 @@ mod tests {
         );
 
         // Type a character — Ctrl+D sends ForwardToPty(0x04).
-        pane.emit_input_key_for_test(gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK);
+        let _ =
+            pane.emit_input_key_for_test(gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK);
         pump_events(50);
 
         let adj = pane.vte().vadjustment().expect("vadjustment should exist");
@@ -2323,7 +2325,8 @@ mod tests {
         let scrolled_pos = adj.value();
 
         // Type a character.
-        pane.emit_input_key_for_test(gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK);
+        let _ =
+            pane.emit_input_key_for_test(gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK);
         pump_events(50);
 
         let adj = pane.vte().vadjustment().expect("vadjustment should exist");

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -2270,10 +2270,7 @@ mod tests {
         );
 
         // Type a character — Ctrl+D sends ForwardToPty(0x04).
-        pane.emit_input_key_for_test(
-            gtk4::gdk::Key::d,
-            gtk4::gdk::ModifierType::CONTROL_MASK,
-        );
+        pane.emit_input_key_for_test(gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK);
         pump_events(50);
 
         let adj = pane.vte().vadjustment().expect("vadjustment should exist");
@@ -2326,10 +2323,7 @@ mod tests {
         let scrolled_pos = adj.value();
 
         // Type a character.
-        pane.emit_input_key_for_test(
-            gtk4::gdk::Key::d,
-            gtk4::gdk::ModifierType::CONTROL_MASK,
-        );
+        pane.emit_input_key_for_test(gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK);
         pump_events(50);
 
         let adj = pane.vte().vadjustment().expect("vadjustment should exist");

--- a/clients/rttx/src/window/input.rs
+++ b/clients/rttx/src/window/input.rs
@@ -92,6 +92,7 @@ impl Window {
         let font_desc = gtk4::pango::FontDescription::from_string(&prefs.font);
         pane.vte().set_font(Some(&font_desc));
         pane.vte().set_scrollback_lines(prefs.scrollback_lines);
+        pane.vte().set_scroll_on_keystroke(prefs.scroll_on_keystroke);
         pane.vte().set_audible_bell(prefs.audible_bell);
         pane.set_visual_bell(prefs.visual_bell);
         pane.set_smart_clipboard(prefs.smart_clipboard);

--- a/clients/rttx/tests/scroll_position_tests.rs
+++ b/clients/rttx/tests/scroll_position_tests.rs
@@ -181,3 +181,51 @@ fn feed_snapshot_scrolls_to_bottom_after_reconnect() {
 
     window.close();
 }
+
+/// Typing in a scrolled-up daemon-backed pane must scroll the viewport to
+/// the bottom so the user can see what they are typing. VTE's built-in
+/// `scroll_on_keystroke` has no effect because keystrokes are intercepted
+/// before reaching VTE's native input handler. Regression for #753.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn typing_scrolls_to_bottom_in_managed_pane() {
+    require_display!();
+
+    let pane = PersistentPaneView::new("type-scroll-1", "runtime-1");
+    let window = gtk4::Window::new();
+    window.set_default_size(640, 480);
+    window.set_child(Some(&pane));
+    window.present();
+    pump_events(100);
+
+    let connected =
+        rttx::runtime::present_connection_status(&rttx::runtime::ConnectionStatus::Connected);
+    pane.set_connection_presentation(&rttx::runtime::ConnectionStatus::Connected, &connected);
+
+    pane.connect_input(|_| {});
+
+    feed_scrollback(&pane, 200);
+    pump_events(100);
+
+    // Scroll up.
+    let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+    let bottom = adj.upper() - adj.page_size();
+    assert!(bottom > 0.0, "scrollback should be large enough to scroll");
+    adj.set_value(0.0);
+    pump_events(50);
+    assert!(adj.value() < bottom - 1.0, "viewport should be scrolled up");
+
+    // Type Ctrl+D (ForwardToPty).
+    let _ = pane.emit_input_key_for_test(gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK);
+    pump_events(50);
+
+    let adj = pane.vte().vadjustment().expect("vadjustment should exist");
+    let bottom = adj.upper() - adj.page_size();
+    assert!(
+        (adj.value() - bottom).abs() < 1.0,
+        "typing must scroll to bottom; got {} expected ~{bottom}",
+        adj.value()
+    );
+
+    window.close();
+}


### PR DESCRIPTION
## What changed and why

When a user scrolls up in a daemon-backed (persistent) pane and starts typing, the viewport stayed at the scrolled-up position — the user couldn't see what they were typing.

**Root cause:** VTE's built-in `scroll_on_keystroke` property only works when VTE processes keystrokes through its own input handler. For daemon-backed panes, keyboard input is intercepted by a Capture-phase `EventControllerKey` and forwarded to the daemon as `Input` messages. The keystrokes never reach VTE's native handler, so the property had no effect.

**Fix:** Added `scroll_to_bottom_if_enabled()` to `PersistentPaneView` that manually scrolls VTE to the bottom of the scrollback buffer when forwarding input. Called from both the key controller (`ForwardToPty`) and IMContext commit paths. Respects the `scroll_on_keystroke` VTE property so the user preference is honored.

Also fixed a secondary issue: `apply_preferences_to_persistent_pane` was not applying the `scroll_on_keystroke` preference to persistent panes.

## How to manually verify

1. Open a persistent workspace (daemon-backed)
2. Run a command that produces enough output to create scrollback (e.g. `seq 1 500`)
3. Scroll up in the terminal
4. Start typing
5. Verify the viewport scrolls to the bottom

## Tests added

- `scroll_to_bottom_on_keystroke_in_managed_pane` — verifies that typing in a scrolled-up managed pane scrolls the viewport to the bottom
- `no_scroll_on_keystroke_when_preference_disabled` — verifies that when `scroll_on_keystroke` is disabled, typing does NOT scroll the viewport

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (both new GTK tests ran and passed)

Fixes #753