### PR TITLE
refactor(server): move sync I/O out of server mutex

### DIFF
--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -143,18 +143,9 @@ impl Pane {
         }
 
         let path = scrollback_log(state_dir, session_id, self.id);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        let mut file = std::fs::OpenOptions::new().create(true).append(true).open(&path)?;
-        let clean = strip_client_queries(&self.pending_flush);
-        file.write_all(&clean)?;
-        self.pending_flush = Vec::new();
-        self.scrollback_log_path = Some(path.clone());
-
-        // Rotate when the file exceeds the cap.
-        rotate_scrollback_log(&path, DEFAULT_MAX_SCROLLBACK_LOG, SCROLLBACK_ROTATE_KEEP)?;
+        let data = std::mem::take(&mut self.pending_flush);
+        write_scrollback_to_disk(&path, &data)?;
+        self.scrollback_log_path = Some(path);
 
         Ok(())
     }
@@ -169,6 +160,15 @@ impl Pane {
     #[must_use]
     pub const fn pending_flush_len(&self) -> usize {
         self.pending_flush.len()
+    }
+
+    /// Drain pending scrollback bytes for out-of-lock flushing.
+    ///
+    /// Returns the accumulated bytes and resets the internal buffer.
+    /// The caller is responsible for writing the returned bytes to disk.
+    #[must_use]
+    pub fn take_pending_flush(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.pending_flush)
     }
 
     /// Read the child process CWD from /proc/<pid>/cwd.
@@ -264,6 +264,21 @@ impl Pane {
         self.screen.restore_cursor_visible(snap.cursor_visible);
         self.output_seq = snap.pane_output_seq;
     }
+}
+
+/// Write scrollback data to disk: strip client queries, append, and rotate.
+///
+/// This is the I/O-only counterpart of [`Pane::flush_scrollback`]. It can
+/// be called outside the server mutex after draining pending bytes with
+/// [`Pane::take_pending_flush`].
+pub fn write_scrollback_to_disk(path: &Path, data: &[u8]) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let clean = strip_client_queries(data);
+    let mut file = std::fs::OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(&clean)?;
+    rotate_scrollback_log(path, DEFAULT_MAX_SCROLLBACK_LOG, SCROLLBACK_ROTATE_KEEP)
 }
 
 /// Rotate a scrollback log file when it exceeds `max_bytes`.
