### PR TITLE
fix: preserve tilde in Place paths for remote host compatibility

### DIFF
--- a/clients/rttx/src/new_workspace_dialog.rs
+++ b/clients/rttx/src/new_workspace_dialog.rs
@@ -178,19 +178,15 @@ pub fn resolve_place_path_public(path: &str) -> Option<String> {
     resolve_place_path(path)
 }
 
-/// Resolve `~` to the actual home directory for local paths.
+/// Resolve a place path for use as a working directory.
+///
+/// Tilde prefixes are preserved so the remote shell resolves `~` on the
+/// correct host.  Expanding locally would substitute the *local* home
+/// directory, which does not exist on a remote machine.
 fn resolve_place_path(path: &str) -> Option<String> {
     let trimmed = path.trim();
     if trimmed.is_empty() || trimmed == "~" {
         return None; // Home — let the shell decide
-    }
-    if trimmed == "/" {
-        return Some("/".into());
-    }
-    if let Some(rest) = trimmed.strip_prefix("~/")
-        && let Ok(home) = std::env::var("HOME")
-    {
-        return Some(format!("{home}/{rest}"));
     }
     Some(trimmed.into())
 }
@@ -220,12 +216,13 @@ mod tests {
     }
 
     #[test]
-    fn resolve_tilde_prefix_expands_home() {
-        let result = resolve_place_path("~/projects");
-        assert!(result.is_some());
-        let resolved = result.unwrap();
-        assert!(resolved.ends_with("/projects"));
-        assert!(!resolved.starts_with('~'));
+    fn resolve_tilde_prefix_preserves_tilde() {
+        assert_eq!(resolve_place_path("~/projects"), Some("~/projects".into()));
+    }
+
+    #[test]
+    fn resolve_tilde_bin_preserves_tilde() {
+        assert_eq!(resolve_place_path("~/bin/"), Some("~/bin/".into()));
     }
 
     #[test]

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -4486,6 +4486,48 @@ fn open_place_action_resolves_tilde_path() {
 }
 
 #[test]
+#[ignore = "requires isolated GTK harness"]
+fn open_place_preserves_tilde_prefix_path() {
+    require_display!();
+
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.open-place-tilde-prefix-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    let terminal_uuid = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    window.imp().focused_terminal_uuid.replace(Some(terminal_uuid.clone()));
+
+    // ~/bin should NOT be expanded to /home/user/bin — the shell resolves ~.
+    window.open_place_in_current_pane("~/bin");
+
+    let term = window
+        .imp()
+        .terminals
+        .borrow()
+        .get(&terminal_uuid)
+        .cloned()
+        .expect("terminal should exist");
+    assert_eq!(
+        term.pending_shell_inputs_for_test(),
+        vec!["cd ~/bin\n"],
+        "tilde-prefix path must be preserved for remote host compatibility"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
 fn visible_session_host_key_defaults_to_local() {
     // The underlying logic defaults to LOCAL_KEY when no visible session is found.
     assert_eq!(crate::host::LOCAL_KEY, "local");

--- a/services/rttx-server/tests/pty_io.rs
+++ b/services/rttx-server/tests/pty_io.rs
@@ -298,6 +298,33 @@ async fn ctrl_d_at_shell_prompt_produces_pane_exited_message() {
 
     let mut client = TestClient::connect(&sock).await;
     let (runtime_id, pane_id) = setup_attached_pane(&mut client).await;
+
+    // Wait for the shell to produce at least one Delta (prompt), so we know
+    // it is ready to accept input.  A fixed drain(500ms) is not enough on
+    // machines with heavy shell startup files.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        assert!(!remaining.is_zero(), "timed out waiting for shell prompt");
+        match client.try_recv(remaining).await {
+            Some(msg) if matches!(msg.msg, Some(proto::server_message::Msg::Delta(_))) => break,
+            Some(_) => {}
+            None => panic!("timed out waiting for shell prompt"),
+        }
+    }
+    // Drain any remaining startup output.
+    client.drain(Duration::from_millis(300)).await;
+
+    // Send a newline first to ensure the input line is empty, then Ctrl+D.
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Input(proto::Input {
+                runtime_id: runtime_id.clone(),
+                pane_id: pane_id.clone(),
+                data: bytes::Bytes::from_static(b"\n"),
+            })),
+        })
+        .await;
     client.drain(Duration::from_millis(500)).await;
 
     client
@@ -310,7 +337,7 @@ async fn ctrl_d_at_shell_prompt_produces_pane_exited_message() {
         })
         .await;
 
-    let msgs = client.drain(Duration::from_secs(3)).await;
+    let msgs = client.drain(Duration::from_secs(10)).await;
     let exited = msgs.iter().find_map(|m| match &m.msg {
         Some(proto::server_message::Msg::PaneExited(pe)) => Some(pe.clone()),
         _ => None,


### PR DESCRIPTION
## What changed and why

`resolve_place_path()` was expanding `~/path` to `$HOME/path` using the local home directory. When a Place was opened on a remote host (via the New Workspace dialog or sidebar), the expanded path did not exist because the remote machine has a different home directory.

Removed the client-side tilde expansion entirely. Both the local daemon and remote shells resolve `~` natively, so the client never needs to expand it.

Also hardened the `ctrl_d_at_shell_prompt_produces_pane_exited_message` pty_io test which was failing consistently in environments with slow shell startup (e.g. NVM in .bashrc).

## How to manually verify

1. Create a Place with path `~/bin/`
2. Open it on a remote host — the daemon receives `~/bin/` (not `/home/localuser/bin/`)
3. Open it via the sidebar on a remote pane — the `cd` command uses `~/bin` (not expanded)
4. Open it locally — still works correctly (shell resolves `~`)

## Tests added

### Unit tests (new_workspace_dialog)
- `resolve_tilde_prefix_preserves_tilde` — verifies `~/projects` is not expanded
- `resolve_tilde_bin_preserves_tilde` — verifies `~/bin/` is not expanded (exact bug scenario)

### GTK widget test (window/tests.rs)
- `open_place_preserves_tilde_prefix_path` — verifies the sidebar sends `cd ~/bin\n` (not `cd /home/user/bin\n`)

### Pre-existing test fix (pty_io.rs)
- Hardened `ctrl_d_at_shell_prompt_produces_pane_exited_message` to wait for shell prompt before sending Ctrl+D

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo build -p rttx-server` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (655 passed, 185 ignored GTK)
- `cargo test -p rttx-server --lib` ✅ (371 passed)
- `cargo test -p rttx-server --test pty_io` ✅ (7 passed)
- `cargo test -p rttx-proto` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests passed via Broadway)
  - `open_place_preserves_tilde_prefix_path` ✅
  - `open_place_action_resolves_tilde_path` ✅
  - `open_place_action_sends_cd_to_focused_terminal` ✅

## Limitations

- The flaky `burst_output_produces_coalesced_deltas` test in pty_coalesce is a pre-existing timing issue unrelated to this change.

Fixes #789