### PR TITLE
feat(commands): implement RFC-025 MVP (clone, raw clipboard, env-var parameters)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.15"
+version = "0.4.16"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -7,6 +7,20 @@ pub enum CommandRunMode {
     Insert,
 }
 
+/// A fixed-choice parameter declared on a saved command.
+///
+/// The command body references the parameter via `$NAME` or `${NAME}`.
+/// At runtime rttx prompts for all declared parameters and injects them
+/// as `export` statements.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommandParameter {
+    pub name: String,
+    pub label: String,
+    pub choices: Vec<String>,
+    #[serde(default)]
+    pub default: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SavedCommand {
     pub uuid: String,
@@ -17,6 +31,12 @@ pub struct SavedCommand {
     /// Host keys this command is scoped to. Empty means global (visible everywhere).
     #[serde(default)]
     pub host_tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<CommandParameter>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
 }
 
 const fn default_run_mode() -> CommandRunMode {
@@ -32,7 +52,26 @@ impl SavedCommand {
             body: body.into(),
             default_run_mode: CommandRunMode::Run,
             host_tags: Vec::new(),
+            parameters: Vec::new(),
+            description: String::new(),
+            labels: Vec::new(),
         }
+    }
+
+    /// Create a duplicate with a new UUID and a "(copy)" title suffix.
+    #[must_use]
+    pub fn duplicate(&self) -> Self {
+        Self {
+            uuid: uuid::Uuid::new_v4().to_string(),
+            title: format!("{} (copy)", self.title),
+            ..self.clone()
+        }
+    }
+
+    /// Whether this command has declared parameters.
+    #[must_use]
+    pub const fn has_parameters(&self) -> bool {
+        !self.parameters.is_empty()
     }
 
     #[must_use]
@@ -96,6 +135,47 @@ pub fn reorder(items: &mut Vec<SavedCommand>, source_uuid: &str, target_uuid: &s
     };
     let item = items.remove(src);
     items.insert(tgt, item);
+}
+
+/// Shell-escape a value for safe inclusion in a single-quoted string.
+///
+/// Wraps the value in single quotes, escaping any embedded single quotes.
+#[must_use]
+pub fn shell_escape(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+/// Resolve the effective default value for a parameter.
+///
+/// Returns `default` if present in `choices`, otherwise the first choice,
+/// otherwise the empty string.
+#[must_use]
+pub fn resolve_default(param: &CommandParameter) -> &str {
+    if let Some(ref d) = param.default
+        && param.choices.contains(d)
+    {
+        return d;
+    }
+    param.choices.first().map_or("", String::as_str)
+}
+
+/// Render the env-var injection block for a parameterized command.
+///
+/// Wraps the body in a subshell with `export` statements for each parameter
+/// in declaration order.
+#[must_use]
+pub fn render_env_block(body: &str, values: &[(String, String)]) -> String {
+    use std::fmt::Write;
+    let mut result = String::from("(\n");
+    for (name, value) in values {
+        let _ = writeln!(result, "export {}={}", name, shell_escape(value));
+    }
+    result.push_str(body);
+    if !body.ends_with('\n') {
+        result.push('\n');
+    }
+    result.push(')');
+    result
 }
 
 #[cfg(test)]
@@ -279,5 +359,189 @@ mod tests {
         let mut commands = vec![command];
         migrate_legacy(&mut commands);
         assert_eq!(commands[0].host_tags, vec!["example.com"]);
+    }
+
+    // ── Parameters ──────────────────────────────────────────────
+
+    #[test]
+    fn shell_escape_plain_value() {
+        assert_eq!(shell_escape("prod"), "'prod'");
+    }
+
+    #[test]
+    fn shell_escape_value_with_spaces() {
+        assert_eq!(shell_escape("hello world"), "'hello world'");
+    }
+
+    #[test]
+    fn shell_escape_value_with_single_quotes() {
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn shell_escape_value_with_dollar_sign() {
+        assert_eq!(shell_escape("$HOME"), "'$HOME'");
+    }
+
+    #[test]
+    fn shell_escape_value_with_semicolons_and_newlines() {
+        assert_eq!(shell_escape("a;b\nc"), "'a;b\nc'");
+    }
+
+    #[test]
+    fn shell_escape_empty_string() {
+        assert_eq!(shell_escape(""), "''");
+    }
+
+    #[test]
+    fn render_env_block_single_parameter() {
+        let result =
+            render_env_block("systemctl restart $SERVICE", &[("SERVICE".into(), "api".into())]);
+        assert_eq!(result, "(\nexport SERVICE='api'\nsystemctl restart $SERVICE\n)");
+    }
+
+    #[test]
+    fn render_env_block_multiple_parameters_preserves_order() {
+        let result = render_env_block(
+            "kubectl logs -n $NS $POD",
+            &[("NS".into(), "prod".into()), ("POD".into(), "web-1".into())],
+        );
+        assert_eq!(result, "(\nexport NS='prod'\nexport POD='web-1'\nkubectl logs -n $NS $POD\n)");
+    }
+
+    #[test]
+    fn render_env_block_body_with_trailing_newline() {
+        let result = render_env_block("echo done\n", &[("X".into(), "1".into())]);
+        assert_eq!(result, "(\nexport X='1'\necho done\n)");
+    }
+
+    #[test]
+    fn render_env_block_escapes_values() {
+        let result = render_env_block("echo $MSG", &[("MSG".into(), "it's a test".into())]);
+        assert_eq!(result, "(\nexport MSG='it'\\''s a test'\necho $MSG\n)");
+    }
+
+    #[test]
+    fn resolve_default_uses_declared_default_when_in_choices() {
+        let param = CommandParameter {
+            name: "ENV".into(),
+            label: "Environment".into(),
+            choices: vec!["dev".into(), "staging".into(), "prod".into()],
+            default: Some("staging".into()),
+        };
+        assert_eq!(resolve_default(&param), "staging");
+    }
+
+    #[test]
+    fn resolve_default_falls_back_to_first_choice_when_default_not_in_choices() {
+        let param = CommandParameter {
+            name: "ENV".into(),
+            label: "Environment".into(),
+            choices: vec!["dev".into(), "prod".into()],
+            default: Some("staging".into()),
+        };
+        assert_eq!(resolve_default(&param), "dev");
+    }
+
+    #[test]
+    fn resolve_default_falls_back_to_first_choice_when_no_default() {
+        let param = CommandParameter {
+            name: "ENV".into(),
+            label: "Environment".into(),
+            choices: vec!["dev".into(), "prod".into()],
+            default: None,
+        };
+        assert_eq!(resolve_default(&param), "dev");
+    }
+
+    #[test]
+    fn resolve_default_returns_empty_when_no_choices() {
+        let param = CommandParameter {
+            name: "ENV".into(),
+            label: "Environment".into(),
+            choices: vec![],
+            default: None,
+        };
+        assert_eq!(resolve_default(&param), "");
+    }
+
+    #[test]
+    fn duplicate_creates_new_uuid_and_copy_title() {
+        let mut original = SavedCommand::new("Deploy", "cargo build");
+        original.parameters = vec![CommandParameter {
+            name: "ENV".into(),
+            label: "Environment".into(),
+            choices: vec!["prod".into()],
+            default: None,
+        }];
+        original.description = "Deploys the app".into();
+        original.labels = vec!["deploy".into()];
+
+        let copy = original.duplicate();
+        assert_ne!(copy.uuid, original.uuid);
+        assert_eq!(copy.title, "Deploy (copy)");
+        assert_eq!(copy.body, original.body);
+        assert_eq!(copy.parameters, original.parameters);
+        assert_eq!(copy.description, original.description);
+        assert_eq!(copy.labels, original.labels);
+        assert_eq!(copy.host_tags, original.host_tags);
+    }
+
+    #[test]
+    fn has_parameters_returns_false_for_plain_command() {
+        let command = SavedCommand::new("Test", "echo hi");
+        assert!(!command.has_parameters());
+    }
+
+    #[test]
+    fn has_parameters_returns_true_when_parameters_present() {
+        let mut command = SavedCommand::new("Test", "echo $X");
+        command.parameters = vec![CommandParameter {
+            name: "X".into(),
+            label: "X".into(),
+            choices: vec!["1".into()],
+            default: None,
+        }];
+        assert!(command.has_parameters());
+    }
+
+    #[test]
+    fn serde_roundtrip_with_parameters() {
+        let mut command = SavedCommand::new("Parameterized", "systemctl restart $SERVICE");
+        command.parameters = vec![CommandParameter {
+            name: "SERVICE".into(),
+            label: "Service name".into(),
+            choices: vec!["api".into(), "web".into(), "worker".into()],
+            default: Some("api".into()),
+        }];
+        command.description = "Restart a service".into();
+        command.labels = vec!["ops".into(), "restart".into()];
+
+        let json = serde_json::to_string(&[&command]).unwrap();
+        let loaded: Vec<SavedCommand> = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded, vec![command]);
+    }
+
+    #[test]
+    fn legacy_json_without_new_fields_deserializes_with_defaults() {
+        let json = r#"[{
+            "uuid": "abc",
+            "title": "Old",
+            "body": "echo old",
+            "default_run_mode": "run"
+        }]"#;
+        let commands: Vec<SavedCommand> = serde_json::from_str(json).unwrap();
+        assert!(commands[0].parameters.is_empty());
+        assert!(commands[0].description.is_empty());
+        assert!(commands[0].labels.is_empty());
+    }
+
+    #[test]
+    fn empty_parameters_not_serialized() {
+        let command = SavedCommand::new("Plain", "echo hi");
+        let json = serde_json::to_string(&command).unwrap();
+        assert!(!json.contains("parameters"));
+        assert!(!json.contains("description"));
+        assert!(!json.contains("labels"));
     }
 }

