### PR TITLE
fix: restore focus_reporting and cursor_hidden from managed snapshots on reconnect

### DIFF
--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -577,12 +577,11 @@ impl PersistentPaneView {
         if modes.application_keypad {
             vte.feed(b"\x1b=");
         }
-        let mouse_tracking = u32::from(
-            rttx_proto::v3_terminal_modes::tracking_value_from_mouse_mode(
+        let mouse_tracking =
+            u32::from(rttx_proto::v3_terminal_modes::tracking_value_from_mouse_mode(
                 rttx_proto::v3::MouseMode::try_from(modes.mouse_mode)
                     .unwrap_or(rttx_proto::v3::MouseMode::None),
-            ),
-        );
+            ));
         match mouse_tracking {
             1000 => vte.feed(b"\x1b[?1000h"),
             1002 => vte.feed(b"\x1b[?1002h"),

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -567,30 +567,36 @@ impl PersistentPaneView {
     /// Inject DECSET/DECKPAM sequences into VTE to restore interaction modes
     /// that may have been lost when the mode-setting sequence fell outside the
     /// retained snapshot tail.
-    pub fn restore_interaction_modes(
-        &self,
-        application_cursor_keys: bool,
-        application_keypad: bool,
-        mouse_tracking_mode: u32,
-        sgr_mouse_mode: bool,
-    ) {
-        self.imp().application_cursor_keys.set(application_cursor_keys);
-        self.imp().application_keypad.set(application_keypad);
+    pub fn restore_interaction_modes(&self, modes: &rttx_proto::v3::TerminalModeState) {
+        self.imp().application_cursor_keys.set(modes.application_cursor_keys);
+        self.imp().application_keypad.set(modes.application_keypad);
         let vte = &self.imp().vte;
-        if application_cursor_keys {
+        if modes.application_cursor_keys {
             vte.feed(b"\x1b[?1h");
         }
-        if application_keypad {
+        if modes.application_keypad {
             vte.feed(b"\x1b=");
         }
-        match mouse_tracking_mode {
+        let mouse_tracking = u32::from(
+            rttx_proto::v3_terminal_modes::tracking_value_from_mouse_mode(
+                rttx_proto::v3::MouseMode::try_from(modes.mouse_mode)
+                    .unwrap_or(rttx_proto::v3::MouseMode::None),
+            ),
+        );
+        match mouse_tracking {
             1000 => vte.feed(b"\x1b[?1000h"),
             1002 => vte.feed(b"\x1b[?1002h"),
             1003 => vte.feed(b"\x1b[?1003h"),
             _ => {}
         }
-        if sgr_mouse_mode {
+        if modes.sgr_mouse {
             vte.feed(b"\x1b[?1006h");
+        }
+        if modes.focus_reporting {
+            vte.feed(b"\x1b[?1004h");
+        }
+        if modes.cursor_hidden {
+            vte.feed(b"\x1b[?25l");
         }
     }
 
@@ -1928,9 +1934,13 @@ mod tests {
         require_display!();
 
         let pane = PersistentPaneView::new("pane-1", "runtime-1");
-        // Calling restore_interaction_modes should not panic and should
-        // feed the appropriate escape sequences into VTE.
-        pane.restore_interaction_modes(true, true, 1003, true);
+        pane.restore_interaction_modes(&rttx_proto::v3::TerminalModeState {
+            application_cursor_keys: true,
+            application_keypad: true,
+            mouse_mode: rttx_proto::v3::MouseMode::Any as i32,
+            sgr_mouse: true,
+            ..Default::default()
+        });
         // No panic means VTE accepted the sequences.
     }
 
@@ -1963,7 +1973,11 @@ mod tests {
         require_display!();
 
         let pane = PersistentPaneView::new("restore-mode-1", "runtime-1");
-        pane.restore_interaction_modes(true, true, 0, false);
+        pane.restore_interaction_modes(&rttx_proto::v3::TerminalModeState {
+            application_cursor_keys: true,
+            application_keypad: true,
+            ..Default::default()
+        });
         let modes = pane.terminal_modes();
         assert!(modes.application_cursor_keys);
         assert!(modes.application_keypad);
@@ -1975,8 +1989,24 @@ mod tests {
         require_display!();
 
         let pane = PersistentPaneView::new("pane-1", "runtime-1");
-        pane.restore_interaction_modes(false, false, 0, false);
+        pane.restore_interaction_modes(&rttx_proto::v3::TerminalModeState::default());
         // No sequences injected, no panic.
+    }
+
+    /// `restore_interaction_modes` injects focus reporting and cursor hidden
+    /// sequences into VTE without panic. #765.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn restore_interaction_modes_focus_and_cursor_hidden() {
+        require_display!();
+
+        let pane = PersistentPaneView::new("focus-cursor-1", "runtime-1");
+        pane.restore_interaction_modes(&rttx_proto::v3::TerminalModeState {
+            focus_reporting: true,
+            cursor_hidden: true,
+            ..Default::default()
+        });
+        // VTE accepted DECSET 1004 and DECRST 25 sequences without panic.
     }
 
     #[test]

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -650,15 +650,10 @@ impl Window {
         pane.feed_snapshot(&restore.scrollback_tail);
         if let Some(ref modes) = restore.terminal_modes {
             pane.set_bracketed_paste_mode(modes.bracketed_paste);
-            pane.restore_interaction_modes(
-                modes.application_cursor_keys,
-                modes.application_keypad,
-                u32::from(rttx_proto::v3_terminal_modes::tracking_value_from_mouse_mode(
-                    rttx_proto::v3::MouseMode::try_from(modes.mouse_mode)
-                        .unwrap_or(rttx_proto::v3::MouseMode::None),
-                )),
-                modes.sgr_mouse,
-            );
+            // alternate_screen is intentionally not restored: the snapshot
+            // already contains the rendered screen content, and switching
+            // VTE into alt-screen mode would discard it.
+            pane.restore_interaction_modes(modes);
         }
         pane.set_current_directory(Some(&restore.cwd));
         if !restore.title.is_empty() && pane.custom_title().is_none() {

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -5931,6 +5931,79 @@ fn restore_managed_snapshot_feeds_scrollback_and_cwd_to_pane() {
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
 
+/// Reconnect restore applies `focus_reporting` and `cursor_hidden` from the
+/// snapshot even when the scrollback tail does not contain the original
+/// enabling escape sequences. #765.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn restore_managed_snapshot_applies_focus_and_cursor_modes() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.restore-focus-cursor-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    let layout_uuid = "focus-cursor-pane";
+    let session_state = crate::test_helpers::managed_session(
+        "ws-fc",
+        "Focus Cursor Test",
+        LayoutNode::new_terminal_with_uuid(layout_uuid),
+    );
+    window.imp().state.borrow_mut().workspaces.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    // Scrollback tail intentionally lacks the enabling escape sequences —
+    // the restore path must re-apply modes from the snapshot metadata.
+    let restore = crate::workspace_state::WorkspacePaneRestore {
+        layout_terminal_uuid: layout_uuid.to_string(),
+        title: "htop".to_string(),
+        cwd: "/home/user".to_string(),
+        pane_output_seq: 0,
+        scrollback_tail: bytes::Bytes::from_static(b"plain text only\r\n"),
+        scrollback_complete: true,
+        cols: 80,
+        rows: 24,
+        terminal_modes: Some(rttx_proto::v3::TerminalModeState {
+            bracketed_paste: true,
+            focus_reporting: true,
+            cursor_hidden: true,
+            application_cursor_keys: true,
+            application_keypad: false,
+            alternate_screen: false,
+            mouse_mode: rttx_proto::v3::MouseMode::None as i32,
+            sgr_mouse: false,
+        }),
+    };
+    window.restore_managed_snapshot(&restore);
+
+    let pane = window
+        .imp()
+        .persistent_terminals
+        .borrow()
+        .get(layout_uuid)
+        .cloned()
+        .expect("pane should exist");
+
+    assert!(
+        pane.imp().bracketed_paste_mode.get(),
+        "bracketed paste should be restored from snapshot"
+    );
+    assert!(
+        pane.imp().application_cursor_keys.get(),
+        "application cursor keys should be restored from snapshot"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
 #[test]
 #[ignore = "requires isolated GTK harness"]
 fn restore_managed_snapshot_skips_missing_pane() {

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1196,10 +1196,8 @@ mod tests {
             snapshot: snapshot(&runtime_id, vec![snap]),
         });
 
-        let modes = transition.pane_snapshot_restores[0]
-            .terminal_modes
-            .as_ref()
-            .expect("modes present");
+        let modes =
+            transition.pane_snapshot_restores[0].terminal_modes.as_ref().expect("modes present");
         assert!(modes.focus_reporting);
         assert!(modes.cursor_hidden);
         assert!(modes.alternate_screen);

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1173,6 +1173,38 @@ mod tests {
         assert!(modes.bracketed_paste);
     }
 
+    /// Snapshot with `focus_reporting` and `cursor_hidden` propagates through
+    /// reconciliation so the restore path can re-apply them. #765.
+    #[test]
+    fn reconcile_snapshot_carries_focus_and_cursor_modes() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let terminal_uuid = uuid::Uuid::new_v4().to_string();
+        let mut state =
+            window_state(vec![managed_session("workspace-1", "Workspace", term(&terminal_uuid))]);
+
+        let mut snap = pane_snapshot(&terminal_uuid, "htop", "/home", b"");
+        snap.terminal_modes = Some(v3::TerminalModeState {
+            focus_reporting: true,
+            cursor_hidden: true,
+            alternate_screen: true,
+            ..Default::default()
+        });
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "workspace-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(&runtime_id, vec![snap]),
+        });
+
+        let modes = transition.pane_snapshot_restores[0]
+            .terminal_modes
+            .as_ref()
+            .expect("modes present");
+        assert!(modes.focus_reporting);
+        assert!(modes.cursor_hidden);
+        assert!(modes.alternate_screen);
+    }
+
     #[test]
     fn reconcile_endpoint_event_pane_created_updates_binding_and_requests_recovery() {
         let mut state =

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -1386,6 +1386,7 @@ fn v3_snapshot_terminal_modes_propagate_through_reconciliation() {
     assert!(restore.scrollback_complete);
     let modes = restore.terminal_modes.as_ref().expect("modes should be present");
     assert!(modes.bracketed_paste);
+    assert!(modes.focus_reporting);
     assert!(modes.application_cursor_keys);
     assert!(modes.alternate_screen);
     assert_eq!(modes.mouse_mode, rttx_proto::v3::MouseMode::Normal as i32);

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -1393,6 +1393,68 @@ fn v3_snapshot_terminal_modes_propagate_through_reconciliation() {
     assert!(modes.sgr_mouse);
 }
 
+/// Snapshot with `focus_reporting` and `cursor_hidden` active propagates
+/// through reconciliation so the restore path can re-apply them. #765.
+#[test]
+fn v3_snapshot_focus_and_cursor_modes_propagate_through_reconciliation() {
+    use rttx::workspace::{WindowState, WorkspaceState};
+
+    let runtime_id = uuid::Uuid::new_v4().to_string();
+    let pane_id = uuid::Uuid::new_v4().to_string();
+    let mut state = WindowState {
+        workspaces: vec![WorkspaceState::new_managed_local(
+            "Test".into(),
+            rttx::runtime::WorkspacePolicy::Persistent,
+            None,
+        )],
+        ..WindowState::default()
+    };
+    let ws_id = state.workspaces[0].uuid.clone();
+
+    let snapshot = rttx_proto::v3::RuntimeSnapshot {
+        runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
+        panes: vec![rttx_proto::v3::PaneSnapshot {
+            pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane_id).unwrap()),
+            pane_output_seq: 10,
+            title: "htop".into(),
+            cwd: "/home".into(),
+            cols: 80,
+            rows: 24,
+            exit_status: None,
+            terminal_modes: Some(rttx_proto::v3::TerminalModeState {
+                focus_reporting: true,
+                cursor_hidden: true,
+                bracketed_paste: false,
+                application_cursor_keys: false,
+                application_keypad: false,
+                alternate_screen: false,
+                mouse_mode: rttx_proto::v3::MouseMode::None as i32,
+                sgr_mouse: false,
+            }),
+            scrollback_tail: bytes::Bytes::from_static(b"plain text"),
+            total_scrollback_bytes: 10,
+            scrollback_complete: true,
+        }],
+        runtime_revision: 1,
+        client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
+    };
+
+    let transition =
+        state.reconcile_endpoint_event(&rttx::daemon_bridge::EndpointEvent::WorkspaceOpened {
+            workspace_id: ws_id,
+            runtime_id,
+            snapshot,
+        });
+
+    assert_eq!(transition.pane_snapshot_restores.len(), 1);
+    let modes = transition.pane_snapshot_restores[0]
+        .terminal_modes
+        .as_ref()
+        .expect("modes should be present");
+    assert!(modes.focus_reporting, "focus_reporting must propagate");
+    assert!(modes.cursor_hidden, "cursor_hidden must propagate");
+}
+
 /// Serialized workspace state must not contain the legacy `mode` field.
 /// The `runtime` struct carries endpoint and policy; `mode` is import-only.
 #[test]


### PR DESCRIPTION
## What changed and why

The managed reconnect restore path (`restore_managed_snapshot`) was incomplete — it restored bracketed paste, application cursor/keypad, mouse tracking, and SGR mouse from the v3 snapshot `TerminalModeState`, but did not restore **focus reporting** (DECSET 1004) or **cursor visibility** (DECRST 25).

This left reconnect semantics weaker than the snapshot contract and caused visible drift for TUI applications that rely on these modes.

### Changes

- Refactored `restore_interaction_modes` on `PersistentPaneView` to accept `&v3::TerminalModeState` directly instead of individual bool parameters (also fixes clippy `fn_params_excessive_bools` lint)
- Added DECSET 1004 (focus reporting) and DECRST 25 (cursor hidden) sequence injection
- Moved mouse mode conversion into `restore_interaction_modes` for better encapsulation
- Documented that `alternate_screen` is intentionally not restored (the snapshot already contains the rendered screen content)

### Manual verification

1. Build with `cargo build -p rttx --no-default-features --features vte-0_76`
2. Run a TUI app (e.g. htop) in a daemon-backed workspace
3. Disconnect and reconnect — focus reporting and cursor visibility should match pre-disconnect state

### Tests added

**Unit tests:**
- `reconcile_snapshot_carries_focus_and_cursor_modes` — verifies focus_reporting and cursor_hidden propagate through reconciliation

**GTK widget tests:**
- `restore_interaction_modes_focus_and_cursor_hidden` — verifies VTE accepts DECSET 1004 and DECRST 25 sequences without panic

**GTK integration tests:**
- `restore_managed_snapshot_applies_focus_and_cursor_modes` — end-to-end test proving mode restoration from snapshot metadata even when scrollback tail lacks the original enabling sequences

**Strengthened existing tests:**
- `v3_snapshot_terminal_modes_propagate_through_reconciliation` — added `focus_reporting` assertion

### Tests run

- `cargo test --workspace` (with VTE 0.76 features) — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — 673 passed, 0 failed; all new GTK tests confirmed running and passing

Fixes #765