### PR TITLE
fix(terminal): make managed key encoding mode-aware and prove parity against direct VTE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "bytes",
  "prost",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.10"
+version = "0.4.11"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -57,14 +57,32 @@ pub(crate) fn populate_places_submenu(menu: &gtk4::gio::Menu, host_key: &str) {
     }
 }
 
-/// Test-only re-export of `encode_terminal_key_input`.
+/// Test-only re-export of `encode_terminal_key_input` (normal mode).
 #[doc(hidden)]
 #[must_use]
 pub fn encode_terminal_key_input_for_test(
     key: gtk4::gdk::Key,
     state: gtk4::gdk::ModifierType,
 ) -> Option<Vec<u8>> {
-    encode_terminal_key_input(key, state)
+    encode_terminal_key_input(key, state, TerminalModes::default())
+}
+
+/// Test-only re-export of mode-aware `encode_terminal_key_input`.
+#[doc(hidden)]
+#[must_use]
+pub fn encode_terminal_key_input_with_modes_for_test(
+    key: gtk4::gdk::Key,
+    state: gtk4::gdk::ModifierType,
+    modes: TerminalModes,
+) -> Option<Vec<u8>> {
+    encode_terminal_key_input(key, state, modes)
+}
+
+/// Terminal interaction modes that affect key encoding.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TerminalModes {
+    pub application_cursor_keys: bool,
+    pub application_keypad: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,26 +212,91 @@ fn ss3_or_csi(suffix: u8, modifier: u8) -> Vec<u8> {
     }
 }
 