--- a/clients/rttx/src/commands_window.rs
+++ b/clients/rttx/src/commands_window.rs
@@ -2,7 +2,7 @@ use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
 
-use crate::commands::{CommandRunMode, SavedCommand};
+use crate::commands::{CommandParameter, CommandRunMode, SavedCommand};
 use crate::form_dialog::FormDialog;
 use crate::host_tag_picker::HostTagPicker;
 use crate::window::Window;
@@ -35,9 +35,23 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
     let behavior_group = adw::PreferencesGroup::new();
     behavior_group.add(&run_mode_row);
 
+    // Parameters section
+    let params_group = adw::PreferencesGroup::builder().title("Parameters").build();
+    let params_box = gtk4::Box::new(gtk4::Orientation::Vertical, 6);
+    let params_list = gtk4::ListBox::new();
+    params_list.add_css_class("boxed-list");
+    params_list.set_selection_mode(gtk4::SelectionMode::None);
+    params_box.append(&params_list);
+
+    let add_param_button = gtk4::Button::with_label("Add parameter");
+    add_param_button.add_css_class("flat");
+    params_box.append(&add_param_button);
+    params_group.add(&params_box);
+
     form.content_box.append(&title_group);
     form.content_box.append(&body_scroll);
     form.content_box.append(&behavior_group);
