### PR TITLE
fix(test): replace sleep-based timing with polling in scrollback cap test

### DIFF
--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -172,6 +172,47 @@ pub async fn wait_for_state_file(state_dir: &std::path::Path, timeout: std::time
     }
 }
 
+/// Wait until at least one `.log` file appears under
+/// `base_dir/state/rttx/daemon/runtimes/<id>/scrollback/`.
+/// Polls every 200ms for up to `timeout`.
+pub async fn wait_for_scrollback_log(
+    base_dir: &std::path::Path,
+    timeout: std::time::Duration,
+) -> Vec<std::path::PathBuf> {
+    let runtimes_dir = base_dir.join("state/rttx/daemon/runtimes");
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let logs = find_scrollback_logs(&runtimes_dir);
+        if !logs.is_empty() {
+            return logs;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "no scrollback log appeared under {} within {}s",
+            runtimes_dir.display(),
+            timeout.as_secs()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
+fn find_scrollback_logs(runtimes_dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut logs = Vec::new();
+    let Ok(entries) = std::fs::read_dir(runtimes_dir) else { return logs };
+    for entry in entries.flatten() {
+        let scrollback_dir = entry.path().join("scrollback");
+        if let Ok(files) = std::fs::read_dir(&scrollback_dir) {
+            for file in files.flatten() {
+                let path = file.path();
+                if path.extension().is_some_and(|ext| ext == "log") {
+                    logs.push(path);
+                }
+            }
+        }
+    }
+    logs
+}
+
 /// Wait until any v2 runtime file under the state dir contains a specific
 /// substring. Polls every 200ms for up to `timeout`.
 ///

--- a/services/rttx-server/tests/scrollback.rs
+++ b/services/rttx-server/tests/scrollback.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{TestClient, start_test_server, wait_for_state_containing};
+use common::{TestClient, start_test_server, wait_for_scrollback_log, wait_for_state_containing};
 use rttx_proto::proto;
 use std::time::Duration;
 
@@ -232,38 +232,11 @@ async fn scrollback_log_capped_at_max_size() {
     };
     client.send(&input).await;
 
-    // Wait for command to finish + serialization ticks to flush and cap.
-    tokio::time::sleep(Duration::from_secs(8)).await;
+    // Poll until the scrollback log file appears (covers command execution +
+    // serialization tick flush). Generous timeout for slow CI runners.
+    let log_files = wait_for_scrollback_log(tmp.path(), Duration::from_secs(30)).await;
 
-    // Find the scrollback log file in the state directory.
-    let runtimes_dir = tmp.path().join("state/rttx/daemon/runtimes");
-
-    // Wait for the runtimes directory to appear (scrollback flush creates it).
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    while !runtimes_dir.exists() {
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "runtimes directory did not appear at {}",
-            runtimes_dir.display()
-        );
-        tokio::time::sleep(Duration::from_millis(200)).await;
-    }
-
-    let mut log_files = Vec::new();
-    for runtime_dir in std::fs::read_dir(&runtimes_dir).unwrap() {
-        let runtime_dir = runtime_dir.unwrap().path();
-        let scrollback_dir = runtime_dir.join("scrollback");
-        if scrollback_dir.is_dir() {
-            for entry in std::fs::read_dir(&scrollback_dir).unwrap() {
-                let entry = entry.unwrap().path();
-                if entry.extension().is_some_and(|ext| ext == "log") {
-                    log_files.push(entry);
-                }
-            }
-        }
-    }
-
-    assert!(!log_files.is_empty(), "expected at least one scrollback log");
+    assert_eq!(log_files.len(), 1, "expected exactly one scrollback log, found: {log_files:?}");
 
     let size = std::fs::metadata(&log_files[0]).unwrap().len();
     let max = 10 * 1024 * 1024_u64; // 10 MB


### PR DESCRIPTION
## What changed and why

The `scrollback_log_capped_at_max_size` integration test used a fixed 8-second `tokio::time::sleep` followed by a 5-second directory existence check. On slow CI runners the scrollback log files may not be flushed by the time the assertions run, causing intermittent `expected at least one scrollback log` failures.

Replaced the sleep + manual directory scan with a polling `wait_for_scrollback_log` helper (30-second timeout, 200ms poll interval), consistent with how other scrollback tests use `wait_for_state_containing`.

## Manual verification

- Ran `scrollback_log_capped_at_max_size` 5 times in a row — all passed
- Confirmed the test completes faster on average (polls until ready vs fixed 8s sleep)

## Tests added

- No new tests — this is a test infrastructure fix
- Extracted `wait_for_scrollback_log` + `find_scrollback_logs` into `tests/common/mod.rs` for reuse

## Tests run

- `cargo test -p rttx-server --test scrollback` — 4/4 passed
- `cargo test -p rttx-server` — all passed
- `cargo test -p rttx-proto` — all passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed
- `cargo build -p rttx --no-default-features --features vte-0_76` — clean

Fixes #817