### PR TITLE
feat: add Rename Pane action to pane context menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.20"
+version = "0.4.21"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -249,6 +249,19 @@ pub fn run() -> glib::ExitCode {
     });
     app.add_action(&rename_workspace_action);
 
+    let rename_pane_action =
+        gtk4::gio::SimpleAction::new("rename-pane", Some(glib::VariantTy::STRING));
+    let app_ref = app.clone();
+    rename_pane_action.connect_activate(move |_, param| {
+        if let Some(win) = app_ref.active_window()
+            && let Ok(win) = win.downcast::<Window>()
+            && let Some(name) = param.and_then(glib::Variant::get::<String>)
+        {
+            win.rename_focused_pane_direct(&name);
+        }
+    });
+    app.add_action(&rename_pane_action);
+
     let save_state_action = gtk4::gio::SimpleAction::new("save-state", None);
     let app_ref = app.clone();
     save_state_action.connect_activate(move |_, _| {

--- a/clients/rttx/src/terminal/handle.rs
+++ b/clients/rttx/src/terminal/handle.rs
@@ -52,6 +52,23 @@ impl TerminalHandle {
         }
     }
 
+    /// Get the custom title, if set.
+    #[must_use]
+    pub fn custom_title(&self) -> Option<String> {
+        match self {
+            Self::Direct(terminal) => terminal.custom_title(),
+            Self::Managed(pane) => pane.custom_title(),
+        }
+    }
+
+    /// Set or clear the custom title override.
+    pub fn set_custom_title(&self, title: Option<&str>) {
+        match self {
+            Self::Direct(terminal) => terminal.set_custom_title(title),
+            Self::Managed(pane) => pane.set_custom_title(title),
+        }
+    }
+
     /// Toggle the pane's inline search UI.
     pub fn toggle_search(&self) {
         match self {

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1515,4 +1515,28 @@ mod search_tests {
         assert!(!modes.application_cursor_keys);
         assert!(!modes.application_keypad);
     }
+
+    /// `TerminalHandle::set_custom_title` propagates to the underlying
+    /// widget and clearing reverts to the daemon-reported title. #819.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn handle_set_custom_title_propagates_and_clears() {
+        if !crate::test_helpers::ensure_gtk() {
+            eprintln!("SKIPPED: no display available");
+            return;
+        }
+
+        let pane = super::persistent_widget::PersistentPaneView::new("ct-mod-1", "rt-1");
+        pane.set_daemon_title("auto title");
+        let handle = super::handle::TerminalHandle::Managed(pane.clone());
+
+        assert!(handle.custom_title().is_none());
+        handle.set_custom_title(Some("renamed"));
+        assert_eq!(handle.custom_title().as_deref(), Some("renamed"));
+        assert_eq!(pane.title_label().label(), "renamed");
+
+        handle.set_custom_title(None);
+        assert!(handle.custom_title().is_none());
+        assert_eq!(pane.title_label().label(), "auto title");
+    }
 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -219,6 +219,7 @@ mod imp {
             pane_section.append(Some("Split Vertically"), Some("win.split-vertical"));
             pane_section.append(Some("Rotate Layout"), Some("win.rotate-layout"));
             pane_section.append(Some("Repair Terminal"), Some("win.repair-terminal"));
+            pane_section.append(Some("Rename Pane"), Some("win.rename-pane"));
             pane_section.append(Some("Confidential Mode"), Some("win.toggle-no-persist"));
             let session_section = gtk4::gio::Menu::new();
             session_section.append(Some("New Session"), Some("win.new-session"));

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -237,6 +237,7 @@ mod imp {
             pane_section.append(Some("Split Vertically"), Some("win.split-vertical"));
             pane_section.append(Some("Rotate Layout"), Some("win.rotate-layout"));
             pane_section.append(Some("Repair Terminal"), Some("win.repair-terminal"));
+            pane_section.append(Some("Rename Pane"), Some("win.rename-pane"));
             let session_section = gtk4::gio::Menu::new();
             session_section.append(Some("New Session"), Some("win.new-session"));
             session_section.append(Some("Toggle Input Sync"), Some("win.toggle-input-sync"));
@@ -394,6 +395,10 @@ impl TerminalWidget {
         self.imp().custom_title.replace(title.map(str::to_string));
         if let Some(title) = title {
             self.set_title(title);
+        } else {
+            let vte_title = self.imp().vte.window_title().unwrap_or_default();
+            let cleaned = crate::terminal::persistent_widget::strip_user_host_prefix(&vte_title);
+            self.set_title(cleaned);
         }
     }
 

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -41,6 +41,7 @@ impl Window {
             ("toggle-pane-zoom", Self::toggle_pane_zoom),
             ("rotate-layout", Self::rotate_layout),
             ("repair-terminal", Self::repair_focused_terminal),
+            ("rename-pane", Self::rename_focused_pane),
             ("new-session", Self::add_session),
             ("new-ephemeral-workspace", Self::add_ephemeral_session),
             ("new-remote-workspace", Self::show_new_remote_workspace_dialog),
@@ -290,6 +291,28 @@ impl Window {
         {
             terminal.repair_terminal();
             self.show_toast("Terminal repaired");
+        }
+    }
+
+    fn rename_focused_pane(&self) {
+        if let Some(uuid) = self.focused_terminal_uuid()
+            && let Some(terminal) = self.terminal_handle(&uuid)
+        {
+            self.show_rename_pane_dialog(&uuid, &terminal);
+        }
+    }
+
+    /// Rename the focused pane directly (for D-Bus / test automation).
+    /// Empty string clears the custom title.
+    pub(crate) fn rename_focused_pane_direct(&self, name: &str) {
+        if let Some(uuid) = self.focused_terminal_uuid()
+            && let Some(handle) = self.terminal_handle(&uuid)
+        {
+            if name.is_empty() {
+                handle.set_custom_title(None);
+            } else {
+                handle.set_custom_title(Some(name));
+            }
         }
     }
 

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -16,6 +16,50 @@ impl Window {
         alert.present(Some(self));
     }
 
+    pub(super) fn show_rename_pane_dialog(&self, terminal_uuid: &str, handle: &TerminalHandle) {
+        let current_title = handle.title();
+        let has_custom = handle.custom_title().is_some();
+
+        let alert = adw::AlertDialog::new(Some("Rename Pane"), None);
+        alert.add_response("cancel", "Cancel");
+        if has_custom {
+            alert.add_response("reset", "Reset");
+        }
+        alert.add_response("rename", "Rename");
+        alert.set_response_appearance("rename", adw::ResponseAppearance::Suggested);
+        alert.set_default_response(Some("rename"));
+        alert.set_close_response("cancel");
+
+        let entry = adw::EntryRow::builder().title("Pane title").build();
+        entry.set_text(&current_title);
+
+        let group = adw::PreferencesGroup::new();
+        group.add(&entry);
+        alert.set_extra_child(Some(&group));
+
+        alert.connect_response(None, {
+            let win = self.clone();
+            let uuid = terminal_uuid.to_string();
+            move |_, response| match response {
+                "rename" => {
+                    let text = entry.text().trim().to_string();
+                    if !text.is_empty()
+                        && let Some(handle) = win.terminal_handle(&uuid)
+                    {
+                        handle.set_custom_title(Some(&text));
+                    }
+                }
+                "reset" => {
+                    if let Some(handle) = win.terminal_handle(&uuid) {
+                        handle.set_custom_title(None);
+                    }
+                }
+                _ => {}
+            }
+        });
+        alert.present(Some(self));
+    }
+
     pub(super) fn confirm_close_others(&self, keep_uuid: &str) {
         let other_uuids: Vec<String> = {
             let state = self.imp().state.borrow();

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -7082,3 +7082,40 @@ fn run_in_new_pane_respects_split_depth_limit() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn rename_focused_pane_direct_sets_custom_title() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.rename-pane-direct-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    let terminal_uuid = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    window.imp().focused_terminal_uuid.replace(Some(terminal_uuid.clone()));
+
+    window.rename_focused_pane_direct("My Pane");
+    let handle = window.terminal_handle(&terminal_uuid).unwrap();
+    assert_eq!(handle.custom_title().as_deref(), Some("My Pane"));
+    assert_eq!(handle.title(), "My Pane");
+
+    window.rename_focused_pane_direct("");
+    let handle = window.terminal_handle(&terminal_uuid).unwrap();
+    assert!(handle.custom_title().is_none(), "empty string should clear custom title");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2684,3 +2684,91 @@ fn repair_terminal_works_on_direct_pane() {
     handle.repair_terminal();
     // No panic — cleanup bytes accepted by VTE.
 }
+
+/// `TerminalHandle::set_custom_title` sets and clears on direct panes.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn terminal_handle_custom_title_direct() {
+    require_display!();
+
+    let term = rttx::terminal::widget::TerminalWidget::new("ct-direct-1", None);
+    let handle = rttx::terminal::handle::TerminalHandle::Direct(term);
+
+    assert!(handle.custom_title().is_none());
+    handle.set_custom_title(Some("my pane"));
+    assert_eq!(handle.custom_title().as_deref(), Some("my pane"));
+    assert_eq!(handle.title(), "my pane");
+
+    handle.set_custom_title(None);
+    assert!(handle.custom_title().is_none());
+}
+
+/// `TerminalHandle::set_custom_title` sets and clears on managed panes.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn terminal_handle_custom_title_managed() {
+    require_display!();
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("ct-managed-1", "rt-1");
+    pane.set_daemon_title("daemon title");
+    let handle = rttx::terminal::handle::TerminalHandle::Managed(pane);
+
+    assert!(handle.custom_title().is_none());
+    handle.set_custom_title(Some("custom name"));
+    assert_eq!(handle.custom_title().as_deref(), Some("custom name"));
+    assert_eq!(handle.title(), "custom name");
+
+    handle.set_custom_title(None);
+    assert!(handle.custom_title().is_none());
+    assert_eq!(handle.title(), "daemon title");
+}
+
+/// Context menu for `TerminalWidget` includes "Rename Pane".
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn terminal_widget_context_menu_has_rename_pane() {
+    require_display!();
+
+    let term = rttx::terminal::widget::TerminalWidget::new("ctx-rename-1", None);
+    let menu = term.imp().context_menu.borrow();
+    let popover = menu.as_ref().expect("context menu should exist");
+    let model = popover.menu_model().expect("menu model should exist");
+    let has_rename = menu_model_contains_label(&model, "Rename Pane");
+    assert!(has_rename, "context menu should contain 'Rename Pane'");
+}
+
+/// Context menu for `PersistentPaneView` includes "Rename Pane".
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn persistent_pane_context_menu_has_rename_pane() {
+    require_display!();
+
+    let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("ctx-rename-2", "rt-1");
+    let menu = pane.imp().context_menu.borrow();
+    let popover = menu.as_ref().expect("context menu should exist");
+    let model = popover.menu_model().expect("menu model should exist");
+    let has_rename = menu_model_contains_label(&model, "Rename Pane");
+    assert!(has_rename, "context menu should contain 'Rename Pane'");
+}
+
+fn menu_model_contains_label(model: &gtk4::gio::MenuModel, label: &str) -> bool {
+    for i in 0..model.n_items() {
+        if let Some(item_label) =
+            model.item_attribute_value(i, "label", Some(gtk4::glib::VariantTy::STRING))
+            && item_label.get::<String>().is_some_and(|l| l == label)
+        {
+            return true;
+        }
+        if let Some(section) = model.item_link(i, "section")
+            && menu_model_contains_label(&section, label)
+        {
+            return true;
+        }
+        if let Some(submenu) = model.item_link(i, "submenu")
+            && menu_model_contains_label(&submenu, label)
+        {
+            return true;
+        }
+    }
+    false
+}

--- a/clients/rttx/tests/ui/common.py
+++ b/clients/rttx/tests/ui/common.py
@@ -590,7 +590,7 @@ class AppFixture:
         bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
         params = GLib.Variant("(sava{sv})", (
             action_name,
-            [GLib.Variant("s", parameter)] if parameter else [],
+            [GLib.Variant("s", parameter)] if parameter is not None else [],
             {},
         ))
         bus.call_sync(

--- a/clients/rttx/tests/ui/test_rename_pane.py
+++ b/clients/rttx/tests/ui/test_rename_pane.py
@@ -1,0 +1,100 @@
+"""UI test: rename pane via context menu action.
+
+Covers #819 — the rename-pane action must set a custom title on the
+focused pane, and clearing it must revert to the auto-derived title.
+"""
+
+import time
+import unittest
+
+import gi
+
+gi.require_version("Atspi", "2.0")
+from gi.repository import Atspi
+
+from common import (
+    AppFixture,
+    find_all_by_role,
+    is_showing,
+    wait_for_showing_role,
+)
+
+
+def pane_header_labels(app: Atspi.Accessible) -> list[str]:
+    """Return the accessible names of visible LABEL nodes inside terminal pane headers."""
+    labels = []
+    for node in find_all_by_role(app, Atspi.Role.LABEL):
+        try:
+            if is_showing(node) and node.get_name():
+                labels.append(node.get_name())
+        except Exception:  # noqa: BLE001
+            pass
+    return labels
+
+
+def wait_for_label_text(
+    app: Atspi.Accessible, text: str, timeout: float = 5.0
+) -> bool:
+    """Poll until a visible LABEL with the given text appears."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if text in pane_header_labels(app):
+            return True
+        time.sleep(0.2)
+    return text in pane_header_labels(app)
+
+
+class TestRenamePaneAction(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.fixture = AppFixture()
+        self.fixture.start()
+        wait_for_showing_role(self.fixture.atspi_app, Atspi.Role.TERMINAL, count=1, timeout=10.0)
+
+    def tearDown(self) -> None:
+        self.fixture.stop()
+
+    def test_rename_pane_sets_custom_title(self) -> None:
+        """Activating rename-pane with a name must update the pane header label."""
+        self.fixture.activate_action("rename-pane", "My Custom Pane")
+        found = wait_for_label_text(self.fixture.atspi_app, "My Custom Pane", timeout=5.0)
+        self.assertTrue(
+            found,
+            f"Pane header should show 'My Custom Pane', got labels: {pane_header_labels(self.fixture.atspi_app)}",
+        )
+
+    def test_rename_pane_empty_clears_custom_title(self) -> None:
+        """Activating rename-pane with empty string must clear the custom title."""
+        self.fixture.activate_action("rename-pane", "Temporary Name")
+        found = wait_for_label_text(self.fixture.atspi_app, "Temporary Name", timeout=5.0)
+        self.assertTrue(found, "Custom title should be set first")
+
+        self.fixture.activate_action("rename-pane", "")
+        time.sleep(1.0)
+        labels = pane_header_labels(self.fixture.atspi_app)
+        self.assertNotIn(
+            "Temporary Name", labels,
+            "Custom title should be cleared after empty rename",
+        )
+
+    def test_renamed_pane_persists_across_restart(self) -> None:
+        """A renamed pane title must survive a save/restore cycle."""
+        self.fixture.activate_action("rename-pane", "Persistent Pane Title")
+        found = wait_for_label_text(self.fixture.atspi_app, "Persistent Pane Title", timeout=5.0)
+        self.assertTrue(found, "Rename should take effect before restart")
+
+        self.fixture.activate_action("save-state")
+        time.sleep(0.5)
+
+        self.fixture.restart_app()
+        wait_for_showing_role(self.fixture.atspi_app, Atspi.Role.TERMINAL, count=1, timeout=10.0)
+
+        found = wait_for_label_text(self.fixture.atspi_app, "Persistent Pane Title", timeout=5.0)
+        self.assertTrue(
+            found,
+            f"Renamed pane title should persist across restart, got labels: {pane_header_labels(self.fixture.atspi_app)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.20',
+  version: '0.4.21',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds a "Rename Pane" action to the terminal context menu for both ephemeral (`TerminalWidget`) and persistent (`PersistentPaneView`) pane types. Closes #819.

On activation, an `adw::AlertDialog` with an `adw::EntryRow` prefilled with the current title lets the user set a custom pane title. When a custom title is already set, a "Reset" button appears that clears the override and reverts to the auto-derived title (VTE window title for ephemeral panes, daemon-reported title for persistent panes).

### Changes

- **`terminal/handle.rs`**: Add `custom_title()` and `set_custom_title()` to `TerminalHandle`
- **`window/actions.rs`**: Register `win.rename-pane` action; add `rename_focused_pane_direct()` for D-Bus/test automation
- **`window/dialogs.rs`**: Add `show_rename_pane_dialog()` with AdwAlertDialog + AdwEntryRow
- **`terminal/widget.rs`**: Add "Rename Pane" to context menu; fix `set_custom_title(None)` to revert to VTE title
- **`terminal/persistent_widget.rs`**: Add "Rename Pane" to context menu
- **`application.rs`**: Register app-level `rename-pane` D-Bus action
- **`tests/ui/common.py`**: Fix `activate_action` to handle empty string parameters (`is not None` instead of truthiness)
- Version bump to 0.4.21

### Manual verification

1. Right-click a terminal pane → "Rename Pane" appears in context menu
2. Click "Rename Pane" → dialog prefilled with current title
3. Enter new name → pane header updates
4. Reopen dialog → "Reset" button appears; click it → title reverts
5. Save state, restart → custom title persists

### Tests added

**GTK widget tests** (`gtk_widget_tests.rs`):
- `terminal_handle_custom_title_direct` — set/clear custom title on direct pane
- `terminal_handle_custom_title_managed` — set/clear custom title on managed pane (verifies daemon title revert)
- `terminal_widget_context_menu_has_rename_pane` — context menu contains "Rename Pane"
- `persistent_pane_context_menu_has_rename_pane` — context menu contains "Rename Pane"

**Window tests** (`window/tests.rs`):
- `rename_focused_pane_direct_sets_custom_title` — set and clear via `rename_focused_pane_direct()`

**AT-SPI behavioral tests** (`tests/ui/test_rename_pane.py`):
- `test_rename_pane_sets_custom_title` — D-Bus action updates pane header label
- `test_rename_pane_empty_clears_custom_title` — empty string clears custom title
- `test_renamed_pane_persists_across_restart` — custom title survives save/restore cycle

### Tests run

All local checks pass:
- `cargo build --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 5 new GTK tests + 1 window test pass)
- `./run_ui_tests.sh` ✅ (all 3 new AT-SPI tests pass)