+/// Encode a cursor/navigation key: SS3 when application cursor mode is active
+/// and no modifiers are held, CSI otherwise.
+fn cursor_key(suffix: u8, modifier: u8, application_cursor: bool) -> Vec<u8> {
+    if modifier == 0 && application_cursor {
+        vec![0x1b, b'O', suffix]
+    } else {
+        csi_letter(suffix, modifier)
+    }
+}
+
+/// Map a keypad key to its SS3 application-mode byte, if applicable.
+const fn keypad_application_byte(key: gtk4::gdk::Key) -> Option<u8> {
+    match key {
+        gtk4::gdk::Key::KP_0 => Some(b'p'),
+        gtk4::gdk::Key::KP_1 => Some(b'q'),
+        gtk4::gdk::Key::KP_2 => Some(b'r'),
+        gtk4::gdk::Key::KP_3 => Some(b's'),
+        gtk4::gdk::Key::KP_4 => Some(b't'),
+        gtk4::gdk::Key::KP_5 => Some(b'u'),
+        gtk4::gdk::Key::KP_6 => Some(b'v'),
+        gtk4::gdk::Key::KP_7 => Some(b'w'),
+        gtk4::gdk::Key::KP_8 => Some(b'x'),
+        gtk4::gdk::Key::KP_9 => Some(b'y'),
+        gtk4::gdk::Key::KP_Add => Some(b'k'),
+        gtk4::gdk::Key::KP_Subtract => Some(b'm'),
+        gtk4::gdk::Key::KP_Multiply => Some(b'j'),
+        gtk4::gdk::Key::KP_Divide => Some(b'o'),
+        gtk4::gdk::Key::KP_Decimal => Some(b'n'),
+        gtk4::gdk::Key::KP_Enter => Some(b'M'),
+        _ => None,
+    }
+}
+
+fn encode_printable_or_control(key: gtk4::gdk::Key, ctrl: bool, alt: bool) -> Option<Vec<u8>> {
+    let ch = key.to_unicode()?;
+    if ctrl && alt {
+        let ctrl_byte = encode_control_character(ch)?;
+        Some(vec![0x1b, ctrl_byte])
+    } else if ctrl {
+        Some(vec![encode_control_character(ch)?])
+    } else if alt {
+        let mut prefixed = vec![0x1b];
+        prefixed.extend(ch.to_string().bytes());
+        Some(prefixed)
+    } else {
+        Some(ch.to_string().into_bytes())
+    }
+}
+
 fn encode_terminal_key_input(
     key: gtk4::gdk::Key,
     state: gtk4::gdk::ModifierType,
+    modes: TerminalModes,
 ) -> Option<Vec<u8>> {
     let ctrl = state.contains(gtk4::gdk::ModifierType::CONTROL_MASK);
     let alt = state.contains(gtk4::gdk::ModifierType::ALT_MASK);
     let m = xterm_modifier_param(state);
 
     let seq = match key {
+        gtk4::gdk::Key::KP_Enter if modes.application_keypad => {
+            return Some(vec![0x1b, b'O', b'M']);
+        }
         gtk4::gdk::Key::Return | gtk4::gdk::Key::KP_Enter => vec![b'\r'],
         gtk4::gdk::Key::BackSpace => vec![0x7f],
         gtk4::gdk::Key::Tab | gtk4::gdk::Key::KP_Tab => vec![b'\t'],
         gtk4::gdk::Key::ISO_Left_Tab => b"\x1b[Z".to_vec(),
         gtk4::gdk::Key::Escape => vec![0x1b],
-        gtk4::gdk::Key::Up | gtk4::gdk::Key::KP_Up => return Some(csi_letter(b'A', m)),
-        gtk4::gdk::Key::Down | gtk4::gdk::Key::KP_Down => return Some(csi_letter(b'B', m)),
-        gtk4::gdk::Key::Right | gtk4::gdk::Key::KP_Right => return Some(csi_letter(b'C', m)),
-        gtk4::gdk::Key::Left | gtk4::gdk::Key::KP_Left => return Some(csi_letter(b'D', m)),
-        gtk4::gdk::Key::Home | gtk4::gdk::Key::KP_Home => return Some(csi_letter(b'H', m)),
-        gtk4::gdk::Key::End | gtk4::gdk::Key::KP_End => return Some(csi_letter(b'F', m)),
+        gtk4::gdk::Key::Up | gtk4::gdk::Key::KP_Up => {
+            return Some(cursor_key(b'A', m, modes.application_cursor_keys));
+        }
+        gtk4::gdk::Key::Down | gtk4::gdk::Key::KP_Down => {
+            return Some(cursor_key(b'B', m, modes.application_cursor_keys));
+        }
+        gtk4::gdk::Key::Right | gtk4::gdk::Key::KP_Right => {
+            return Some(cursor_key(b'C', m, modes.application_cursor_keys));
+        }
+        gtk4::gdk::Key::Left | gtk4::gdk::Key::KP_Left => {
+            return Some(cursor_key(b'D', m, modes.application_cursor_keys));
+        }
+        gtk4::gdk::Key::Home | gtk4::gdk::Key::KP_Home => {
+            return Some(cursor_key(b'H', m, modes.application_cursor_keys));
+        }
+        gtk4::gdk::Key::End | gtk4::gdk::Key::KP_End => {
+            return Some(cursor_key(b'F', m, modes.application_cursor_keys));
+        }
         gtk4::gdk::Key::Insert | gtk4::gdk::Key::KP_Insert => return Some(csi_tilde("2", m)),
         gtk4::gdk::Key::Delete | gtk4::gdk::Key::KP_Delete => return Some(csi_tilde("3", m)),
         gtk4::gdk::Key::Page_Up | gtk4::gdk::Key::KP_Page_Up => return Some(csi_tilde("5", m)),
@@ -232,20 +315,14 @@ fn encode_terminal_key_input(
         gtk4::gdk::Key::F10 => return Some(csi_tilde("21", m)),
         gtk4::gdk::Key::F11 => return Some(csi_tilde("23", m)),
         gtk4::gdk::Key::F12 => return Some(csi_tilde("24", m)),
-        _ => {
-            let ch = key.to_unicode()?;
-            if ctrl && alt {
-                let ctrl_byte = encode_control_character(ch)?;
-                vec![0x1b, ctrl_byte]
-            } else if ctrl {
-                vec![encode_control_character(ch)?]
-            } else if alt {
-                let mut prefixed = vec![0x1b];
-                prefixed.extend(ch.to_string().bytes());
-                return Some(prefixed);
-            } else {
-                ch.to_string().into_bytes()
+        _ if modes.application_keypad => {
+            if let Some(ss3) = keypad_application_byte(key) {
+                return Some(vec![0x1b, b'O', ss3]);
             }
+            return encode_printable_or_control(key, ctrl, alt);
+        }
+        _ => {
+            return encode_printable_or_control(key, ctrl, alt);
         }
     };
 
@@ -279,6 +356,7 @@ fn terminal_key_action(
     modifiers: gtk4::gdk::ModifierType,
     has_selection: bool,
     smart_clipboard_enabled: bool,
+    modes: TerminalModes,
 ) -> TerminalKeyAction {
     let normalized = normalized_shortcut_modifiers(modifiers);
 
@@ -312,7 +390,7 @@ fn terminal_key_action(
 
     match backend {
         TerminalInputBackend::Direct => TerminalKeyAction::PassThrough,
-        TerminalInputBackend::Managed => encode_terminal_key_input(key, modifiers)
+        TerminalInputBackend::Managed => encode_terminal_key_input(key, modifiers, modes)
             .map_or(TerminalKeyAction::PassThrough, TerminalKeyAction::ForwardToPty),
     }
 }
@@ -320,8 +398,12 @@ fn terminal_key_action(
 #[cfg(test)]
 mod tests {
     use super::{
-        TerminalInputBackend, TerminalKeyAction, encode_terminal_key_input, terminal_key_action,
+        TerminalInputBackend, TerminalKeyAction, TerminalModes, encode_terminal_key_input,
+        terminal_key_action,
     };
+
+    const DEFAULT_MODES: TerminalModes =
+        TerminalModes { application_cursor_keys: false, application_keypad: false };
 
     #[test]
     fn direct_and_managed_share_clipboard_policy() {
@@ -336,6 +418,7 @@ mod tests {
                 modifiers,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -346,6 +429,7 @@ mod tests {
                 modifiers,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -362,6 +446,7 @@ mod tests {
                 modifiers,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -372,6 +457,7 @@ mod tests {
                 modifiers,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -386,6 +472,7 @@ mod tests {
                 gtk4::gdk::ModifierType::SUPER_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -396,6 +483,7 @@ mod tests {
                 gtk4::gdk::ModifierType::SUPER_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -410,6 +498,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x03])
         );
@@ -420,6 +509,7 @@ mod tests {
                 gtk4::gdk::ModifierType::ALT_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::ForwardToPty(b"\x1bx".to_vec())
         );
@@ -428,7 +518,11 @@ mod tests {
     #[test]
     fn ctrl_d_encodes_eof_byte() {
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::d, gtk4::gdk::ModifierType::CONTROL_MASK),
+            encode_terminal_key_input(
+                gtk4::gdk::Key::d,
+                gtk4::gdk::ModifierType::CONTROL_MASK,
+                DEFAULT_MODES
+            ),
             Some(vec![0x04])
         );
         assert_eq!(
@@ -438,6 +532,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x04])
         );
@@ -456,6 +551,7 @@ mod tests {
                 modifiers,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -464,31 +560,59 @@ mod tests {
     #[test]
     fn encode_terminal_key_input_maps_basic_shell_keys() {
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::a, gtk4::gdk::ModifierType::empty()),
+            encode_terminal_key_input(
+                gtk4::gdk::Key::a,
+                gtk4::gdk::ModifierType::empty(),
+                DEFAULT_MODES
+            ),
             Some(vec![b'a'])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Return, gtk4::gdk::ModifierType::empty()),
+            encode_terminal_key_input(
+                gtk4::gdk::Key::Return,
+                gtk4::gdk::ModifierType::empty(),
+                DEFAULT_MODES
+            ),
             Some(vec![b'\r'])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::BackSpace, gtk4::gdk::ModifierType::empty()),
+            encode_terminal_key_input(
+                gtk4::gdk::Key::BackSpace,
+                gtk4::gdk::ModifierType::empty(),
+                DEFAULT_MODES
+            ),
             Some(vec![0x7f])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Left, gtk4::gdk::ModifierType::empty()),
+            encode_terminal_key_input(
+                gtk4::gdk::Key::Left,
+                gtk4::gdk::ModifierType::empty(),
+                DEFAULT_MODES
+            ),
             Some(b"\x1b[D".to_vec())
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::c, gtk4::gdk::ModifierType::CONTROL_MASK),
+            encode_terminal_key_input(
+                gtk4::gdk::Key::c,
+                gtk4::gdk::ModifierType::CONTROL_MASK,
+                DEFAULT_MODES
+            ),
             Some(vec![0x03])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::x, gtk4::gdk::ModifierType::ALT_MASK),
+            encode_terminal_key_input(
+                gtk4::gdk::Key::x,
+                gtk4::gdk::ModifierType::ALT_MASK,
+                DEFAULT_MODES
+            ),
             Some(b"\x1bx".to_vec())
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Shift_L, gtk4::gdk::ModifierType::SHIFT_MASK,),
+            encode_terminal_key_input(
+                gtk4::gdk::Key::Shift_L,
+                gtk4::gdk::ModifierType::SHIFT_MASK,
+                DEFAULT_MODES
+            ),
             None
         );
     }
@@ -505,6 +629,7 @@ mod tests {
                 modifiers,
                 false,
                 false, // smart clipboard OFF
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -522,6 +647,7 @@ mod tests {
                 modifiers,
                 true,  // has selection
                 false, // smart clipboard OFF
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::CopySelection
         );
@@ -545,7 +671,8 @@ mod tests {
             (gtk4::gdk::Key::F12, b"\x1b[24~"),
         ];
         for (key, seq) in expected {
-            let result = encode_terminal_key_input(*key, gtk4::gdk::ModifierType::empty());
+            let result =
+                encode_terminal_key_input(*key, gtk4::gdk::ModifierType::empty(), DEFAULT_MODES);
             assert_eq!(
                 result.as_deref(),
                 Some(*seq as &[u8]),
@@ -563,6 +690,7 @@ mod tests {
             gtk4::gdk::ModifierType::empty(),
             false,
             false,
+            DEFAULT_MODES,
         );
         assert!(
             matches!(action, TerminalKeyAction::ForwardToPty(_)),
@@ -573,8 +701,11 @@ mod tests {
     /// Alt+F-key must use xterm modifier param 3. #293.
     #[test]
     fn alt_fkey_uses_modifier_encoding() {
-        let result =
-            encode_terminal_key_input(gtk4::gdk::Key::F2, gtk4::gdk::ModifierType::ALT_MASK);
+        let result = encode_terminal_key_input(
+            gtk4::gdk::Key::F2,
+            gtk4::gdk::ModifierType::ALT_MASK,
+            DEFAULT_MODES,
+        );
         assert_eq!(result.as_deref(), Some(b"\x1b[1;3Q" as &[u8]));
     }
 
@@ -583,19 +714,19 @@ mod tests {
     fn ctrl_arrow_uses_xterm_modifier_encoding() {
         let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Right, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Right, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;5C" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Left, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Left, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;5D" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Up, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Up, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;5A" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Down, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Down, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;5B" as &[u8])
         );
     }
@@ -605,11 +736,11 @@ mod tests {
     fn shift_arrow_uses_xterm_modifier_encoding() {
         let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Right, shift).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Right, shift, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;2C" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Left, shift).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Left, shift, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;2D" as &[u8])
         );
     }
@@ -619,11 +750,11 @@ mod tests {
     fn ctrl_home_end_uses_xterm_modifier_encoding() {
         let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Home, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Home, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;5H" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::End, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::End, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;5F" as &[u8])
         );
     }
@@ -633,7 +764,7 @@ mod tests {
     fn ctrl_shift_arrow_uses_modifier_6() {
         let mods = gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK;
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Right, mods).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Right, mods, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;6C" as &[u8])
         );
     }
@@ -643,7 +774,7 @@ mod tests {
     fn alt_ctrl_arrow_uses_modifier_7() {
         let mods = gtk4::gdk::ModifierType::ALT_MASK | gtk4::gdk::ModifierType::CONTROL_MASK;
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Right, mods).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Right, mods, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;7C" as &[u8])
         );
     }
@@ -654,12 +785,12 @@ mod tests {
         let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
         // F5 = CSI 15~ → Ctrl+F5 = CSI 15;5~
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::F5, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::F5, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[15;5~" as &[u8])
         );
         // F1 = SS3 P → Ctrl+F1 = CSI 1;5P
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::F1, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::F1, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;5P" as &[u8])
         );
     }
@@ -669,11 +800,11 @@ mod tests {
     fn ctrl_tilde_keys_use_modified_format() {
         let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Delete, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Delete, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[3;5~" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Page_Up, ctrl).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Page_Up, ctrl, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[5;5~" as &[u8])
         );
     }
@@ -683,15 +814,15 @@ mod tests {
     fn unmodified_navigation_keys_unchanged() {
         let none = gtk4::gdk::ModifierType::empty();
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Right, none).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Right, none, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[C" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Home, none).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Home, none, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[H" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::F1, none).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::F1, none, DEFAULT_MODES).as_deref(),
             Some(b"\x1bOP" as &[u8])
         );
     }
