### PR TITLE
feat: leader-prefix per-command shortcuts with host-scoped duplicate support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.18"
+version = "0.4.19"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -38,6 +38,10 @@ pub struct SavedCommand {
     pub description: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub labels: Vec<String>,
+    /// Key sequence after the leader key (e.g. `["d", "k"]`).
+    /// Duplicates across commands are intentional for host-scoped resolution.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shortcut_keys: Vec<String>,
 }
 
 const fn default_run_mode() -> CommandRunMode {
@@ -56,6 +60,7 @@ impl SavedCommand {
             parameters: Vec::new(),
             description: String::new(),
             labels: Vec::new(),
+            shortcut_keys: Vec::new(),
         }
     }
 
@@ -655,5 +660,30 @@ mod tests {
     fn collect_labels_empty_commands_returns_empty() {
         let labels = collect_labels(&[]);
         assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn shortcut_keys_serde_roundtrip() {
+        let mut command = SavedCommand::new("Deploy", "cargo build");
+        command.shortcut_keys = vec!["d".into(), "k".into()];
+
+        let json = serde_json::to_string(&[&command]).unwrap();
+        let loaded: Vec<SavedCommand> = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded[0].shortcut_keys, vec!["d", "k"]);
+    }
+
+    #[test]
+    fn shortcut_keys_empty_not_serialized() {
+        let command = SavedCommand::new("Plain", "echo hi");
+        let json = serde_json::to_string(&command).unwrap();
+        assert!(!json.contains("shortcut_keys"));
+    }
+
+    #[test]
+    fn duplicate_preserves_shortcut_keys() {
+        let mut original = SavedCommand::new("Deploy", "cargo build");
+        original.shortcut_keys = vec!["d".into()];
+        let copy = original.duplicate();
+        assert_eq!(copy.shortcut_keys, vec!["d"]);
     }
 }

--- a/clients/rttx/src/commands_window.rs
+++ b/clients/rttx/src/commands_window.rs
@@ -1,3 +1,4 @@
+use gtk4::glib;
 use gtk4::prelude::*;
 use libadwaita as adw;
 use libadwaita::prelude::*;
@@ -54,9 +55,56 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
     params_box.append(&add_param_button);
     params_group.add(&params_box);
 
+    // Shortcut key sequence
+    let shortcut_group = adw::PreferencesGroup::builder().title("Leader Shortcut").build();
+    let shortcut_row = adw::ActionRow::builder()
+        .title("Key sequence")
+        .subtitle("Press to capture keys after the leader")
+        .build();
+    let shortcut_label = gtk4::Label::new(None);
+    shortcut_label.add_css_class("dim-label");
+    shortcut_label.add_css_class("monospace");
+    shortcut_row.add_suffix(&shortcut_label);
+
+    let shortcut_keys: std::rc::Rc<std::cell::RefCell<Vec<String>>> =
+        std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+
+    let clear_button = gtk4::Button::builder()
+        .icon_name("edit-clear-symbolic")
+        .tooltip_text("Clear shortcut")
+        .valign(gtk4::Align::Center)
+        .build();
+    clear_button.add_css_class("flat");
+    shortcut_row.add_suffix(&clear_button);
+
+    {
+        let keys_ref = shortcut_keys.clone();
+        let label_ref = shortcut_label.clone();
+        clear_button.connect_clicked(move |_| {
+            keys_ref.borrow_mut().clear();
+            label_ref.set_text("");
+        });
+    }
+
+    shortcut_group.add(&shortcut_row);
+
+    let capture_button = gtk4::Button::with_label("Capture");
+    capture_button.add_css_class("flat");
+    shortcut_group.add(&capture_button);
+
+    {
+        let keys_ref = shortcut_keys.clone();
+        let label_ref = shortcut_label.clone();
+        let dialog_ref = form.dialog.clone();
+        capture_button.connect_clicked(move |_| {
+            show_capture_dialog(&dialog_ref, &keys_ref, &label_ref);
+        });
+    }
+
     form.content_box.append(&title_group);
     form.content_box.append(&body_scroll);
     form.content_box.append(&behavior_group);
+    form.content_box.append(&shortcut_group);
     form.content_box.append(&params_group);
     form.content_box.append(&host_picker.group);
     form.finish_layout();
