### PR TITLE
feat(server): emit terminal cleanup sequence on pane process exit

### DIFF
--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -192,6 +192,20 @@ impl Pane {
         self.exit_status = Some(status);
     }
 
+    /// Feed the terminal cleanup sequence into the pane's screen state.
+    ///
+    /// Called when the pane process exits so that alt-screen, mouse tracking,
+    /// hidden cursor, and other TUI modes are reset. Returns the cleanup
+    /// bytes for the caller to broadcast to attached clients and append to
+    /// the scrollback log.
+    pub fn feed_cleanup(&mut self) -> &'static [u8] {
+        let cleanup = crate::screen::terminal_cleanup_bytes();
+        self.screen.feed(cleanup);
+        self.pending_flush.extend_from_slice(cleanup);
+        self.output_seq += 1;
+        cleanup
+    }
+
     /// Release the in-memory scrollback buffer and pending flush data.
     ///
     /// Called when the pane process exits so the up-to-10 MB `raw_bytes`
@@ -826,5 +840,103 @@ mod tests {
         // Metadata wins over replay-derived state.
         assert!(!pane.screen.bracketed_paste_mode());
         assert!(!pane.screen.application_cursor_keys());
+    }
+
+    // ── feed_cleanup tests ──────────────────────────────────────────
+
+    #[test]
+    fn feed_cleanup_resets_dirty_screen_modes() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"\x1b[?1049h"); // alt-screen
+        pane.feed_output(b"\x1b[?25l"); // hide cursor
+        pane.feed_output(b"\x1b[?1003h"); // any-event mouse
+        pane.feed_output(b"\x1b[?1006h"); // SGR mouse
+        pane.feed_output(b"\x1b[?1004h"); // focus reporting
+        pane.feed_output(b"\x1b[?1h"); // application cursor keys
+        pane.feed_output(b"\x1b="); // application keypad
+        pane.feed_output(b"\x1b[?2004h"); // bracketed paste
+
+        pane.feed_cleanup();
+
+        assert!(!pane.screen.alternate_screen());
+        assert!(pane.screen.cursor_visible());
+        assert_eq!(pane.screen.mouse_tracking_mode(), 0);
+        assert!(!pane.screen.sgr_mouse_mode());
+        assert!(!pane.screen.focus_event_mode());
+        assert!(!pane.screen.application_cursor_keys());
+        assert!(!pane.screen.application_keypad());
+        assert!(!pane.screen.bracketed_paste_mode());
+    }
+
+    #[test]
+    fn feed_cleanup_appends_to_pending_flush() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"hello");
+        let before = pane.pending_flush_len();
+
+        pane.feed_cleanup();
+
+        let cleanup_len = crate::screen::terminal_cleanup_bytes().len();
+        assert_eq!(pane.pending_flush_len(), before + cleanup_len);
+    }
+
+    #[test]
+    fn feed_cleanup_increments_output_seq() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let before = pane.output_seq;
+        pane.feed_cleanup();
+        assert_eq!(pane.output_seq, before + 1);
+    }
+
+    #[test]
+    fn feed_cleanup_returns_cleanup_bytes() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let returned = pane.feed_cleanup();
+        assert_eq!(returned, crate::screen::terminal_cleanup_bytes());
+    }
+
+    #[test]
+    fn feed_cleanup_is_idempotent_on_clean_state() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"hello\r\n");
+
+        pane.feed_cleanup();
+        pane.feed_cleanup();
+
+        assert!(pane.screen.cursor_visible());
+        assert_eq!(pane.screen.mouse_tracking_mode(), 0);
+        assert!(!pane.screen.alternate_screen());
+    }
+
+    #[test]
+    fn snapshot_after_cleanup_shows_clean_modes() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"\x1b[?1049h\x1b[?25l\x1b[?1003h\x1b[?2004h");
+
+        pane.feed_cleanup();
+
+        let snap = pane.to_screen_snapshot();
+        assert!(snap.cursor_visible);
+        assert!(!snap.modes.bracketed_paste);
+        assert_eq!(snap.modes.mouse_tracking_mode, 0);
+        assert!(!snap.modes.application_cursor_keys);
+    }
+
+    #[test]
+    fn cleanup_bytes_flushed_to_scrollback_log() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let session_id = Uuid::new_v4();
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"hello");
+        pane.feed_cleanup();
+        pane.flush_scrollback(tmp.path(), session_id).unwrap();
+
+        let log_path = pane.scrollback_log_path.as_ref().unwrap();
+        let content = std::fs::read(log_path).unwrap();
+        let cleanup = crate::screen::terminal_cleanup_bytes();
+        assert!(
+            content.ends_with(cleanup),
+            "scrollback log should end with cleanup bytes"
+        );
     }
 }

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -934,9 +934,6 @@ mod tests {
         let log_path = pane.scrollback_log_path.as_ref().unwrap();
         let content = std::fs::read(log_path).unwrap();
         let cleanup = crate::screen::terminal_cleanup_bytes();
-        assert!(
-            content.ends_with(cleanup),
-            "scrollback log should end with cleanup bytes"
-        );
+        assert!(content.ends_with(cleanup), "scrollback log should end with cleanup bytes");
     }
 }

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -507,6 +507,34 @@ fn csi_query_len(data: &[u8]) -> Option<usize> {
     }
 }
 