@@ -701,9 +832,15 @@ mod tests {
     fn ctrl_alt_letter_preserves_alt_prefix() {
         let mods = gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::ALT_MASK;
         // Ctrl+Alt+a → ESC 0x01
-        assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::a, mods), Some(vec![0x1b, 0x01]));
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::a, mods, DEFAULT_MODES),
+            Some(vec![0x1b, 0x01])
+        );
         // Ctrl+Alt+c → ESC 0x03
-        assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::c, mods), Some(vec![0x1b, 0x03]));
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::c, mods, DEFAULT_MODES),
+            Some(vec![0x1b, 0x03])
+        );
     }
 
     /// Ctrl+Alt+letter must be forwarded as `ForwardToPty` in managed mode. #457.
@@ -716,6 +853,7 @@ mod tests {
             mods,
             false,
             false,
+            DEFAULT_MODES,
         );
         assert_eq!(action, TerminalKeyAction::ForwardToPty(vec![0x1b, 0x01]));
     }
@@ -738,7 +876,7 @@ mod tests {
         ];
         for (key, byte) in expected {
             assert_eq!(
-                encode_terminal_key_input(*key, none),
+                encode_terminal_key_input(*key, none, DEFAULT_MODES),
                 Some(vec![*byte]),
                 "KP digit {key:?} should produce ASCII digit"
             );
@@ -758,7 +896,7 @@ mod tests {
         ];
         for (key, bytes) in expected {
             assert_eq!(
-                encode_terminal_key_input(*key, none),
+                encode_terminal_key_input(*key, none, DEFAULT_MODES),
                 Some(bytes.to_vec()),
                 "KP operator {key:?} should produce ASCII"
             );
@@ -770,19 +908,19 @@ mod tests {
     fn shift_tilde_keys_use_modified_format() {
         let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Insert, shift).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Insert, shift, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[2;2~" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Delete, shift).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Delete, shift, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[3;2~" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Page_Up, shift).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Page_Up, shift, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[5;2~" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Page_Down, shift).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Page_Down, shift, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[6;2~" as &[u8])
         );
     }
@@ -792,11 +930,11 @@ mod tests {
     fn shift_home_end_uses_modified_format() {
         let shift = gtk4::gdk::ModifierType::SHIFT_MASK;
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::Home, shift).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::Home, shift, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;2H" as &[u8])
         );
         assert_eq!(
-            encode_terminal_key_input(gtk4::gdk::Key::End, shift).as_deref(),
+            encode_terminal_key_input(gtk4::gdk::Key::End, shift, DEFAULT_MODES).as_deref(),
             Some(b"\x1b[1;2F" as &[u8])
         );
     }
