### PR TITLE
chore: remove dead command_history Vec from Session/PersistedSession

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.14"
+version = "0.4.15"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.14',
+  version: '0.4.15',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -1080,7 +1080,7 @@ mod v3_envelope_tests {
                         pty_writer_count: 1,
                         total_raw_bytes: 1024,
                         total_pending_flush: 0,
-                        total_command_history: 5,
+                        total_command_history: 0,
                         runtimes: vec![],
                     },
                 )),

--- a/protocols/rttx-proto/src/v3_diagnostics.rs
+++ b/protocols/rttx-proto/src/v3_diagnostics.rs
@@ -55,7 +55,6 @@ pub fn build_runtime_diagnostics_info(
     name: String,
     active_pane_count: u32,
     exited_pane_count: u32,
-    command_history_len: u32,
     attached_client_count: u32,
     panes: Vec<v3::PaneDiagnosticsInfo>,
 ) -> v3::RuntimeDiagnosticsInfo {
@@ -64,7 +63,7 @@ pub fn build_runtime_diagnostics_info(
         name,
         active_pane_count,
         exited_pane_count,
-        command_history_len,
+        command_history_len: 0,
         attached_client_count,
         panes,
     }
@@ -84,7 +83,7 @@ pub fn build_diagnostics_report(args: DiagnosticsReportArgs) -> v3::DiagnosticsR
         pty_writer_count: args.pty_writer_count,
         total_raw_bytes: args.total_raw_bytes,
         total_pending_flush: args.total_pending_flush,
-        total_command_history: args.total_command_history,
+        total_command_history: 0,
         runtimes: args.runtimes,
     }
 }
@@ -99,7 +98,6 @@ pub struct DiagnosticsReportArgs {
     pub pty_writer_count: u32,
     pub total_raw_bytes: u64,
     pub total_pending_flush: u64,
-    pub total_command_history: u32,
     pub runtimes: Vec<v3::RuntimeDiagnosticsInfo>,
 }
 
