### PR TITLE
chore(client): remove legacy sessions.json fallback and v1 persistence code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,7 +331,6 @@ Key rules:
 - Store paths are injectable via `StorePaths` for tests.
 - New persisted fields must use `#[serde(default)]` for backward compatibility.
 - New documents require a schema identifier and version in the envelope.
-- `SessionMode` is import-only — new code must not create canonical `SessionMode` records.
 
 See `designs/RFC-023-client-configuration-state-store.md` for the full design.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.12"
+version = "0.4.13"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/store/models/workspaces.rs
+++ b/clients/rttx/src/store/models/workspaces.rs
@@ -441,7 +441,6 @@ impl WorkspaceRecord {
                 .collect(),
             active_terminal_uuid: self.active_pane_id.clone(),
             input_sync: matches!(self.input_sync, InputSyncState::On),
-            mode: state::WorkspaceMode::default(),
             runtime,
             color: (&self.color).into(),
             zoomed_terminal_uuid: self.zoomed_pane_id.clone(),

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1399,13 +1399,12 @@ mod search_tests {
         assert_eq!(prefs.paste_guard_threshold, 1024);
     }
 
-    /// Legacy persisted state with bookmark source must deserialize without
-    /// error after the Bookmark variant was removed from `PaneSource`.
+    /// Removed `PaneSource` variants must fail to deserialize now that the
+    /// legacy backward-compat layer is gone.
     #[test]
-    fn legacy_bookmark_pane_source_deserializes_after_removal() {
+    fn removed_pane_source_variant_rejects_on_deserialize() {
         let json = r#"{"source":{"bookmark":{"name":"Prod"}},"target":null,"startup":[]}"#;
-        let recovery: crate::workspace::PaneRecovery = serde_json::from_str(json).unwrap();
-        assert_eq!(recovery.source, crate::workspace::PaneSource::Manual);
+        assert!(serde_json::from_str::<crate::workspace::PaneRecovery>(json).is_err());
     }
 
     #[test]

--- a/clients/rttx/src/test_helpers.rs
+++ b/clients/rttx/src/test_helpers.rs
@@ -5,8 +5,7 @@
 use crate::color_scheme::ColorScheme;
 use crate::runtime::{RuntimeEndpoint, WorkspacePolicy, WorkspaceRuntime};
 use crate::workspace::{
-    LayoutNode, PaneRecovery, SplitOrientation, WindowState, WorkspaceColor, WorkspaceMode,
-    WorkspaceState,
+    LayoutNode, PaneRecovery, SplitOrientation, WindowState, WorkspaceColor, WorkspaceState,
 };
 use std::path::{Path, PathBuf};
 
@@ -72,7 +71,6 @@ pub fn workspace(id: &str, name: &str, layout: LayoutNode) -> WorkspaceState {
         terminal_recovery: std::collections::BTreeMap::default(),
         active_terminal_uuid: None,
         input_sync: false,
-        mode: WorkspaceMode::default(),
         runtime: WorkspaceRuntime::default(),
         color: WorkspaceColor::default(),
         zoomed_terminal_uuid: None,
@@ -117,7 +115,6 @@ pub fn managed_session_with_runtime(
         terminal_recovery,
         active_terminal_uuid,
         input_sync: false,
-        mode: WorkspaceMode::default(),
         runtime: WorkspaceRuntime {
             managed: true,
             endpoint,
@@ -237,26 +234,6 @@ pub fn remove_env(key: &str) {
 }
 
 // ── Persistence helpers ──────────────────────────────────────────
-
-/// Save a window state to a temp directory (bypasses glib config dir).
-pub fn save_state_to(dir: &Path, state: &WindowState) -> Result<(), Box<dyn std::error::Error>> {
-    let workspaces_dir = dir.join(crate::config::CONFIG_DIR).join("sessions");
-    std::fs::create_dir_all(&workspaces_dir)?;
-    let path = workspaces_dir.join("window-state.json");
-    let json = serde_json::to_string_pretty(state)?;
-    std::fs::write(path, json)?;
-    Ok(())
-}
-
-/// Load a window state from a temp directory (bypasses glib config dir).
-#[must_use]
-pub fn load_state_from(dir: &Path) -> WindowState {
-    let path = dir.join(crate::config::CONFIG_DIR).join("sessions").join("window-state.json");
-    std::fs::read_to_string(path).map_or_else(
-        |_| WindowState::default(),
-        |json| serde_json::from_str(&json).unwrap_or_default(),
-    )
-}
 
 /// Save a color scheme to a temp directory.
 pub fn save_scheme_to(

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -365,28 +365,23 @@ impl Window {
     fn load_state(&self) {
         let store = crate::store::default_store();
 
-        // Load workspace state from the new store, falling back to legacy.
         let ws_store = store.load_workspaces().into_value().unwrap_or_default();
         let ui = store.load_ui_state().into_value().unwrap_or_default();
         let cache = store.load_runtime_cache().into_value().unwrap_or_default();
 
-        let state = if ws_store.workspaces.is_empty() {
-            // One-time legacy import: read sessions.json and migrate
-            // WorkspaceMode into WorkspaceRuntime.
-            let mut legacy = workspace::load_window_state();
-            legacy.dismissed_runtime_ids.extend(cache.dismissed_runtime_ids);
-            legacy
+        let workspaces: Vec<_> = ws_store
+            .workspaces
+            .iter()
+            .map(crate::store::models::workspaces::WorkspaceRecord::to_workspace_state)
+            .collect();
+        let active_workspace_index = ws_store
+            .active_workspace_id
+            .as_ref()
+            .and_then(|id| workspaces.iter().position(|ws| ws.uuid == *id))
+            .unwrap_or(0);
+        let state = if workspaces.is_empty() {
+            WindowState::default()
         } else {
-            let workspaces: Vec<_> = ws_store
-                .workspaces
-                .iter()
-                .map(crate::store::models::workspaces::WorkspaceRecord::to_workspace_state)
-                .collect();
-            let active_workspace_index = ws_store
-                .active_workspace_id
-                .as_ref()
-                .and_then(|id| workspaces.iter().position(|ws| ws.uuid == *id))
-                .unwrap_or(0);
             WindowState {
                 workspaces,
                 active_workspace_index,

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -156,7 +156,6 @@ fn make_state_two_sessions() -> WindowState {
                 terminal_recovery: Default::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: Default::default(),
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
@@ -169,7 +168,6 @@ fn make_state_two_sessions() -> WindowState {
                 terminal_recovery: Default::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: Default::default(),
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
@@ -216,7 +214,6 @@ fn terminal_in_visible_session_with_split_suppresses_notification() {
             terminal_recovery: Default::default(),
             active_terminal_uuid: None,
             input_sync: false,
-            mode: Default::default(),
             runtime: Default::default(),
             color: Default::default(),
             zoomed_terminal_uuid: None,
@@ -256,7 +253,6 @@ fn preferred_command_target_uuid_uses_focused_terminal_first() {
             terminal_recovery: Default::default(),
             active_terminal_uuid: None,
             input_sync: false,
-            mode: Default::default(),
             runtime: Default::default(),
             color: Default::default(),
             zoomed_terminal_uuid: None,
@@ -284,7 +280,6 @@ fn preferred_command_target_uuid_falls_back_to_visible_session() {
                 terminal_recovery: Default::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: Default::default(),
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
@@ -302,7 +297,6 @@ fn preferred_command_target_uuid_falls_back_to_visible_session() {
                 terminal_recovery: Default::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: Default::default(),
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
@@ -571,7 +565,6 @@ fn failed_structured_recovery_keeps_terminal_alive_and_allows_retry() {
             )]),
             active_terminal_uuid: Some(terminal_uuid.clone()),
             input_sync: false,
-            mode: Default::default(),
             runtime: Default::default(),
             color: Default::default(),
             zoomed_terminal_uuid: None,
@@ -2726,7 +2719,6 @@ fn load_state_keeps_selected_row_and_visible_session_in_sync() {
                 terminal_recovery: Default::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: Default::default(),
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
@@ -2739,7 +2731,6 @@ fn load_state_keeps_selected_row_and_visible_session_in_sync() {
                 terminal_recovery: Default::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: Default::default(),
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
@@ -3021,7 +3012,6 @@ fn save_state_persists_terminated_workspace_without_runtime_id() {
     );
     assert_eq!(saved_session.runtime.policy, WorkspacePolicy::Persistent);
     assert_eq!(saved_session.runtime.runtime_id, None);
-    assert_eq!(saved_session.mode, crate::workspace::WorkspaceMode::Direct,);
     assert_eq!(
         saved_session.runtime.pane_bindings.get("managed-pane").map(String::as_str),
         Some("managed-pane")

--- a/clients/rttx/src/workspace/mod.rs
+++ b/clients/rttx/src/workspace/mod.rs
@@ -4,42 +4,10 @@ pub mod state;
 
 pub use layout::{Direction, LayoutNode, MAX_SPLIT_DEPTH, SplitOrientation};
 pub use recovery::{PaneRecovery, PaneSource, PaneTarget, StartupStep};
-pub use state::{WindowState, WorkspaceColor, WorkspaceMode, WorkspaceState};
+pub use state::{WindowState, WorkspaceColor, WorkspaceState};
 
-use crate::config;
 use gtk4::glib;
 use gtk4::prelude::*;
-use std::fs;
-use std::path::PathBuf;
-
-/// Returns the path to the sessions directory in `XDG_CONFIG_HOME`.
-#[must_use]
-pub fn workspaces_dir() -> Option<PathBuf> {
-    Some(config::config_dir_path())
-}
-
-/// Load the legacy window state from `sessions.json`, or return default.
-///
-/// Used only for one-time import when the new store is empty.
-/// New code should use `ClientStore` instead.
-#[must_use]
-pub fn load_window_state() -> WindowState {
-    let Some(mut path) = workspaces_dir() else {
-        return WindowState::default();
-    };
-    path.push("sessions.json");
-    fs::read_to_string(path).map_or_else(
-        |_| WindowState::default(),
-        |json| {
-            let mut state = serde_json::from_str::<WindowState>(&json).unwrap_or_default();
-            for session in &mut state.workspaces {
-                session.normalize_runtime_metadata();
-                session.normalize_active_terminal();
-            }
-            state
-        },
-    )
-}
 
 /// Walk the live widget tree and apply split ratios to `GtkPaned` positions.
 ///
@@ -271,7 +239,6 @@ fn apply_initial_paned_ratios(layout: &LayoutNode, widget: &gtk4::Widget) {
 mod tests {
     use super::*;
     use std::sync::Once;
-    use tempfile::TempDir;
 
     static GTK_INIT: Once = Once::new();
     static GTK_AVAILABLE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
@@ -301,72 +268,6 @@ mod tests {
                 return;
             }
         };
-    }
-
-    #[test]
-    fn save_and_load_roundtrip() {
-        let tmp = TempDir::new().unwrap();
-        let state = WindowState { width: 123, height: 456, ..WindowState::default() };
-
-        let path = tmp.path().join("sessions.json");
-        let json = serde_json::to_string_pretty(&state).unwrap();
-        fs::write(&path, json).unwrap();
-
-        let loaded = load_state_from(tmp.path());
-        assert_eq!(state.width, loaded.width);
-        assert_eq!(state.height, loaded.height);
-    }
-
-    #[test]
-    fn save_complex_layout_and_reload() {
-        let tmp = TempDir::new().unwrap();
-        let mut state = WindowState::default();
-        let root = LayoutNode::Terminal {
-            uuid: "t1".into(),
-            profile: None,
-            cwd: None,
-            custom_title: None,
-        };
-        state.workspaces[0].layout = root.split(SplitOrientation::Horizontal);
-
-        let path = tmp.path().join("sessions.json");
-        let json = serde_json::to_string_pretty(&state).unwrap();
-        fs::write(&path, json).unwrap();
-
-        let loaded = load_state_from(tmp.path());
-        assert_eq!(state.workspaces[0].layout, loaded.workspaces[0].layout);
-    }
-
-    #[rstest::rstest]
-    #[case(0)]
-    #[case(1)]
-    #[case(99)]
-    fn window_state_active_index_preserved(#[case] index: usize) {
-        let tmp = TempDir::new().unwrap();
-        let state = WindowState { active_workspace_index: index, ..WindowState::default() };
-
-        let path = tmp.path().join("sessions.json");
-        let json = serde_json::to_string_pretty(&state).unwrap();
-        fs::write(&path, json).unwrap();
-
-        let loaded = load_state_from(tmp.path());
-        assert_eq!(state.active_workspace_index, loaded.active_workspace_index);
-    }
-
-    #[test]
-    fn load_returns_default_when_no_file() {
-        let tmp = TempDir::new().unwrap();
-        let loaded = load_state_from(tmp.path());
-        assert_eq!(loaded, WindowState::default_for_test());
-    }
-
-    #[test]
-    fn load_returns_default_on_corrupt_json() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("sessions.json");
-        fs::write(path, "{corrupt").unwrap();
-        let loaded = load_state_from(tmp.path());
-        assert_eq!(loaded, WindowState::default_for_test());
     }
 
     #[test]
@@ -432,13 +333,5 @@ mod tests {
             (inner_ratio - 0.7).abs() < 0.03,
             "inner split should restore saved ratio from a non-sentinel position, got {inner_ratio}"
         );
-    }
-
-    fn load_state_from(dir: &std::path::Path) -> WindowState {
-        let path = dir.join("sessions.json");
-        fs::read_to_string(path).map_or_else(
-            |_| WindowState::default_for_test(),
-            |json| serde_json::from_str(&json).unwrap_or_else(|_| WindowState::default_for_test()),
-        )
     }
 }

--- a/clients/rttx/src/workspace/recovery.rs
+++ b/clients/rttx/src/workspace/recovery.rs
@@ -8,37 +8,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::shell_quote;
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum PaneSource {
     EmptyShell,
     Command { title: String },
     Manual,
-}
-
-impl<'de> Deserialize<'de> for PaneSource {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        /// Mirror of `PaneSource` that includes removed variants for backward
-        /// compatibility with persisted state.
-        #[derive(Deserialize)]
-        #[serde(rename_all = "kebab-case")]
-        #[allow(dead_code)] // fields in removed variants are intentionally discarded
-        enum Raw {
-            EmptyShell,
-            Bookmark { name: String },
-            Command { title: String },
-            SessionTemplate { name: String },
-            Manual,
-        }
-        match Raw::deserialize(deserializer)? {
-            Raw::EmptyShell => Ok(Self::EmptyShell),
-            Raw::Command { title } => Ok(Self::Command { title }),
-            Raw::Bookmark { .. } | Raw::SessionTemplate { .. } | Raw::Manual => Ok(Self::Manual),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -57,23 +32,10 @@ pub enum PaneTarget {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PaneRecovery {
     pub source: PaneSource,
-    #[serde(default, deserialize_with = "deserialize_pane_target")]
+    #[serde(default)]
     pub target: Option<PaneTarget>,
     #[serde(default)]
     pub startup: Vec<StartupStep>,
-}
-
-/// Deserializes `Option<PaneTarget>`, mapping removed variants (local-tmux,
-/// remote-tmux) to `None` so old persisted state loads without error.
-fn deserialize_pane_target<'de, D>(deserializer: D) -> Result<Option<PaneTarget>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value: Option<serde_json::Value> = Option::deserialize(deserializer)?;
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    Ok(serde_json::from_value::<PaneTarget>(value).ok())
 }
 
 impl PaneRecovery {
@@ -179,43 +141,20 @@ mod tests {
     }
 
     #[test]
-    fn legacy_local_tmux_target_deserializes_as_none() {
-        let json = r#"{"source":"empty-shell","target":{"local-tmux":{"session":"dev"}}}"#;
-        let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
-        assert_eq!(recovery.target, None);
+    fn removed_pane_source_variants_fail_to_deserialize() {
+        let bookmark_json = r#"{"source":{"bookmark":{"name":"Prod"}}}"#;
+        assert!(serde_json::from_str::<PaneRecovery>(bookmark_json).is_err());
+
+        let template_json = r#"{"source":{"session-template":{"name":"Dev Setup"}}}"#;
+        assert!(serde_json::from_str::<PaneRecovery>(template_json).is_err());
     }
 
     #[test]
-    fn legacy_remote_tmux_target_deserializes_as_none() {
-        let json = r#"{"source":{"bookmark":{"name":"Prod"}},"target":{"remote-tmux":{"ssh_target":"host","tmux_session":"web"}}}"#;
-        let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
-        assert_eq!(recovery.target, None);
-        assert_eq!(recovery.source, PaneSource::Manual);
-    }
+    fn removed_pane_target_variants_fail_to_deserialize() {
+        let local_tmux = r#"{"source":"empty-shell","target":{"local-tmux":{"session":"dev"}}}"#;
+        assert!(serde_json::from_str::<PaneRecovery>(local_tmux).is_err());
 
-    #[test]
-    fn legacy_session_template_source_deserializes_as_manual() {
-        let json = r#"{"source":{"session-template":{"name":"Dev Setup"}}}"#;
-        let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
-        assert_eq!(recovery.source, PaneSource::Manual);
-    }
-
-    #[test]
-    fn legacy_bookmark_source_deserializes_as_manual() {
-        let json = r#"{"source":{"bookmark":{"name":"Prod"}}}"#;
-        let recovery: PaneRecovery = serde_json::from_str(json).unwrap();
-        assert_eq!(recovery.source, PaneSource::Manual);
-    }
-
-    #[test]
-    fn session_template_variant_absent_from_enum() {
-        let json = serde_json::to_string(&PaneSource::Manual).unwrap();
-        assert!(!json.contains("session-template"));
-    }
-
-    #[test]
-    fn bookmark_variant_absent_from_serialized_enum() {
-        let json = serde_json::to_string(&PaneSource::Manual).unwrap();
-        assert!(!json.contains("bookmark"));
+        let remote_tmux = r#"{"source":"manual","target":{"remote-tmux":{"ssh_target":"host","tmux_session":"web"}}}"#;
+        assert!(serde_json::from_str::<PaneRecovery>(remote_tmux).is_err());
     }
 }

--- a/clients/rttx/src/workspace/state.rs
+++ b/clients/rttx/src/workspace/state.rs
@@ -3,10 +3,6 @@
 //! `WorkspaceState` is the in-memory representation of a single workspace.
 //! `WindowState` is the in-memory aggregate used by the window; persistence
 //! is handled by `ClientStore` (RFC-023).
-//!
-//! Legacy `sessions.json` files are still readable for one-time import.
-//! Changes to `WorkspaceState` must preserve backward compatibility via
-//! `#[serde(default)]` for that import path.
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -14,47 +10,6 @@ use std::collections::BTreeMap;
 use super::layout::LayoutNode;
 use super::recovery::PaneRecovery;
 use crate::runtime::{RuntimeEndpoint, WorkspacePolicy, WorkspaceRuntime};
-
-/// How a session's terminals are backed.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub enum WorkspaceMode {
-    #[default]
-    Direct,
-    Persistent {
-        #[serde(alias = "daemon_session_id")]
-        daemon_runtime_id: String,
-    },
-    RemotePersistent {
-        host: String,
-        #[serde(alias = "daemon_session_id")]
-        daemon_runtime_id: String,
-    },
-}
-
-impl WorkspaceMode {
-    #[must_use]
-    pub const fn is_persistent(&self) -> bool {
-        !matches!(self, Self::Direct)
-    }
-
-    #[must_use]
-    pub fn daemon_runtime_id(&self) -> Option<&str> {
-        match self {
-            Self::Direct => None,
-            Self::Persistent { daemon_runtime_id }
-            | Self::RemotePersistent { daemon_runtime_id, .. } => Some(daemon_runtime_id),
-        }
-    }
-
-    #[must_use]
-    pub fn host(&self) -> Option<&str> {
-        match self {
-            Self::RemotePersistent { host, .. } => Some(host),
-            _ => None,
-        }
-    }
-}
 
 /// Accent color for a session's sidebar indicator dot.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -112,8 +67,6 @@ pub struct WorkspaceState {
     pub active_terminal_uuid: Option<String>,
     #[serde(default)]
     pub input_sync: bool,
-    #[serde(default, skip_serializing)]
-    pub mode: WorkspaceMode,
     #[serde(default)]
     pub runtime: WorkspaceRuntime,
     #[serde(default)]
@@ -150,7 +103,6 @@ impl WorkspaceState {
             terminal_recovery,
             active_terminal_uuid,
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -195,7 +147,6 @@ impl WorkspaceState {
             terminal_recovery,
             active_terminal_uuid: Some("test-terminal-uuid".to_string()),
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -207,38 +158,12 @@ impl WorkspaceState {
 impl WorkspaceState {
     #[must_use]
     pub const fn uses_managed_runtime(&self) -> bool {
-        self.runtime.is_managed() || self.mode.is_persistent()
+        self.runtime.is_managed()
     }
 
     #[must_use]
     pub const fn is_zoomed(&self) -> bool {
         self.zoomed_terminal_uuid.is_some()
-    }
-
-    pub fn normalize_runtime_metadata(&mut self) {
-        if !self.runtime.is_managed() {
-            match &self.mode {
-                WorkspaceMode::Direct => {}
-                WorkspaceMode::Persistent { daemon_runtime_id } => {
-                    self.runtime.managed = true;
-                    self.runtime.endpoint = RuntimeEndpoint::Local;
-                    self.runtime.policy = WorkspacePolicy::Persistent;
-                    if !daemon_runtime_id.is_empty() {
-                        self.runtime.runtime_id = Some(daemon_runtime_id.clone());
-                    }
-                }
-                WorkspaceMode::RemotePersistent { host, daemon_runtime_id } => {
-                    self.runtime.managed = true;
-                    self.runtime.endpoint = RuntimeEndpoint::Remote { host: host.clone() };
-                    self.runtime.policy = WorkspacePolicy::Persistent;
-                    if !daemon_runtime_id.is_empty() {
-                        self.runtime.runtime_id = Some(daemon_runtime_id.clone());
-                    }
-                }
-            }
-        }
-
-        self.runtime.ensure_placeholder_bindings(&self.layout.terminal_uuids());
     }
 
     pub fn set_recovery(&mut self, terminal_uuid: &str, recovery: PaneRecovery) {
@@ -325,9 +250,7 @@ const fn default_right_sidebar_width() -> i32 {
 /// Persistent state of the entire application window.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WindowState {
-    #[serde(alias = "sessions")]
     pub workspaces: Vec<WorkspaceState>,
-    #[serde(alias = "active_session_index")]
     pub active_workspace_index: usize,
     pub width: i32,
     pub height: i32,
@@ -402,7 +325,6 @@ mod tests {
             terminal_recovery,
             active_terminal_uuid: Some("t2".into()),
             input_sync: true,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -453,72 +375,12 @@ mod tests {
     }
 
     #[test]
-    fn mode_is_not_written_to_json() {
+    fn mode_field_absent_from_workspace_state() {
         let session =
             WorkspaceState::new_managed_local("Test".into(), WorkspacePolicy::Persistent, None);
-        assert!(session.runtime.is_managed());
         let json = serde_json::to_string(&session).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert!(
-            value.get("mode").is_none(),
-            "mode must not be serialized — it is import-only for legacy files"
-        );
-    }
-
-    #[test]
-    fn legacy_mode_still_deserializes_for_import() {
-        let json = r#"{
-            "uuid": "s1",
-            "name": "Legacy",
-            "layout": {"Terminal": {"uuid": "t1"}},
-            "mode": {"persistent": {"daemon_runtime_id": "rt-1"}}
-        }"#;
-        let session: WorkspaceState = serde_json::from_str(json).unwrap();
-        assert_eq!(session.mode, WorkspaceMode::Persistent { daemon_runtime_id: "rt-1".into() });
-    }
-
-    #[test]
-    fn backward_compat_session_without_mode_field() {
-        let json = r#"{
-            "uuid": "s1",
-            "name": "Old",
-            "layout": {"Terminal": {"uuid": "t1", "profile": null, "cwd": null, "custom_title": null}},
-            "terminal_recovery": {},
-            "active_terminal_uuid": "t1",
-            "input_sync": false
-        }"#;
-        let session: WorkspaceState = serde_json::from_str(json).unwrap();
-        assert_eq!(session.mode, WorkspaceMode::Direct);
-    }
-
-    #[test]
-    fn persistent_session_in_window_state_roundtrips_via_runtime() {
-        let mut session = WorkspaceState::new("Persistent".into());
-        session.mode = WorkspaceMode::Persistent { daemon_runtime_id: "ds-1".into() };
-        session.normalize_runtime_metadata();
-
-        let state = WindowState {
-            workspaces: vec![WorkspaceState::new("Direct".into()), session],
-            active_workspace_index: 1,
-            width: 1920,
-            height: 1080,
-            is_maximized: false,
-            ..WindowState::default()
-        };
-        let json = serde_json::to_string(&state).unwrap();
-        let restored: WindowState = serde_json::from_str(&json).unwrap();
-        assert_eq!(
-            restored.workspaces[0].mode,
-            WorkspaceMode::Direct,
-            "mode is no longer serialized"
-        );
-        assert_eq!(
-            restored.workspaces[1].mode,
-            WorkspaceMode::Direct,
-            "mode is no longer serialized"
-        );
-        assert!(restored.workspaces[1].runtime.is_managed());
-        assert_eq!(restored.workspaces[1].runtime.runtime_id.as_deref(), Some("ds-1"));
+        assert!(value.get("mode").is_none(), "mode field must not exist in WorkspaceState");
     }
 
     #[test]
@@ -531,60 +393,6 @@ mod tests {
         assert_eq!(session.runtime.pane_bindings.len(), 1);
         let only_binding = session.runtime.pane_bindings.iter().next().unwrap();
         assert_eq!(only_binding.0, only_binding.1);
-    }
-
-    #[test]
-    fn normalize_runtime_metadata_migrates_remote_legacy_mode() {
-        let mut session = WorkspaceState::new("Remote".into());
-        session.mode = WorkspaceMode::RemotePersistent {
-            host: "deploy@example.com".into(),
-            daemon_runtime_id: "runtime-1".into(),
-        };
-        session.normalize_runtime_metadata();
-        assert!(session.runtime.is_managed());
-        assert_eq!(
-            session.runtime.endpoint,
-            RuntimeEndpoint::Remote { host: "deploy@example.com".into() }
-        );
-        assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
-        assert_eq!(session.runtime.runtime_id.as_deref(), Some("runtime-1"));
-        assert_eq!(session.runtime.pane_bindings.len(), 1);
-    }
-
-    #[test]
-    fn normalize_runtime_metadata_preserves_detached_remote_workspace_without_runtime_id() {
-        let json = r#"{
-            "uuid": "workspace-1",
-            "name": "Detached Remote",
-            "layout": {"Terminal": {"uuid": "pane-1", "profile": null, "cwd": null, "custom_title": null}},
-            "terminal_recovery": {},
-            "active_terminal_uuid": "pane-1",
-            "input_sync": false,
-            "mode": {
-                "remote-persistent": {
-                    "host": "deploy@example.com",
-                    "daemon_runtime_id": ""
-                }
-            }
-        }"#;
-        let mut session: WorkspaceState = serde_json::from_str(json).unwrap();
-        session.normalize_runtime_metadata();
-        assert!(session.runtime.is_managed());
-        assert_eq!(
-            session.runtime.endpoint,
-            RuntimeEndpoint::Remote { host: "deploy@example.com".into() }
-        );
-        assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
-        assert_eq!(session.runtime.runtime_id, None);
-        assert_eq!(
-            session.mode,
-            WorkspaceMode::RemotePersistent {
-                host: "deploy@example.com".into(),
-                daemon_runtime_id: String::new(),
-            }
-        );
-        assert_eq!(session.runtime.pane_bindings.get("pane-1").map(String::as_str), Some("pane-1"));
-        assert!(session.runtime.pending_layout_panes.contains("pane-1"));
     }
 
     #[test]
@@ -645,7 +453,6 @@ mod tests {
             ]),
             active_terminal_uuid: Some("ghost".into()),
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -667,7 +474,6 @@ mod tests {
             terminal_recovery: BTreeMap::default(),
             active_terminal_uuid: Some("ghost".into()),
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -701,7 +507,6 @@ mod tests {
             terminal_recovery,
             active_terminal_uuid: Some("t1".into()),
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -745,22 +550,20 @@ mod tests {
             "height": 600,
             "is_maximized": false
         }"#;
-        let state: WindowState = serde_json::from_str(json).unwrap();
-        assert_eq!(state.workspaces.len(), 1);
-        assert_eq!(state.workspaces[0].name, "Old");
-        assert_eq!(state.active_workspace_index, 0);
+        let result = serde_json::from_str::<WindowState>(json);
+        assert!(result.is_err(), "legacy sessions/active_session_index keys must no longer parse");
     }
 
     #[test]
-    fn workspace_mode_loads_legacy_daemon_session_id() {
+    fn unknown_mode_field_is_ignored_on_deserialize() {
         let json = r#"{
             "uuid": "s1",
             "name": "Legacy",
             "layout": {"Terminal": {"uuid": "t1"}},
-            "mode": {"persistent": {"daemon_session_id": "ds-1"}}
+            "mode": {"persistent": {"daemon_runtime_id": "rt-1"}}
         }"#;
-        let ws: WorkspaceState = serde_json::from_str(json).unwrap();
-        assert_eq!(ws.mode.daemon_runtime_id(), Some("ds-1"));
+        let session: WorkspaceState = serde_json::from_str(json).unwrap();
+        assert!(!session.uses_managed_runtime(), "unknown mode field should be silently ignored");
     }
 }
 
@@ -808,7 +611,6 @@ mod module_boundary_tests {
             RuntimeEndpoint::Remote { host: "server.example.com".into() }
         );
         assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
-        assert_eq!(session.mode, WorkspaceMode::Direct, "mode is no longer written");
         assert_eq!(
             session.layout.terminal_cwd(&session.layout.terminal_uuids()[0]).as_deref(),
             Some("/home/user")

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -663,6 +663,15 @@ mod tests {
         }
     }
 
+    /// `WorkspaceMode` was removed — serialized state must not contain it.
+    #[test]
+    fn serialized_workspace_state_has_no_mode_field() {
+        let state = window_state(vec![managed_session("ws-1", "Workspace", term("pane-1"))]);
+        let json = serde_json::to_string(&state.workspaces[0]).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value.get("mode").is_none(), "WorkspaceMode must be fully removed");
+    }
+
     #[test]
     fn managed_terminal_binding_ignores_placeholders_and_uses_explicit_runtime_bindings() {
         let runtime_id = uuid::Uuid::new_v4().to_string();

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1958,23 +1958,4 @@ mod tests {
         assert!(round_tripped.smart_clipboard);
         assert_eq!(round_tripped.paste_guard_threshold, 512);
     }
-
-    #[test]
-    fn runtime_operations_do_not_write_legacy_mode() {
-        use crate::workspace::WorkspaceMode;
-
-        let mut state = window_state(vec![managed_session("ws-1", "Workspace", term("pane-1"))]);
-
-        // Simulate pane creation — mode must stay Direct.
-        state.apply_managed_pane_created("ws-1", "pane-1", "rt-1", "daemon-pane-1");
-        assert_eq!(state.workspaces[0].mode, WorkspaceMode::Direct);
-
-        // Simulate runtime termination — mode must stay Direct.
-        let _ = state.reconcile_endpoint_event(&EndpointEvent::RuntimeTerminated {
-            workspace_id: "ws-1".into(),
-            runtime_id: "rt-1".into(),
-            reason: rttx_proto::v3::RuntimeTerminationReason::Explicit,
-        });
-        assert_eq!(state.workspaces[0].mode, WorkspaceMode::Direct);
-    }
 }

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -161,7 +161,6 @@ fn contract_any_constructible_state_roundtrips() {
                 terminal_recovery: Default::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: Default::default(),
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
@@ -180,7 +179,6 @@ fn contract_any_constructible_state_roundtrips() {
                 terminal_recovery: Default::default(),
                 active_terminal_uuid: None,
                 input_sync: true,
-                mode: Default::default(),
                 runtime: Default::default(),
                 color: Default::default(),
                 zoomed_terminal_uuid: None,
@@ -202,7 +200,6 @@ fn contract_any_constructible_state_roundtrips() {
                     terminal_recovery: Default::default(),
                     active_terminal_uuid: None,
                     input_sync: false,
-                    mode: Default::default(),
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
@@ -221,7 +218,6 @@ fn contract_any_constructible_state_roundtrips() {
                     terminal_recovery: Default::default(),
                     active_terminal_uuid: None,
                     input_sync: i % 2 == 0,
-                    mode: Default::default(),
                     runtime: Default::default(),
                     color: Default::default(),
                     zoomed_terminal_uuid: None,
@@ -254,7 +250,7 @@ fn contract_any_constructible_state_roundtrips() {
 fn contract_forward_compat_missing_fields() {
     // Simulate v0.1 state without input_sync or custom_title
     let old_json = r#"{
-        "sessions": [{
+        "workspaces": [{
             "uuid": "s1", "name": "Old",
             "layout": {"Split": {
                 "orientation": "horizontal",
@@ -278,7 +274,7 @@ fn contract_forward_compat_missing_fields() {
 #[test]
 fn contract_backward_compat_extra_fields() {
     let future_json = r#"{
-        "sessions": [{
+        "workspaces": [{
             "uuid": "s1", "name": "Future",
             "layout": {"Terminal": {"uuid": "t1", "profile": null, "cwd": null, "custom_title": null}},
             "input_sync": false,
@@ -620,7 +616,7 @@ fn contract_borrow_released_before_signal_does_not_panic() {
 #[test]
 fn contract_active_workspace_index_out_of_bounds_is_clamped_safely() {
     let json = r#"{
-        "sessions": [
+        "workspaces": [
             {"uuid":"s1","name":"Only","layout":{"Terminal":{"uuid":"t1","profile":null,"cwd":null,"custom_title":null}},"input_sync":false}
         ],
         "active_workspace_index": 99,
@@ -646,7 +642,7 @@ fn contract_active_workspace_index_out_of_bounds_is_clamped_safely() {
 #[test]
 fn contract_empty_sessions_is_handled_without_panic() {
     let json = r#"{
-        "sessions": [],
+        "workspaces": [],
         "active_workspace_index": 0,
         "width": 800, "height": 600, "is_maximized": false
     }"#;
@@ -683,7 +679,6 @@ fn zoom_state_survives_serialization_roundtrip() {
             terminal_recovery: Default::default(),
             active_terminal_uuid: Some("t1".into()),
             input_sync: false,
-            mode: Default::default(),
             runtime: Default::default(),
             color: Default::default(),
             zoomed_terminal_uuid: Some("t1".into()),
@@ -700,7 +695,7 @@ fn zoom_state_survives_serialization_roundtrip() {
 #[test]
 fn old_state_without_zoom_field_deserializes_cleanly() {
     let json = r#"{
-        "sessions": [{
+        "workspaces": [{
             "uuid": "s1",
             "name": "Work",
             "layout": {"Terminal": {"uuid": "t1"}}

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -90,7 +90,7 @@ fn preferences_unknown_fields_are_ignored() {
 #[test]
 fn preferences_input_sync_persists_in_session_state() {
     use rttx::runtime::WorkspaceRuntime;
-    use rttx::workspace::{LayoutNode, WindowState, WorkspaceColor, WorkspaceMode, WorkspaceState};
+    use rttx::workspace::{LayoutNode, WindowState, WorkspaceColor, WorkspaceState};
 
     let state = WindowState {
         workspaces: vec![WorkspaceState {
@@ -100,7 +100,6 @@ fn preferences_input_sync_persists_in_session_state() {
             terminal_recovery: std::collections::BTreeMap::default(),
             active_terminal_uuid: None,
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -124,7 +123,7 @@ fn preferences_input_sync_persists_in_session_state() {
 fn preferences_backward_compat_missing_input_sync() {
     // Old session state JSON without input_sync or active_terminal_uuid should default safely.
     let json = r#"{
-        "sessions": [{
+        "workspaces": [{
             "uuid": "s1",
             "name": "Test",
             "layout": {"Terminal": {"uuid": "t1", "profile": null, "cwd": null, "custom_title": null}}
@@ -143,7 +142,7 @@ fn preferences_backward_compat_missing_input_sync() {
 #[test]
 fn custom_title_persists_in_layout() {
     use rttx::runtime::WorkspaceRuntime;
-    use rttx::workspace::{LayoutNode, WindowState, WorkspaceColor, WorkspaceMode, WorkspaceState};
+    use rttx::workspace::{LayoutNode, WindowState, WorkspaceColor, WorkspaceState};
 
     let state = WindowState {
         workspaces: vec![WorkspaceState {
@@ -158,7 +157,6 @@ fn custom_title_persists_in_layout() {
             terminal_recovery: std::collections::BTreeMap::default(),
             active_terminal_uuid: None,
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -180,7 +178,7 @@ fn custom_title_persists_in_layout() {
 fn custom_title_backward_compat_null() {
     // Old JSON without custom_title should deserialize as None
     let json = r#"{
-        "sessions": [{
+        "workspaces": [{
             "uuid": "s1",
             "name": "Test",
             "layout": {"Terminal": {"uuid": "t1", "profile": null, "cwd": null, "custom_title": null}}

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -71,7 +71,6 @@ fn workflow_multi_session_state() {
             terminal_recovery: std::collections::BTreeMap::default(),
             active_terminal_uuid: None,
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -84,7 +83,6 @@ fn workflow_multi_session_state() {
             terminal_recovery: std::collections::BTreeMap::default(),
             active_terminal_uuid: None,
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -97,7 +95,6 @@ fn workflow_multi_session_state() {
             terminal_recovery: std::collections::BTreeMap::default(),
             active_terminal_uuid: None,
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -156,7 +153,6 @@ fn workflow_persist_and_restore_with_cwds() {
             terminal_recovery: std::collections::BTreeMap::default(),
             active_terminal_uuid: None,
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::default(),
             zoomed_terminal_uuid: None,
@@ -244,7 +240,6 @@ fn empty_workspace_name_is_valid() {
         terminal_recovery: std::collections::BTreeMap::default(),
         active_terminal_uuid: None,
         input_sync: false,
-        mode: WorkspaceMode::default(),
         runtime: WorkspaceRuntime::default(),
         color: WorkspaceColor::default(),
         zoomed_terminal_uuid: None,
@@ -266,7 +261,6 @@ fn session_order_persists_through_serialization() {
                 terminal_recovery: std::collections::BTreeMap::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: WorkspaceMode::default(),
                 runtime: WorkspaceRuntime::default(),
                 color: WorkspaceColor::default(),
                 zoomed_terminal_uuid: None,
@@ -279,7 +273,6 @@ fn session_order_persists_through_serialization() {
                 terminal_recovery: std::collections::BTreeMap::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: WorkspaceMode::default(),
                 runtime: WorkspaceRuntime::default(),
                 color: WorkspaceColor::default(),
                 zoomed_terminal_uuid: None,
@@ -292,7 +285,6 @@ fn session_order_persists_through_serialization() {
                 terminal_recovery: std::collections::BTreeMap::default(),
                 active_terminal_uuid: None,
                 input_sync: false,
-                mode: WorkspaceMode::default(),
                 runtime: WorkspaceRuntime::default(),
                 color: WorkspaceColor::default(),
                 zoomed_terminal_uuid: None,
@@ -326,7 +318,7 @@ fn module_split_reexports_are_complete() {
 
     // State types
     let session = WorkspaceState::new("reexport-test".into());
-    assert_eq!(session.mode, WorkspaceMode::Direct);
+    assert!(!session.uuid.is_empty());
 
     let state = WindowState::default();
     assert!(!state.workspaces.is_empty());
@@ -541,7 +533,7 @@ fn new_managed_remote_produces_remote_persistent_session() {
 #[test]
 fn remote_managed_session_persists_and_restores() {
     use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
-    use rttx::workspace::{WorkspaceMode, WorkspaceState};
+    use rttx::workspace::WorkspaceState;
 
     let session = WorkspaceState::new_managed_remote(
         "Remote Work".into(),
@@ -558,7 +550,6 @@ fn remote_managed_session_persists_and_restores() {
         restored.runtime.endpoint,
         RuntimeEndpoint::Remote { host: "dev@build-host".into() }
     );
-    assert_eq!(restored.mode, WorkspaceMode::Direct, "mode is no longer serialized");
     assert_eq!(
         restored.layout.terminal_cwd(&restored.layout.terminal_uuids()[0]).as_deref(),
         Some("/home/dev/project")
@@ -993,7 +984,6 @@ fn zoom_toggle_sets_and_clears_zoomed_terminal() {
         terminal_recovery: std::collections::BTreeMap::default(),
         active_terminal_uuid: Some("t1".into()),
         input_sync: false,
-        mode: WorkspaceMode::default(),
         runtime: WorkspaceRuntime::default(),
         color: WorkspaceColor::default(),
         zoomed_terminal_uuid: None,
@@ -1022,7 +1012,6 @@ fn zoom_state_not_persisted_when_cleared_before_save() {
         terminal_recovery: std::collections::BTreeMap::default(),
         active_terminal_uuid: Some("t1".into()),
         input_sync: false,
-        mode: WorkspaceMode::default(),
         runtime: WorkspaceRuntime::default(),
         color: WorkspaceColor::default(),
         zoomed_terminal_uuid: Some("t1".into()),
@@ -1046,7 +1035,6 @@ fn zoom_on_single_pane_session_is_noop() {
         terminal_recovery: std::collections::BTreeMap::default(),
         active_terminal_uuid: Some("t1".into()),
         input_sync: false,
-        mode: WorkspaceMode::default(),
         runtime: WorkspaceRuntime::default(),
         color: WorkspaceColor::default(),
         zoomed_terminal_uuid: None,
@@ -1068,7 +1056,6 @@ fn zoom_preserves_layout_tree_integrity() {
         terminal_recovery: std::collections::BTreeMap::default(),
         active_terminal_uuid: Some("t2".into()),
         input_sync: false,
-        mode: WorkspaceMode::default(),
         runtime: WorkspaceRuntime::default(),
         color: WorkspaceColor::default(),
         zoomed_terminal_uuid: None,
@@ -1236,11 +1223,10 @@ fn input_sync_fan_out_targets_all_bound_managed_siblings() {
     assert_eq!(restored.input_sync_targets("pane-1").len(), 2);
 }
 
-/// Legacy persisted `WindowState` with bookmark-sourced panes must load
-/// without error after the Bookmark variant was removed from `PaneSource`.
+/// Legacy persisted `WindowState` with the old `sessions` key must fail
+/// to deserialize now that the alias is removed.
 #[test]
-fn legacy_bookmark_sourced_pane_loads_after_removal() {
-    use rttx::workspace::PaneSource;
+fn legacy_sessions_key_rejects_on_deserialize() {
     use rttx::workspace::state::WindowState;
 
     let json = r#"{
@@ -1251,21 +1237,11 @@ fn legacy_bookmark_sourced_pane_loads_after_removal() {
         "sessions": [{
             "uuid": "s1",
             "name": "Legacy",
-            "layout": {"Terminal": {"uuid": "t1"}},
-            "terminal_recovery": {
-                "t1": {
-                    "source": {"bookmark": {"name": "Prod"}},
-                    "target": null,
-                    "startup": []
-                }
-            }
+            "layout": {"Terminal": {"uuid": "t1"}}
         }]
     }"#;
 
-    let state: WindowState = serde_json::from_str(json).unwrap();
-    assert_eq!(state.workspaces.len(), 1);
-    let recovery = &state.workspaces[0].terminal_recovery["t1"];
-    assert_eq!(recovery.source, PaneSource::Manual);
+    assert!(serde_json::from_str::<WindowState>(json).is_err());
 }
 
 /// Dismissed runtime IDs that are no longer in the daemon inventory

--- a/clients/rttx/tests/workspace_persistence_e2e.rs
+++ b/clients/rttx/tests/workspace_persistence_e2e.rs
@@ -56,13 +56,12 @@ fn split_ratio(
 /// dir caching.
 fn save_and_load(state: &WindowState) -> WindowState {
     let tmp = tempfile::TempDir::new().unwrap();
-    let path = tmp.path().join("sessions.json");
+    let path = tmp.path().join("workspaces.json");
     let json = serde_json::to_string_pretty(state).unwrap();
     std::fs::write(&path, &json).unwrap();
     let loaded_json = std::fs::read_to_string(&path).unwrap();
     let mut loaded: WindowState = serde_json::from_str(&loaded_json).unwrap();
     for session in &mut loaded.workspaces {
-        session.normalize_runtime_metadata();
         session.normalize_active_terminal();
     }
     loaded
@@ -75,7 +74,7 @@ fn save_and_load(state: &WindowState) -> WindowState {
 #[test]
 fn older_format_without_sidebar_widths_loads_with_defaults() {
     let json = r#"{
-        "sessions": [{
+        "workspaces": [{
             "uuid": "s1",
             "name": "Legacy",
             "layout": {"Terminal": {"uuid": "t1"}}
@@ -98,7 +97,7 @@ fn older_format_without_sidebar_widths_loads_with_defaults() {
 #[test]
 fn older_format_without_runtime_or_color_fields_loads_gracefully() {
     let json = r#"{
-        "sessions": [{
+        "workspaces": [{
             "uuid": "s1",
             "name": "Old Session",
             "layout": {"Terminal": {"uuid": "t1"}},
@@ -126,7 +125,7 @@ fn older_format_without_runtime_or_color_fields_loads_gracefully() {
 #[test]
 fn older_format_without_dismissed_runtime_ids_loads_empty() {
     let json = r#"{
-        "sessions": [{"uuid": "s1", "name": "W", "layout": {"Terminal": {"uuid": "t1"}}}],
+        "workspaces": [{"uuid": "s1", "name": "W", "layout": {"Terminal": {"uuid": "t1"}}}],
         "active_workspace_index": 0,
         "width": 800,
         "height": 600,
@@ -137,10 +136,10 @@ fn older_format_without_dismissed_runtime_ids_loads_empty() {
     assert!(state.dismissed_runtime_ids.is_empty());
 }
 
-/// A session saved with the legacy `Persistent` mode (before the `runtime`
-/// struct existed) must normalize into the modern runtime metadata.
+/// State with a legacy `mode` field must deserialize without error,
+/// silently ignoring the removed field.
 #[test]
-fn legacy_persistent_mode_normalizes_to_runtime_metadata() {
+fn legacy_mode_field_is_silently_ignored() {
     let json = r#"{
         "uuid": "s1",
         "name": "Legacy Persistent",
@@ -151,13 +150,12 @@ fn legacy_persistent_mode_normalizes_to_runtime_metadata() {
         "mode": {"persistent": {"daemon_runtime_id": "runtime-abc"}}
     }"#;
 
-    let mut session: WorkspaceState = serde_json::from_str(json).unwrap();
-    session.normalize_runtime_metadata();
-
-    assert!(session.runtime.is_managed());
-    assert_eq!(session.runtime.endpoint, RuntimeEndpoint::Local);
-    assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
-    assert_eq!(session.runtime.runtime_id.as_deref(), Some("runtime-abc"));
+    let session: WorkspaceState = serde_json::from_str(json).unwrap();
+    assert!(
+        !session.uses_managed_runtime(),
+        "unknown mode field must not activate managed runtime"
+    );
+    assert_eq!(session.uuid, "s1");
 }
 
 // ── Corrupted state ─────────────────────────────────────────────
@@ -199,7 +197,7 @@ fn empty_string_falls_back_to_default() {
 #[test]
 fn unknown_fields_are_ignored_gracefully() {
     let json = r#"{
-        "sessions": [{
+        "workspaces": [{
             "uuid": "s1",
             "name": "Future",
             "layout": {"Terminal": {"uuid": "t1"}},
@@ -241,7 +239,6 @@ fn large_layout_persists_and_restores_through_file() {
             terminal_recovery: BTreeMap::default(),
             active_terminal_uuid: Some("t7".into()),
             input_sync: true,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::Teal,
             zoomed_terminal_uuid: None,
@@ -293,7 +290,6 @@ fn multi_workspace_mixed_config_persists_through_file() {
             terminal_recovery: BTreeMap::default(),
             active_terminal_uuid: Some("t2".into()),
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::Green,
             zoomed_terminal_uuid: None,
@@ -316,7 +312,6 @@ fn multi_workspace_mixed_config_persists_through_file() {
             terminal_recovery: BTreeMap::default(),
             active_terminal_uuid: Some("t-mon".into()),
             input_sync: false,
-            mode: WorkspaceMode::default(),
             runtime: WorkspaceRuntime::default(),
             color: WorkspaceColor::Purple,
             zoomed_terminal_uuid: None,
@@ -394,7 +389,6 @@ fn full_roundtrip_through_file_persistence() {
                 terminal_recovery: BTreeMap::default(),
                 active_terminal_uuid: Some("t2".into()),
                 input_sync: true,
-                mode: WorkspaceMode::default(),
                 runtime: WorkspaceRuntime::default(),
                 color: WorkspaceColor::Orange,
                 zoomed_terminal_uuid: None,
@@ -407,7 +401,6 @@ fn full_roundtrip_through_file_persistence() {
                 terminal_recovery: BTreeMap::default(),
                 active_terminal_uuid: Some("t3".into()),
                 input_sync: false,
-                mode: WorkspaceMode::default(),
                 runtime: WorkspaceRuntime::default(),
                 color: WorkspaceColor::Blue,
                 zoomed_terminal_uuid: None,

--- a/clients/rttx/tests/workspace_persistence_e2e.rs
+++ b/clients/rttx/tests/workspace_persistence_e2e.rs
@@ -459,3 +459,21 @@ fn full_roundtrip_through_file_persistence() {
     assert!(!s2.input_sync);
     assert_eq!(s2.color, WorkspaceColor::Blue);
 }
+
+/// Workspace state serialized after legacy removal must not contain a
+/// `mode` field, and must round-trip cleanly through the current format.
+#[test]
+fn workspace_state_roundtrip_has_no_legacy_mode_field() {
+    let session = WorkspaceState::new_managed_local(
+        "Managed".into(),
+        WorkspacePolicy::Persistent,
+        Some("/home/user".into()),
+    );
+    let json = serde_json::to_string(&session).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(value.get("mode").is_none(), "mode field must not exist after removal");
+
+    let restored: WorkspaceState = serde_json::from_str(&json).unwrap();
+    assert!(restored.uses_managed_runtime());
+    assert_eq!(restored.runtime.endpoint, RuntimeEndpoint::Local);
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.12',
+  version: '0.4.13',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Removes the transitional legacy import path that read `sessions.json` from `$XDG_CONFIG_HOME/rttx/` when no `workspaces.json` existed. This was a one-time migration path during the RFC-023 rollout that is no longer needed before v1.

### Removed
- `WorkspaceMode` enum and all its methods (`is_persistent`, `daemon_runtime_id`, `host`)
- `normalize_runtime_metadata()` on `WorkspaceState`
- `load_window_state()` and `workspaces_dir()` from `workspace/mod.rs`
- Custom `PaneSource` deserializer with `Bookmark`/`SessionTemplate` backward-compat fallbacks
- Custom `PaneTarget` deserializer with `local-tmux`/`remote-tmux` backward-compat fallbacks
- Legacy serde aliases (`sessions`, `active_session_index`, `daemon_session_id`)
- Legacy test helpers (`save_state_to`, `load_state_from` for sessions.json)
- All backward-compat tests for removed code paths
- `SessionMode` mention from CONTRIBUTING.md

### After this change
- `load_state()` only reads from `ClientStore` (envelope-based documents)
- If no store files exist, start with defaults (no fallback)
- `WorkspaceMode` is fully gone from the codebase
- Removed `PaneSource`/`PaneTarget` variants now fail to deserialize cleanly

## How to manually verify
1. Delete `~/.local/state/rttx-devel/client/workspaces.json` and run `RTTX_DEV_MODE=1 cargo run -p rttx` — should start with a fresh default workspace
2. Normal startup with existing `workspaces.json` should work unchanged
3. Verify no `sessions.json` fallback occurs

## Tests added
- `mode_field_absent_from_workspace_state` — verifies mode field does not exist in WorkspaceState
- `unknown_mode_field_is_ignored_on_deserialize` — verifies JSON with unknown mode field deserializes without error
- `window_state_loads_legacy_sessions_key` — verifies legacy `sessions` key now fails to parse
- `removed_pane_source_variants_fail_to_deserialize` — verifies removed PaneSource variants reject
- `removed_pane_target_variants_fail_to_deserialize` — verifies removed PaneTarget variants reject
- `removed_pane_source_variant_rejects_on_deserialize` (terminal/mod.rs) — verifies bookmark source rejects
- `legacy_sessions_key_rejects_on_deserialize` (workspace_lifecycle) — verifies legacy sessions key rejects
- `legacy_mode_field_is_silently_ignored` (workspace_persistence_e2e) — verifies mode field is silently ignored

## Tests run
- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (656 passed, 184 ignored, 0 failed)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all suites pass, 0 failures)

Fixes #760