### PR TITLE
fix(server): wire pane_output_seq end-to-end in v2-to-v3 push conversion

### DIFF
--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -69,12 +69,13 @@ fn send_to_collected(
     runtime_id: Uuid,
     pane_id: Uuid,
     msg: &ClientMsg,
+    pane_output_seq: u64,
 ) -> Vec<Uuid> {
     let mut v3_msg: Option<ClientMsg> = None;
     let mut overflowed = Vec::new();
     for (client_id, sender, protocol) in senders {
         let outgoing = if matches!(protocol, Some(ClientProtocol::V3 { .. })) {
-            v3_msg.get_or_insert_with(|| convert_v2_push_to_v3(msg))
+            v3_msg.get_or_insert_with(|| convert_v2_push_to_v3(msg, pane_output_seq))
         } else {
             msg
         };
@@ -95,7 +96,7 @@ fn send_to_collected(
 ///
 /// Falls back to the original v2 message if conversion is not applicable
 /// (e.g., the message is already v3 or is not a push event).
-fn convert_v2_push_to_v3(msg: &ClientMsg) -> ClientMsg {
+fn convert_v2_push_to_v3(msg: &ClientMsg, pane_output_seq: u64) -> ClientMsg {
     let ClientMsg::V2(v2) = msg else {
         return msg.clone();
     };
@@ -108,7 +109,7 @@ fn convert_v2_push_to_v3(msg: &ClientMsg) -> ClientMsg {
                 runtime_id: d.runtime_id.clone(),
                 pane_id: d.pane_id.clone(),
                 data: d.data.clone(),
-                pane_output_seq: 0,
+                pane_output_seq,
             })
         }
         proto::server_message::Msg::TitleChanged(t) => {
@@ -514,7 +515,7 @@ impl Server {
             let outgoing =
                 if matches!(self.client_protocols.get(&client_id), Some(ClientProtocol::V3 { .. }))
                 {
-                    v3_msg.get_or_insert_with(|| convert_v2_push_to_v3(msg))
+                    v3_msg.get_or_insert_with(|| convert_v2_push_to_v3(msg, 0))
                 } else {
                     msg
                 };
@@ -2141,7 +2142,7 @@ fn spawn_pty_read_loop(
                             let data = batch.split().freeze();
 
                             // Phase 1: hold lock for state mutation and handle collection.
-                            let (new_cwd, new_title, pending_replies, pty_writer, senders, _output_seq) = {
+                            let (new_cwd, new_title, pending_replies, pty_writer, senders, output_seq) = {
                                 let lock_start = std::time::Instant::now();
                                 let mut s = server.lock().await;
                                 let (new_cwd, new_title, pending_replies, output_seq) = if let Some(rt) = s.runtimes.get_mut(&runtime_id)
@@ -2206,15 +2207,15 @@ fn spawn_pty_read_loop(
                             let mut all_overflows = Vec::new();
                             if !client_data.is_empty() {
                                 let msg = ClientMsg::V2(protocol::delta(runtime_id, pane_id, bytes::Bytes::from(client_data.clone())));
-                                all_overflows.extend(send_to_collected(&senders, runtime_id, pane_id, &msg));
+                                all_overflows.extend(send_to_collected(&senders, runtime_id, pane_id, &msg, output_seq));
                             }
                             if let Some((cwd, revision)) = new_cwd {
                                 let msg = ClientMsg::V2(protocol::cwd_changed(runtime_id, pane_id, cwd, revision));
-                                all_overflows.extend(send_to_collected(&senders, runtime_id, pane_id, &msg));
+                                all_overflows.extend(send_to_collected(&senders, runtime_id, pane_id, &msg, 0));
                             }
                             if let Some((title, revision)) = new_title {
                                 let msg = ClientMsg::V2(protocol::title_changed(runtime_id, pane_id, title, revision));
-                                all_overflows.extend(send_to_collected(&senders, runtime_id, pane_id, &msg));
+                                all_overflows.extend(send_to_collected(&senders, runtime_id, pane_id, &msg, 0));
                             }
                             if !all_overflows.is_empty() {
                                 all_overflows.sort_unstable();

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1471,7 +1471,7 @@ async fn send_to_collected_delivers_messages() {
     let senders = vec![(client_id, tx, None)];
 
     let msg = ClientMsg::V2(protocol::delta(runtime_id, pane_id, bytes::Bytes::from_static(b"hi")));
-    send_to_collected(&senders, runtime_id, pane_id, &msg);
+    send_to_collected(&senders, runtime_id, pane_id, &msg, 0);
 
     let received = rx.try_recv().unwrap();
     assert!(
@@ -1489,11 +1489,11 @@ async fn send_to_collected_returns_overflowed_clients() {
     let senders = vec![(client_id, tx, None)];
 
     let msg = ClientMsg::V2(protocol::delta(runtime_id, pane_id, bytes::Bytes::from_static(b"a")));
-    let overflows = send_to_collected(&senders, runtime_id, pane_id, &msg);
+    let overflows = send_to_collected(&senders, runtime_id, pane_id, &msg, 0);
     assert!(overflows.is_empty(), "first send should succeed");
 
     // Channel is now full.
-    let overflows = send_to_collected(&senders, runtime_id, pane_id, &msg);
+    let overflows = send_to_collected(&senders, runtime_id, pane_id, &msg, 0);
     assert_eq!(overflows.len(), 1, "second send should report overflow");
     assert_eq!(overflows[0], client_id);
     assert!(logs_contain("channel full"));
@@ -1974,6 +1974,22 @@ async fn v3_pane_output_seq_increments_on_feed() {
     assert_eq!(pane.output_seq, 1);
     pane.feed_output(b"world");
     assert_eq!(pane.output_seq, 2);
+}
+
+#[tokio::test]
+async fn v3_convert_delta_carries_pane_output_seq() {
+    let runtime_id = Uuid::new_v4();
+    let pane_id = Uuid::new_v4();
+    let msg =
+        ClientMsg::V2(protocol::delta(runtime_id, pane_id, bytes::Bytes::from_static(b"data")));
+    let converted = convert_v2_push_to_v3(&msg, 42);
+    let ClientMsg::V3(env) = converted else {
+        panic!("expected V3 message");
+    };
+    let Some(v3::server_envelope::Payload::OutputDelta(delta)) = env.payload else {
+        panic!("expected OutputDelta");
+    };
+    assert_eq!(delta.pane_output_seq, 42);
 }
 
 #[tokio::test]

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -375,3 +375,183 @@ pub async fn wait_for_state_containing(
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
 }
+
+// ── V3 test client ──────────────────────────────────────────────
+
+use rttx_proto::v3;
+
+/// A test client that speaks the v3 protocol over a real Unix socket.
+pub struct TestV3Client {
+    stream: UnixStream,
+    read_buf: BytesMut,
+    request_id: std::sync::atomic::AtomicU64,
+}
+
+impl TestV3Client {
+    /// Connect to the server and perform the v3 handshake.
+    pub async fn connect(path: &Path) -> Self {
+        let stream = UnixStream::connect(path).await.expect("failed to connect to server");
+        let mut client = Self {
+            stream,
+            read_buf: BytesMut::with_capacity(8192),
+            request_id: std::sync::atomic::AtomicU64::new(1),
+        };
+        client.v3_handshake().await;
+        client
+    }
+
+    async fn v3_handshake(&mut self) {
+        let hello = rttx_proto::v3_handshake::build_client_hello(
+            uuid::Uuid::new_v4(),
+            "test-v3",
+            "0.0.0",
+            rttx_proto::v3_handshake::CORE_CAPABILITIES,
+        );
+        let mut buf = BytesMut::new();
+        encode_frame(&hello, &mut buf).expect("encode ClientHello");
+        self.stream.write_all(&buf).await.expect("write ClientHello");
+
+        // Read ServerHello
+        loop {
+            match decode_frame::<v3::ServerHello>(&mut self.read_buf) {
+                Ok(_) => return,
+                Err(rttx_proto::FrameError::Incomplete) => {}
+                Err(e) => panic!("decode ServerHello error: {e}"),
+            }
+            let n = self.stream.read_buf(&mut self.read_buf).await.expect("read");
+            assert!(n > 0, "unexpected EOF during v3 handshake");
+        }
+    }
+
+    fn next_request_id(&self) -> u64 {
+        self.request_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Send a v3 client envelope.
+    pub async fn send(&mut self, env: &v3::ClientEnvelope) {
+        let mut buf = BytesMut::new();
+        encode_frame(env, &mut buf).expect("encode");
+        self.stream.write_all(&buf).await.expect("write");
+    }
+
+    /// Receive a v3 server envelope.
+    pub async fn recv(&mut self) -> v3::ServerEnvelope {
+        loop {
+            match decode_frame::<v3::ServerEnvelope>(&mut self.read_buf) {
+                Ok(env) => return env,
+                Err(rttx_proto::FrameError::Incomplete) => {}
+                Err(e) => panic!("decode error: {e}"),
+            }
+            let n = self.stream.read_buf(&mut self.read_buf).await.expect("read");
+            assert!(n > 0, "unexpected EOF");
+        }
+    }
+
+    /// Receive with timeout.
+    pub async fn recv_timeout(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Option<v3::ServerEnvelope> {
+        tokio::time::timeout(timeout, self.recv()).await.ok()
+    }
+
+    /// Create a runtime via v3 and return the `runtime_id` bytes.
+    pub async fn create_runtime(&mut self, name: &str) -> Vec<u8> {
+        let env = v3::ClientEnvelope {
+            request_id: self.next_request_id(),
+            command: Some(v3::client_envelope::Command::CreateRuntime(v3::CreateRuntime {
+                name: name.into(),
+                policy: v3::RuntimePolicy::Persistent as i32,
+            })),
+        };
+        self.send(&env).await;
+        loop {
+            let resp = self.recv().await;
+            match resp.payload {
+                Some(v3::server_envelope::Payload::RuntimeCreated(rc)) => return rc.runtime_id,
+                Some(v3::server_envelope::Payload::OutputDelta(_)) => {}
+                other => panic!("expected RuntimeCreated, got {other:?}"),
+            }
+        }
+    }
+
+    /// Attach read-write and return the snapshot.
+    pub async fn attach_rw(&mut self, runtime_id: &[u8]) -> v3::RuntimeSnapshot {
+        let env = v3::ClientEnvelope {
+            request_id: self.next_request_id(),
+            command: Some(v3::client_envelope::Command::AttachRuntime(v3::AttachRuntime {
+                runtime_id: runtime_id.to_vec(),
+                attach_mode: v3::RuntimeAttachMode::ReadWrite as i32,
+            })),
+        };
+        self.send(&env).await;
+        loop {
+            let resp = self.recv().await;
+            match resp.payload {
+                Some(v3::server_envelope::Payload::RuntimeSnapshot(snap)) => return snap,
+                Some(v3::server_envelope::Payload::OutputDelta(_)) => {}
+                other => panic!("expected RuntimeSnapshot, got {other:?}"),
+            }
+        }
+    }
+
+    /// Create a pane and return the `pane_id` bytes.
+    pub async fn create_pane(&mut self, runtime_id: &[u8]) -> Vec<u8> {
+        let env = v3::ClientEnvelope {
+            request_id: self.next_request_id(),
+            command: Some(v3::client_envelope::Command::CreatePane(v3::CreatePane {
+                runtime_id: runtime_id.to_vec(),
+                cwd: None,
+                dark_background: None,
+                cols: 80,
+                rows: 24,
+                no_persist: None,
+            })),
+        };
+        self.send(&env).await;
+        loop {
+            let resp = self.recv().await;
+            match resp.payload {
+                Some(v3::server_envelope::Payload::PaneCreated(pc)) => return pc.pane_id,
+                Some(v3::server_envelope::Payload::OutputDelta(_)) => {}
+                other => panic!("expected PaneCreated, got {other:?}"),
+            }
+        }
+    }
+
+    /// Send raw input to a pane.
+    pub async fn send_input(&mut self, runtime_id: &[u8], pane_id: &[u8], data: &[u8]) {
+        let env = v3::ClientEnvelope {
+            request_id: self.next_request_id(),
+            command: Some(v3::client_envelope::Command::TerminalInput(v3::TerminalInput {
+                runtime_id: runtime_id.to_vec(),
+                pane_id: pane_id.to_vec(),
+                kind: Some(v3::terminal_input::Kind::Raw(v3::RawInput {
+                    data: bytes::Bytes::copy_from_slice(data),
+                })),
+            })),
+        };
+        self.send(&env).await;
+    }
+
+    /// Collect all `OutputDelta` messages within a time window, returning their `pane_output_seq` values.
+    pub async fn collect_output_seqs(&mut self, window: std::time::Duration) -> Vec<u64> {
+        let mut seqs = Vec::new();
+        let deadline = tokio::time::Instant::now() + window;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match self.recv_timeout(remaining).await {
+                Some(env) => {
+                    if let Some(v3::server_envelope::Payload::OutputDelta(delta)) = env.payload {
+                        seqs.push(delta.pane_output_seq);
+                    }
+                }
+                None => break,
+            }
+        }
+        seqs
+    }
+}

--- a/services/rttx-server/tests/v3_output_seq.rs
+++ b/services/rttx-server/tests/v3_output_seq.rs
@@ -1,0 +1,145 @@
+//! End-to-end tests for v3 `pane_output_seq` continuity.
+//!
+//! Verifies that the live daemon path produces correct per-pane output
+//! sequences in both attach snapshots and pushed `OutputDelta` messages,
+//! as required by RFC-021.
+
+mod common;
+
+/// Attach snapshot includes the current `pane_output_seq` for each pane.
+#[tokio::test]
+async fn snapshot_carries_pane_output_seq() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, _handle) = common::start_test_server(tmp.path()).await;
+
+    let mut client = common::TestV3Client::connect(&socket_path).await;
+    let runtime_id = client.create_runtime("seq-snap").await;
+    let _snap = client.attach_rw(&runtime_id).await;
+    let pane_id = client.create_pane(&runtime_id).await;
+
+    // Drain initial shell output so the pane's output_seq advances.
+    let _ = client.collect_output_seqs(std::time::Duration::from_secs(2)).await;
+
+    // Detach and reattach — snapshot should carry the current seq.
+    let env = rttx_proto::v3::ClientEnvelope {
+        request_id: 100,
+        command: Some(rttx_proto::v3::client_envelope::Command::DetachRuntime(
+            rttx_proto::v3::DetachRuntime { runtime_id: runtime_id.clone() },
+        )),
+    };
+    client.send(&env).await;
+    // Drain until detached.
+    loop {
+        let resp = client.recv().await;
+        if matches!(
+            resp.payload,
+            Some(
+                rttx_proto::v3::server_envelope::Payload::RuntimeDetached(_)
+                    | rttx_proto::v3::server_envelope::Payload::RuntimeTerminated(_)
+            )
+        ) {
+            break;
+        }
+    }
+
+    let snap = client.attach_rw(&runtime_id).await;
+    assert!(!snap.panes.is_empty(), "snapshot should contain the pane");
+    let pane_snap = snap.panes.iter().find(|p| p.pane_id == pane_id).expect("pane not in snapshot");
+    // The pane had output, so seq must be > 0.
+    assert!(
+        pane_snap.pane_output_seq > 0,
+        "snapshot pane_output_seq should reflect prior output, got {}",
+        pane_snap.pane_output_seq
+    );
+}
+
+/// Live `OutputDelta` messages carry contiguous `pane_output_seq` starting
+/// from `snapshot_seq + 1`.
+#[tokio::test]
+async fn live_deltas_carry_contiguous_pane_output_seq() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, _handle) = common::start_test_server(tmp.path()).await;
+
+    let mut client = common::TestV3Client::connect(&socket_path).await;
+    let runtime_id = client.create_runtime("seq-delta").await;
+    let _snap = client.attach_rw(&runtime_id).await;
+    let _pane_id = client.create_pane(&runtime_id).await;
+
+    // Collect output deltas from shell startup.
+    let seqs = client.collect_output_seqs(std::time::Duration::from_secs(2)).await;
+
+    // Must have received at least one delta.
+    assert!(!seqs.is_empty(), "expected at least one OutputDelta from shell startup");
+
+    // All seqs must be > 0 (not the hardcoded 0).
+    for (i, &seq) in seqs.iter().enumerate() {
+        assert!(seq > 0, "delta[{i}] pane_output_seq must be > 0, got {seq}");
+    }
+
+    // Seqs must be contiguous (each increments by 1).
+    for window in seqs.windows(2) {
+        assert_eq!(
+            window[1],
+            window[0] + 1,
+            "pane_output_seq must be contiguous: {} followed by {}",
+            window[0],
+            window[1]
+        );
+    }
+}
+
+/// After attach, the next delta carries `snapshot_seq + 1`.
+#[tokio::test]
+async fn delta_seq_continues_from_snapshot_seq() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (socket_path, _handle) = common::start_test_server(tmp.path()).await;
+
+    let mut client = common::TestV3Client::connect(&socket_path).await;
+    let runtime_id = client.create_runtime("seq-cont").await;
+    let _snap = client.attach_rw(&runtime_id).await;
+    let pane_id = client.create_pane(&runtime_id).await;
+
+    // Drain initial output.
+    let _ = client.collect_output_seqs(std::time::Duration::from_secs(2)).await;
+
+    // Detach.
+    let env = rttx_proto::v3::ClientEnvelope {
+        request_id: 200,
+        command: Some(rttx_proto::v3::client_envelope::Command::DetachRuntime(
+            rttx_proto::v3::DetachRuntime { runtime_id: runtime_id.clone() },
+        )),
+    };
+    client.send(&env).await;
+    loop {
+        let resp = client.recv().await;
+        if matches!(
+            resp.payload,
+            Some(
+                rttx_proto::v3::server_envelope::Payload::RuntimeDetached(_)
+                    | rttx_proto::v3::server_envelope::Payload::RuntimeTerminated(_)
+            )
+        ) {
+            break;
+        }
+    }
+
+    // Reattach and record snapshot seq.
+    let snap = client.attach_rw(&runtime_id).await;
+    let pane_snap = snap.panes.iter().find(|p| p.pane_id == pane_id).expect("pane not in snapshot");
+    let snapshot_seq = pane_snap.pane_output_seq;
+
+    // Send input to trigger output.
+    client.send_input(&runtime_id, &pane_id, b"echo hello\n").await;
+
+    // Collect deltas.
+    let seqs = client.collect_output_seqs(std::time::Duration::from_secs(3)).await;
+    assert!(!seqs.is_empty(), "expected output after echo");
+
+    // First delta must be snapshot_seq + 1.
+    assert_eq!(
+        seqs[0],
+        snapshot_seq + 1,
+        "first delta after reattach should be snapshot_seq({snapshot_seq}) + 1, got {}",
+        seqs[0]
+    );
+}


### PR DESCRIPTION
## What changed and why

The v2-to-v3 push conversion path in `convert_v2_push_to_v3` hardcoded `pane_output_seq: 0` in `OutputDelta` messages. The pane's real `output_seq` was captured in the PTY read loop but discarded (prefixed with `_`). This broke client-side gap detection and `StreamOverflow` fallback semantics defined in RFC-021.

### Root cause

In `server.rs`, the PTY read loop correctly increments `pane.output_seq` on every `feed_output` call and the attach snapshot already carries the real seq. However, the live push path constructed a V2 delta message (which has no seq field) and then lazily converted it to V3 with a hardcoded `0`.

### Fix

Pass the real `output_seq` from the pane through `send_to_collected` → `convert_v2_push_to_v3` so v3 clients receive correct contiguous sequences starting from `snapshot_seq + 1`.

## Manual verification

1. Start daemon: `RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground`
2. Start client: `RTTX_DEV_MODE=1 cargo run -p rttx`
3. Create a workspace, type commands — output flows normally
4. Detach and reattach — output continues without gaps

## Tests added

- **Unit test**: `v3_convert_delta_carries_pane_output_seq` — verifies the conversion function uses the provided seq instead of hardcoded 0
- **Integration test**: `live_deltas_carry_contiguous_pane_output_seq` — verifies live daemon deltas have seq > 0 and are contiguous
- **Integration test**: `snapshot_carries_pane_output_seq` — verifies attach snapshot includes real seq
- **Integration test**: `delta_seq_continues_from_snapshot_seq` — verifies first delta after reattach is `snapshot_seq + 1`
- **Test infrastructure**: `TestV3Client` added to common test helpers for v3 end-to-end testing

## Tests run

- `cargo test -p rttx-proto -p rttx-server` — all pass
- `cargo test -p rttx --no-default-features --features vte-0_76` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass (0 failures)

Fixes #763