### PR TITLE
fix(split): new pane must inherit parent pane's current directory, not original workspace cwd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.9"
+version = "0.4.10"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -6644,9 +6644,8 @@ fn split_managed_pane_inherits_parent_cwd() {
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.split-managed-cwd-test")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.split-managed-cwd-test").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
@@ -6654,11 +6653,8 @@ fn split_managed_pane_inherits_parent_cwd() {
     // Create a managed workspace whose layout node starts with an initial CWD.
     let mut layout = LayoutNode::new_terminal_with_uuid("parent-pane");
     layout.set_terminal_cwd("parent-pane", Some("/home/user/original".into()));
-    let session_state = crate::test_helpers::managed_session(
-        "ws-managed-cwd",
-        "Managed CWD Workspace",
-        layout,
-    );
+    let session_state =
+        crate::test_helpers::managed_session("ws-managed-cwd", "Managed CWD Workspace", layout);
     window.imp().state.borrow_mut().workspaces.push(session_state.clone());
     window.build_session(&session_state, false);
 

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -6630,3 +6630,69 @@ fn paste_guard_dialog_defaults_to_paste() {
     assert_eq!(dialog.default_response().as_deref(), Some("paste"));
     assert_eq!(dialog.close_response(), "cancel");
 }
+
+/// Splitting a managed pane must propagate the parent pane's live CWD
+/// into the new layout node so the daemon receives the correct CWD in
+/// the CreatePane request. The widget CWD must win over a stale layout
+/// node CWD. Regression test for #773.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn split_managed_pane_inherits_parent_cwd() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.split-managed-cwd-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    // Create a managed workspace whose layout node starts with an initial CWD.
+    let mut layout = LayoutNode::new_terminal_with_uuid("parent-pane");
+    layout.set_terminal_cwd("parent-pane", Some("/home/user/original".into()));
+    let session_state = crate::test_helpers::managed_session(
+        "ws-managed-cwd",
+        "Managed CWD Workspace",
+        layout,
+    );
+    window.imp().state.borrow_mut().workspaces.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    // Simulate the daemon reporting a CWD change — the user cd'd.
+    let pane = window
+        .imp()
+        .persistent_terminals
+        .borrow()
+        .get("parent-pane")
+        .cloned()
+        .expect("parent pane should be present");
+    pane.set_current_directory(Some("/home/user/changed-dir"));
+
+    // Do NOT update the layout node — this simulates the race where the
+    // widget has the live CWD but the layout node is stale.
+
+    window.split_terminal("parent-pane", SplitOrientation::Horizontal);
+
+    let state = window.imp().state.borrow();
+    let session = state
+        .workspaces
+        .iter()
+        .find(|s| s.uuid == "ws-managed-cwd")
+        .expect("workspace should exist");
+    let uuids = session.layout.terminal_uuids();
+    assert_eq!(uuids.len(), 2, "split should produce two panes");
+    let new_uuid = uuids.into_iter().find(|u| u != "parent-pane").unwrap();
+
+    assert_eq!(
+        session.layout.terminal_cwd(&new_uuid).as_deref(),
+        Some("/home/user/changed-dir"),
+        "new managed pane must inherit parent pane's live CWD, not stale layout node CWD"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.9',
+  version: '0.4.10',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/src/runtime.rs
+++ b/services/rttx-server/src/runtime.rs
@@ -471,6 +471,13 @@ impl Runtime {
         Some(self.revision())
     }
 
+    /// Return the effective CWD of any live pane in this runtime.
+    /// Used as a fallback when `CreatePane` arrives without an explicit CWD.
+    #[must_use]
+    pub fn any_pane_cwd(&self) -> Option<String> {
+        self.panes.values().find_map(Pane::effective_cwd)
+    }
+
     /// Append a history entry, evicting the oldest if the cap is reached.
     pub fn add_history_entry(&mut self, entry: HistoryEntry) {
         self.command_history.push(entry);
@@ -1093,5 +1100,18 @@ mod tests {
         let rf = runtime.to_runtime_file();
         let restored = Runtime::from_runtime_file(&rf);
         assert!(restored.panes[&pane_id].no_persist);
+    }
+
+    #[test]
+    fn any_pane_cwd_returns_cwd_from_existing_pane() {
+        let mut runtime = Runtime::new("test".into());
+        assert!(runtime.any_pane_cwd().is_none());
+
+        let pane_id = Uuid::new_v4();
+        let mut pane = Pane::new(pane_id, 80, 24);
+        pane.cwd = Some("/home/user/projects".into());
+        runtime.add_pane(pane);
+
+        assert_eq!(runtime.any_pane_cwd().as_deref(), Some("/home/user/projects"));
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -829,7 +829,8 @@ impl Server {
                     let cwd = req.cwd.or_else(|| rt.any_pane_cwd());
                     let cols = if req.cols > 0 { req.cols as u16 } else { 80 };
                     let rows = if req.rows > 0 { req.rows as u16 } else { 24 };
-                    let config = PaneSpawnConfig { command: vec![], cwd: cwd.clone(), env, cols, rows };
+                    let config =
+                        PaneSpawnConfig { command: vec![], cwd: cwd.clone(), env, cols, rows };
                     (s.engine.spawn_pane(pane_id, &config), label, cols, rows, cwd)
                 };
 

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -794,7 +794,7 @@ impl Server {
 
                 let pane_id = Uuid::new_v4();
                 let no_persist = req.no_persist.unwrap_or(false);
-                let (pty_result, runtime_label, cols, rows) = {
+                let (pty_result, runtime_label, cols, rows, initial_cwd) = {
                     let s = server.lock().await;
                     let Some(rt) = s.runtimes.get(&runtime_id) else {
                         return Some(protocol::error(
@@ -826,11 +826,11 @@ impl Server {
                     let colorfgbg =
                         if req.dark_background.unwrap_or(true) { "15;0" } else { "0;15" };
                     env.push(("COLORFGBG".into(), colorfgbg.into()));
-                    let cwd = req.cwd;
+                    let cwd = req.cwd.or_else(|| rt.any_pane_cwd());
                     let cols = if req.cols > 0 { req.cols as u16 } else { 80 };
                     let rows = if req.rows > 0 { req.rows as u16 } else { 24 };
-                    let config = PaneSpawnConfig { command: vec![], cwd, env, cols, rows };
-                    (s.engine.spawn_pane(pane_id, &config), label, cols, rows)
+                    let config = PaneSpawnConfig { command: vec![], cwd: cwd.clone(), env, cols, rows };
+                    (s.engine.spawn_pane(pane_id, &config), label, cols, rows, cwd)
                 };
 
                 match pty_result {
@@ -850,6 +850,7 @@ impl Server {
                             let mut pane = Pane::new(pane_id, cols, rows);
                             pane.child_pid = child_pid;
                             pane.no_persist = no_persist;
+                            pane.cwd = initial_cwd;
                             rt.add_pane(pane);
                             let revision = rt.revision();
                             let name = rt.name.clone();

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -1695,7 +1695,7 @@ impl Server {
         };
         let pane_id = Uuid::new_v4();
         let no_persist = req.no_persist.unwrap_or(false);
-        let (pty_result, runtime_label, cols, rows) = {
+        let (pty_result, runtime_label, cols, rows, initial_cwd) = {
             let s = server.lock().await;
             let Some(rt) = s.runtimes.get(&runtime_id) else {
                 return Some(rttx_proto::v3_error::build_error_response(
@@ -1734,8 +1734,8 @@ impl Server {
             let cols = if req.cols > 0 { req.cols as u16 } else { 80 };
             let rows = if req.rows > 0 { req.rows as u16 } else { 24 };
             let cwd = req.cwd.or_else(|| rt.any_pane_cwd());
-            let config = PaneSpawnConfig { command: vec![], cwd, env, cols, rows };
-            (s.engine.spawn_pane(pane_id, &config), label, cols, rows)
+            let config = PaneSpawnConfig { command: vec![], cwd: cwd.clone(), env, cols, rows };
+            (s.engine.spawn_pane(pane_id, &config), label, cols, rows, cwd)
         };
         match pty_result {
             Ok(pty) => {
@@ -1758,6 +1758,7 @@ impl Server {
                     let mut pane = Pane::new(pane_id, cols, rows);
                     pane.child_pid = child_pid;
                     pane.no_persist = no_persist;
+                    pane.cwd = initial_cwd;
                     rt.add_pane(pane);
                     let revision = rt.revision();
                     let name = rt.name.clone();

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -1733,7 +1733,8 @@ impl Server {
             env.push(("COLORFGBG".into(), colorfgbg.into()));
             let cols = if req.cols > 0 { req.cols as u16 } else { 80 };
             let rows = if req.rows > 0 { req.rows as u16 } else { 24 };
-            let config = PaneSpawnConfig { command: vec![], cwd: req.cwd, env, cols, rows };
+            let cwd = req.cwd.or_else(|| rt.any_pane_cwd());
+            let config = PaneSpawnConfig { command: vec![], cwd, env, cols, rows };
             (s.engine.spawn_pane(pane_id, &config), label, cols, rows)
         };
         match pty_result {

--- a/services/rttx-server/tests/split_cwd.rs
+++ b/services/rttx-server/tests/split_cwd.rs
@@ -163,3 +163,78 @@ async fn create_pane_without_cwd_starts_in_home_directory() {
     }
     panic!("pwd output did not contain home directory {home:?} within timeout.\nOutput: {output}");
 }
+
+/// When a second pane is created without an explicit CWD, the daemon
+/// falls back to the effective CWD of an existing pane in the same
+/// runtime. Regression test for #773.
+#[tokio::test]
+async fn create_pane_without_cwd_inherits_sibling_cwd() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "sibling-cwd-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let runtime_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+
+    let target_dir = std::env::temp_dir();
+    let canonical_target =
+        std::fs::canonicalize(&target_dir).unwrap_or_else(|_| target_dir.clone());
+    let target_str = canonical_target.to_string_lossy().to_string();
+
+    // First pane: explicit CWD.
+    let _first_pane =
+        create_pane_with_cwd(&mut client, &runtime_id, Some(target_str.clone())).await;
+
+    // Second pane: no CWD — should inherit from the first pane.
+    let second_pane = create_pane_with_cwd(&mut client, &runtime_id, None).await;
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
+            runtime_id: runtime_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(_)) => break,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    }
+
+    let input = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            runtime_id: runtime_id.clone(),
+            pane_id: second_pane.clone(),
+            data: bytes::Bytes::from_static(b"pwd\n"),
+        })),
+    };
+    client.send(&input).await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut output = String::new();
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(delta)) = msg.msg
+        {
+            output.push_str(&String::from_utf8_lossy(&delta.data));
+            if output.contains(&target_str) {
+                return;
+            }
+        }
+    }
+    panic!(
+        "second pane pwd should contain sibling CWD {target_str:?} within timeout.\nOutput: {output}"
+    );
+}


### PR DESCRIPTION
## What changed and why

When splitting a managed (daemon-backed) pane, the new pane could start in the original workspace directory instead of the parent pane's current directory. This happened when the client had not yet received an OSC 7 CWD update from the daemon — the `CreatePane` message was sent with `cwd: None`, and the daemon spawned the shell in its own working directory.

### Root cause

The daemon's `CreatePane` handler used `req.cwd` directly. When the client could not determine the parent pane's CWD (e.g., OSC 7 not yet received), it sent `None`, and the daemon fell back to its own CWD instead of using the CWD of an existing pane in the same runtime.

### Fix

The daemon now falls back to the effective CWD of any existing pane in the same runtime when `CreatePane` arrives without an explicit CWD. This uses the daemon's `effective_cwd()` which checks both OSC 7 and `/proc/<pid>/cwd`.

## How to manually verify

1. Create a managed workspace
2. `cd` to a different directory
3. Split the pane
4. The new pane should start in the same directory as the parent pane

## Tests added

- `any_pane_cwd_returns_cwd_from_existing_pane` — unit test for the new `Runtime::any_pane_cwd()` method
- `split_managed_pane_inherits_parent_cwd` — GTK regression test verifying the split path prefers the parent pane's live widget CWD over a stale layout node CWD

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (including GTK test `split_managed_pane_inherits_parent_cwd`)

Fixes #773