### PR TITLE
fix: default paste guard dialog button to Paste instead of Cancel

### DIFF
--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -679,18 +679,7 @@ impl Window {
         use crate::terminal::paste_guard::{analyse, flatten_to_single_line};
 
         let analysis = analyse(text);
-        let body = format!(
-            "{} lines, {} bytes\n\n{}",
-            analysis.line_count, analysis.byte_len, analysis.preview
-        );
-
-        let alert = adw::AlertDialog::new(Some("Confirm Paste"), Some(&body));
-        alert.add_response("cancel", "Cancel");
-        alert.add_response("single-line", "Paste as Single Line");
-        alert.add_response("paste", "Paste");
-        alert.set_response_appearance("paste", adw::ResponseAppearance::Suggested);
-        alert.set_default_response(Some("cancel"));
-        alert.set_close_response("cancel");
+        let alert = build_paste_guard_dialog(&analysis);
 
         let win = self.clone();
         let uuid = terminal_uuid.to_string();
@@ -710,4 +699,24 @@ impl Window {
         });
         alert.present(Some(self));
     }
+}
+
+/// Build the paste guard confirmation dialog.
+///
+/// Extracted so the dialog configuration can be tested without a full Window.
+pub(crate) fn build_paste_guard_dialog(
+    analysis: &crate::terminal::paste_guard::PasteAnalysis,
+) -> adw::AlertDialog {
+    let body = format!(
+        "{} lines, {} bytes\n\n{}",
+        analysis.line_count, analysis.byte_len, analysis.preview
+    );
+    let alert = adw::AlertDialog::new(Some("Confirm Paste"), Some(&body));
+    alert.add_response("cancel", "Cancel");
+    alert.add_response("single-line", "Paste as Single Line");
+    alert.add_response("paste", "Paste");
+    alert.set_response_appearance("paste", adw::ResponseAppearance::Suggested);
+    alert.set_default_response(Some("paste"));
+    alert.set_close_response("cancel");
+    alert
 }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -30,7 +30,7 @@ use crate::workspace_state::{EndpointEventTransition, WorkspacePaneRestore};
 use std::collections::HashMap;
 
 mod actions;
-mod dialogs;
+pub(crate) mod dialogs;
 mod input;
 mod runtime;
 mod sidebar;

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -6620,3 +6620,13 @@ fn c4_split_preserves_child_exited_handler_identity() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn paste_guard_dialog_defaults_to_paste() {
+    require_display!();
+    let analysis = crate::terminal::paste_guard::analyse("line1\nline2\nline3");
+    let dialog = super::dialogs::build_paste_guard_dialog(&analysis);
+    assert_eq!(dialog.default_response().as_deref(), Some("paste"));
+    assert_eq!(dialog.close_response(), "cancel");
+}


### PR DESCRIPTION
## What changed and why

When the multi-line paste guard dialog appears, the default button was "Cancel". This meant pressing Enter would cancel the paste, requiring an extra mouse click to confirm. Since pasting multi-line text is a common operation, the default should be "Paste" to reduce friction.

Changed `set_default_response` from `"cancel"` to `"paste"`. The close response (Escape key) remains "Cancel" for safe dismissal.

Extracted dialog construction into `build_paste_guard_dialog()` so the configuration can be tested without a full Window.

## How to manually verify

1. Copy multi-line text to clipboard
2. Paste into an rttx terminal (Ctrl+Shift+V)
3. The "Confirm Paste" dialog appears with "Paste" as the focused default button
4. Press Enter — text is pasted (previously this would cancel)
5. Press Escape — dialog dismisses without pasting (unchanged)

## Tests added

- `paste_guard_dialog_defaults_to_paste` — GTK widget test that asserts `default_response` is `"paste"` and `close_response` is `"cancel"`

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (GTK test `paste_guard_dialog_defaults_to_paste` ran and passed)

Fixes #770