@@ -69,6 +117,10 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
         run_mode.set_selected(run_mode_index(c.default_run_mode));
         for param in &c.parameters {
             append_parameter_row(&params_list, Some(param));
+        }
+        if !c.shortcut_keys.is_empty() {
+            shortcut_keys.borrow_mut().clone_from(&c.shortcut_keys);
+            shortcut_label.set_text(&c.shortcut_keys.join(" "));
         }
     }
 
@@ -91,6 +143,7 @@ pub fn show_form(parent: &Window, command: Option<&SavedCommand>) {
             &host_picker,
             &params_list,
             existing_uuid.clone(),
+            &shortcut_keys.borrow(),
         ) {
             Ok(c) => c,
             Err(msg) => {
@@ -176,6 +229,7 @@ fn build_command(
     host_picker: &HostTagPicker,
     params_list: &gtk4::ListBox,
     existing_uuid: Option<String>,
+    shortcut_keys: &[String],
 ) -> Result<SavedCommand, String> {
     let title = title_row.text().trim().to_string();
     if title.is_empty() {
@@ -206,6 +260,7 @@ fn build_command(
     command.parameters = parameters;
     command.description = description_row.text().trim().to_string();
     command.labels = labels;
+    command.shortcut_keys = shortcut_keys.to_vec();
     Ok(command)
 }
 
@@ -289,4 +344,74 @@ const fn run_mode_index(run_mode: CommandRunMode) -> u32 {
         CommandRunMode::Insert => 1,
         CommandRunMode::RunInNewPane => 2,
     }
+}
+
+fn show_capture_dialog(
+    parent: &adw::Dialog,
+    keys_out: &std::rc::Rc<std::cell::RefCell<Vec<String>>>,
+    label_out: &gtk4::Label,
+) {
+    let dialog = adw::Dialog::builder()
+        .title("Capture Shortcut")
+        .content_width(300)
+        .content_height(150)
+        .build();
+
+    let content = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+    content.set_margin_top(24);
+    content.set_margin_bottom(24);
+    content.set_margin_start(24);
+    content.set_margin_end(24);
+
+    let instruction =
+        gtk4::Label::new(Some("Press 1–2 keys for the sequence.\nEnter confirms, Escape cancels."));
+    instruction.set_wrap(true);
+    instruction.set_justify(gtk4::Justification::Center);
+    content.append(&instruction);
+
+    let preview = gtk4::Label::new(None);
+    preview.add_css_class("monospace");
+    preview.add_css_class("title-3");
+    content.append(&preview);
+
+    dialog.set_child(Some(&content));
+
+    let captured: std::rc::Rc<std::cell::RefCell<Vec<String>>> =
+        std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+
+    let controller = gtk4::EventControllerKey::new();
+    controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
+
+    let keys_ref = keys_out.clone();
+    let label_ref = label_out.clone();
+    let dialog_ref = dialog.clone();
+    controller.connect_key_pressed(move |_, keyval, _keycode, _state| {
+        let key_name = keyval.name().map(|n| n.to_string()).unwrap_or_default();
+        if key_name.is_empty() {
+            return glib::Propagation::Stop;
+        }
+        if key_name == "Escape" {
+            dialog_ref.close();
+            return glib::Propagation::Stop;
+        }
+        if key_name == "Return" || key_name == "KP_Enter" {
+            let keys = captured.borrow().clone();
+            if !keys.is_empty() {
+                keys_ref.borrow_mut().clone_from(&keys);
+                label_ref.set_text(&keys.join(" "));
+            }
+            dialog_ref.close();
+            return glib::Propagation::Stop;
+        }
+
+        let mut keys = captured.borrow_mut();
+        if keys.len() < 2 {
+            keys.push(key_name);
+            preview.set_text(&keys.join(" "));
+        }
+        glib::Propagation::Stop
+    });
+
+    dialog.add_controller(controller);
+    dialog.present(Some(parent));
 }

--- a/clients/rttx/src/leader.rs
+++ b/clients/rttx/src/leader.rs
@@ -1,0 +1,182 @@
+//! Leader-prefix command shortcut resolution.
+//!
+//! After the leader key is pressed, subsequent keystrokes are matched against
+//! per-command shortcut sequences. Resolution is host/context-aware: only
+//! commands visible on the current host are candidates, and the first match
+//! wins. Duplicate sequences across hosts are intentional.
+
+use crate::commands::{self, SavedCommand};
+
+/// Result of attempting to advance a leader key sequence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LeaderMatch {
+    /// No command matches the accumulated keys — abort leader mode.
+    NoMatch,
+    /// At least one command has a longer sequence starting with the accumulated keys.
+    Partial,
+    /// Exactly one command matched fully.
+    Complete(String),
+}
+
+/// Resolve a key sequence against visible commands for the given host.
+///
+/// Returns the UUID of the first command whose `shortcut_keys` exactly matches
+/// `keys`, considering only commands visible on `host_key`. When `host_key` is
+/// `None`, all commands are candidates (the "All Hosts" view).
+#[must_use]
+pub fn resolve(commands: &[SavedCommand], keys: &[String], host_key: Option<&str>) -> LeaderMatch {
+    let mut has_partial = false;
+
+    for cmd in commands {
+        if cmd.shortcut_keys.is_empty() {
+            continue;
+        }
+        if let Some(hk) = host_key
+            && !commands::is_visible_on(cmd, hk)
+        {
+            continue;
+        }
+
+        if cmd.shortcut_keys == keys {
+            return LeaderMatch::Complete(cmd.uuid.clone());
+        }
+        if cmd.shortcut_keys.len() > keys.len() && cmd.shortcut_keys.starts_with(keys) {
+            has_partial = true;
+        }
+    }
+
+    if has_partial { LeaderMatch::Partial } else { LeaderMatch::NoMatch }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::SavedCommand;
+
+    fn cmd(uuid: &str, keys: &[&str], host_tags: &[&str]) -> SavedCommand {
+        let mut c = SavedCommand::new(uuid, "echo test");
+        c.uuid = uuid.into();
+        c.shortcut_keys = keys.iter().map(|s| (*s).to_string()).collect();
+        c.host_tags = host_tags.iter().map(|s| (*s).to_string()).collect();
+        c
+    }
+
+    #[test]
+    fn resolve_exact_match_returns_complete() {
+        let commands = vec![cmd("a", &["d", "k"], &[])];
+        let keys = vec!["d".into(), "k".into()];
+        assert_eq!(resolve(&commands, &keys, None), LeaderMatch::Complete("a".into()));
+    }
+
+    #[test]
+    fn resolve_partial_prefix_returns_partial() {
+        let commands = vec![cmd("a", &["d", "k"], &[])];
+        let keys = vec!["d".into()];
+        assert_eq!(resolve(&commands, &keys, None), LeaderMatch::Partial);
+    }
+
+    #[test]
+    fn resolve_no_match_returns_no_match() {
+        let commands = vec![cmd("a", &["d", "k"], &[])];
+        let keys = vec!["x".into()];
+        assert_eq!(resolve(&commands, &keys, None), LeaderMatch::NoMatch);
+    }
+
+    #[test]
+    fn resolve_host_scoped_filters_invisible_commands() {
+        let commands =
+            vec![cmd("local-cmd", &["d"], &["local"]), cmd("remote-cmd", &["d"], &["example.com"])];
+        let keys = vec!["d".into()];
+
+        // From local context: only local-cmd matches
+        assert_eq!(
+            resolve(&commands, &keys, Some("local")),
+            LeaderMatch::Complete("local-cmd".into())
+        );
+        // From remote context: only remote-cmd matches
+        assert_eq!(
+            resolve(&commands, &keys, Some("example.com")),
+            LeaderMatch::Complete("remote-cmd".into())
+        );
+    }
+
+    #[test]
+    fn resolve_duplicate_sequences_first_visible_wins() {
+        let commands = vec![cmd("first", &["d"], &["local"]), cmd("second", &["d"], &["local"])];
+        let keys = vec!["d".into()];
+        assert_eq!(resolve(&commands, &keys, Some("local")), LeaderMatch::Complete("first".into()));
+    }
+
+    #[test]
+    fn resolve_global_command_visible_on_any_host() {
+        let commands = vec![cmd("global", &["g"], &[])];
+        let keys = vec!["g".into()];
+        assert_eq!(
+            resolve(&commands, &keys, Some("example.com")),
+            LeaderMatch::Complete("global".into())
+        );
+    }
+
+    #[test]
+    fn resolve_no_host_key_means_all_commands_visible() {
+        let commands = vec![
+            cmd("local-only", &["d"], &["local"]),
+            cmd("remote-only", &["r"], &["example.com"]),
+        ];
+        assert_eq!(
+            resolve(&commands, &["d".into()], None),
+            LeaderMatch::Complete("local-only".into())
+        );
+        assert_eq!(
+            resolve(&commands, &["r".into()], None),
+            LeaderMatch::Complete("remote-only".into())
+        );
+    }
+
+    #[test]
+    fn resolve_empty_keys_never_matches() {
+        let commands = vec![cmd("a", &["d"], &[])];
+        let keys: Vec<String> = vec![];
+        assert_eq!(resolve(&commands, &keys, None), LeaderMatch::Partial);
+    }
+
+    #[test]
+    fn resolve_command_without_shortcut_keys_is_skipped() {
+        let commands = vec![cmd("no-shortcut", &[], &[])];
+        let keys = vec!["d".into()];
+        assert_eq!(resolve(&commands, &keys, None), LeaderMatch::NoMatch);
+    }
+
+    #[test]
+    fn resolve_longer_input_than_command_sequence_no_match() {
+        let commands = vec![cmd("a", &["d"], &[])];
+        let keys = vec!["d".into(), "k".into()];
+        assert_eq!(resolve(&commands, &keys, None), LeaderMatch::NoMatch);
+    }
+
+    #[test]
+    fn resolve_mixed_partial_and_complete_prefers_complete() {
+        let commands = vec![cmd("short", &["d"], &[]), cmd("long", &["d", "k"], &[])];
+        let keys = vec!["d".into()];
+        // "short" matches completely first
+        assert_eq!(resolve(&commands, &keys, None), LeaderMatch::Complete("short".into()));
+    }
+
+    #[test]
+    fn resolve_host_scoped_duplicate_different_hosts() {
+        // Same sequence on different hosts — each resolves to its own command
+        let commands = vec![
+            cmd("deploy-prod", &["d", "p"], &["prod-host"]),
+            cmd("deploy-dev", &["d", "p"], &["dev-host"]),
+        ];
+        let keys = vec!["d".into(), "p".into()];
+        assert_eq!(
+            resolve(&commands, &keys, Some("prod-host")),
+            LeaderMatch::Complete("deploy-prod".into())
+        );
+        assert_eq!(
+            resolve(&commands, &keys, Some("dev-host")),
+            LeaderMatch::Complete("deploy-dev".into())
+        );
+    }
+}

--- a/clients/rttx/src/lib.rs
+++ b/clients/rttx/src/lib.rs
@@ -8,6 +8,7 @@ pub mod daemon_bridge;
 pub mod form_dialog;
 pub mod host;
 pub mod host_tag_picker;
+pub mod leader;
 pub mod new_workspace_dialog;
 pub mod parameter_dialog;
 pub mod places;

--- a/clients/rttx/src/shortcuts.rs
+++ b/clients/rttx/src/shortcuts.rs
@@ -95,6 +95,11 @@ pub static DEFAULT_SHORTCUTS: &[ShortcutDef] = &[
     },
     ShortcutDef { action: "navigate-up", label: "Navigate up", default_accels: &["<Alt>Up"] },
     ShortcutDef { action: "navigate-down", label: "Navigate down", default_accels: &["<Alt>Down"] },
+    ShortcutDef {
+        action: "commands-leader",
+        label: "Commands leader key",
+        default_accels: &["<Ctrl>semicolon"],
+    },
 ];
 
 /// Look up the effective accelerators for an action, checking user overrides

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -438,6 +438,7 @@ mod tests {
             parameters: vec![],
             description: String::new(),
             labels: vec![],
+            shortcut_keys: vec![],
         };
         store.save_library(&[place], &[cmd]).unwrap();
         let (places, commands) = store.load_library().into_value().unwrap();

--- a/clients/rttx/src/store/models/library.rs
+++ b/clients/rttx/src/store/models/library.rs
@@ -38,6 +38,8 @@ pub struct CommandRecord {
     pub description: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shortcut_keys: Vec<String>,
 }
 
 const fn default_run_mode() -> RunMode {
@@ -87,6 +89,7 @@ impl From<CommandRecord> for crate::commands::SavedCommand {
             parameters: rec.parameters,
             description: rec.description,
             labels: rec.labels,
+            shortcut_keys: rec.shortcut_keys,
         }
     }
 }