+/// Terminal cleanup byte sequence fed into a pane's screen when its
+/// process exits.
+///
+/// Resets every mode a TUI might have left enabled so that reconnecting
+/// clients and persisted snapshots see a clean terminal state.
+///
+/// Contents (in order):
+/// 1. `CAN` (`\x18`) — abort any in-progress escape sequence
+/// 2. Exit alt-screen: DECRST 1049 (modern) + DECRST 47 (legacy)
+/// 3. Show cursor: DECSET 25
+/// 4. Disable mouse: DECRST 1000, 1002, 1003, 1006, 1015
+/// 5. Disable focus reporting: DECRST 1004
+/// 6. Normal cursor keys: DECRST 1
+/// 7. Numeric keypad: DECPNM (`ESC >`)
+/// 8. Disable bracketed paste: DECRST 2004
+/// 9. Reset SGR: `ESC [ m`
+#[must_use]
+pub const fn terminal_cleanup_bytes() -> &'static [u8] {
+    b"\x18\
+      \x1b[?1049l\x1b[?47l\
+      \x1b[?25h\
+      \x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\
+      \x1b[?1004l\
+      \x1b[?1l\x1b>\
+      \x1b[?2004l\
+      \x1b[m"
+}
+
 fn parse_osc7_current_directory(uri: &str) -> Option<String> {
     let path_with_host = uri.strip_prefix("file://")?;
     let path_start = path_with_host.find('/')?;
@@ -1403,5 +1431,61 @@ mod tests {
         // Snapshot says cursor was visible.
         screen.restore_cursor_visible(true);
         assert!(screen.cursor_visible());
+    }
+
+    // ── terminal_cleanup_bytes ──────────────────────────────────────
+
+    #[test]
+    fn terminal_cleanup_bytes_contains_required_sequences() {
+        let bytes = terminal_cleanup_bytes();
+        assert_eq!(bytes[0], 0x18, "must start with CAN");
+        assert!(bytes.windows(8).any(|w| w == b"\x1b[?1049l"), "alt-screen modern off");
+        assert!(bytes.windows(6).any(|w| w == b"\x1b[?47l"), "alt-screen legacy off");
+        assert!(bytes.windows(6).any(|w| w == b"\x1b[?25h"), "cursor visible");
+        assert!(bytes.windows(8).any(|w| w == b"\x1b[?1000l"), "mouse normal off");
+        assert!(bytes.windows(8).any(|w| w == b"\x1b[?1002l"), "mouse button off");
+        assert!(bytes.windows(8).any(|w| w == b"\x1b[?1003l"), "mouse any off");
+        assert!(bytes.windows(8).any(|w| w == b"\x1b[?1006l"), "SGR mouse off");
+        assert!(bytes.windows(8).any(|w| w == b"\x1b[?1015l"), "urxvt mouse off");
+        assert!(bytes.windows(8).any(|w| w == b"\x1b[?1004l"), "focus reporting off");
+        assert!(bytes.windows(5).any(|w| w == b"\x1b[?1l"), "DECCKM off");
+        assert!(bytes.windows(2).any(|w| w == b"\x1b>"), "DECPNM");
+        assert!(bytes.windows(8).any(|w| w == b"\x1b[?2004l"), "bracketed paste off");
+        assert!(bytes.windows(3).any(|w| w == b"\x1b[m"), "SGR reset");
+    }
+
+    #[test]
+    fn cleanup_bytes_reset_dirty_screen_state() {
+        let mut screen = PaneScreen::new(4096);
+        // Simulate a TUI that enabled everything.
+        screen.feed(b"\x1b[?1049h"); // alt-screen
+        screen.feed(b"\x1b[?25l"); // hide cursor
+        screen.feed(b"\x1b[?1003h"); // any-event mouse
+        screen.feed(b"\x1b[?1006h"); // SGR mouse
+        screen.feed(b"\x1b[?1004h"); // focus reporting
+        screen.feed(b"\x1b[?1h"); // application cursor keys
+        screen.feed(b"\x1b="); // application keypad
+        screen.feed(b"\x1b[?2004h"); // bracketed paste
+
+        assert!(screen.alternate_screen());
+        assert!(!screen.cursor_visible());
+        assert_eq!(screen.mouse_tracking_mode(), 1003);
+        assert!(screen.sgr_mouse_mode());
+        assert!(screen.focus_event_mode());
+        assert!(screen.application_cursor_keys());
+        assert!(screen.application_keypad());
+        assert!(screen.bracketed_paste_mode());
+
+        // Feed cleanup.
+        screen.feed(terminal_cleanup_bytes());
+
+        assert!(!screen.alternate_screen());
+        assert!(screen.cursor_visible());
+        assert_eq!(screen.mouse_tracking_mode(), 0);
+        assert!(!screen.sgr_mouse_mode());
+        assert!(!screen.focus_event_mode());
+        assert!(!screen.application_cursor_keys());
+        assert!(!screen.application_keypad());
+        assert!(!screen.bracketed_paste_mode());
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -2211,6 +2211,22 @@ fn spawn_pty_read_loop(
         };
 
         let mut s = server.lock().await;
+
+        // Feed terminal cleanup sequence so the screen state and
+        // scrollback reflect a clean terminal (alt-screen off, cursor
+        // visible, mouse off, etc.) before marking the pane as exited.
+        if let Some(rt) = s.runtimes.get_mut(&runtime_id)
+            && let Some(pane) = rt.panes.get_mut(&pane_id)
+        {
+            pane.feed_cleanup();
+        }
+        let cleanup_delta = ClientMsg::V2(protocol::delta(
+            runtime_id,
+            pane_id,
+            bytes::Bytes::from_static(crate::screen::terminal_cleanup_bytes()),
+        ));
+        s.broadcast_to_runtime(runtime_id, &cleanup_delta);
+
         let exit_msg = if let Some(rt) = s.runtimes.get_mut(&runtime_id) {
             let msg = rt.set_pane_exit_status(pane_id, Some(status)).map(|revision| {
                 ClientMsg::V2(protocol::pane_exited(runtime_id, pane_id, status, revision))

--- a/services/rttx-server/tests/pane_exit_cleanup.rs
+++ b/services/rttx-server/tests/pane_exit_cleanup.rs
@@ -1,0 +1,114 @@
+//! Integration test: server emits terminal cleanup sequence on pane process exit.
+//!
+//! Verifies that when a pane's leaf process dies, the server feeds the
+//! cleanup byte sequence into the pane's screen state and broadcasts it
+//! to attached clients. This ensures reconnecting clients see a clean
+//! terminal (alt-screen off, cursor visible, mouse off, etc.).
+
+mod common;
+
+use common::*;
+use rttx_proto::proto;
+use std::time::Duration;
+
+/// Collect all Delta data bytes received before `PaneExited`.
+async fn collect_deltas_until_exit(
+    client: &mut TestClient,
+    timeout: Duration,
+) -> (Vec<u8>, Option<proto::PaneExited>) {
+    let mut all_data = Vec::new();
+    let mut exit_msg = None;
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let Some(msg) = client.try_recv(remaining).await else { break };
+        match msg.msg {
+            Some(proto::server_message::Msg::Delta(d)) => {
+                all_data.extend_from_slice(&d.data);
+            }
+            Some(proto::server_message::Msg::PaneExited(pe)) => {
+                exit_msg = Some(pe);
+                break;
+            }
+            _ => {}
+        }
+    }
+    (all_data, exit_msg)
+}
+
+#[tokio::test]
+async fn cleanup_sequence_broadcast_on_pane_exit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let sid =
+        create_runtime(&mut client, "cleanup-test", proto::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &sid).await;
+    let pane_id = create_pane(&mut client, &sid).await;
+
+    // Send "exit" to make the shell terminate.
+    send_input(&mut client, &sid, &pane_id, b"exit\n").await;
+
+    let (delta_data, exit_msg) = collect_deltas_until_exit(&mut client, Duration::from_secs(15)).await;
+
+    assert!(exit_msg.is_some(), "should receive PaneExited");
+
+    // The cleanup sequence should appear in the delta stream before PaneExited.
+    let cleanup = rttx_server::screen::terminal_cleanup_bytes();
+    assert!(
+        delta_data.windows(cleanup.len()).any(|w| w == cleanup),
+        "delta stream should contain the terminal cleanup sequence"
+    );
+}
+
+#[tokio::test]
+async fn reattach_after_exit_sees_clean_terminal_modes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let sid =
+        create_runtime(&mut client, "reattach-test", proto::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &sid).await;
+    let pane_id = create_pane(&mut client, &sid).await;
+
+    // Send "exit" to make the shell terminate.
+    send_input(&mut client, &sid, &pane_id, b"exit\n").await;
+
+    // Wait for PaneExited.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        assert!(!remaining.is_zero(), "timed out waiting for PaneExited");
+        if let Some(msg) = client.try_recv(remaining).await
+            && matches!(msg.msg, Some(proto::server_message::Msg::PaneExited(_)))
+        {
+            break;
+        }
+    }
+
+    // Detach and reattach to get a fresh snapshot.
+    detach_runtime(&mut client, &sid).await;
+    let snapshot = attach_rw(&mut client, &sid).await;
+
+    let pane = snapshot
+        .panes
+        .iter()
+        .find(|p| p.pane_id == pane_id)
+        .expect("pane should still be in snapshot");
+
+    // After cleanup, all TUI modes should be off.
+    assert!(!pane.bracketed_paste_mode, "bracketed paste should be off");
+    assert!(!pane.application_cursor_keys, "application cursor keys should be off");
+    assert!(!pane.application_keypad, "application keypad should be off");
+    assert_eq!(pane.mouse_tracking_mode, 0, "mouse tracking should be off");
+    assert!(!pane.sgr_mouse_mode, "SGR mouse should be off");
+}

--- a/services/rttx-server/tests/pane_exit_cleanup.rs
+++ b/services/rttx-server/tests/pane_exit_cleanup.rs
@@ -47,15 +47,15 @@ async fn cleanup_sequence_broadcast_on_pane_exit() {
     let mut client = TestClient::connect(&sock).await;
     client.handshake().await;
 
-    let sid =
-        create_runtime(&mut client, "cleanup-test", proto::RuntimePolicy::Persistent).await;
+    let sid = create_runtime(&mut client, "cleanup-test", proto::RuntimePolicy::Persistent).await;
     attach_rw(&mut client, &sid).await;
     let pane_id = create_pane(&mut client, &sid).await;
 
     // Send "exit" to make the shell terminate.
     send_input(&mut client, &sid, &pane_id, b"exit\n").await;
 
-    let (delta_data, exit_msg) = collect_deltas_until_exit(&mut client, Duration::from_secs(15)).await;
+    let (delta_data, exit_msg) =
+        collect_deltas_until_exit(&mut client, Duration::from_secs(15)).await;
 
     assert!(exit_msg.is_some(), "should receive PaneExited");
 
@@ -75,8 +75,7 @@ async fn reattach_after_exit_sees_clean_terminal_modes() {
     let mut client = TestClient::connect(&sock).await;
     client.handshake().await;
 
-    let sid =
-        create_runtime(&mut client, "reattach-test", proto::RuntimePolicy::Persistent).await;
+    let sid = create_runtime(&mut client, "reattach-test", proto::RuntimePolicy::Persistent).await;
     attach_rw(&mut client, &sid).await;
     let pane_id = create_pane(&mut client, &sid).await;
 


### PR DESCRIPTION
## What changed and why

When a pane's leaf process exits (e.g. `ssh` drops while the user is in vim, OOM kill, segfault), the server now feeds a terminal cleanup byte sequence into the pane's screen state before marking it as exited. This resets alt-screen, cursor visibility, mouse tracking, focus reporting, bracketed paste, application cursor keys, application keypad, and SGR attributes that the dying process never got to clean up.

Previously, VTE was left with stale TUI modes (alt-screen on, mouse tracking on, cursor hidden, etc.) and the user had to type `reset` to recover.

### Cleanup sequence

```
CAN (\x18)                    — abort in-progress escape
DECRST 1049 + DECRST 47      — exit alt-screen (modern + legacy)
DECSET 25                     — show cursor
DECRST 1000/1002/1003/1006/1015 — disable all mouse modes
DECRST 1004                   — disable focus reporting
DECRST 1 + DECPNM             — normal cursor keys + numeric keypad
DECRST 2004                   — disable bracketed paste
SGR reset (\x1b[m)            — default text attributes
```

### What happens on pane exit

1. Cleanup bytes are fed into the pane's `PaneScreen` (resets mode flags)
2. Cleanup bytes are broadcast to attached clients as a Delta (before `PaneExited`)
3. Cleanup bytes are appended to the scrollback pending flush (persisted on next tick)
4. A fresh client attaching to an exited pane sees clean terminal modes in the snapshot

## How to manually verify

1. Start rttx with a daemon
2. In a pane, run `vim` (enters alt-screen, hides cursor, enables mouse)
3. Kill the pane process externally: `kill -9 <pid>`
4. The pane should show a clean terminal (no alt-screen artifacts, cursor visible)
5. Detach and reattach — snapshot should show all modes off

## Tests added

### Unit tests (screen.rs)
- `terminal_cleanup_bytes_contains_required_sequences` — validates all escape sequences present
- `cleanup_bytes_reset_dirty_screen_state` — feeds cleanup into a dirty screen, verifies all modes reset

### Unit tests (pane.rs)
- `feed_cleanup_resets_dirty_screen_modes` — full mode reset through Pane API
- `feed_cleanup_appends_to_pending_flush` — cleanup bytes queued for scrollback
- `feed_cleanup_increments_output_seq` — output sequence counter advances
- `feed_cleanup_returns_cleanup_bytes` — return value matches constant
- `feed_cleanup_is_idempotent_on_clean_state` — safe to call on already-clean pane
- `snapshot_after_cleanup_shows_clean_modes` — snapshot metadata reflects cleanup
- `cleanup_bytes_flushed_to_scrollback_log` — cleanup persisted to disk

### Integration tests (pane_exit_cleanup.rs)
- `cleanup_sequence_broadcast_on_pane_exit` — Delta stream contains cleanup bytes before PaneExited
- `reattach_after_exit_sees_clean_terminal_modes` — snapshot after exit has all modes off

## Tests run

- `cargo test -p rttx-server --lib` — 380 passed
- `cargo test -p rttx-server --tests` — all integration tests passed
- `cargo test -p rttx-proto` — 9 passed
- `bash .github/scripts/run-clippy.sh` — passed
- `bash .github/scripts/run-quality-tests.sh` — passed (pre-existing flaky `pty_coalesce::burst_output_produces_coalesced_deltas` intermittently fails on mainline too)

Fixes #810