@@ -815,8 +953,14 @@ mod tests {
             (gtk4::gdk::Key::F5, gtk4::gdk::ModifierType::empty()),
         ];
         for (key, mods) in keys_and_mods {
-            let action =
-                terminal_key_action(TerminalInputBackend::Managed, *key, *mods, false, false);
+            let action = terminal_key_action(
+                TerminalInputBackend::Managed,
+                *key,
+                *mods,
+                false,
+                false,
+                DEFAULT_MODES,
+            );
             assert!(
                 matches!(action, TerminalKeyAction::ForwardToPty(_)),
                 "managed backend must intercept {key:?}+{mods:?}, got {action:?}"
@@ -837,7 +981,7 @@ mod tests {
         ];
         for key in &dead_keys {
             assert_eq!(
-                encode_terminal_key_input(*key, none),
+                encode_terminal_key_input(*key, none, DEFAULT_MODES),
                 None,
                 "dead key {key:?} must return None so IMContext handles it"
             );
@@ -856,6 +1000,7 @@ mod tests {
                 none,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough,
         );
@@ -866,8 +1011,14 @@ mod tests {
     #[test]
     fn control_keys_still_encoded_with_ime_active() {
         let ctrl = gtk4::gdk::ModifierType::CONTROL_MASK;
-        assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::c, ctrl), Some(vec![0x03]),);
-        assert_eq!(encode_terminal_key_input(gtk4::gdk::Key::d, ctrl), Some(vec![0x04]),);
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::c, ctrl, DEFAULT_MODES),
+            Some(vec![0x03]),
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::d, ctrl, DEFAULT_MODES),
+            Some(vec![0x04]),
+        );
     }
 
     /// Keys that produce `ForwardToPty` in managed mode are the ones that
