### PR TITLE
feat(commands): add labels and label-based filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.16"
+version = "0.4.17"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -100,6 +100,30 @@ pub fn matches_query(command: &SavedCommand, query: &str) -> bool {
         || command.body.to_ascii_lowercase().contains(&query)
         || command.description.to_ascii_lowercase().contains(&query)
         || command.host_tags.iter().any(|tag| tag.to_ascii_lowercase().contains(&query))
+        || command.labels.iter().any(|l| l.to_ascii_lowercase().contains(&query))
+}
+
+/// Returns `true` if the command has at least one label in `active_labels`.
+///
+/// When `active_labels` is empty, all commands match (no filter active).
+#[must_use]
+pub fn matches_labels(command: &SavedCommand, active_labels: &[String]) -> bool {
+    if active_labels.is_empty() {
+        return true;
+    }
+    command.labels.iter().any(|l| active_labels.contains(l))
+}
+
+/// Collect all distinct labels from a set of commands, sorted alphabetically.
+#[must_use]
+pub fn collect_labels(commands: &[SavedCommand]) -> Vec<String> {
+    let mut labels: Vec<String> = commands
+        .iter()
+        .flat_map(|c| c.labels.iter().cloned())
+        .collect();
+    labels.sort();
+    labels.dedup();
+    labels
 }
 
 /// Returns `true` if the command should be visible for the given host key.