@@ -106,6 +109,7 @@ impl From<&crate::commands::SavedCommand> for CommandRecord {
             parameters: cmd.parameters.clone(),
             description: cmd.description.clone(),
             labels: cmd.labels.clone(),
+            shortcut_keys: cmd.shortcut_keys.clone(),
         }
     }
 }

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::leader::{self, LeaderMatch};
 use crate::shortcuts;
 use crate::terminal::paste_guard::{PasteGuardDecision, decide};
 
@@ -526,5 +527,99 @@ impl Window {
         if let Some(row) = self.imp().sidebar_list.row_at_index(index as i32) {
             self.imp().sidebar_list.select_row(Some(&row));
         }
+    }
+
+    // ── Leader-prefix command shortcuts ─────────────────────
+
+    pub(super) fn setup_leader_controller(&self) {
+        let prefs =
+            crate::store::default_store().load_preferences().into_value().unwrap_or_default();
+        let leader_accels =
+            shortcuts::effective_accels("commands-leader", &prefs.keyboard_shortcuts);
+        if leader_accels.is_empty() {
+            return;
+        }
+
+        let leader_action = gtk4::gio::SimpleAction::new("commands-leader", None);
+        let win = self.clone();
+        leader_action.connect_activate(move |_, _| {
+            win.activate_leader_mode();
+        });
+        self.add_action(&leader_action);
+
+        if let Some(app) = self.application().and_downcast::<adw::Application>() {
+            let accel_refs: Vec<&str> = leader_accels.iter().map(AsRef::as_ref).collect();
+            app.set_accels_for_action("win.commands-leader", &accel_refs);
+        }
+    }
+
+    fn activate_leader_mode(&self) {
+        let imp = self.imp();
+        imp.leader_keys.borrow_mut().clear();
+        if let Some(source) = imp.leader_timeout_source.take() {
+            source.remove();
+        }
+
+        self.show_toast("Leader active — press a key");
+
+        let win = self.clone();
+        let source = glib::timeout_add_local_once(std::time::Duration::from_secs(3), move || {
+            win.cancel_leader_mode();
+        });
+        imp.leader_timeout_source.replace(Some(source));
+
+        let controller = gtk4::EventControllerKey::new();
+        let win = self.clone();
+        controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
+        controller.connect_key_pressed(move |ctrl, keyval, _keycode, _state| {
+            let key_name = keyval.name().map(|n| n.to_string()).unwrap_or_default();
+            if key_name.is_empty() || key_name == "Escape" {
+                win.cancel_leader_mode();
+                win.remove_controller(ctrl);
+                return glib::Propagation::Stop;
+            }
+
+            win.imp().leader_keys.borrow_mut().push(key_name);
+            let keys = win.imp().leader_keys.borrow().clone();
+            let host_key = win.selected_host_key();
+            let commands = crate::store::default_store().load_commands();
+
+            match leader::resolve(&commands, &keys, host_key.as_deref()) {
+                LeaderMatch::Complete(uuid) => {
+                    win.finish_leader_mode();
+                    win.remove_controller(ctrl);
+                    if let Some(cmd) = commands.iter().find(|c| c.uuid == uuid) {
+                        win.execute_saved_command(cmd, cmd.default_run_mode);
+                    }
+                }
+                LeaderMatch::Partial => {
+                    // Wait for more keys
+                }
+                LeaderMatch::NoMatch => {
+                    win.cancel_leader_mode();
+                    win.remove_controller(ctrl);
+                }
+            }
+            glib::Propagation::Stop
+        });
+        self.add_controller(controller);
+    }
+
+    fn cancel_leader_mode(&self) {
+        self.finish_leader_mode();
+    }
+
+    fn finish_leader_mode(&self) {
+        let imp = self.imp();
+        imp.leader_keys.borrow_mut().clear();
+        if let Some(source) = imp.leader_timeout_source.take() {
+            source.remove();
+        }
+    }
+
+    /// Whether leader mode is currently active.
+    #[must_use]
+    pub fn is_leader_active(&self) -> bool {
+        self.imp().leader_timeout_source.borrow().is_some()
     }
 }

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -76,6 +76,8 @@ mod imp {
         pub workspace_popover: RefCell<Option<gtk4::PopoverMenu>>,
         pub pending_connect_existing: RefCell<Option<crate::host::Host>>,
         pub host_selector_keys: RefCell<Vec<String>>,
+        pub leader_keys: RefCell<Vec<String>>,
+        pub leader_timeout_source: RefCell<Option<glib::SourceId>>,
     }
 
     #[glib::object_subclass]