@@ -882,13 +1033,79 @@ mod tests {
             (gtk4::gdk::Key::Up, gtk4::gdk::ModifierType::empty()),
         ];
         for (key, mods) in typing_keys {
-            let action =
-                terminal_key_action(TerminalInputBackend::Managed, *key, *mods, false, false);
+            let action = terminal_key_action(
+                TerminalInputBackend::Managed,
+                *key,
+                *mods,
+                false,
+                false,
+                DEFAULT_MODES,
+            );
             assert!(
                 matches!(action, TerminalKeyAction::ForwardToPty(_)),
                 "{key:?}+{mods:?} must produce ForwardToPty (scroll-on-keystroke trigger)"
             );
         }
+    }
+
+    /// Application cursor mode: unmodified arrows use SS3. #767.
+    #[test]
+    fn app_cursor_mode_arrows_use_ss3() {
+        let modes = TerminalModes { application_cursor_keys: true, application_keypad: false };
+        let none = gtk4::gdk::ModifierType::empty();
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Up, none, modes).as_deref(),
+            Some(b"\x1bOA" as &[u8])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::Down, none, modes).as_deref(),
+            Some(b"\x1bOB" as &[u8])
+        );
+    }
+
+    /// Application cursor mode: modified arrows still use CSI. #767.
+    #[test]
+    fn app_cursor_mode_modified_arrows_use_csi() {
+        let modes = TerminalModes { application_cursor_keys: true, application_keypad: false };
+        assert_eq!(
+            encode_terminal_key_input(
+                gtk4::gdk::Key::Up,
+                gtk4::gdk::ModifierType::CONTROL_MASK,
+                modes
+            )
+            .as_deref(),
+            Some(b"\x1b[1;5A" as &[u8])
+        );
+    }
+
+    /// Application keypad mode: digits use SS3. #767.
+    #[test]
+    fn app_keypad_mode_digits_use_ss3() {
+        let modes = TerminalModes { application_cursor_keys: false, application_keypad: true };
+        let none = gtk4::gdk::ModifierType::empty();
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::KP_0, none, modes).as_deref(),
+            Some(b"\x1bOp" as &[u8])
+        );
+        assert_eq!(
+            encode_terminal_key_input(gtk4::gdk::Key::KP_5, none, modes).as_deref(),
+            Some(b"\x1bOu" as &[u8])
+        );
+    }
+
+    /// Managed terminal with app cursor mode forwards SS3 arrows. #767.
+    #[test]
+    fn managed_app_cursor_forwards_ss3_arrows() {
+        let modes = TerminalModes { application_cursor_keys: true, application_keypad: false };
+        let action = terminal_key_action(
+            TerminalInputBackend::Managed,
+            gtk4::gdk::Key::Up,
+            gtk4::gdk::ModifierType::empty(),
+            false,
+            false,
+            modes,
+        );
+        assert_eq!(action, TerminalKeyAction::ForwardToPty(b"\x1bOA".to_vec()));
     }
 }
 

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -35,6 +35,8 @@ mod imp {
         pub accepts_input: Cell<bool>,
         pub exited: Cell<bool>,
         pub bracketed_paste_mode: Cell<bool>,
+        pub application_cursor_keys: Cell<bool>,
+        pub application_keypad: Cell<bool>,
         pub input_connected: Cell<bool>,
         pub resize_connected: Cell<bool>,
         pub input_key_controller: RefCell<Option<gtk4::EventControllerKey>>,
@@ -69,6 +71,8 @@ mod imp {
                 accepts_input: Cell::default(),
                 exited: Cell::default(),
                 bracketed_paste_mode: Cell::default(),
+                application_cursor_keys: Cell::default(),
+                application_keypad: Cell::default(),
                 input_connected: Cell::default(),
                 resize_connected: Cell::default(),
                 input_key_controller: RefCell::default(),
@@ -545,6 +549,21 @@ impl PersistentPaneView {
         self.imp().bracketed_paste_mode.set(enabled);
     }
 
+    /// Update terminal interaction modes from a `TerminalModeChanged` event.
+    pub fn set_application_modes(&self, cursor_keys: bool, keypad: bool) {
+        self.imp().application_cursor_keys.set(cursor_keys);
+        self.imp().application_keypad.set(keypad);
+    }
+
+    /// Current terminal modes for key encoding.
+    #[must_use]
+    pub fn terminal_modes(&self) -> crate::terminal::TerminalModes {
+        crate::terminal::TerminalModes {
+            application_cursor_keys: self.imp().application_cursor_keys.get(),
+            application_keypad: self.imp().application_keypad.get(),
+        }
+    }
+
     /// Inject DECSET/DECKPAM sequences into VTE to restore interaction modes
     /// that may have been lost when the mode-setting sequence fell outside the
     /// retained snapshot tail.
@@ -555,6 +574,8 @@ impl PersistentPaneView {
         mouse_tracking_mode: u32,
         sgr_mouse_mode: bool,
     ) {
+        self.imp().application_cursor_keys.set(application_cursor_keys);
+        self.imp().application_keypad.set(application_keypad);
         let vte = &self.imp().vte;
         if application_cursor_keys {
             vte.feed(b"\x1b[?1h");
@@ -828,6 +849,7 @@ impl PersistentPaneView {
                 state,
                 pane.vte().has_selection(),
                 pane.imp().smart_clipboard.get(),
+                pane.terminal_modes(),
             ) {
                 TerminalKeyAction::CopySelection => {
                     crate::terminal::copy_to_clipboard(pane.vte());
@@ -1192,6 +1214,10 @@ fn csi_response_len(data: &[u8]) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
+    use crate::terminal::TerminalModes;
+    const DEFAULT_MODES: TerminalModes =
+        TerminalModes { application_cursor_keys: false, application_keypad: false };
+
     use super::*;
     use crate::runtime::present_connection_status;
     use std::cell::RefCell;
@@ -1289,6 +1315,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 true,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::CopySelection
         );
@@ -1299,6 +1326,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -1310,6 +1338,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1321,6 +1350,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -1337,6 +1367,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | pointer_mask,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -1349,6 +1380,7 @@ mod tests {
                     | pointer_mask,
                 true,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::CopySelection
         );
@@ -1363,6 +1395,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1375,6 +1408,7 @@ mod tests {
                     | gtk4::gdk::ModifierType::ALT_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1385,6 +1419,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1395,6 +1430,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1409,6 +1445,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x03])
         );
@@ -1419,6 +1456,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x16])
         );