+    form.content_box.append(&params_group);
     form.content_box.append(&host_picker.group);
     form.finish_layout();
 
@@ -45,7 +59,16 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
         title_row.set_text(&c.title);
         body_buffer.set_text(&c.body);
         run_mode.set_selected(run_mode_index(c.default_run_mode));
+        for param in &c.parameters {
+            append_parameter_row(&params_list, Some(param));
+        }
     }
+
+    // Add parameter button
+    let list_for_add = params_list.clone();
+    add_param_button.connect_clicked(move |_| {
+        append_parameter_row(&list_for_add, None);
+    });
 
     let dialog = form.dialog.clone();
     let status_label = form.status_label.clone();
@@ -56,6 +79,7 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
             &body_buffer,
             &run_mode,
             &host_picker,
+            &params_list,
             existing_uuid.clone(),
         ) {
             Ok(c) => c,
@@ -82,11 +106,62 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
     form.present(parent);
 }
 
+fn append_parameter_row(list: &gtk4::ListBox, param: Option<&CommandParameter>) {
+    let row_box = gtk4::Box::new(gtk4::Orientation::Vertical, 6);
+    row_box.set_margin_start(6);
+    row_box.set_margin_end(6);
+    row_box.set_margin_top(6);
+    row_box.set_margin_bottom(6);
+
+    let name_entry = adw::EntryRow::builder().title("Variable name").build();
+    let label_entry = adw::EntryRow::builder().title("Label").build();
+    let choices_entry = adw::EntryRow::builder().title("Choices (comma-separated)").build();
+    let default_entry = adw::EntryRow::builder().title("Default").build();
+
+    if let Some(p) = param {
+        name_entry.set_text(&p.name);
+        label_entry.set_text(&p.label);
+        choices_entry.set_text(&p.choices.join(", "));
+        if let Some(ref d) = p.default {
+            default_entry.set_text(d);
+        }
+    }
+
+    let remove_button = gtk4::Button::builder()
+        .icon_name("user-trash-symbolic")
+        .tooltip_text("Remove parameter")
+        .halign(gtk4::Align::End)
+        .build();
+    remove_button.add_css_class("flat");
+    remove_button.add_css_class("destructive-action");
+
+    let entries_group = adw::PreferencesGroup::new();
+    entries_group.add(&name_entry);
+    entries_group.add(&label_entry);
+    entries_group.add(&choices_entry);
+    entries_group.add(&default_entry);
+
+    row_box.append(&entries_group);
+    row_box.append(&remove_button);
+
+    let list_row = gtk4::ListBoxRow::new();
+    list_row.set_child(Some(&row_box));
+    list_row.set_selectable(false);
+    list_row.set_activatable(false);
+    list.append(&list_row);
+
+    let list_ref = list.clone();
+    remove_button.connect_clicked(move |_| {
+        list_ref.remove(&list_row);
+    });
+}
+
 fn build_command(
     title_row: &adw::EntryRow,
     body_buffer: &gtk4::TextBuffer,
     run_mode: &gtk4::DropDown,
     host_picker: &HostTagPicker,
+    params_list: &gtk4::ListBox,
     existing_uuid: Option<String>,
 ) -> Result<SavedCommand, String> {
     let title = title_row.text().trim().to_string();
@@ -100,13 +175,82 @@ fn build_command(
         return Err("Command body is required".into());
     }
 
+    let parameters = extract_parameters(params_list)?;
+
     let mut command = SavedCommand::new(title, body);
     if let Some(uuid) = existing_uuid {
         command.uuid = uuid;
     }
     command.default_run_mode = run_mode_from_index(run_mode.selected());
     command.host_tags = host_picker.selected_tags();
+    command.parameters = parameters;
     Ok(command)
+}
+
+fn extract_parameters(list: &gtk4::ListBox) -> Result<Vec<CommandParameter>, String> {
+    let mut params = Vec::new();
+    let mut idx = 0;
+    while let Some(row) = list.row_at_index(idx) {
+        idx += 1;
+        let Some(row_box) = row.child().and_then(|c| c.downcast::<gtk4::Box>().ok()) else {
+            continue;
+        };
+        let Some(group) =
+            row_box.first_child().and_then(|c| c.downcast::<adw::PreferencesGroup>().ok())
+        else {
+            continue;
+        };
+
+        let entries = collect_entry_rows(&group);
+        if entries.len() < 4 {
+            continue;
+        }
+
+        let name = entries[0].text().trim().to_string();
+        if name.is_empty() {
+            return Err("Parameter variable name is required".into());
+        }
+        let label = entries[1].text().trim().to_string();
+        if label.is_empty() {
+            return Err("Parameter label is required".into());
+        }
+        let choices_text = entries[2].text().trim().to_string();
+        let choices: Vec<String> = choices_text
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let default_text = entries[3].text().trim().to_string();
+        let default = if default_text.is_empty() { None } else { Some(default_text) };
+
+        params.push(CommandParameter { name, label, choices, default });
+    }
+    Ok(params)
+}
+
+fn collect_entry_rows(group: &adw::PreferencesGroup) -> Vec<adw::EntryRow> {
+    let mut entries = Vec::new();
+    let listbox = group.first_child().and_then(|c| {
+        // PreferencesGroup wraps content in a Box > ListBox
+        let mut child = Some(c);
+        while let Some(c) = child {
+            if let Ok(lb) = c.clone().downcast::<gtk4::ListBox>() {
+                return Some(lb);
+            }
+            child = c.next_sibling();
+        }
+        None
+    });
+    if let Some(lb) = listbox {
+        let mut i = 0;
+        while let Some(row) = lb.row_at_index(i) {
+            if let Ok(entry) = row.downcast::<adw::EntryRow>() {
+                entries.push(entry);
+            }
+            i += 1;
+        }
+    }
+    entries
 }
 
 const fn run_mode_from_index(index: u32) -> CommandRunMode {

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -9,6 +9,7 @@ pub mod form_dialog;
 pub mod host;
 pub mod host_tag_picker;
 pub mod new_workspace_dialog;
+pub mod parameter_dialog;
 pub mod places;
 pub mod places_window;
 pub mod preferences;

--- a/clients/rttx/src/parameter_dialog.rs
+++ b/clients/rttx/src/parameter_dialog.rs
@@ -1,0 +1,139 @@
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+
+use crate::commands::{CommandRunMode, SavedCommand, render_env_block};
+use crate::window::Window;
+
+/// Show the runtime parameter dialog for a parameterized command.
+///
+/// Presents one `adw::ComboRow` per declared parameter with a live preview
+/// of the rendered shell block. The primary action matches `run_mode`.
+pub fn show(parent: &Window, command: &SavedCommand, run_mode: CommandRunMode) {
+    let dialog = adw::Dialog::builder().title(&command.title).content_width(480).build();
+
+    let header = adw::HeaderBar::new();
+
+    let action_label = match run_mode {
+        CommandRunMode::Run => "Run",
+        CommandRunMode::Insert => "Insert",
+    };
+    let action_button = gtk4::Button::with_label(action_label);
+    action_button.add_css_class("suggested-action");
+    header.pack_end(&action_button);
+
+    let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+    content_box.set_margin_start(18);
+    content_box.set_margin_end(18);
+    content_box.set_margin_top(18);
+    content_box.set_margin_bottom(18);
+
+    let params_group = adw::PreferencesGroup::builder().title("Parameters").build();
+
+    let combo_rows: Vec<(String, adw::ComboRow)> = command
+        .parameters
+        .iter()
+        .map(|param| {
+            let choices: Vec<&str> = param.choices.iter().map(String::as_str).collect();
+            let string_list = gtk4::StringList::new(&choices);
+            let row = adw::ComboRow::builder().title(&param.label).model(&string_list).build();
+
+            let default_idx = resolve_default_index(param);
+            row.set_selected(default_idx);
+
+            params_group.add(&row);
+            (param.name.clone(), row)
+        })
+        .collect();
+
+    let preview_label = gtk4::Label::builder().label("Preview").xalign(0.0).build();
+    preview_label.add_css_class("dim-label");
+    preview_label.add_css_class("caption");
+
+    let preview_buffer = gtk4::TextBuffer::new(None);
+    let preview_view = gtk4::TextView::with_buffer(&preview_buffer);
+    preview_view.set_editable(false);
+    preview_view.set_monospace(true);
+    preview_view.set_wrap_mode(gtk4::WrapMode::WordChar);
+    preview_view.add_css_class("card");
+    let preview_scroll =
+        gtk4::ScrolledWindow::builder().min_content_height(100).child(&preview_view).build();
+
+    content_box.append(&params_group);
+    content_box.append(&preview_label);
+    content_box.append(&preview_scroll);
+
+    let toolbar_view = adw::ToolbarView::new();
+    toolbar_view.add_top_bar(&header);
+    toolbar_view.set_content(Some(&content_box));
+    dialog.set_child(Some(&toolbar_view));
+
+    // Initial preview render
+    let body = command.body.clone();
+    let parameters = command.parameters.clone();
+    update_preview(&preview_buffer, &body, &parameters, &combo_rows);
+
+    // Update preview on every combo change
+    for (_, row) in &combo_rows {
+        let buf = preview_buffer.clone();
+        let body = body.clone();
+        let params = parameters.clone();
+        let rows = combo_rows.clone();
+        row.connect_selected_notify(move |_| {
+            update_preview(&buf, &body, &params, &rows);
+        });
+    }
+
+    // Action button
+    let dialog_ref = dialog.clone();
+    let parent_win = parent.clone();
+    let command_clone = command.clone();
+    let rows_for_action = combo_rows;
+    action_button.connect_clicked(move |_| {
+        let values = collect_values(&command_clone.parameters, &rows_for_action);
+        let rendered = render_env_block(&command_clone.body, &values);
+        let text = match run_mode {
+            CommandRunMode::Run => format!("{rendered}\n"),
+            CommandRunMode::Insert => rendered,
+        };
+        parent_win.execute_command_text(&command_clone, run_mode, &text);
+        dialog_ref.close();
+    });
+
+    dialog.present(Some(parent));
+}
+
+fn update_preview(
+    buffer: &gtk4::TextBuffer,
+    body: &str,
+    parameters: &[crate::commands::CommandParameter],
+    combo_rows: &[(String, adw::ComboRow)],
+) {
+    let values = collect_values(parameters, combo_rows);
+    let rendered = render_env_block(body, &values);
+    buffer.set_text(&rendered);
+}
+
+fn collect_values(
+    parameters: &[crate::commands::CommandParameter],
+    combo_rows: &[(String, adw::ComboRow)],
+) -> Vec<(String, String)> {
+    parameters
+        .iter()
+        .zip(combo_rows.iter())
+        .map(|(param, (name, row))| {
+            let selected = row.selected() as usize;
+            let value = param.choices.get(selected).cloned().unwrap_or_default();
+            (name.clone(), value)
+        })
+        .collect()
+}
+
+fn resolve_default_index(param: &crate::commands::CommandParameter) -> u32 {
+    if let Some(ref d) = param.default
+        && let Some(idx) = param.choices.iter().position(|c| c == d)
+    {
+        return idx as u32;
+    }
+    0
+}

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -435,6 +435,9 @@ mod tests {
             body: "echo hi".into(),
             default_run_mode: crate::commands::CommandRunMode::Insert,
             host_tags: vec![],
+            parameters: vec![],
+            description: String::new(),
+            labels: vec![],
         };
         store.save_library(&[place], &[cmd]).unwrap();
         let (places, commands) = store.load_library().into_value().unwrap();

--- a/clients/rttx/src/store/models/library.rs
+++ b/clients/rttx/src/store/models/library.rs
@@ -32,6 +32,12 @@ pub struct CommandRecord {
     /// Empty means global visibility. Values are endpoint keys.
     #[serde(default)]
     pub host_tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<crate::commands::CommandParameter>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
 }
 
 const fn default_run_mode() -> RunMode {
@@ -77,6 +83,9 @@ impl From<CommandRecord> for crate::commands::SavedCommand {
                 RunMode::Insert => crate::commands::CommandRunMode::Insert,
             },
             host_tags: rec.host_tags,
+            parameters: rec.parameters,
+            description: rec.description,
+            labels: rec.labels,
         }
     }
 }