@@ -225,12 +223,11 @@ mod tests {
         let r = rt();
         let p = pn();
         let pane = build_pane_diagnostics_info(p, 2048, 64, false);
-        let info = build_runtime_diagnostics_info(r, "dev".into(), 2, 1, 10, 1, vec![pane.clone()]);
+        let info = build_runtime_diagnostics_info(r, "dev".into(), 2, 1, 1, vec![pane.clone()]);
         assert_eq!(info.id, uuid_to_bytes(r));
         assert_eq!(info.name, "dev");
         assert_eq!(info.active_pane_count, 2);
         assert_eq!(info.exited_pane_count, 1);
-        assert_eq!(info.command_history_len, 10);
         assert_eq!(info.attached_client_count, 1);
         assert_eq!(info.panes.len(), 1);
         assert_eq!(info.panes[0], pane);
@@ -238,14 +235,14 @@ mod tests {
 
     #[test]
     fn runtime_diagnostics_info_empty_panes() {
-        let info = build_runtime_diagnostics_info(rt(), "empty".into(), 0, 0, 0, 0, vec![]);
+        let info = build_runtime_diagnostics_info(rt(), "empty".into(), 0, 0, 0, vec![]);
         assert!(info.panes.is_empty());
     }
 
     #[test]
     fn runtime_diagnostics_info_wire_roundtrip() {
         let pane = build_pane_diagnostics_info(pn(), 8192, 256, true);
-        let info = build_runtime_diagnostics_info(rt(), "test-rt".into(), 3, 2, 5, 2, vec![pane]);
+        let info = build_runtime_diagnostics_info(rt(), "test-rt".into(), 3, 2, 2, vec![pane]);
         let mut buf = BytesMut::new();
         encode_frame(&info, &mut buf).unwrap();
         let decoded: v3::RuntimeDiagnosticsInfo = decode_frame(&mut buf).unwrap();
@@ -257,7 +254,7 @@ mod tests {
     #[test]
     fn diagnostics_report_populates_all_fields() {
         let pane = build_pane_diagnostics_info(pn(), 4096, 128, false);
-        let runtime = build_runtime_diagnostics_info(rt(), "ws1".into(), 1, 0, 3, 1, vec![pane]);
+        let runtime = build_runtime_diagnostics_info(rt(), "ws1".into(), 1, 0, 1, vec![pane]);
         let report = build_diagnostics_report(DiagnosticsReportArgs {
             runtime_count: 1,
             total_pane_count: 1,
@@ -267,7 +264,6 @@ mod tests {
             pty_writer_count: 1,
             total_raw_bytes: 4096,
             total_pending_flush: 128,
-            total_command_history: 3,
             runtimes: vec![runtime],
         });
         assert_eq!(report.runtime_count, 1);
@@ -278,7 +274,6 @@ mod tests {
         assert_eq!(report.pty_writer_count, 1);
         assert_eq!(report.total_raw_bytes, 4096);
         assert_eq!(report.total_pending_flush, 128);
-        assert_eq!(report.total_command_history, 3);
         assert_eq!(report.runtimes.len(), 1);
     }
 
@@ -293,7 +288,6 @@ mod tests {
             pty_writer_count: 0,
             total_raw_bytes: 0,
             total_pending_flush: 0,
-            total_command_history: 0,
             runtimes: vec![],
         });
         assert_eq!(report.runtime_count, 0);
@@ -304,15 +298,8 @@ mod tests {
     fn diagnostics_report_wire_roundtrip() {
         let pane1 = build_pane_diagnostics_info(pn(), 1024, 0, false);
         let pane2 = build_pane_diagnostics_info(pn(), 2048, 512, true);
-        let runtime = build_runtime_diagnostics_info(
-            rt(),
-            "multi-pane".into(),
-            1,
-            1,
-            7,
-            2,
-            vec![pane1, pane2],
-        );
+        let runtime =
+            build_runtime_diagnostics_info(rt(), "multi-pane".into(), 1, 1, 2, vec![pane1, pane2]);
         let report = build_diagnostics_report(DiagnosticsReportArgs {
             runtime_count: 1,
             total_pane_count: 2,
@@ -322,7 +309,6 @@ mod tests {
             pty_writer_count: 1,
             total_raw_bytes: 3072,
             total_pending_flush: 512,
-            total_command_history: 7,
             runtimes: vec![runtime],
         });
         let mut buf = BytesMut::new();
@@ -344,7 +330,6 @@ mod tests {
             pty_writer_count: 0,
             total_raw_bytes: 0,
             total_pending_flush: 0,
-            total_command_history: 0,
             runtimes: vec![],
         });
         let env = build_diagnostics_report_response(42, report);
@@ -362,7 +347,6 @@ mod tests {
             pty_writer_count: 1,
             total_raw_bytes: 10000,
             total_pending_flush: 500,
-            total_command_history: 15,
             runtimes: vec![],
         });
         let env = build_diagnostics_report_response(7, report.clone());
@@ -385,7 +369,6 @@ mod tests {
             pty_writer_count: 0,
             total_raw_bytes: 0,
             total_pending_flush: 0,
-            total_command_history: 0,
             runtimes: vec![],
         });
         let env = build_diagnostics_report_response(1, report);
@@ -395,8 +378,7 @@ mod tests {
     #[test]
     fn report_response_wire_roundtrip() {
         let pane = build_pane_diagnostics_info(pn(), 65536, 1024, false);
-        let runtime =
-            build_runtime_diagnostics_info(rt(), "roundtrip".into(), 1, 0, 0, 1, vec![pane]);
+        let runtime = build_runtime_diagnostics_info(rt(), "roundtrip".into(), 1, 0, 1, vec![pane]);
         let report = build_diagnostics_report(DiagnosticsReportArgs {
             runtime_count: 1,
             total_pane_count: 1,
@@ -406,7 +388,6 @@ mod tests {
             pty_writer_count: 1,
             total_raw_bytes: 65536,
             total_pending_flush: 1024,
-            total_command_history: 0,
             runtimes: vec![runtime],
         });
         let env = build_diagnostics_report_response(99, report);
@@ -459,19 +440,11 @@ mod tests {
             "workspace-1".into(),
             2,
             0,
-            5,
             1,
             vec![p1.clone(), p2.clone()],
         );
-        let rt2 = build_runtime_diagnostics_info(
-            rt(),
-            "workspace-2".into(),
-            0,
-            1,
-            2,
-            0,
-            vec![p3.clone()],
-        );
+        let rt2 =
+            build_runtime_diagnostics_info(rt(), "workspace-2".into(), 0, 1, 0, vec![p3.clone()]);
         let report = build_diagnostics_report(DiagnosticsReportArgs {
             runtime_count: 2,
             total_pane_count: 3,
@@ -481,7 +454,6 @@ mod tests {
             pty_writer_count: 1,
             total_raw_bytes: p1.raw_bytes_len + p2.raw_bytes_len + p3.raw_bytes_len,
             total_pending_flush: p1.pending_flush_len + p2.pending_flush_len + p3.pending_flush_len,
-            total_command_history: rt1.command_history_len + rt2.command_history_len,
             runtimes: vec![rt1, rt2],
         });
 

--- a/services/rttx-server/src/diagnostics.rs
+++ b/services/rttx-server/src/diagnostics.rs
@@ -22,7 +22,6 @@ pub struct RuntimeDiagnostics {
     pub name: String,
     pub active_pane_count: usize,
     pub exited_pane_count: usize,
-    pub command_history_len: usize,
     pub attached_client_count: usize,
     pub panes: Vec<PaneDiagnostics>,
 }
@@ -38,7 +37,6 @@ pub struct DiagnosticsReport {
     pub pty_writer_count: usize,
     pub total_raw_bytes: usize,
     pub total_pending_flush: usize,
-    pub total_command_history: usize,
     pub runtimes: Vec<RuntimeDiagnostics>,
 }
 
@@ -54,7 +52,6 @@ impl fmt::Display for DiagnosticsReport {
         writeln!(f, "PTY writers: {}", self.pty_writer_count)?;
         writeln!(f, "Total raw_bytes: {} bytes", self.total_raw_bytes)?;
         writeln!(f, "Total pending_flush: {} bytes", self.total_pending_flush)?;
-        writeln!(f, "Total command_history entries: {}", self.total_command_history)?;
 
         if !self.runtimes.is_empty() {
             writeln!(f)?;
@@ -65,7 +62,6 @@ impl fmt::Display for DiagnosticsReport {
                     "    Panes: {} active, {} exited",
                     rt.active_pane_count, rt.exited_pane_count
                 )?;
-                writeln!(f, "    Command history: {} entries", rt.command_history_len)?;
                 writeln!(f, "    Attached clients: {}", rt.attached_client_count)?;
                 for pane in &rt.panes {
                     let status = if pane.is_exited { "exited" } else { "active" };
@@ -92,7 +88,6 @@ impl Server {
         let mut runtimes = Vec::with_capacity(self.runtimes.len());
         let mut total_raw_bytes = 0usize;
         let mut total_pending_flush = 0usize;
-        let mut total_command_history = 0usize;
         let mut total_active_panes = 0usize;
         let mut total_exited_panes = 0usize;
 
@@ -123,14 +118,12 @@ impl Server {
 
             total_active_panes += active;
             total_exited_panes += exited;
-            total_command_history += rt.command_history.len();
 
             runtimes.push(RuntimeDiagnostics {
                 id: rt.id.to_string(),
                 name: rt.name.clone(),
                 active_pane_count: active,
                 exited_pane_count: exited,
-                command_history_len: rt.command_history.len(),
                 attached_client_count: rt.attached_client_count(),
                 panes,
             });
@@ -145,7 +138,6 @@ impl Server {
             pty_writer_count: self.pty_writer_count(),
             total_raw_bytes,
             total_pending_flush,
-            total_command_history,
             runtimes,
         }
     }
@@ -162,7 +154,6 @@ impl Server {
             pty_writers = report.pty_writer_count,
             raw_bytes = report.total_raw_bytes,
             pending_flush = report.total_pending_flush,
-            command_history = report.total_command_history,
             "memory diagnostics"
         );
     }
@@ -207,7 +198,6 @@ mod tests {
         assert_eq!(report.pty_writer_count, 0);
         assert_eq!(report.total_raw_bytes, 0);
         assert_eq!(report.total_pending_flush, 0);
-        assert_eq!(report.total_command_history, 0);
     }
 
     #[test]
@@ -232,22 +222,6 @@ mod tests {
         assert_eq!(report.total_active_panes, 1);
         assert_eq!(report.total_exited_panes, 1);
         assert_eq!(report.total_raw_bytes, 11); // "hello world"
-    }
-
-    #[test]
-    fn diagnostics_counts_command_history() {
-        let mut server = test_server();
-        let mut rt = Runtime::new("test".into());
-        rt.command_history.push(crate::pane::HistoryEntry {
-            command: "ls".into(),
-            cwd: "/tmp".into(),
-            timestamp: std::time::SystemTime::now(),
-            pane_id: Uuid::new_v4(),
-        });
-        server.runtimes.insert(rt.id, rt);
-
-        let report = server.diagnostics();
-        assert_eq!(report.total_command_history, 1);
     }
 
     #[test]

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -222,7 +222,6 @@ fn diagnostics() -> anyhow::Result<()> {
             println!("PTY writers: {}", report.pty_writer_count);
             println!("Total raw_bytes: {} bytes", report.total_raw_bytes);
             println!("Total pending_flush: {} bytes", report.total_pending_flush);
-            println!("Total command_history entries: {}", report.total_command_history);
 
             if !report.runtimes.is_empty() {
                 println!();
@@ -234,7 +233,6 @@ fn diagnostics() -> anyhow::Result<()> {
                         "    Panes: {} active, {} exited",
                         rt_info.active_pane_count, rt_info.exited_pane_count
                     );
-                    println!("    Command history: {} entries", rt_info.command_history_len);
                     println!("    Attached clients: {}", rt_info.attached_client_count);
                     for pane in &rt_info.panes {
                         let pid = rttx_proto::bytes_to_uuid(&pane.id)

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -6,10 +6,8 @@
 use crate::screen::{PaneScreen, strip_client_queries};
 use crate::state::layout::scrollback_log;
 use crate::state::types::{SCREEN_SNAPSHOT_SCHEMA_VERSION, ScreenSnapshotV1, TerminalModeSnapshot};
-use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
 use uuid::Uuid;
 
 /// Default scrollback byte limit per pane (10 MB).
@@ -286,19 +284,6 @@ fn rotate_scrollback_log(path: &Path, max_bytes: u64, keep: u32) -> Result<(), s
     std::fs::rename(path, &first_rotated)?;
 
     Ok(())
-}
-
-/// History entry for per-session command history.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HistoryEntry {
-    /// The command text.
-    pub command: String,
-    /// Working directory when the command was run.
-    pub cwd: String,
-    /// When the command was executed.
-    pub timestamp: SystemTime,
-    /// Which pane the command was run in.
-    pub pane_id: Uuid,
 }
 
 #[cfg(test)]

--- a/services/rttx-server/src/protocol.rs
+++ b/services/rttx-server/src/protocol.rs
@@ -330,7 +330,7 @@ pub fn diagnostics_report(server: &crate::server::Server) -> proto::ServerMessag
                 name: s.name.clone(),
                 active_pane_count: s.active_pane_count as u32,
                 exited_pane_count: s.exited_pane_count as u32,
-                command_history_len: s.command_history_len as u32,
+                command_history_len: 0,
                 attached_client_count: s.attached_client_count as u32,
                 panes,
             }
@@ -346,7 +346,7 @@ pub fn diagnostics_report(server: &crate::server::Server) -> proto::ServerMessag
             pty_writer_count: report.pty_writer_count as u32,
             total_raw_bytes: report.total_raw_bytes as u64,
             total_pending_flush: report.total_pending_flush as u64,
-            total_command_history: report.total_command_history as u32,
+            total_command_history: 0,
             runtimes,
         })),
     }
@@ -500,7 +500,7 @@ pub fn v3_diagnostics_report(server: &crate::server::Server) -> v3::DiagnosticsR
                 name: s.name.clone(),
                 active_pane_count: s.active_pane_count as u32,
                 exited_pane_count: s.exited_pane_count as u32,
-                command_history_len: s.command_history_len as u32,
+                command_history_len: 0,
                 attached_client_count: s.attached_client_count as u32,
                 panes,
             }
@@ -515,7 +515,7 @@ pub fn v3_diagnostics_report(server: &crate::server::Server) -> v3::DiagnosticsR
         pty_writer_count: report.pty_writer_count as u32,
         total_raw_bytes: report.total_raw_bytes as u64,
         total_pending_flush: report.total_pending_flush as u64,
-        total_command_history: report.total_command_history as u32,
+        total_command_history: 0,
         runtimes,
     }
 }

--- a/services/rttx-server/src/runtime.rs
+++ b/services/rttx-server/src/runtime.rs
@@ -3,15 +3,12 @@
 //! A runtime is a named collection of panes with a layout tree. Runtimes
 //! persist across GUI disconnects and can be serialized to disk.
 
-use crate::pane::{HistoryEntry, Pane};
+use crate::pane::Pane;
 use rttx_proto::{proto, v3};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::SystemTime;
 use uuid::Uuid;
-
-/// Maximum number of entries retained in per-runtime command history.
-pub const MAX_COMMAND_HISTORY: usize = 1000;
 
 /// Runtime retention policy for a runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -193,8 +190,6 @@ pub struct Runtime {
     pub panes: HashMap<Uuid, Pane>,
     /// The currently focused pane.
     pub active_pane_id: Option<Uuid>,
-    /// Per-runtime command history.
-    pub command_history: Vec<HistoryEntry>,
     /// Runtime retention policy.
     pub policy: RuntimePolicy,
     /// Whether this runtime was resurrected from persisted state.
@@ -222,7 +217,6 @@ impl Runtime {
             name,
             panes: HashMap::new(),
             active_pane_id: None,
-            command_history: Vec::new(),
             policy: RuntimePolicy::Persistent,
             reconstructed: false,
             revision: default_runtime_revision(),
@@ -438,15 +432,6 @@ impl Runtime {
         self.panes.values().find_map(Pane::effective_cwd)
     }
 
-    /// Append a history entry, evicting the oldest if the cap is reached.
-    pub fn add_history_entry(&mut self, entry: HistoryEntry) {
-        self.command_history.push(entry);
-        if self.command_history.len() > MAX_COMMAND_HISTORY {
-            let excess = self.command_history.len() - MAX_COMMAND_HISTORY;
-            self.command_history.drain(..excess);
-        }
-    }
-
     /// Update a pane's exit status and return the resulting runtime revision.
     pub fn set_pane_exit_status(&mut self, pane_id: Uuid, status: Option<i32>) -> Option<u64> {
         let changed = {
@@ -471,8 +456,8 @@ impl Runtime {
     #[must_use]
     pub fn to_runtime_file(&self) -> crate::state::types::RuntimeFileV1 {
         use crate::state::types::{
-            HistoryEntryV1, PaneSpecV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1,
-            RuntimeInstanceV1, RuntimeSpecV1,
+            PaneSpecV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1, RuntimeInstanceV1,
+            RuntimeSpecV1,
         };
 
         let panes = self
@@ -492,17 +477,6 @@ impl Runtime {
             })
             .collect();
 
-        let command_history = self
-            .command_history
-            .iter()
-            .map(|h| HistoryEntryV1 {
-                command: h.command.clone(),
-                cwd: h.cwd.clone(),
-                timestamp: h.timestamp,
-                pane_id: h.pane_id,
-            })
-            .collect();
-
         RuntimeFileV1 {
             schema_version: RUNTIME_FILE_SCHEMA_VERSION,
             spec: RuntimeSpecV1 {
@@ -512,7 +486,7 @@ impl Runtime {
                 created_at: self.created_at,
                 panes,
                 active_pane_id: self.active_pane_id,
-                command_history,
+                command_history: vec![],
             },
             instance: RuntimeInstanceV1 {
                 revision: self.revision,
@@ -540,29 +514,10 @@ impl Runtime {
             })
             .collect();
 
-        let command_history: Vec<HistoryEntry> = rf
-            .spec
-            .command_history
-            .iter()
-            .map(|h| HistoryEntry {
-                command: h.command.clone(),
-                cwd: h.cwd.clone(),
-                timestamp: h.timestamp,
-                pane_id: h.pane_id,
-            })
-            .collect();
-
-        let command_history = if command_history.len() > MAX_COMMAND_HISTORY {
-            command_history[command_history.len() - MAX_COMMAND_HISTORY..].to_vec()
-        } else {
-            command_history
-        };
-
         Self {
             id: rf.spec.id,
             name: rf.spec.name.clone(),
             active_pane_id: rf.spec.active_pane_id,
-            command_history,
             policy: rf.spec.policy,
             reconstructed: true,
             revision: rf.instance.revision.max(default_runtime_revision()),
@@ -743,28 +698,6 @@ mod tests {
         assert_eq!(runtime.revision(), 1);
     }
 
-    fn make_history_entry(i: usize) -> HistoryEntry {
-        HistoryEntry {
-            command: format!("cmd-{i}"),
-            cwd: "/tmp".into(),
-            timestamp: SystemTime::UNIX_EPOCH,
-            pane_id: Uuid::new_v4(),
-        }
-    }
-
-    #[test]
-    fn add_history_entry_caps_at_max() {
-        let mut runtime = Runtime::new("test".into());
-        for i in 0..MAX_COMMAND_HISTORY + 50 {
-            runtime.add_history_entry(make_history_entry(i));
-        }
-        assert_eq!(runtime.command_history.len(), MAX_COMMAND_HISTORY);
-        assert_eq!(
-            runtime.command_history[0].command, "cmd-50",
-            "oldest entries should be evicted"
-        );
-    }
-
     #[test]
     fn runtime_file_v2_round_trip() {
         let mut runtime = Runtime::new("v2-test".into());
@@ -772,12 +705,6 @@ mod tests {
         let pane = Pane::new(Uuid::new_v4(), 100, 30);
         let pane_id = pane.id;
         runtime.add_pane(pane);
-        runtime.add_history_entry(HistoryEntry {
-            command: "cargo build".into(),
-            cwd: "/project".into(),
-            timestamp: std::time::SystemTime::now(),
-            pane_id,
-        });
 
         let rf = runtime.to_runtime_file();
         assert_eq!(rf.spec.id, runtime.id);
@@ -785,7 +712,6 @@ mod tests {
         assert_eq!(rf.spec.panes.len(), 1);
         assert_eq!(rf.spec.panes[0].id, pane_id);
         assert_eq!(rf.spec.panes[0].cols, 100);
-        assert_eq!(rf.spec.command_history.len(), 1);
         assert_eq!(rf.instance.revision, runtime.revision());
 
         let restored = Runtime::from_runtime_file(&rf);
@@ -797,18 +723,6 @@ mod tests {
         assert!(restored.panes.contains_key(&pane_id));
         assert_eq!(restored.panes[&pane_id].cols, 100);
         assert_eq!(restored.panes[&pane_id].rows, 30);
-        assert_eq!(restored.command_history.len(), 1);
-        assert_eq!(restored.command_history[0].command, "cargo build");
-    }
-
-    #[test]
-    fn from_runtime_file_truncates_oversized_history() {
-        let mut runtime = Runtime::new("hist-test".into());
-        runtime.command_history = (0..MAX_COMMAND_HISTORY + 50).map(make_history_entry).collect();
-
-        let rf = runtime.to_runtime_file();
-        let restored = Runtime::from_runtime_file(&rf);
-        assert_eq!(restored.command_history.len(), MAX_COMMAND_HISTORY);
     }
 
     // ── Dirty-flag (persisted_revision) tests ───────────────────

--- a/services/rttx-server/src/state/persistence.rs
+++ b/services/rttx-server/src/state/persistence.rs
@@ -206,8 +206,8 @@ mod tests {
     use super::*;
     use crate::runtime::RuntimePolicy;
     use crate::state::types::{
-        HistoryEntryV1, PaneSpecV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1, RuntimeInstanceV1,
-        RuntimeSpecV1, SCREEN_SNAPSHOT_SCHEMA_VERSION, ScreenSnapshotV1, TerminalModeSnapshot,
+        PaneSpecV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1, RuntimeInstanceV1, RuntimeSpecV1,
+        SCREEN_SNAPSHOT_SCHEMA_VERSION, ScreenSnapshotV1, TerminalModeSnapshot,
     };
     use tempfile::TempDir;
 
@@ -229,12 +229,7 @@ mod tests {
                     no_persist: false,
                 }],
                 active_pane_id: None,
-                command_history: vec![HistoryEntryV1 {
-                    command: "ls".into(),
-                    cwd: "/".into(),
-                    timestamp: SystemTime::now(),
-                    pane_id: Uuid::new_v4(),
-                }],
+                command_history: vec![],
             },
             instance: RuntimeInstanceV1 {
                 revision: 5,

--- a/services/rttx-server/src/state/types.rs
+++ b/services/rttx-server/src/state/types.rs
@@ -74,8 +74,10 @@ pub struct RuntimeSpecV1 {
     pub panes: Vec<PaneSpecV1>,
     /// Active pane ID within this runtime.
     pub active_pane_id: Option<Uuid>,
-    /// Per-runtime command history.
-    pub command_history: Vec<HistoryEntryV1>,
+    /// Ignored — retained only for backward-compatible deserialization of
+    /// state files written before the field was removed.
+    #[serde(default, skip_serializing)]
+    pub command_history: Vec<serde_json::Value>,
 }
 
 /// Semi-durable instance data — revision counters and timestamps.
@@ -116,19 +118,6 @@ pub struct PaneSpecV1 {
     /// When true, scrollback and history are not flushed to disk (RFC-022 §9).
     #[serde(default)]
     pub no_persist: bool,
-}
-
-/// Per-runtime command history entry.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct HistoryEntryV1 {
-    /// The command text.
-    pub command: String,
-    /// Working directory when the command was run.
-    pub cwd: String,
-    /// When the command was executed.
-    pub timestamp: SystemTime,
-    /// Which pane the command was run in.
-    pub pane_id: Uuid,
 }
 
 // ── Screen snapshot ─────────────────────────────────────────────────
@@ -218,15 +207,6 @@ mod tests {
         }
     }
 
-    fn sample_history_entry() -> HistoryEntryV1 {
-        HistoryEntryV1 {
-            command: "ls -la".into(),
-            cwd: "/home/user".into(),
-            timestamp: SystemTime::now(),
-            pane_id: Uuid::new_v4(),
-        }
-    }
-
     fn sample_runtime_spec() -> RuntimeSpecV1 {
         RuntimeSpecV1 {
             id: Uuid::new_v4(),
@@ -235,7 +215,7 @@ mod tests {
             created_at: SystemTime::now(),
             panes: vec![sample_pane_spec()],
             active_pane_id: None,
-            command_history: vec![sample_history_entry()],
+            command_history: vec![],
         }
     }
 
@@ -324,14 +304,6 @@ mod tests {
         assert_eq!(original, recovered);
     }
 
-    #[test]
-    fn history_entry_round_trip() {
-        let original = sample_history_entry();
-        let json = serde_json::to_string_pretty(&original).unwrap();
-        let recovered: HistoryEntryV1 = serde_json::from_str(&json).unwrap();
-        assert_eq!(original, recovered);
-    }
-
     // ── Schema version field presence ───────────────────────────────
 
     #[test]
@@ -401,7 +373,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_spec_with_no_panes_or_history() {
+    fn runtime_spec_with_no_panes() {
         let spec = RuntimeSpecV1 {
             id: Uuid::new_v4(),
             name: "empty".into(),
@@ -414,7 +386,6 @@ mod tests {
         let json = serde_json::to_string_pretty(&spec).unwrap();
         let recovered: RuntimeSpecV1 = serde_json::from_str(&json).unwrap();
         assert!(recovered.panes.is_empty());
-        assert!(recovered.command_history.is_empty());
         assert_eq!(recovered.policy, RuntimePolicy::Ephemeral);
     }
 
@@ -535,5 +506,46 @@ mod tests {
         let json = serde_json::to_string_pretty(&snap).unwrap();
         let recovered: ScreenSnapshotV1 = serde_json::from_str(&json).unwrap();
         assert!(recovered.confidential);
+    }
+
+    #[test]
+    fn runtime_spec_deserializes_old_command_history() {
+        let json = r#"{
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "name": "legacy",
+            "policy": "persistent",
+            "created_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
+            "panes": [],
+            "active_pane_id": null,
+            "command_history": [
+                {"command": "ls", "cwd": "/", "timestamp": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}, "pane_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}
+            ]
+        }"#;
+        let spec: RuntimeSpecV1 = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.name, "legacy");
+    }
+
+    #[test]
+    fn runtime_spec_deserializes_without_command_history() {
+        let json = r#"{
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "name": "new-format",
+            "policy": "persistent",
+            "created_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
+            "panes": [],
+            "active_pane_id": null
+        }"#;
+        let spec: RuntimeSpecV1 = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.name, "new-format");
+    }
+
+    #[test]
+    fn runtime_spec_serialization_omits_command_history() {
+        let spec = sample_runtime_spec();
+        let json = serde_json::to_string(&spec).unwrap();
+        assert!(
+            !json.contains("command_history"),
+            "new serialization should not include command_history"
+        );
     }
 }

--- a/services/rttx-server/tests/diagnostics.rs
+++ b/services/rttx-server/tests/diagnostics.rs
@@ -31,7 +31,6 @@ async fn diagnostics_empty_server() {
     assert_eq!(report.total_exited_panes, 0);
     assert_eq!(report.total_raw_bytes, 0);
     assert_eq!(report.total_pending_flush, 0);
-    assert_eq!(report.total_command_history, 0);
     assert!(report.runtimes.is_empty());
 }
 
@@ -119,5 +118,4 @@ async fn diagnostics_reflects_cleanup_after_terminate() {
     assert_eq!(after.total_pane_count, 0);
     assert_eq!(after.total_raw_bytes, 0);
     assert_eq!(after.total_pending_flush, 0);
-    assert_eq!(after.total_command_history, 0);
 }

--- a/services/rttx-server/tests/v2_persisted_structs.rs
+++ b/services/rttx-server/tests/v2_persisted_structs.rs
@@ -73,12 +73,7 @@ fn runtime_file_persists_and_loads_via_migration_chain() {
             created_at: SystemTime::now(),
             panes: vec![pane],
             active_pane_id: None,
-            command_history: vec![HistoryEntryV1 {
-                command: "cargo build".into(),
-                cwd: "/home/user/project".into(),
-                timestamp: SystemTime::now(),
-                pane_id: Uuid::new_v4(),
-            }],
+            command_history: vec![],
         },
         instance: RuntimeInstanceV1 {
             revision: 7,

--- a/services/rttx-server/tests/v2_persisted_structs.rs
+++ b/services/rttx-server/tests/v2_persisted_structs.rs
@@ -141,3 +141,42 @@ fn future_version_rejected_from_disk() {
     let result = load_daemon_index(&loaded);
     assert!(result.is_err());
 }
+
+#[test]
+fn old_runtime_file_with_command_history_loads_through_migration() {
+    let json = r#"{
+        "schema_version": 1,
+        "spec": {
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "name": "legacy-ws",
+            "policy": "persistent",
+            "created_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
+            "panes": [{
+                "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cwd": "/home/user",
+                "title": "bash",
+                "exit_status": null,
+                "cols": 80,
+                "rows": 24
+            }],
+            "active_pane_id": null,
+            "command_history": [
+                {
+                    "command": "cargo build",
+                    "cwd": "/home/user/project",
+                    "timestamp": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
+                    "pane_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                }
+            ]
+        },
+        "instance": {
+            "revision": 5,
+            "last_active_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
+            "last_snapshot_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}
+        }
+    }"#;
+    let loaded = load_runtime_file(json).unwrap();
+    assert_eq!(loaded.spec.name, "legacy-ws");
+    assert_eq!(loaded.spec.panes.len(), 1);
+    assert_eq!(loaded.instance.revision, 5);
+}

--- a/services/rttx-server/tests/v3_diagnostics.rs
+++ b/services/rttx-server/tests/v3_diagnostics.rs
@@ -36,7 +36,6 @@ fn v3_diagnostics_full_flow_wire_roundtrip() {
         "workspace-1".into(),
         1,
         1,
-        5,
         1,
         vec![p1, p2],
     );
@@ -49,7 +48,6 @@ fn v3_diagnostics_full_flow_wire_roundtrip() {
         pty_writer_count: 1,
         total_raw_bytes: 4096,
         total_pending_flush: 128,
-        total_command_history: 5,
         runtimes: vec![rt1],
     });
 
@@ -111,7 +109,6 @@ fn v3_diagnostics_empty_server_report() {
         pty_writer_count: 0,
         total_raw_bytes: 0,
         total_pending_flush: 0,
-        total_command_history: 0,
         runtimes: vec![],
     });
     let resp_env = v3_diagnostics::build_diagnostics_report_response(req_env.request_id, report);


### PR DESCRIPTION
## What changed and why

Removes the in-memory `command_history: Vec<HistoryEntry>` from `Runtime` and `PersistedSession` (`RuntimeSpecV1`). This field was never populated in production — `add_history_entry()` was only called from tests and diagnostics. The Vec was always empty, serialized as `[]` in state files, and added dead weight to persistence and diagnostics.

The real command history lives in per-pane HISTFILE files on disk, managed by the shell. The daemon doesn't need an in-memory copy.

### Removed
- `HistoryEntry` struct (`pane.rs`)
- `HistoryEntryV1` struct (`state/types.rs`)
- `MAX_COMMAND_HISTORY` constant
- `Session::add_history_entry()` method
- `command_history` field from `Runtime` struct
- `command_history_len` / `total_command_history` from diagnostics structs, Display, CLI output, and log_diagnostics
- Related test helpers and tests

### Kept
- `history_path()` — still used for HISTFILE
- `.hist` files on disk — that's the real history

### Backward compatibility
- `RuntimeSpecV1.command_history` uses `#[serde(default, skip_serializing)]` so old state files with `command_history` still deserialize, but new files omit the field
- Proto fields (`command_history_len`, `total_command_history`) are preserved in the wire format but always set to 0

### Version bump
0.4.14 → 0.4.15 (>3 source files changed)

## How to manually verify
1. Build and run `rttx-server start --foreground`
2. Create a workspace, run some commands
3. Stop and restart the daemon — workspaces should restore normally
4. Run `rttx-server diagnostics` — output should not mention command history

## Tests added
- `runtime_spec_deserializes_old_command_history` — old state files with command_history entries still load
- `runtime_spec_deserializes_without_command_history` — new state files without the field load
- `runtime_spec_serialization_omits_command_history` — new serialization does not write command_history

## Tests run
- `cargo test -p rttx-proto -p rttx-server` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass
- `cargo build -p rttx --no-default-features --features vte-0_76` — clean

Fixes #688