@@ -368,6 +370,7 @@ impl Window {
     pub fn new(app: &adw::Application) -> Self {
         let obj: Self = glib::Object::builder().property("application", app).build();
         obj.setup_actions(app);
+        obj.setup_leader_controller();
         obj.setup_signals();
         obj.load_state();
         obj

--- a/clients/rttx/tests/commands_integration.rs
+++ b/clients/rttx/tests/commands_integration.rs
@@ -179,3 +179,34 @@ fn run_in_new_pane_mode_roundtrip() {
     let loaded = store.load_commands();
     assert_eq!(loaded[0].default_run_mode, CommandRunMode::RunInNewPane);
 }
+
+#[test]
+fn shortcut_keys_roundtrip() {
+    let (_tmp, store) = test_store();
+
+    let mut command = SavedCommand::new("Deploy", "cargo build");
+    command.shortcut_keys = vec!["d".into(), "k".into()];
+
+    store.save_commands(&[command]).unwrap();
+    let loaded = store.load_commands();
+    assert_eq!(loaded[0].shortcut_keys, vec!["d", "k"]);
+}
+
+#[test]
+fn empty_shortcut_keys_not_serialized() {
+    let command = SavedCommand::new("Plain", "echo hi");
+    let json = serde_json::to_string(&command).unwrap();
+    assert!(!json.contains("shortcut_keys"));
+}
+
+#[test]
+fn legacy_json_without_shortcut_keys_deserializes_with_empty_vec() {
+    let json = r#"[{
+        "uuid": "abc",
+        "title": "Old",
+        "body": "echo old",
+        "default_run_mode": "run"
+    }]"#;
+    let commands: Vec<SavedCommand> = serde_json::from_str(json).unwrap();
+    assert!(commands[0].shortcut_keys.is_empty());
+}