@@ -92,6 +101,9 @@ impl From<&crate::commands::SavedCommand> for CommandRecord {
                 crate::commands::CommandRunMode::Insert => RunMode::Insert,
             },
             host_tags: cmd.host_tags.clone(),
+            parameters: cmd.parameters.clone(),
+            description: cmd.description.clone(),
+            labels: cmd.labels.clone(),
         }
     }
 }

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -133,6 +133,38 @@ impl Window {
         });
         self.add_action(&delete_command_action);
 
+        let duplicate_command_action =
+            gtk4::gio::SimpleAction::new("duplicate-command", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        duplicate_command_action.connect_activate(move |_, param| {
+            let uuid: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            let all_commands = crate::store::default_store().load_commands();
+            if let Some(command) = all_commands.iter().find(|c| c.uuid == uuid) {
+                let copy = command.duplicate();
+                let mut items = crate::store::default_store().load_commands();
+                items.push(copy.clone());
+                let _ = crate::store::default_store().save_commands(&items);
+                win.refresh_command_sidebar();
+                crate::commands_window::show_form(&win, Some(&copy));
+            }
+        });
+        self.add_action(&duplicate_command_action);
+
+        let copy_body_action =
+            gtk4::gio::SimpleAction::new("copy-command-body", Some(glib::VariantTy::STRING));
+        let win = self.clone();
+        copy_body_action.connect_activate(move |_, param| {
+            let uuid: String = param.and_then(glib::Variant::get).unwrap_or_default();
+            let all_commands = crate::store::default_store().load_commands();
+            if let Some(command) = all_commands.iter().find(|c| c.uuid == uuid)
+                && let Some(display) = gtk4::gdk::Display::default()
+            {
+                display.clipboard().set_text(&command.body);
+                win.show_toast("Copied to clipboard");
+            }
+        });
+        self.add_action(&copy_body_action);
+
         let edit_place_action =
             gtk4::gio::SimpleAction::new("edit-place", Some(glib::VariantTy::STRING));
         let win = self.clone();

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -301,6 +301,14 @@ impl Window {
             action_row.set_subtitle(&command.preview());
             action_row.set_activatable(true);
 
+            if command.has_parameters() {
+                let chip = gtk4::Label::new(Some("ENV"));
+                chip.add_css_class("dim-label");
+                chip.add_css_class("caption");
+                chip.set_valign(gtk4::Align::Center);
+                action_row.add_suffix(&chip);
+            }
+
             let insert_button = gtk4::Button::builder()
                 .icon_name("insert-text-symbolic")
                 .tooltip_text("Insert into current pane")
@@ -312,11 +320,23 @@ impl Window {
             let edit_item = gtk4::gio::MenuItem::new(Some("Edit"), None);
             edit_item
                 .set_action_and_target_value(Some("win.edit-command"), Some(&uuid.to_variant()));
+            let duplicate_item = gtk4::gio::MenuItem::new(Some("Duplicate"), None);
+            duplicate_item.set_action_and_target_value(
+                Some("win.duplicate-command"),
+                Some(&uuid.to_variant()),
+            );
+            let copy_body_item = gtk4::gio::MenuItem::new(Some("Copy body"), None);
+            copy_body_item.set_action_and_target_value(
+                Some("win.copy-command-body"),
+                Some(&uuid.to_variant()),
+            );
             let delete_item = gtk4::gio::MenuItem::new(Some("Delete"), None);
             delete_item
                 .set_action_and_target_value(Some("win.delete-command"), Some(&uuid.to_variant()));
             let menu = gtk4::gio::Menu::new();
             menu.append_item(&edit_item);
+            menu.append_item(&duplicate_item);
+            menu.append_item(&copy_body_item);
             menu.append_item(&delete_item);
             let more_button = gtk4::MenuButton::builder()
                 .icon_name("view-more-symbolic")
@@ -409,6 +429,19 @@ impl Window {
     }
 
     pub(crate) fn execute_saved_command(&self, command: &SavedCommand, run_mode: CommandRunMode) {
+        if command.has_parameters() {
+            crate::parameter_dialog::show(self, command, run_mode);
+            return;
+        }
+        self.execute_command_text(command, run_mode, &command.input_for(run_mode));
+    }
+
+    pub(crate) fn execute_command_text(
+        &self,
+        command: &SavedCommand,
+        run_mode: CommandRunMode,
+        text: &str,
+    ) {
         let Some(terminal_uuid) = self.command_target_terminal_uuid() else {
             return;
         };
@@ -424,7 +457,7 @@ impl Window {
                 }],
             },
         );
-        self.send_input_to_terminal(&terminal_uuid, &command.input_for(run_mode));
+        self.send_input_to_terminal(&terminal_uuid, text);
     }
 
     fn command_target_terminal_uuid(&self) -> Option<String> {

--- a/clients/rttx/tests/commands_integration.rs
+++ b/clients/rttx/tests/commands_integration.rs
@@ -55,3 +55,45 @@ fn legacy_commands_without_host_tags_deserialize_and_migrate() {
     let reloaded: Vec<SavedCommand> = serde_json::from_str(&json2).unwrap();
     assert_eq!(reloaded[0].host_tags, vec!["local"], "migrated tags persist");
 }
+
+#[test]
+fn commands_with_parameters_roundtrip() {
+    let (_tmp, store) = test_store();
+
+    let mut command = SavedCommand::new("Restart service", "systemctl restart $SERVICE");
+    command.parameters = vec![rttx::commands::CommandParameter {
+        name: "SERVICE".into(),
+        label: "Service name".into(),
+        choices: vec!["api".into(), "web".into(), "worker".into()],
+        default: Some("api".into()),
+    }];
+    command.description = "Restart a systemd service".into();
+    command.labels = vec!["ops".into()];
+
+    store.save_commands(&[command.clone()]).unwrap();
+    let loaded = store.load_commands();
+    assert_eq!(loaded, vec![command]);
+}
+
+#[test]
+fn duplicate_command_persists_with_new_uuid() {
+    let (_tmp, store) = test_store();
+
+    let mut command = SavedCommand::new("Deploy", "cargo build");
+    command.parameters = vec![rttx::commands::CommandParameter {
+        name: "ENV".into(),
+        label: "Environment".into(),
+        choices: vec!["prod".into(), "dev".into()],
+        default: Some("dev".into()),
+    }];
+
+    store.save_commands(&[command.clone()]).unwrap();
+    let copy = command.duplicate();
+    store.save_commands(&[command.clone(), copy]).unwrap();
+
+    let loaded = store.load_commands();
+    assert_eq!(loaded.len(), 2);
+    assert_ne!(loaded[0].uuid, loaded[1].uuid);
+    assert_eq!(loaded[1].title, "Deploy (copy)");
+    assert_eq!(loaded[1].parameters, command.parameters);
+}

--- a/clients/rttx/tests/document_models.rs
+++ b/clients/rttx/tests/document_models.rs
@@ -296,6 +296,9 @@ fn library_preserves_orphaned_host_tags() {
             body: "echo hi".into(),
             default_run_mode: rttx::store::models::commands::RunMode::Run,
             host_tags: vec!["deleted-host-key".into()],
+            parameters: vec![],
+            description: String::new(),
+            labels: vec![],
         }],
     };
     let env = DocumentEnvelope::new(library::SCHEMA, library::CURRENT_VERSION, lib);

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.15',
+  version: '0.4.16',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Implements the MVP portion of RFC-025 (issue #797):

- **Data model**: Added `CommandParameter` struct and extended `SavedCommand` with `parameters`, `description`, and `labels` fields (all `#[serde(default)]` for backward compat)
- **Shell helpers**: `shell_escape`, `render_env_block`, `resolve_default` for env-var injection
- **Runtime parameter dialog**: `adw::Dialog` with one `adw::ComboRow` per parameter, live preview of rendered shell block, primary action matches Run/Insert
- **Duplicate action**: Creates a copy with new UUID and "(copy)" title suffix, opens editor
- **Copy body action**: Copies raw command body to clipboard with toast confirmation
- **Parameter chip**: "ENV" label shown in sidebar rows for parameterized commands
- **Editor extension**: Parameters section with name, label, choices (comma-separated), and default fields

## Manual verification steps

1. Create a command with parameters (e.g., body: `systemctl restart $SERVICE`, add parameter SERVICE with choices api,web,worker)
2. Click the command → parameter dialog appears with combo rows and live preview
3. Select values → preview updates → Run/Insert executes the rendered shell block
4. Right-click menu → Duplicate creates a copy and opens editor
5. Right-click menu → Copy body copies raw body text to clipboard
6. Parameterized commands show "ENV" chip in sidebar

## Tests added

Unit tests (in `commands.rs`):
- `shell_escape_*` (6 tests): plain, spaces, quotes, dollar signs, semicolons/newlines, empty
- `render_env_block_*` (4 tests): single param, multiple params order, trailing newline, escaping
- `resolve_default_*` (4 tests): declared default, fallback to first, no default, no choices
- `duplicate_*` (1 test): new UUID, copy title, preserves all fields
- `has_parameters_*` (2 tests): false for plain, true when present
- `serde_roundtrip_with_parameters`: full roundtrip with all new fields
- `legacy_json_without_new_fields_deserializes_with_defaults`: backward compat
- `empty_parameters_not_serialized`: skip_serializing_if works

Integration tests (in `commands_integration.rs`):
- `commands_with_parameters_roundtrip`: full store persistence
- `duplicate_command_persists_with_new_uuid`: duplicate through store

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76`) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` — 860 tests (675 pass, 185 ignored GTK) ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — all pass, no failures ✅

## Remaining limitations

- Parameter editor uses comma-separated choices (no individual entry rows per choice) — simpler than RFC spec but functional
- No AT-SPI behavioral tests (follow-up per RFC-025 development plan)
- Description and labels fields are persisted but not yet surfaced in the UI (follow-up issues per RFC)

Fixes #797