@@ -1429,6 +1467,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x04])
         );
@@ -1439,6 +1478,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x18])
         );
@@ -1892,6 +1932,41 @@ mod tests {
         // feed the appropriate escape sequences into VTE.
         pane.restore_interaction_modes(true, true, 1003, true);
         // No panic means VTE accepted the sequences.
+    }
+
+    /// `set_application_modes` updates tracked mode state for key encoding. #767.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn set_application_modes_updates_terminal_modes() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("mode-1", "runtime-1");
+        let modes = pane.terminal_modes();
+        assert!(!modes.application_cursor_keys);
+        assert!(!modes.application_keypad);
+
+        pane.set_application_modes(true, false);
+        let modes = pane.terminal_modes();
+        assert!(modes.application_cursor_keys);
+        assert!(!modes.application_keypad);
+
+        pane.set_application_modes(false, true);
+        let modes = pane.terminal_modes();
+        assert!(!modes.application_cursor_keys);
+        assert!(modes.application_keypad);
+    }
+
+    /// `restore_interaction_modes` also updates tracked mode state. #767.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn restore_interaction_modes_updates_tracked_modes() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("restore-mode-1", "runtime-1");
+        pane.restore_interaction_modes(true, true, 0, false);
+        let modes = pane.terminal_modes();
+        assert!(modes.application_cursor_keys);
+        assert!(modes.application_keypad);
     }
 
     #[test]

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -171,6 +171,7 @@ mod imp {
                     state,
                     vte.has_selection(),
                     term.imp().smart_clipboard.get(),
+                    crate::terminal::TerminalModes::default(),
                 ) {
                     TerminalKeyAction::CopySelection => {
                         crate::terminal::copy_to_clipboard(&vte);
@@ -728,10 +729,15 @@ impl TerminalWidget {
 
 #[cfg(test)]
 mod tests {
-    use crate::terminal::{TerminalInputBackend, TerminalKeyAction, terminal_key_action};
+    use crate::terminal::{
+        TerminalInputBackend, TerminalKeyAction, TerminalModes, terminal_key_action,
+    };
     use gtk4::glib;
     use gtk4::prelude::*;
     use gtk4::subclass::prelude::ObjectSubclassIsExt;
+
+    const DEFAULT_MODES: TerminalModes =
+        TerminalModes { application_cursor_keys: false, application_keypad: false };
 
     /// Verify that the RESET constant inside `reset_terminal_state()` contains
     /// the expected escape sequences without requiring a live VTE widget.
@@ -771,6 +777,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 true,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::CopySelection
         );
@@ -781,6 +788,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -795,6 +803,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -805,6 +814,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -815,6 +825,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK,
                 false,
                 false,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -831,6 +842,7 @@ mod tests {
                 gtk4::gdk::ModifierType::CONTROL_MASK | pointer_mask,
                 false,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -843,6 +855,7 @@ mod tests {
                     | pointer_mask,
                 true,
                 true,
+                DEFAULT_MODES,
             ),
             TerminalKeyAction::CopySelection
         );

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -919,6 +919,14 @@ impl Window {
                 }
             }
             Payload::Bell(_) => pane.flash_bell(),
+            Payload::TerminalModeChanged(m) => {
+                if let Some(modes) = m.modes {
+                    pane.set_application_modes(
+                        modes.application_cursor_keys,
+                        modes.application_keypad,
+                    );
+                }
+            }
             Payload::PaneResized(_)
             | Payload::PaneCreated(_)
             | Payload::PaneClosed(_)
@@ -932,7 +940,6 @@ impl Window {
             | Payload::Pong(_)
             | Payload::Error(_)
             | Payload::DiagnosticsReport(_)
-            | Payload::TerminalModeChanged(_)
             | Payload::StreamOverflow(_)
             | Payload::ScrollbackChunk(_)
             | Payload::TakeoverCompleted(_)

--- a/clients/rttx/tests/vte_parity.rs
+++ b/clients/rttx/tests/vte_parity.rs
@@ -8,7 +8,9 @@
 //! This is the required regression layer for future terminal input fixes
 //! (see GitHub issue #464).
 
+use rttx::terminal::TerminalModes;
 use rttx::terminal::encode_terminal_key_input_for_test as encode;
+use rttx::terminal::encode_terminal_key_input_with_modes_for_test as encode_with_modes;
 
 type Mods = gtk4::gdk::ModifierType;
 type Key = gtk4::gdk::Key;
@@ -384,4 +386,165 @@ fn modifier_parameter_values_follow_xterm_convention() {
         let actual = encode(Key::Up, *mods);
         assert_eq!(actual.as_deref(), Some(*expected), "Up + {mods:?} modifier param");
     }
+}
+
+// ── Application cursor mode (DECCKM) ───────────────────────────
+
+fn assert_mode_parity(modes: TerminalModes, cases: &[(Key, Mods, &[u8])]) {
+    for (key, mods, expected) in cases {
+        let actual = encode_with_modes(*key, *mods, modes);
+        assert_eq!(
+            actual.as_deref(),
+            Some(*expected),
+            "mode parity mismatch for {key:?} + {mods:?} (modes={modes:?}): expected {expected:?}, got {actual:?}"
+        );
+    }
+}
+
+const APP_CURSOR: TerminalModes =
+    TerminalModes { application_cursor_keys: true, application_keypad: false };
+
+#[test]
+fn app_cursor_arrows_use_ss3() {
+    assert_mode_parity(
+        APP_CURSOR,
+        &[
+            (Key::Up, NONE, b"\x1bOA"),
+            (Key::Down, NONE, b"\x1bOB"),
+            (Key::Right, NONE, b"\x1bOC"),
+            (Key::Left, NONE, b"\x1bOD"),
+        ],
+    );
+}
+
+#[test]
+fn app_cursor_home_end_use_ss3() {
+    assert_mode_parity(APP_CURSOR, &[(Key::Home, NONE, b"\x1bOH"), (Key::End, NONE, b"\x1bOF")]);
+}
+
+#[test]
+fn app_cursor_modified_arrows_still_use_csi() {
+    assert_mode_parity(
+        APP_CURSOR,
+        &[
+            (Key::Up, CTRL, b"\x1b[1;5A"),
+            (Key::Down, SHIFT, b"\x1b[1;2B"),
+            (Key::Right, ALT, b"\x1b[1;3C"),
+            (Key::Left, CTRL.union(SHIFT), b"\x1b[1;6D"),
+        ],
+    );
+}
+
+#[test]
+fn app_cursor_keypad_nav_uses_ss3() {
+    assert_mode_parity(
+        APP_CURSOR,
+        &[
+            (Key::KP_Up, NONE, b"\x1bOA"),
+            (Key::KP_Down, NONE, b"\x1bOB"),
+            (Key::KP_Right, NONE, b"\x1bOC"),
+            (Key::KP_Left, NONE, b"\x1bOD"),
+            (Key::KP_Home, NONE, b"\x1bOH"),
+            (Key::KP_End, NONE, b"\x1bOF"),
+        ],
+    );
+}
+
+#[test]
+fn normal_mode_arrows_use_csi() {
+    let normal = TerminalModes::default();
+    assert_mode_parity(
+        normal,
+        &[
+            (Key::Up, NONE, b"\x1b[A"),
+            (Key::Down, NONE, b"\x1b[B"),
+            (Key::Right, NONE, b"\x1b[C"),
+            (Key::Left, NONE, b"\x1b[D"),
+        ],
+    );
+}
+
+// ── Application keypad mode (DECKPAM) ──────────────────────────
+
+const APP_KEYPAD: TerminalModes =
+    TerminalModes { application_cursor_keys: false, application_keypad: true };
+
+#[test]
+fn app_keypad_digits_use_ss3() {
+    assert_mode_parity(
+        APP_KEYPAD,
+        &[
+            (Key::KP_0, NONE, b"\x1bOp"),
+            (Key::KP_1, NONE, b"\x1bOq"),
+            (Key::KP_2, NONE, b"\x1bOr"),
+            (Key::KP_3, NONE, b"\x1bOs"),
+            (Key::KP_4, NONE, b"\x1bOt"),
+            (Key::KP_5, NONE, b"\x1bOu"),
+            (Key::KP_6, NONE, b"\x1bOv"),
+            (Key::KP_7, NONE, b"\x1bOw"),
+            (Key::KP_8, NONE, b"\x1bOx"),
+            (Key::KP_9, NONE, b"\x1bOy"),
+        ],
+    );
+}
+
+#[test]
+fn app_keypad_operators_use_ss3() {
+    assert_mode_parity(
+        APP_KEYPAD,
+        &[
+            (Key::KP_Add, NONE, b"\x1bOk"),
+            (Key::KP_Subtract, NONE, b"\x1bOm"),
+            (Key::KP_Multiply, NONE, b"\x1bOj"),
+            (Key::KP_Divide, NONE, b"\x1bOo"),
+            (Key::KP_Decimal, NONE, b"\x1bOn"),
+        ],
+    );
+}
+
+#[test]
+fn app_keypad_enter_uses_ss3() {
+    assert_mode_parity(APP_KEYPAD, &[(Key::KP_Enter, NONE, b"\x1bOM")]);
+}
+
+#[test]
+fn normal_keypad_digits_produce_ascii() {
+    let normal = TerminalModes::default();
+    assert_mode_parity(
+        normal,
+        &[(Key::KP_0, NONE, b"0"), (Key::KP_5, NONE, b"5"), (Key::KP_9, NONE, b"9")],
+    );
+}
+
+#[test]
+fn app_keypad_printable_keys_unchanged() {
+    assert_mode_parity(
+        APP_KEYPAD,
+        &[(Key::a, NONE, b"a"), (Key::z, NONE, b"z"), (Key::space, NONE, b" ")],
+    );
+}
+
+// ── Both modes active ──────────────────────────────────────────
+
+const BOTH_MODES: TerminalModes =
+    TerminalModes { application_cursor_keys: true, application_keypad: true };
+
+#[test]
+fn both_modes_arrows_use_ss3_and_keypad_uses_ss3() {
+    assert_mode_parity(
+        BOTH_MODES,
+        &[
+            (Key::Up, NONE, b"\x1bOA"),
+            (Key::KP_0, NONE, b"\x1bOp"),
+            (Key::KP_Enter, NONE, b"\x1bOM"),
+        ],
+    );
+}
+
+#[test]
+fn both_modes_modified_arrows_still_use_csi() {
+    assert_mode_parity(
+        BOTH_MODES,
+        &[(Key::Up, CTRL, b"\x1b[1;5A"), (Key::Left, SHIFT, b"\x1b[1;2D")],
+    );
 }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.10',
+  version: '0.4.11',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Managed terminal key encoding was stateless — it chose escape sequences from key/modifier combinations alone without consulting terminal interaction modes. This caused incorrect sequences for TUI applications that enable application cursor mode (DECCKM) or application keypad mode (DECKPAM).

### Changes

- **`TerminalModes` struct**: New `Copy` struct with `application_cursor_keys` and `application_keypad` fields, passed by value to encoding functions.
- **Mode-aware encoding**: `encode_terminal_key_input` now consults modes:
  - Unmodified arrow/Home/End keys use SS3 (`\x1bO`) in application cursor mode instead of CSI (`\x1b[`)
  - Modified arrows still use CSI with xterm modifier params (unchanged)
  - Keypad digits/operators/Enter use SS3 sequences in application keypad mode
- **Mode tracking**: `PersistentPaneView` tracks `application_cursor_keys` and `application_keypad` in `Cell<bool>` fields, passed to key encoding on every keystroke.
- **`TerminalModeChanged` handling**: The daemon's `TerminalModeChanged` messages now update the tracked mode state instead of being silently ignored.
- **`restore_interaction_modes`**: Also updates tracked state for consistency after snapshot restore.
- **Version bump**: 0.4.10 → 0.4.11 (4+ source files changed).

## How to manually verify

1. Start rttx with a daemon-backed workspace
2. Run `vim` or `less` (enables application cursor mode)
3. Arrow keys should navigate correctly (SS3 sequences)
4. Exit vim — arrow keys should revert to normal CSI sequences
5. Run `bc` or another keypad-aware app — keypad should produce correct sequences

## Tests added

### Unit tests (mod.rs)
- `app_cursor_mode_arrows_use_ss3` — unmodified arrows produce SS3 in DECCKM
- `app_cursor_mode_modified_arrows_use_csi` — Ctrl+arrow still uses CSI
- `app_keypad_mode_digits_use_ss3` — keypad digits produce SS3 in DECKPAM
- `managed_app_cursor_forwards_ss3_arrows` — end-to-end managed terminal action

### Parity tests (vte_parity.rs) — 12 new tests
- `app_cursor_arrows_use_ss3` / `app_cursor_home_end_use_ss3`
- `app_cursor_modified_arrows_still_use_csi`
- `app_cursor_keypad_nav_uses_ss3`
- `normal_mode_arrows_use_csi`
- `app_keypad_digits_use_ss3` / `app_keypad_operators_use_ss3` / `app_keypad_enter_uses_ss3`
- `normal_keypad_digits_produce_ascii`
- `app_keypad_printable_keys_unchanged`
- `both_modes_arrows_use_ss3_and_keypad_uses_ss3`
- `both_modes_modified_arrows_still_use_csi`

### GTK widget tests (persistent_widget.rs)
- `set_application_modes_updates_terminal_modes` — mode setter/getter roundtrip
- `restore_interaction_modes_updates_tracked_modes` — restore also tracks state

## Tests run

- `cargo test -p rttx --lib`: 672 passed, 0 failed, 182 ignored
- `cargo test -p rttx --test vte_parity`: 39 passed (27 existing + 12 new)
- `cargo test -p rttx-proto`: 333 passed
- `cargo test -p rttx-server --lib`: 383 passed
- `bash .github/scripts/run-clippy.sh`: clean
- `bash .github/scripts/run-quality-tests.sh`: all pass including GTK tests via Broadway

Fixes #767