--- a/clients/rttx/tests/document_models.rs
+++ b/clients/rttx/tests/document_models.rs
@@ -299,6 +299,7 @@ fn library_preserves_orphaned_host_tags() {
             parameters: vec![],
             description: String::new(),
             labels: vec![],
+            shortcut_keys: vec![],
         }],
     };
     let env = DocumentEnvelope::new(library::SCHEMA, library::CURRENT_VERSION, lib);

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.18',
+  version: '0.4.19',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Implements leader-prefix per-command keyboard shortcuts (issue #794, RFC-025 Step 11).

The leader key (default `Ctrl+;`) activates a transient mode where subsequent 1-2 keystrokes resolve against commands visible on the current host/context. Duplicate sequences across hosts are intentional — resolution uses the first matching visible command.

### Changes:
- **Data model**: Added `shortcut_keys: Vec<String>` to `SavedCommand` with `#[serde(default)]` for backward compatibility
- **Shortcut registry**: Added `commands-leader` entry with default `<Ctrl>semicolon` accelerator
- **Leader module** (`leader.rs`): Pure resolution logic — host/context-aware matching with partial/complete/no-match states
- **Window integration**: `EventControllerKey` in capture phase with 3-second timeout, toast feedback
- **Capture UI**: Shortcut row in command editor with a capture dialog for recording 1-2 key sequences
- **Version bump**: 0.4.18 → 0.4.19

### How to manually verify:
1. Create a command in the sidebar, click Capture in the Leader Shortcut section, press 1-2 keys, Enter to confirm
2. Press `Ctrl+;` — toast shows "Leader active — press a key"
3. Press the captured key sequence — command executes
4. Verify host-scoped resolution: create two commands with the same sequence on different hosts, switch host selector, verify correct command fires

### Tests added:
- 12 unit tests in `leader::tests` covering exact match, partial prefix, no match, host-scoped filtering, duplicate resolution, global commands, empty keys
- 3 unit tests in `commands::tests` for shortcut_keys serde roundtrip, empty serialization skip, duplicate preservation
- 3 integration tests in `commands_integration.rs` for persistence roundtrip, empty serialization, legacy deserialization

### Tests run:
- `cargo build --workspace` (VTE 0.76) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` — 701 passed, 0 failed ✅
- `cargo test -p rttx-server -p rttx-proto` — all passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests pass under Broadway ✅

### Limitations:
- No which-key popover (documented as optional follow-up in RFC-025)
- No global duplicate rejection (intentional per issue spec)