@@ -552,5 +576,61 @@ mod tests {
         assert!(!json.contains("parameters"));
         assert!(!json.contains("description"));
         assert!(!json.contains("labels"));
+    }
+
+    // ── Label filtering ─────────────────────────────────────────
+
+    #[test]
+    fn matches_query_searches_labels() {
+        let mut command = SavedCommand::new("Deploy", "cargo build");
+        command.labels = vec!["ops".into(), "deploy".into()];
+        assert!(matches_query(&command, "ops"));
+        assert!(matches_query(&command, "deploy"));
+        assert!(!matches_query(&command, "diag"));
+    }
+
+    #[test]
+    fn matches_labels_empty_filter_matches_all() {
+        let command = SavedCommand::new("Test", "echo hi");
+        assert!(matches_labels(&command, &[]));
+    }
+
+    #[test]
+    fn matches_labels_returns_true_when_command_has_matching_label() {
+        let mut command = SavedCommand::new("Deploy", "cargo build");
+        command.labels = vec!["ops".into(), "deploy".into()];
+        assert!(matches_labels(&command, &["ops".into()]));
+        assert!(matches_labels(&command, &["deploy".into()]));
+    }
+
+    #[test]
+    fn matches_labels_returns_false_when_no_match() {
+        let mut command = SavedCommand::new("Deploy", "cargo build");
+        command.labels = vec!["ops".into()];
+        assert!(!matches_labels(&command, &["diag".into()]));
+    }
+
+    #[test]
+    fn matches_labels_unlabeled_command_excluded_when_filter_active() {
+        let command = SavedCommand::new("Plain", "echo hi");
+        assert!(!matches_labels(&command, &["ops".into()]));
+    }
+
+    #[test]
+    fn collect_labels_returns_sorted_unique_labels() {
+        let mut c1 = SavedCommand::new("A", "echo a");
+        c1.labels = vec!["deploy".into(), "ops".into()];
+        let mut c2 = SavedCommand::new("B", "echo b");
+        c2.labels = vec!["ops".into(), "diag".into()];
+        let c3 = SavedCommand::new("C", "echo c");
+
+        let labels = collect_labels(&[c1, c2, c3]);
+        assert_eq!(labels, vec!["deploy", "diag", "ops"]);
+    }
+
+    #[test]
+    fn collect_labels_empty_commands_returns_empty() {
+        let labels = collect_labels(&[]);
+        assert!(labels.is_empty());
     }
 }

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -117,10 +117,7 @@ pub fn matches_labels(command: &SavedCommand, active_labels: &[String]) -> bool 
 /// Collect all distinct labels from a set of commands, sorted alphabetically.
 #[must_use]
 pub fn collect_labels(commands: &[SavedCommand]) -> Vec<String> {
-    let mut labels: Vec<String> = commands
-        .iter()
-        .flat_map(|c| c.labels.iter().cloned())
-        .collect();
+    let mut labels: Vec<String> = commands.iter().flat_map(|c| c.labels.iter().cloned()).collect();
     labels.sort();
     labels.dedup();
     labels

--- a/clients/rttx/src/commands_window.rs
+++ b/clients/rttx/src/commands_window.rs
@@ -16,8 +16,7 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
 
     let description_row = adw::EntryRow::builder().title("Description").build();
 
-    let labels_row =
-        adw::EntryRow::builder().title("Labels (comma-separated)").build();
+    let labels_row = adw::EntryRow::builder().title("Labels (comma-separated)").build();
 
     let body_buffer = gtk4::TextBuffer::new(None);
     let body_view = gtk4::TextView::with_buffer(&body_buffer);

--- a/clients/rttx/src/commands_window.rs
+++ b/clients/rttx/src/commands_window.rs
@@ -16,6 +16,9 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
 
     let description_row = adw::EntryRow::builder().title("Description").build();
 
+    let labels_row =
+        adw::EntryRow::builder().title("Labels (comma-separated)").build();
+
     let body_buffer = gtk4::TextBuffer::new(None);
     let body_view = gtk4::TextView::with_buffer(&body_buffer);
     body_view.set_wrap_mode(gtk4::WrapMode::WordChar);
@@ -34,6 +37,7 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
     let title_group = adw::PreferencesGroup::new();
     title_group.add(&title_row);
     title_group.add(&description_row);
+    title_group.add(&labels_row);
 
     let behavior_group = adw::PreferencesGroup::new();
     behavior_group.add(&run_mode_row);
@@ -61,6 +65,7 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
     if let Some(c) = command {
         title_row.set_text(&c.title);
         description_row.set_text(&c.description);
+        labels_row.set_text(&c.labels.join(", "));
         body_buffer.set_text(&c.body);
         run_mode.set_selected(run_mode_index(c.default_run_mode));
         for param in &c.parameters {
@@ -81,6 +86,7 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
         let cmd = match build_command(
             &title_row,
             &description_row,
+            &labels_row,
             &body_buffer,
             &run_mode,
             &host_picker,
@@ -161,9 +167,11 @@ fn append_parameter_row(list: &gtk4::ListBox, param: Option<&CommandParameter>) 
     });
 }
 
+#[allow(clippy::too_many_arguments)] // Form fields are naturally numerous
 fn build_command(
     title_row: &adw::EntryRow,
     description_row: &adw::EntryRow,
+    labels_row: &adw::EntryRow,
     body_buffer: &gtk4::TextBuffer,
     run_mode: &gtk4::DropDown,
     host_picker: &HostTagPicker,
@@ -183,6 +191,13 @@ fn build_command(
 
     let parameters = extract_parameters(params_list)?;
 
+    let labels: Vec<String> = labels_row
+        .text()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
     let mut command = SavedCommand::new(title, body);
     if let Some(uuid) = existing_uuid {
         command.uuid = uuid;
@@ -191,6 +206,7 @@ fn build_command(
     command.host_tags = host_picker.selected_tags();
     command.parameters = parameters;
     command.description = description_row.text().trim().to_string();
+    command.labels = labels;
     Ok(command)
 }
 

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -59,6 +59,8 @@ mod imp {
         pub command_list: gtk4::ListBox,
         pub command_scroll: gtk4::ScrolledWindow,
         pub command_empty: adw::StatusPage,
+        pub label_filter_box: gtk4::FlowBox,
+        pub active_labels: RefCell<Vec<String>>,
         pub toast_overlay: adw::ToastOverlay,
         pub new_button: gtk4::MenuButton,
         pub connect_button: gtk4::MenuButton,
@@ -278,8 +280,17 @@ mod imp {
             ));
             self.command_empty.set_vexpand(true);
 
+            self.label_filter_box.set_selection_mode(gtk4::SelectionMode::None);
+            self.label_filter_box.set_homogeneous(false);
+            self.label_filter_box.set_margin_start(12);
+            self.label_filter_box.set_margin_end(12);
+            self.label_filter_box.set_row_spacing(4);
+            self.label_filter_box.set_column_spacing(4);
+            self.label_filter_box.set_visible(false);
+
             let commands_page = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
             commands_page.append(&commands_header);
+            commands_page.append(&self.label_filter_box);
             commands_page.append(&self.command_scroll);
             commands_page.append(&self.command_empty);
 

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -222,6 +222,9 @@ impl Window {
         let saved_hosts =
             crate::store::default_store().load_hosts().into_value().unwrap_or_default();
         let selected_key = self.selected_host_key();
+        let active_labels = imp.active_labels.borrow().clone();
+
+        self.rebuild_label_filter_chips(&all_commands);
 
         let any_shown = selected_key.as_ref().map_or_else(
             || {
@@ -233,6 +236,7 @@ impl Window {
                     let visible: Vec<_> = all_commands
                         .iter()
                         .filter(|c| c.host_tags.iter().any(|t| t == key))
+                        .filter(|c| commands::matches_labels(c, &active_labels))
                         .cloned()
                         .collect();
                     if !visible.is_empty() {
@@ -245,15 +249,21 @@ impl Window {
                         shown |= self.append_command_section(&label, &visible, query.as_str());
                     }
                 }
-                let global: Vec<_> =
-                    all_commands.iter().filter(|c| c.host_tags.is_empty()).cloned().collect();
+                let global: Vec<_> = all_commands
+                    .iter()
+                    .filter(|c| c.host_tags.is_empty())
+                    .filter(|c| commands::matches_labels(c, &active_labels))
+                    .cloned()
+                    .collect();
                 shown |= self.append_command_section("Global", &global, query.as_str());
                 shown
             },
             |key| {
-                let visible = commands::visible_for_host(&all_commands, key);
                 let (host_specific, global): (Vec<_>, Vec<_>) =
-                    visible.into_iter().partition(|c| !c.host_tags.is_empty());
+                    commands::visible_for_host(&all_commands, key)
+                        .into_iter()
+                        .filter(|c| commands::matches_labels(c, &active_labels))
+                        .partition(|c| !c.host_tags.is_empty());
 
                 let mut shown = false;
                 if !host_specific.is_empty() {
@@ -268,6 +278,47 @@ impl Window {
 
         imp.command_scroll.set_visible(any_shown);
         imp.command_empty.set_visible(!any_shown);
+    }
+
+    fn rebuild_label_filter_chips(&self, all_commands: &[SavedCommand]) {
+        let imp = self.imp();
+        while let Some(child) = imp.label_filter_box.first_child() {
+            imp.label_filter_box.remove(&child);
+        }
+
+        let labels = commands::collect_labels(all_commands);
+        if labels.is_empty() {
+            imp.label_filter_box.set_visible(false);
+            return;
+        }
+
+        imp.label_filter_box.set_visible(true);
+        let active = imp.active_labels.borrow().clone();
+
+        for label_text in &labels {
+            let button = gtk4::ToggleButton::with_label(label_text);
+            button.add_css_class("pill");
+            button.add_css_class("caption");
+            button.set_active(active.contains(label_text));
+
+            let win = self.clone();
+            let label_owned = label_text.clone();
+            button.connect_toggled(move |btn| {
+                {
+                    let mut active = win.imp().active_labels.borrow_mut();
+                    if btn.is_active() {
+                        if !active.contains(&label_owned) {
+                            active.push(label_owned.clone());
+                        }
+                    } else {
+                        active.retain(|l| l != &label_owned);
+                    }
+                }
+                win.refresh_command_sidebar();
+            });
+
+            imp.label_filter_box.insert(&button, -1);
+        }
     }
 
     fn append_command_section(

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -6893,7 +6893,10 @@ fn command_sidebar_label_filter_hides_non_matching_commands() {
 
     // Before filtering: Global header + 2 commands = 3 items
     let count_before = window.imp().command_list.observe_children().n_items();
-    assert_eq!(count_before, 3, "should show header + 2 commands before filter, got {count_before}");
+    assert_eq!(
+        count_before, 3,
+        "should show header + 2 commands before filter, got {count_before}"
+    );
 
     // Activate the "ops" label filter
     {
@@ -6905,7 +6908,10 @@ fn command_sidebar_label_filter_hides_non_matching_commands() {
 
     // After filtering: Global header + 1 command = 2 items
     let count_after = window.imp().command_list.observe_children().n_items();
-    assert_eq!(count_after, 2, "should show header + 1 command after label filter, got {count_after}");
+    assert_eq!(
+        count_after, 2,
+        "should show header + 1 command after label filter, got {count_after}"
+    );
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -6825,3 +6825,119 @@ fn split_managed_pane_inherits_parent_cwd() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn command_sidebar_label_filter_chips_shown_when_labels_exist() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let mut c1 = crate::commands::SavedCommand::new("Deploy", "cargo build");
+    c1.labels = vec!["ops".into(), "deploy".into()];
+    let c2 = crate::commands::SavedCommand::new("Test", "cargo test");
+    store().save_commands(&[c1, c2]).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.command-label-filter-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(100);
+
+    // Label filter box should be visible with 2 chips (deploy, ops)
+    assert!(
+        window.imp().label_filter_box.is_visible(),
+        "label filter box should be visible when commands have labels"
+    );
+
+    // Count chip buttons
+    let mut chip_count = 0;
+    let mut child = window.imp().label_filter_box.first_child();
+    while let Some(c) = child {
+        chip_count += 1;
+        child = c.next_sibling();
+    }
+    assert_eq!(chip_count, 2, "should show 2 label chips (deploy, ops)");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn command_sidebar_label_filter_hides_non_matching_commands() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let mut c1 = crate::commands::SavedCommand::new("Deploy", "cargo build");
+    c1.labels = vec!["ops".into()];
+    let c2 = crate::commands::SavedCommand::new("Test", "cargo test");
+    store().save_commands(&[c1, c2]).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.command-label-filter-hide-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(100);
+
+    // Before filtering: Global header + 2 commands = 3 items
+    let count_before = window.imp().command_list.observe_children().n_items();
+    assert_eq!(count_before, 3, "should show header + 2 commands before filter, got {count_before}");
+
+    // Activate the "ops" label filter
+    {
+        let mut active = window.imp().active_labels.borrow_mut();
+        active.push("ops".into());
+    }
+    window.refresh_command_sidebar();
+    pump_events(50);
+
+    // After filtering: Global header + 1 command = 2 items
+    let count_after = window.imp().command_list.observe_children().n_items();
+    assert_eq!(count_after, 2, "should show header + 1 command after label filter, got {count_after}");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn command_sidebar_label_filter_hidden_when_no_labels() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let c1 = crate::commands::SavedCommand::new("Deploy", "cargo build");
+    let c2 = crate::commands::SavedCommand::new("Test", "cargo test");
+    store().save_commands(&[c1, c2]).unwrap();
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.command-label-filter-hidden-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(100);
+
+    assert!(
+        !window.imp().label_filter_box.is_visible(),
+        "label filter box should be hidden when no commands have labels"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/commands_integration.rs
+++ b/clients/rttx/tests/commands_integration.rs
@@ -116,3 +116,54 @@ fn empty_description_not_serialized_in_json() {
     let json = serde_json::to_string(&command).unwrap();
     assert!(!json.contains("description"));
 }
+
+#[test]
+fn commands_with_labels_roundtrip() {
+    let (_tmp, store) = test_store();
+
+    let mut command = SavedCommand::new("Deploy", "cargo build");
+    command.labels = vec!["ops".into(), "deploy".into()];
+
+    store.save_commands(&[command.clone()]).unwrap();
+    let loaded = store.load_commands();
+    assert_eq!(loaded, vec![command]);
+}
+
+#[test]
+fn label_filtering_composes_with_text_search() {
+    let mut c1 = SavedCommand::new("Deploy prod", "cargo build --release");
+    c1.labels = vec!["ops".into(), "deploy".into()];
+    let mut c2 = SavedCommand::new("Deploy dev", "cargo build");
+    c2.labels = vec!["ops".into(), "dev".into()];
+    let c3 = SavedCommand::new("Tail logs", "journalctl -fu app");
+
+    let all = [c1, c2, c3];
+
+    // Label filter alone
+    let active = vec!["ops".into()];
+    assert_eq!(all.iter().filter(|c| commands::matches_labels(c, &active)).count(), 2);
+
+    // Label + text search compose with AND
+    let filtered: Vec<_> = all
+        .iter()
+        .filter(|c| commands::matches_labels(c, &active))
+        .filter(|c| commands::matches_query(c, "prod"))
+        .collect();
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].title, "Deploy prod");
+}
+
+#[test]
+fn collect_labels_from_stored_commands() {
+    let (_tmp, store) = test_store();
+
+    let mut c1 = SavedCommand::new("A", "echo a");
+    c1.labels = vec!["deploy".into(), "ops".into()];
+    let mut c2 = SavedCommand::new("B", "echo b");
+    c2.labels = vec!["ops".into(), "diag".into()];
+
+    store.save_commands(&[c1, c2]).unwrap();
+    let loaded = store.load_commands();
+    let labels = commands::collect_labels(&loaded);
+    assert_eq!(labels, vec!["deploy", "diag", "ops"]);
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.16',
+  version: '0.4.17',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Follow-up from RFC-025. Adds free-text labels to saved commands and a filter chip bar in the Commands tab so large command libraries stay usable.

### Changes

- **Label editor**: comma-separated entry row in the command form dialog (below Description)
- **Label filter chip bar**: FlowBox with pill-styled ToggleButtons above the command list, visible only when at least one command has labels
- **Search integration**: `matches_query` now also searches labels; label filter and text search compose with AND
- **Helper functions**: `matches_labels` for filtering, `collect_labels` for extracting sorted unique labels from a command set

### How to verify manually

1. Create a command with labels (e.g. `ops, deploy`)
2. Observe the label chip bar appears above the command list
3. Click a chip to filter — only commands with that label remain visible
4. Type in the search box — search and label filter compose (AND)
5. Remove all labels from commands — chip bar disappears
6. Edit a command — labels field shows existing labels comma-separated

### Tests added

**Unit tests** (`commands.rs`):
- `matches_query_searches_labels`
- `matches_labels_empty_filter_matches_all`
- `matches_labels_returns_true_when_command_has_matching_label`
- `matches_labels_returns_false_when_no_match`
- `matches_labels_unlabeled_command_excluded_when_filter_active`
- `collect_labels_returns_sorted_unique_labels`
- `collect_labels_empty_commands_returns_empty`

**Integration tests** (`commands_integration.rs`):
- `commands_with_labels_roundtrip`
- `label_filtering_composes_with_text_search`
- `collect_labels_from_stored_commands`

**GTK widget tests** (`window/tests.rs`):
- `command_sidebar_label_filter_chips_shown_when_labels_exist`
- `command_sidebar_label_filter_hides_non_matching_commands`
- `command_sidebar_label_filter_hidden_when_no_labels`

### Tests run

- `cargo test --workspace --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 3 new GTK tests pass)

### Limitations

- Labels are independent from host tags (as specified in the issue)
- Label filter state is ephemeral (not persisted across restarts) — this is intentional for a filter control

Fixes #793