@@ -935,5 +950,64 @@ mod tests {
         let content = std::fs::read(log_path).unwrap();
         let cleanup = crate::screen::terminal_cleanup_bytes();
         assert!(content.ends_with(cleanup), "scrollback log should end with cleanup bytes");
+    }
+
+    // ── take_pending_flush / write_scrollback_to_disk tests ─────────
+
+    #[test]
+    fn take_pending_flush_drains_buffer() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"hello world");
+        assert!(pane.has_pending_flush());
+
+        let data = pane.take_pending_flush();
+        assert_eq!(data, b"hello world");
+        assert!(!pane.has_pending_flush());
+        assert_eq!(pane.pending_flush_len(), 0);
+    }
+
+    #[test]
+    fn take_pending_flush_returns_empty_when_nothing_pending() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let data = pane.take_pending_flush();
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn write_scrollback_to_disk_creates_file_and_strips_queries() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("scrollback").join("test.log");
+        let data = b"line1\r\n\x1b[6nline2\r\n";
+
+        write_scrollback_to_disk(&path, data).unwrap();
+
+        let content = std::fs::read(&path).unwrap();
+        assert_eq!(content, b"line1\r\nline2\r\n");
+    }
+
+    #[test]
+    fn write_scrollback_to_disk_appends_to_existing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.log");
+
+        write_scrollback_to_disk(&path, b"first ").unwrap();
+        write_scrollback_to_disk(&path, b"second").unwrap();
+
+        let content = std::fs::read(&path).unwrap();
+        assert_eq!(content, b"first second");
+    }
+
+    #[test]
+    fn write_scrollback_to_disk_rotates_large_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.log");
+
+        let chunk = vec![b'A'; 4 * 1024 * 1024];
+        for _ in 0..4 {
+            write_scrollback_to_disk(&path, &chunk).unwrap();
+        }
+
+        let rotated = path.with_extension("log.1");
+        assert!(rotated.exists(), "rotated segment .1 should exist");
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -299,6 +299,91 @@ impl Server {
     /// `Arc<Mutex<>>` so we can spawn PTY read loops.
     #[allow(clippy::significant_drop_tightening)]
     pub async fn reconstruct_runtimes(server: &Arc<Mutex<Self>>) {
+        enum ReplayData {
+            Snapshot(crate::state::types::ScreenSnapshotV1),
+            Scrollback { clean: Vec<u8>, rewrite: Option<(std::path::PathBuf, Vec<u8>)> },
+            None,
+        }
+
+        // Phase 1: collect pane metadata and paths under the lock.
+        let replay_targets: Vec<(Uuid, Uuid, String, Option<std::path::PathBuf>)>;
+        let state_dir;
+        {
+            let s = server.lock().await;
+            state_dir = s.os.state_dir();
+            replay_targets = s
+                .runtimes
+                .values()
+                .flat_map(|rt| {
+                    let label = format!("\"{}\" ({})", rt.name, short_id(rt.id));
+                    rt.panes.values().map(move |pane| {
+                        (rt.id, pane.id, label.clone(), pane.scrollback_log_path.clone())
+                    })
+                })
+                .collect();
+        }
+
+        // Phase 2: read screen snapshots and scrollback files outside the lock.
+        let mut replay_results: Vec<(Uuid, Uuid, String, ReplayData)> =
+            Vec::with_capacity(replay_targets.len());
+        for (runtime_id, pane_id, label, log_path) in replay_targets {
+            let pane_short = short_id(pane_id);
+
+            if let Some(snap) =
+                crate::state::persistence::load_screen_snapshot(&state_dir, runtime_id, pane_id)
+            {
+                tracing::info!(
+                    "Restoring pane {pane_short} in runtime {label} from screen snapshot ({} bytes, seq={})",
+                    snap.screen_bytes.len(),
+                    snap.pane_output_seq,
+                );
+                replay_results.push((runtime_id, pane_id, label, ReplayData::Snapshot(snap)));
+                continue;
+            }
+
+            if let Some(ref path) = log_path
+                && path.exists()
+            {
+                match std::fs::read(path) {
+                    Ok(data) => {
+                        let restart_safe = restart_safe_scrollback(&data);
+                        let clean = strip_client_queries(restart_safe);
+                        tracing::info!(
+                            "Replaying {} bytes of scrollback for pane {pane_short} in runtime {label} (no snapshot)",
+                            clean.len(),
+                        );
+                        let rewrite =
+                            (clean.len() != data.len()).then(|| (path.clone(), clean.clone()));
+                        replay_results.push((
+                            runtime_id,
+                            pane_id,
+                            label,
+                            ReplayData::Scrollback { clean: clean.clone(), rewrite },
+                        ));
+                        continue;
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to read scrollback log for pane {pane_short} in runtime {label}: {e}",
+                        );
+                    }
+                }
+            }
+            replay_results.push((runtime_id, pane_id, label, ReplayData::None));
+        }
+
+        // Write cleaned scrollback files outside the lock.
+        for (_, _, label, data) in &replay_results {
+            if let ReplayData::Scrollback { rewrite: Some((path, clean)), .. } = data
+                && let Err(e) = std::fs::write(path, clean)
+            {
+                tracing::error!(
+                    "Failed to rewrite restart-safe scrollback in runtime {label}: {e}",
+                );
+            }
+        }
+
+        // Phase 3: feed replay data into pane screens under the lock.
         #[allow(clippy::type_complexity)]
         let panes_to_reconstruct: Vec<(
             Uuid,
@@ -310,58 +395,18 @@ impl Server {
             bool,
         )> = {
             let mut s = server.lock().await;
-            let state_dir = s.os.state_dir();
-
-            for rt in s.runtimes.values_mut() {
-                let label = format!("\"{}\" ({})", rt.name, short_id(rt.id));
-                for pane in rt.panes.values_mut() {
-                    let pane_short = short_id(pane.id);
-
-                    // Prefer screen snapshot over raw scrollback replay.
-                    if let Some(snap) =
-                        crate::state::persistence::load_screen_snapshot(&state_dir, rt.id, pane.id)
-                    {
-                        tracing::info!(
-                            "Restoring pane {pane_short} in runtime {label} from screen snapshot ({} bytes, seq={})",
-                            snap.screen_bytes.len(),
-                            snap.pane_output_seq,
-                        );
-                        pane.restore_from_snapshot(&snap);
-                        continue;
-                    }
-
-                    // Fall back to scrollback log replay.
-                    if let Some(ref log_path) = pane.scrollback_log_path
-                        && log_path.exists()
-                    {
-                        match std::fs::read(log_path) {
-                            Ok(data) => {
-                                let restart_safe = restart_safe_scrollback(&data);
-                                let clean = strip_client_queries(restart_safe);
-                                tracing::info!(
-                                    "Replaying {} bytes of scrollback for pane {pane_short} in runtime {label} (no snapshot)",
-                                    clean.len(),
-                                );
-                                pane.screen.feed(&clean);
-                                if clean.len() != data.len()
-                                    && let Err(e) = std::fs::write(log_path, &clean)
-                                {
-                                    tracing::error!(
-                                        "Failed to rewrite restart-safe scrollback for pane {pane_short} in runtime {label}: {e}",
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to read scrollback log for pane {pane_short} in runtime {label}: {e}",
-                                );
-                            }
-                        }
+            for (runtime_id, pane_id, _, data) in replay_results {
+                if let Some(rt) = s.runtimes.get_mut(&runtime_id)
+                    && let Some(pane) = rt.panes.get_mut(&pane_id)
+                {
+                    match data {
+                        ReplayData::Snapshot(snap) => pane.restore_from_snapshot(&snap),
+                        ReplayData::Scrollback { clean, .. } => pane.screen.feed(&clean),
+                        ReplayData::None => {}
                     }
                 }
             }
 
-            // Collect panes that need fresh shells spawned.
             s.runtimes
                 .values()
                 .flat_map(|rt| {
@@ -2280,17 +2325,24 @@ pub async fn serialization_loop(
         let mut s = server.lock().await;
         let state_dir = s.os.state_dir();
 
+        // Phase 1: drain pending scrollback bytes under the lock (cheap mem::take).
+        let mut flush_jobs: Vec<(std::path::PathBuf, Vec<u8>)> = Vec::new();
         let runtime_ids: Vec<_> = s.runtimes.keys().copied().collect();
         for runtime_id in runtime_ids {
             if let Some(rt) = s.runtimes.get_mut(&runtime_id) {
-                let label = format!("\"{}\" ({})", rt.name, short_id(runtime_id));
                 for pane in rt.panes.values_mut() {
-                    if let Err(e) = pane.flush_scrollback(&state_dir, runtime_id) {
-                        tracing::error!(
-                            "Failed to flush scrollback for pane {} in runtime {label}: {e}",
-                            short_id(pane.id)
-                        );
+                    if !pane.has_pending_flush() || pane.no_persist {
+                        if pane.no_persist {
+                            // Discard pending bytes for no-persist panes.
+                            let _ = pane.take_pending_flush();
+                        }
+                        continue;
                     }
+                    let path =
+                        crate::state::layout::scrollback_log(&state_dir, runtime_id, pane.id);
+                    let data = pane.take_pending_flush();
+                    pane.scrollback_log_path = Some(path.clone());
+                    flush_jobs.push((path, data));
                 }
             }
         }
@@ -2328,6 +2380,13 @@ pub async fn serialization_loop(
         let index_changed = current_ids != last_persisted_ids;
 
         drop(s);
+
+        // Phase 2: flush scrollback to disk outside the lock.
+        for (path, data) in &flush_jobs {
+            if let Err(e) = crate::pane::write_scrollback_to_disk(path, data) {
+                tracing::error!("Failed to flush scrollback to {}: {e}", path.display());
+            }
+        }
 
         // Write v2 daemon index only when runtime IDs changed.
         if index_changed {
@@ -2380,19 +2439,24 @@ pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
     let mut s = server.lock().await;
     let state_dir = s.os.state_dir();
 
+    // Drain pending scrollback bytes under the lock.
+    let mut flush_jobs: Vec<(std::path::PathBuf, Vec<u8>)> = Vec::new();
     for rt in s.runtimes.values_mut() {
-        let label = format!("\"{}\" ({})", rt.name, short_id(rt.id));
         for pane in rt.panes.values_mut() {
-            if let Err(e) = pane.flush_scrollback(&state_dir, rt.id) {
-                tracing::error!(
-                    "Failed to flush scrollback for pane {} in runtime {label}: {e}",
-                    short_id(pane.id)
-                );
+            if !pane.has_pending_flush() || pane.no_persist {
+                if pane.no_persist {
+                    let _ = pane.take_pending_flush();
+                }
+                continue;
             }
+            let path = crate::state::layout::scrollback_log(&state_dir, rt.id, pane.id);
+            let data = pane.take_pending_flush();
+            pane.scrollback_log_path = Some(path.clone());
+            flush_jobs.push((path, data));
         }
     }
 
-    // Write v2 per-runtime files (all persistent, not just dirty).
+    // Collect v2 per-runtime files (all persistent, not just dirty).
     let runtime_files: Vec<_> = s
         .runtimes
         .values()
@@ -2407,6 +2471,22 @@ pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
         .filter(|rt| rt.policy == RuntimePolicy::Persistent)
         .flat_map(|rt| rt.panes.values().map(move |pane| (rt.id, pane.to_screen_snapshot())))
         .collect();
+
+    // Mark all as persisted while still holding the lock.
+    for rt in s.runtimes.values_mut() {
+        if rt.policy == RuntimePolicy::Persistent {
+            rt.mark_persisted();
+        }
+    }
+
+    drop(s);
+
+    // All I/O happens outside the lock.
+    for (path, data) in &flush_jobs {
+        if let Err(e) = crate::pane::write_scrollback_to_disk(path, data) {
+            tracing::error!("Failed to flush scrollback to {} on shutdown: {e}", path.display());
+        }
+    }
 
     let ids: Vec<_> = runtime_files.iter().map(|rf| rf.spec.id).collect();
     if let Err(e) = crate::state::persistence::save_daemon_index(&state_dir, &ids) {
@@ -2428,14 +2508,6 @@ pub async fn persist_and_cleanup(server: &Arc<Mutex<Server>>) {
         }
     }
 
-    // Mark all as persisted.
-    for rt in s.runtimes.values_mut() {
-        if rt.policy == RuntimePolicy::Persistent {
-            rt.mark_persisted();
-        }
-    }
-
-    drop(s);
     tracing::info!("Final state persisted");
 }
 

--- a/services/rttx-server/tests/scrollback_flush_outside_lock.rs
+++ b/services/rttx-server/tests/scrollback_flush_outside_lock.rs
@@ -1,0 +1,95 @@
+//! Integration test for out-of-lock scrollback flushing (#837).
+//!
+//! Verifies that scrollback data is correctly flushed to disk when the
+//! flush I/O happens outside the server mutex (the drain-then-write
+//! pattern introduced in #837).
+
+mod common;
+
+use common::{TestClient, start_test_server, wait_for_scrollback_log};
+use rttx_proto::proto;
+use std::time::Duration;
+
+/// Scrollback is flushed to disk via the out-of-lock path after PTY output.
+///
+/// This exercises the serialization loop's drain-then-write pattern:
+/// pending bytes are drained under the lock, then written to disk after
+/// the lock is released.
+#[tokio::test]
+async fn scrollback_flushed_via_out_of_lock_path() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut c = TestClient::connect(&sock).await;
+    c.handshake().await;
+
+    // Create a persistent runtime with a pane.
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "flush-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    })
+    .await;
+    let runtime_id = match c.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            runtime_id: runtime_id.clone(),
+            cwd: None,
+            dark_background: None,
+            cols: 80,
+            rows: 24,
+            no_persist: None,
+        })),
+    })
+    .await;
+    let pane_id = match c.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    // Attach to receive output.
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
+            runtime_id: runtime_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    })
+    .await;
+    match c.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+    c.drain(Duration::from_millis(500)).await;
+
+    // Send a marker command so we can verify it appears in the scrollback log.
+    let marker = "OUT_OF_LOCK_FLUSH_MARKER_837";
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            runtime_id: runtime_id.clone(),
+            pane_id: pane_id.clone(),
+            data: bytes::Bytes::from(format!("echo {marker}\n").into_bytes()),
+        })),
+    })
+    .await;
+
+    // Wait for the serialization loop to flush scrollback to disk.
+    let logs = wait_for_scrollback_log(tmp.path(), Duration::from_secs(10)).await;
+    assert!(!logs.is_empty(), "at least one scrollback log should exist");
+
+    // Verify the marker appears in the flushed scrollback.
+    let mut found = false;
+    for log_path in &logs {
+        let content = std::fs::read(log_path).unwrap();
+        let text = String::from_utf8_lossy(&content);
+        if text.contains(marker) {
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "scrollback log should contain the marker after out-of-lock flush");
+}


### PR DESCRIPTION
## What changed and why

The serialization loop held the server mutex while performing synchronous filesystem I/O for every pane in every runtime — file open, write (up to 10 MB), and log rotation. During these operations, all PTY reads, client message handling, and new connections were blocked.

This PR applies a drain-then-write pattern:

1. **Serialization loop**: Drain `pending_flush` buffers from panes under the lock (cheap `mem::take`), then perform all file I/O after releasing the lock.

2. **`persist_and_cleanup`**: Same pattern — collect data under the lock, write outside. Previously held the lock for the entire shutdown persistence path including JSON writes.

3. **`reconstruct_runtimes`**: Read scrollback files and screen snapshots outside the lock, then feed data into pane screens after re-acquiring it. This is startup-only but follows the same principle.

New APIs:
- `Pane::take_pending_flush()` — drains the pending buffer without I/O
- `write_scrollback_to_disk()` — standalone I/O function callable outside the lock

## How to manually verify

1. Run the daemon with multiple runtimes and panes
2. Observe that PTY responsiveness is not degraded during the 1-second serialization tick
3. Kill and restart the daemon — scrollback and screen snapshots should restore correctly
4. Verify scrollback log files are created and rotated as before

## Tests added

- `take_pending_flush_drains_buffer` — verifies buffer drain and reset
- `take_pending_flush_returns_empty_when_nothing_pending` — empty case
- `write_scrollback_to_disk_creates_file_and_strips_queries` — file creation + DSR stripping
- `write_scrollback_to_disk_appends_to_existing` — incremental append
- `write_scrollback_to_disk_rotates_large_files` — rotation behavior

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (385 server lib tests, 68+ integration tests)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #837