### PR TITLE
feat(commands): add run-in-new-pane execution mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.17"
+version = "0.4.18"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub enum CommandRunMode {
     Run,
     Insert,
+    RunInNewPane,
 }
 
 /// A fixed-choice parameter declared on a saved command.
@@ -82,7 +83,7 @@ impl SavedCommand {
     #[must_use]
     pub fn input_for(&self, run_mode: CommandRunMode) -> String {
         match run_mode {
-            CommandRunMode::Run => format!("{}\n", self.body),
+            CommandRunMode::Run | CommandRunMode::RunInNewPane => format!("{}\n", self.body),
             CommandRunMode::Insert => self.body.clone(),
         }
     }
@@ -244,6 +245,34 @@ mod tests {
         let command = SavedCommand::new("Build", "cargo test\ncargo clippy");
         assert_eq!(command.input_for(CommandRunMode::Run), "cargo test\ncargo clippy\n");
         assert_eq!(command.input_for(CommandRunMode::Insert), "cargo test\ncargo clippy");
+    }
+
+    #[test]
+    fn run_in_new_pane_appends_newline_like_run() {
+        let command = SavedCommand::new("Build", "cargo test\ncargo clippy");
+        assert_eq!(
+            command.input_for(CommandRunMode::RunInNewPane),
+            "cargo test\ncargo clippy\n"
+        );
+    }
+
+    #[test]
+    fn run_in_new_pane_serde_roundtrip() {
+        let mut command = SavedCommand::new("Deploy", "cargo build");
+        command.default_run_mode = CommandRunMode::RunInNewPane;
+
+        let json = serde_json::to_string(&[&command]).unwrap();
+        let loaded: Vec<SavedCommand> = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded[0].default_run_mode, CommandRunMode::RunInNewPane);
+    }
+
+    #[test]
+    fn run_in_new_pane_serializes_as_kebab_case() {
+        let mut command = SavedCommand::new("Deploy", "cargo build");
+        command.default_run_mode = CommandRunMode::RunInNewPane;
+
+        let json = serde_json::to_string(&command).unwrap();
+        assert!(json.contains("\"run-in-new-pane\""));
     }
 
     #[test]

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -250,10 +250,7 @@ mod tests {
     #[test]
     fn run_in_new_pane_appends_newline_like_run() {
         let command = SavedCommand::new("Build", "cargo test\ncargo clippy");
-        assert_eq!(
-            command.input_for(CommandRunMode::RunInNewPane),
-            "cargo test\ncargo clippy\n"
-        );
+        assert_eq!(command.input_for(CommandRunMode::RunInNewPane), "cargo test\ncargo clippy\n");
     }
 
     #[test]

--- a/clients/rttx/src/commands_window.rs
+++ b/clients/rttx/src/commands_window.rs
@@ -25,7 +25,7 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
     let body_scroll =
         gtk4::ScrolledWindow::builder().min_content_height(150).child(&body_view).build();
 
-    let run_mode = gtk4::DropDown::from_strings(&["Run", "Insert"]);
+    let run_mode = gtk4::DropDown::from_strings(&["Run", "Insert", "Run in new pane"]);
     let run_mode_row = adw::ActionRow::builder().title("Default action").build();
     run_mode_row.add_suffix(&run_mode);
     run_mode_row.set_activatable_widget(Some(&run_mode));
@@ -278,6 +278,7 @@ fn collect_entry_rows(group: &adw::PreferencesGroup) -> Vec<adw::EntryRow> {
 const fn run_mode_from_index(index: u32) -> CommandRunMode {
     match index {
         1 => CommandRunMode::Insert,
+        2 => CommandRunMode::RunInNewPane,
         _ => CommandRunMode::Run,
     }
 }
@@ -286,5 +287,6 @@ const fn run_mode_index(run_mode: CommandRunMode) -> u32 {
     match run_mode {
         CommandRunMode::Run => 0,
         CommandRunMode::Insert => 1,
+        CommandRunMode::RunInNewPane => 2,
     }
 }

--- a/clients/rttx/src/parameter_dialog.rs
+++ b/clients/rttx/src/parameter_dialog.rs
@@ -15,7 +15,7 @@ pub fn show(parent: &Window, command: &SavedCommand, run_mode: CommandRunMode) {
     let header = adw::HeaderBar::new();
 
     let action_label = match run_mode {
-        CommandRunMode::Run => "Run",
+        CommandRunMode::Run | CommandRunMode::RunInNewPane => "Run",
         CommandRunMode::Insert => "Insert",
     };
     let action_button = gtk4::Button::with_label(action_label);
@@ -93,7 +93,7 @@ pub fn show(parent: &Window, command: &SavedCommand, run_mode: CommandRunMode) {
         let values = collect_values(&command_clone.parameters, &rows_for_action);
         let rendered = render_env_block(&command_clone.body, &values);
         let text = match run_mode {
-            CommandRunMode::Run => format!("{rendered}\n"),
+            CommandRunMode::Run | CommandRunMode::RunInNewPane => format!("{rendered}\n"),
             CommandRunMode::Insert => rendered,
         };
         parent_win.execute_command_text(&command_clone, run_mode, &text);

--- a/clients/rttx/src/store/models/commands.rs
+++ b/clients/rttx/src/store/models/commands.rs
@@ -8,4 +8,5 @@ use serde::{Deserialize, Serialize};
 pub enum RunMode {
     Run,
     Insert,
+    RunInNewPane,
 }

--- a/clients/rttx/src/store/models/library.rs
+++ b/clients/rttx/src/store/models/library.rs
@@ -81,6 +81,7 @@ impl From<CommandRecord> for crate::commands::SavedCommand {
             default_run_mode: match rec.default_run_mode {
                 RunMode::Run => crate::commands::CommandRunMode::Run,
                 RunMode::Insert => crate::commands::CommandRunMode::Insert,
+                RunMode::RunInNewPane => crate::commands::CommandRunMode::RunInNewPane,
             },
             host_tags: rec.host_tags,
             parameters: rec.parameters,
@@ -99,6 +100,7 @@ impl From<&crate::commands::SavedCommand> for CommandRecord {
             default_run_mode: match cmd.default_run_mode {
                 crate::commands::CommandRunMode::Run => RunMode::Run,
                 crate::commands::CommandRunMode::Insert => RunMode::Insert,
+                crate::commands::CommandRunMode::RunInNewPane => RunMode::RunInNewPane,
             },
             host_tags: cmd.host_tags.clone(),
             parameters: cmd.parameters.clone(),

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -432,10 +432,7 @@ impl Window {
             let win = self.clone();
             let command_for_run = (*command).clone();
             action_row.connect_activated(move |_| {
-                win.execute_saved_command(
-                    &command_for_run,
-                    command_for_run.default_run_mode,
-                );
+                win.execute_saved_command(&command_for_run, command_for_run.default_run_mode);
             });
 
             let win = self.clone();

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -432,7 +432,10 @@ impl Window {
             let win = self.clone();
             let command_for_run = (*command).clone();
             action_row.connect_activated(move |_| {
-                win.execute_saved_command(&command_for_run, CommandRunMode::Run);
+                win.execute_saved_command(
+                    &command_for_run,
+                    command_for_run.default_run_mode,
+                );
             });
 
             let win = self.clone();
@@ -497,6 +500,11 @@ impl Window {
         run_mode: CommandRunMode,
         text: &str,
     ) {
+        if run_mode == CommandRunMode::RunInNewPane {
+            self.execute_command_in_new_pane(command, text);
+            return;
+        }
+
         let Some(terminal_uuid) = self.command_target_terminal_uuid() else {
             return;
         };
@@ -513,6 +521,32 @@ impl Window {
             },
         );
         self.send_input_to_terminal(&terminal_uuid, text);
+    }
+
+    fn execute_command_in_new_pane(&self, command: &SavedCommand, text: &str) {
+        let Some(terminal_uuid) = self.command_target_terminal_uuid() else {
+            return;
+        };
+
+        let new_uuid = self.split_terminal_returning_uuid(
+            &terminal_uuid,
+            crate::workspace::SplitOrientation::Horizontal,
+        );
+
+        let Some(new_terminal_uuid) = new_uuid else {
+            self.show_toast("Cannot split: maximum depth reached");
+            return;
+        };
+
+        self.set_terminal_recovery(
+            &new_terminal_uuid,
+            PaneRecovery {
+                source: PaneSource::Command { title: command.title.clone() },
+                target: None,
+                startup: vec![StartupStep::SendText { text: command.body.clone(), execute: true }],
+            },
+        );
+        self.send_input_to_terminal(&new_terminal_uuid, text);
     }
 
     fn command_target_terminal_uuid(&self) -> Option<String> {

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -339,6 +339,97 @@ impl Window {
         }
     }
 
+    /// Split a terminal and return the UUID of the newly created pane.
+    ///
+    /// Returns `None` if the split depth limit is reached or the terminal is not found.
+    pub(super) fn split_terminal_returning_uuid(
+        &self,
+        terminal_uuid: &str,
+        orientation: SplitOrientation,
+    ) -> Option<String> {
+        // Unzoom before splitting so the full layout is visible.
+        {
+            let state = self.imp().state.borrow();
+            if let Some(session) =
+                state.workspaces.iter().find(|s| s.layout.contains_terminal(terminal_uuid))
+                && session.is_zoomed()
+            {
+                drop(state);
+                self.toggle_pane_zoom();
+            }
+        }
+
+        let imp = self.imp();
+
+        let terminal_cwd =
+            self.terminal_handle(terminal_uuid).and_then(|terminal| terminal.current_directory());
+
+        let mut state = imp.state.borrow_mut();
+
+        let workspace_idx =
+            state.workspaces.iter().position(|s| s.layout.contains_terminal(terminal_uuid));
+
+        let idx = workspace_idx?;
+
+        let at_limit = state.workspaces[idx]
+            .layout
+            .depth_of_terminal(terminal_uuid)
+            .is_some_and(|d| d >= MAX_SPLIT_DEPTH);
+
+        if at_limit {
+            return None;
+        }
+
+        let source_cwd =
+            terminal_cwd.or_else(|| state.workspaces[idx].layout.terminal_cwd(terminal_uuid));
+
+        let (mut new_layout, new_terminal_uuid) =
+            state.workspaces[idx].layout.split_terminal_with_new_uuid(terminal_uuid, orientation)?;
+
+        if let Some(cwd) = &source_cwd {
+            new_layout.set_terminal_cwd(&new_terminal_uuid, Some(cwd.clone()));
+        }
+        state.workspaces[idx].layout = new_layout;
+        state.workspaces[idx].set_recovery(&new_terminal_uuid, PaneRecovery::empty_shell());
+        let layout_terminal_uuids = state.workspaces[idx].layout.terminal_uuids();
+        state.workspaces[idx].runtime.ensure_placeholder_bindings(&layout_terminal_uuids);
+        state.workspaces[idx].normalize_active_terminal();
+        let session_uuid = state.workspaces[idx].uuid.clone();
+        let session_state = state.workspaces[idx].clone();
+        drop(state);
+
+        if self.split_terminal_in_place(
+            &session_uuid,
+            terminal_uuid,
+            &new_terminal_uuid,
+            orientation,
+            source_cwd.as_deref(),
+        ) {
+            self.refresh_sidebar_subtitle(&session_uuid);
+        } else {
+            self.rebuild_session_content(&session_uuid, &session_state);
+        }
+
+        if session_state.uses_managed_runtime()
+            && let Some(runtime_id) = session_state.runtime.runtime_id.as_deref()
+            && let Some(manager) = self.imp().connection_manager.borrow().as_ref()
+        {
+            let size = self.persistent_terminal_size(terminal_uuid);
+            manager.create_pane(
+                &session_uuid,
+                &session_state.runtime.endpoint,
+                runtime_id,
+                &new_terminal_uuid,
+                source_cwd,
+                adw::StyleManager::default().is_dark(),
+                size,
+                false,
+            );
+        }
+
+        Some(new_terminal_uuid)
+    }
+
     pub(super) fn close_terminal(&self, terminal_uuid: &str) {
         #[derive(Debug)]
         #[allow(clippy::large_enum_variant)]

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -383,8 +383,9 @@ impl Window {
         let source_cwd =
             terminal_cwd.or_else(|| state.workspaces[idx].layout.terminal_cwd(terminal_uuid));
 
-        let (mut new_layout, new_terminal_uuid) =
-            state.workspaces[idx].layout.split_terminal_with_new_uuid(terminal_uuid, orientation)?;
+        let (mut new_layout, new_terminal_uuid) = state.workspaces[idx]
+            .layout
+            .split_terminal_with_new_uuid(terminal_uuid, orientation)?;
 
         if let Some(cwd) = &source_cwd {
             new_layout.set_terminal_cwd(&new_terminal_uuid, Some(cwd.clone()));

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -6947,3 +6947,142 @@ fn command_sidebar_label_filter_hidden_when_no_labels() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn run_in_new_pane_splits_and_sends_command_to_new_terminal() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.run-in-new-pane-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.set_default_size(1200, 800);
+    window.present();
+    pump_events(100);
+
+    let original_uuid = {
+        let state = window.imp().state.borrow();
+        let uuids = state.workspaces[0].layout.terminal_uuids();
+        assert_eq!(uuids.len(), 1, "should start with a single pane");
+        uuids[0].clone()
+    };
+
+    let command = SavedCommand::new("Build", "cargo build");
+    window.execute_saved_command(&command, CommandRunMode::RunInNewPane);
+    pump_events(100);
+
+    let (terminal_uuids, new_uuid) = {
+        let state = window.imp().state.borrow();
+        let uuids = state.workspaces[0].layout.terminal_uuids();
+        assert_eq!(uuids.len(), 2, "RunInNewPane should create a split");
+        let new = uuids.into_iter().find(|u| u != &original_uuid).unwrap();
+        let all = state.workspaces[0].layout.terminal_uuids();
+        (all, new)
+    };
+
+    assert_eq!(terminal_uuids.len(), 2);
+
+    // Verify the command was sent to the new pane, not the original
+    let new_term = window
+        .imp()
+        .terminals
+        .borrow()
+        .get(&new_uuid)
+        .cloned()
+        .expect("new split terminal should exist");
+    assert_eq!(
+        new_term.pending_shell_inputs_for_test(),
+        vec![String::from("cargo build\n")],
+        "command should be queued in the new pane with trailing newline (execute mode)"
+    );
+
+    // Verify recovery is set on the new pane
+    let recovery = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0].recovery_for(&new_uuid).cloned()
+    };
+    assert_eq!(
+        recovery,
+        Some(PaneRecovery {
+            source: PaneSource::Command { title: "Build".into() },
+            target: None,
+            startup: vec![StartupStep::SendText { text: "cargo build".into(), execute: true }],
+        })
+    );
+
+    // Verify the original pane was NOT modified
+    let original_term = window
+        .imp()
+        .terminals
+        .borrow()
+        .get(&original_uuid)
+        .cloned()
+        .expect("original terminal should still exist");
+    assert!(
+        original_term.pending_shell_inputs_for_test().is_empty(),
+        "original pane should not receive the command"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn run_in_new_pane_respects_split_depth_limit() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.run-in-new-pane-depth-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.set_default_size(1200, 800);
+    window.present();
+    pump_events(100);
+
+    // Split to maximum depth (5 levels)
+    for _ in 0..crate::workspace::MAX_SPLIT_DEPTH {
+        let uuid = {
+            let state = window.imp().state.borrow();
+            state.workspaces[0].layout.terminal_uuids().last().unwrap().clone()
+        };
+        window.split_terminal(&uuid, SplitOrientation::Horizontal);
+        pump_events(50);
+    }
+
+    let count_before = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0].layout.terminal_uuids().len()
+    };
+
+    // Attempt RunInNewPane at max depth — should not split further
+    let command = SavedCommand::new("Build", "cargo build");
+    window.execute_saved_command(&command, CommandRunMode::RunInNewPane);
+    pump_events(100);
+
+    let count_after = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0].layout.terminal_uuids().len()
+    };
+
+    assert_eq!(
+        count_before, count_after,
+        "RunInNewPane should not split beyond the maximum depth"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -6957,9 +6957,8 @@ fn run_in_new_pane_splits_and_sends_command_to_new_terminal() {
     crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.run-in-new-pane-tests")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.run-in-new-pane-tests").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);
@@ -7078,10 +7077,7 @@ fn run_in_new_pane_respects_split_depth_limit() {
         state.workspaces[0].layout.terminal_uuids().len()
     };
 
-    assert_eq!(
-        count_before, count_after,
-        "RunInNewPane should not split beyond the maximum depth"
-    );
+    assert_eq!(count_before, count_after, "RunInNewPane should not split beyond the maximum depth");
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");

--- a/clients/rttx/tests/commands_integration.rs
+++ b/clients/rttx/tests/commands_integration.rs
@@ -167,3 +167,15 @@ fn collect_labels_from_stored_commands() {
     let labels = commands::collect_labels(&loaded);
     assert_eq!(labels, vec!["deploy", "diag", "ops"]);
 }
+
+#[test]
+fn run_in_new_pane_mode_roundtrip() {
+    let (_tmp, store) = test_store();
+
+    let mut command = SavedCommand::new("Build", "cargo build");
+    command.default_run_mode = CommandRunMode::RunInNewPane;
+
+    store.save_commands(&[command]).unwrap();
+    let loaded = store.load_commands();
+    assert_eq!(loaded[0].default_run_mode, CommandRunMode::RunInNewPane);
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.17',
+  version: '0.4.18',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## Summary

Add a third command execution mode — **Run in new pane** — that splits the active pane horizontally and runs the command in the newly created pane.

Closes #795

## What changed

- Extended `CommandRunMode` with a `RunInNewPane` variant
- Added `split_terminal_returning_uuid` to Window for programmatic splits that return the new pane UUID
- `execute_command_in_new_pane` splits the current target pane, sets recovery, and sends the command to the new terminal
- Updated the command editor dropdown to include "Run in new pane" as a third option
- Updated the parameter dialog to handle the new mode (uses "Run" label, executes with newline)
- Sidebar row activation now uses the command's `default_run_mode` instead of always using Run
- Bumped version to 0.4.18

## How to verify manually

1. Open rttx, go to the Commands sidebar
2. Create a new command with "Run in new pane" as the default action
3. Click the command row — it should split the current pane and run the command in the new pane
4. Verify the original pane is unaffected
5. Verify that at maximum split depth, a toast appears instead of crashing

## Tests added

**Unit tests:**
- `run_in_new_pane_appends_newline_like_run` — verifies input_for behavior
- `run_in_new_pane_serde_roundtrip` — verifies serialization/deserialization
- `run_in_new_pane_serializes_as_kebab_case` — verifies JSON format

**Integration tests:**
- `run_in_new_pane_mode_roundtrip` — verifies persistence through ClientStore

**GTK widget tests:**
- `run_in_new_pane_splits_and_sends_command_to_new_terminal` — verifies split creation, command routing to new pane, recovery setup, and original pane isolation
- `run_in_new_pane_respects_split_depth_limit` — verifies graceful handling at max depth

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76` — all 686 passed
- `cargo test -p rttx-proto -p rttx-server` — all passed
- `bash .github/scripts/run-clippy.sh` — passed
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests passed including the new ones

## Backward compatibility

- `CommandRunMode::RunInNewPane` serializes as `"run-in-new-pane"` in kebab-case
- Existing commands without this mode continue to work unchanged
- Legacy JSON without the new variant deserializes correctly (defaults to Run)