### PR TITLE
perf(server): move VTE parsing out of the mutex critical section

### DIFF
--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -89,8 +89,23 @@ impl Pane {
     }
 
     /// Feed PTY output into the screen state.
+    ///
+    /// Combines [`accept_output`] and [`parse_and_extract`] in a single
+    /// call. Callers that need to minimize lock hold time should use the
+    /// two-phase API instead.
     pub fn feed_output(&mut self, data: &[u8]) -> FeedResult {
-        self.screen.feed(data);
+        self.accept_output(data);
+        self.parse_and_extract(data)
+    }
+
+    /// Store raw PTY bytes without running the VTE parser.
+    ///
+    /// Updates `pending_flush`, `output_seq`, and the screen's raw-byte
+    /// buffer. This is a fast memcpy suitable for calling inside a
+    /// contended mutex. Call [`parse_and_extract`] afterwards (potentially
+    /// after releasing the lock) to run the expensive VTE state machine.
+    pub fn accept_output(&mut self, data: &[u8]) {
+        self.screen.accept_raw(data);
         self.pending_flush.extend_from_slice(data);
         self.output_seq += 1;
         if self.pending_flush.len() > DEFAULT_MAX_SCROLLBACK {
@@ -98,6 +113,38 @@ impl Pane {
             self.pending_flush.drain(..excess);
             self.pending_flush.shrink_to(DEFAULT_MAX_SCROLLBACK);
         }
+    }
+
+    /// Temporarily take the screen out of this pane for out-of-lock parsing.
+    ///
+    /// Returns the screen, replacing it with a default instance. The caller
+    /// must call [`return_screen`] to put it back after parsing.
+    #[must_use]
+    pub fn take_screen(&mut self) -> PaneScreen {
+        std::mem::replace(&mut self.screen, PaneScreen::new(DEFAULT_MAX_SCROLLBACK))
+    }
+
+    /// Return a previously taken screen and extract metadata changes.
+    ///
+    /// The screen is placed back into the pane and any CWD, title, or
+    /// pending-reply changes are returned.
+    pub fn return_screen(&mut self, screen: PaneScreen) -> FeedResult {
+        self.screen = screen;
+        self.extract_metadata()
+    }
+
+    /// Run the VTE parser and extract metadata changes.
+    ///
+    /// This is the expensive half of [`feed_output`]: it advances the VTE
+    /// state machine byte-by-byte and returns any CWD, title, or DSR
+    /// reply changes. Callers that split the two phases should call this
+    /// after releasing the contended lock.
+    pub fn parse_and_extract(&mut self, data: &[u8]) -> FeedResult {
+        self.screen.parse(data);
+        self.extract_metadata()
+    }
+
+    fn extract_metadata(&mut self) -> FeedResult {
         let new_title = self.screen.title().and_then(|title| {
             let title = title.to_string();
             if self.title.as_deref() == Some(&title) {
@@ -1009,5 +1056,93 @@ mod tests {
 
         let rotated = path.with_extension("log.1");
         assert!(rotated.exists(), "rotated segment .1 should exist");
+    }
+
+    // ── two-phase accept_output / parse_and_extract tests ───────────
+
+    #[test]
+    fn accept_output_stores_raw_bytes_without_vte_parsing() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let osc7 = b"\x1b]7;file://localhost/tmp/test\x07";
+        pane.accept_output(osc7);
+
+        // Raw bytes stored in screen.
+        assert_eq!(pane.screen.raw_bytes(), osc7);
+        // Pending flush updated.
+        assert!(pane.has_pending_flush());
+        // Seq incremented.
+        assert_eq!(pane.output_seq, 1);
+        // VTE not parsed — CWD not extracted yet.
+        assert!(pane.cwd.is_none());
+        assert!(pane.screen.cwd().is_none());
+    }
+
+    #[test]
+    fn parse_and_extract_runs_vte_after_accept() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let osc7 = b"\x1b]7;file://localhost/tmp/test\x07";
+        pane.accept_output(osc7);
+        let result = pane.parse_and_extract(osc7);
+
+        assert_eq!(result.new_cwd.as_deref(), Some("/tmp/test"));
+        assert_eq!(pane.cwd.as_deref(), Some("/tmp/test"));
+    }
+
+    #[test]
+    fn take_screen_and_return_screen_equivalent_to_feed_output() {
+        // feed_output path
+        let mut pane_a = Pane::new(Uuid::new_v4(), 80, 24);
+        let data = b"\x1b]0;my-title\x07\x1b]7;file://localhost/home/user\x07hello\r\n\x1b[6n";
+        let result_a = pane_a.feed_output(data);
+
+        // two-phase path
+        let mut pane_b = Pane::new(Uuid::new_v4(), 80, 24);
+        pane_b.accept_output(data);
+        let mut screen = pane_b.take_screen();
+        screen.parse(data);
+        let result_b = pane_b.return_screen(screen);
+
+        assert_eq!(result_a.new_cwd, result_b.new_cwd);
+        assert_eq!(result_a.new_title, result_b.new_title);
+        assert_eq!(result_a.pending_replies, result_b.pending_replies);
+        assert_eq!(pane_a.cwd, pane_b.cwd);
+        assert_eq!(pane_a.title, pane_b.title);
+        assert_eq!(pane_a.output_seq, pane_b.output_seq);
+    }
+
+    #[test]
+    fn take_screen_returns_screen_with_accumulated_state() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"line1\r\nline2\r\n");
+        let screen = pane.take_screen();
+        assert_eq!(screen.cursor_position(), (2, 0));
+        assert!(!screen.raw_bytes().is_empty());
+    }
+
+    #[test]
+    fn return_screen_restores_screen_state() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.feed_output(b"hello");
+
+        let mut screen = pane.take_screen();
+        // Pane now has a fresh empty screen.
+        assert!(pane.screen.raw_bytes().is_empty());
+
+        screen.parse(b" world");
+        pane.return_screen(screen);
+
+        // Screen is restored with all accumulated state.
+        assert!(!pane.screen.raw_bytes().is_empty());
+        assert_eq!(pane.screen.cursor_position(), (0, 11));
+    }
+
+    #[test]
+    fn accept_output_increments_seq_each_call() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        assert_eq!(pane.output_seq, 0);
+        pane.accept_output(b"a");
+        assert_eq!(pane.output_seq, 1);
+        pane.accept_output(b"b");
+        assert_eq!(pane.output_seq, 2);
     }
 }

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -75,14 +75,32 @@ impl PaneScreen {
 
     /// Feed raw PTY output bytes into the parser.
     pub fn feed(&mut self, data: &[u8]) {
-        // Store raw bytes for snapshot replay.
+        self.accept_raw(data);
+        self.parse(data);
+    }
+
+    /// Store raw bytes for snapshot replay without running the VTE parser.
+    ///
+    /// This is the cheap half of [`feed`]: a memcpy into the scrollback
+    /// buffer, safe to call while holding a contended lock. Call [`parse`]
+    /// separately (potentially after releasing the lock) to run the
+    /// expensive byte-by-byte VTE state machine.
+    pub fn accept_raw(&mut self, data: &[u8]) {
         self.performer.raw_bytes.extend_from_slice(data);
         if self.performer.raw_bytes.len() > self.performer.max_bytes {
             let excess = self.performer.raw_bytes.len() - self.performer.max_bytes;
             self.performer.raw_bytes.drain(..excess);
             self.performer.raw_bytes.shrink_to(self.performer.max_bytes);
         }
+    }
 
+    /// Run the VTE parser over `data`, updating cursor, modes, title, and CWD.
+    ///
+    /// This is the expensive half of [`feed`]: it advances the VTE state
+    /// machine byte-by-byte. Callers that need to minimize lock hold time
+    /// should call [`accept_raw`] under the lock and defer [`parse`] until
+    /// after releasing it.
+    pub fn parse(&mut self, data: &[u8]) {
         for &byte in data {
             self.parser.advance(&mut self.performer, byte);
         }
@@ -1487,5 +1505,55 @@ mod tests {
         assert!(!screen.application_cursor_keys());
         assert!(!screen.application_keypad());
         assert!(!screen.bracketed_paste_mode());
+    }
+
+    // ── accept_raw / parse split tests ──────────────────────────────
+
+    #[test]
+    fn accept_raw_stores_bytes_without_parsing() {
+        let mut screen = PaneScreen::new(1024);
+        screen.accept_raw(b"\x1b]0;title\x07hello");
+        assert_eq!(screen.raw_bytes(), b"\x1b]0;title\x07hello");
+        // VTE not run — title not extracted.
+        assert!(screen.title().is_none());
+        assert_eq!(screen.cursor_position(), (0, 0));
+    }
+
+    #[test]
+    fn parse_advances_vte_state_machine() {
+        let mut screen = PaneScreen::new(1024);
+        screen.accept_raw(b"\x1b]0;title\x07hello");
+        screen.parse(b"\x1b]0;title\x07hello");
+        assert_eq!(screen.title(), Some("title"));
+        assert_eq!(screen.cursor_position(), (0, 5));
+    }
+
+    #[test]
+    fn accept_raw_then_parse_equivalent_to_feed() {
+        let data = b"\x1b[?2004h\x1b]7;file://localhost/tmp\x07text\r\n\x1b[6n";
+
+        let mut screen_a = PaneScreen::new(1024);
+        screen_a.feed(data);
+
+        let mut screen_b = PaneScreen::new(1024);
+        screen_b.accept_raw(data);
+        screen_b.parse(data);
+
+        assert_eq!(screen_a.raw_bytes(), screen_b.raw_bytes());
+        assert_eq!(screen_a.cursor_position(), screen_b.cursor_position());
+        assert_eq!(screen_a.cwd(), screen_b.cwd());
+        assert_eq!(screen_a.bracketed_paste_mode(), screen_b.bracketed_paste_mode());
+        assert_eq!(
+            screen_a.take_pending_replies().len(),
+            screen_b.take_pending_replies().len()
+        );
+    }
+
+    #[test]
+    fn accept_raw_caps_at_max_bytes() {
+        let mut screen = PaneScreen::new(10);
+        screen.accept_raw(b"0123456789abcdef");
+        assert_eq!(screen.raw_bytes().len(), 10);
+        assert_eq!(screen.raw_bytes(), b"6789abcdef");
     }
 }

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -1543,10 +1543,7 @@ mod tests {
         assert_eq!(screen_a.cursor_position(), screen_b.cursor_position());
         assert_eq!(screen_a.cwd(), screen_b.cwd());
         assert_eq!(screen_a.bracketed_paste_mode(), screen_b.bracketed_paste_mode());
-        assert_eq!(
-            screen_a.take_pending_replies().len(),
-            screen_b.take_pending_replies().len()
-        );
+        assert_eq!(screen_a.take_pending_replies().len(), screen_b.take_pending_replies().len());
     }
 
     #[test]

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -2147,31 +2147,17 @@ fn spawn_pty_read_loop(
 
                             let data = batch.split().freeze();
 
-                            // Phase 1: hold lock for state mutation and handle collection.
-                            let (new_cwd, new_title, pending_replies, pty_writer, senders, output_seq) = {
+                            // Phase 1: accept raw bytes under the lock (fast memcpy, no VTE parsing).
+                            let (mut taken_screen, senders, output_seq) = {
                                 let lock_start = std::time::Instant::now();
                                 let mut s = server.lock().await;
-                                let (new_cwd, new_title, pending_replies, output_seq) = if let Some(rt) = s.runtimes.get_mut(&runtime_id)
+                                let (screen, seq) = if let Some(rt) = s.runtimes.get_mut(&runtime_id)
                                     && let Some(pane) = rt.panes.get_mut(&pane_id)
                                 {
-                                    let result = pane.feed_output(&data);
-                                    let seq = pane.output_seq;
-                                    let cwd = result.new_cwd.and_then(|cwd| {
-                                        let rev = rt.set_pane_cwd(pane_id, &cwd)?;
-                                        Some((cwd, rev))
-                                    });
-                                    let title = result.new_title.and_then(|title| {
-                                        let rev = rt.set_pane_title(pane_id, title.clone())?;
-                                        Some((title, rev))
-                                    });
-                                    (cwd, title, result.pending_replies, seq)
+                                    pane.accept_output(&data);
+                                    (Some(pane.take_screen()), pane.output_seq)
                                 } else {
-                                    (None, None, Vec::new(), 0)
-                                };
-                                let pty_writer = if pending_replies.is_empty() {
-                                    None
-                                } else {
-                                    s.pty_writers.get(&pane_id).cloned()
+                                    (None, 0)
                                 };
                                 let senders = s.collect_runtime_senders(runtime_id);
                                 drop(s);
@@ -2184,11 +2170,42 @@ fn spawn_pty_read_loop(
                                         "server mutex held too long in PTY read loop",
                                     );
                                 }
-                                (new_cwd, new_title, pending_replies, pty_writer, senders, output_seq)
+                                (screen, senders, seq)
                             };
-                            // Lock released.
 
-                            // Phase 2: write DSR replies without the server lock.
+                            // Phase 2: VTE parsing outside the server lock.
+                            if let Some(ref mut screen) = taken_screen {
+                                screen.parse(&data);
+                            }
+
+                            // Phase 3: return parsed screen, extract metadata, collect PTY writer.
+                            let (new_cwd, new_title, pending_replies, pty_writer) = {
+                                let mut s = server.lock().await;
+                                if let Some(screen) = taken_screen
+                                    && let Some(rt) = s.runtimes.get_mut(&runtime_id)
+                                    && let Some(pane) = rt.panes.get_mut(&pane_id)
+                                {
+                                    let result = pane.return_screen(screen);
+                                    let cwd = result.new_cwd.and_then(|cwd| {
+                                        let rev = rt.set_pane_cwd(pane_id, &cwd)?;
+                                        Some((cwd, rev))
+                                    });
+                                    let title = result.new_title.and_then(|title| {
+                                        let rev = rt.set_pane_title(pane_id, title.clone())?;
+                                        Some((title, rev))
+                                    });
+                                    let writer = if result.pending_replies.is_empty() {
+                                        None
+                                    } else {
+                                        s.pty_writers.get(&pane_id).cloned()
+                                    };
+                                    (cwd, title, result.pending_replies, writer)
+                                } else {
+                                    (None, None, Vec::new(), None)
+                                }
+                            };
+
+                            // Phase 4: write DSR replies without the server lock.
                             if let Some(writer) = pty_writer {
                                 let mut w = writer.lock().await;
                                 for reply in &pending_replies {
@@ -2205,10 +2222,7 @@ fn spawn_pty_read_loop(
                                 }
                             }
 
-                            // Phase 3: broadcast to clients without the server lock.
-                            // Strip terminal query sequences (DSR, DA1, DA2, DECRQM)
-                            // that the daemon already handles. If forwarded, VTE would
-                            // generate duplicate responses that leak as visible garbage.
+                            // Phase 5: broadcast to clients without the server lock.
                             let client_data = crate::screen::strip_client_queries(&data);
                             let mut all_overflows = Vec::new();
                             if !client_data.is_empty() {

--- a/services/rttx-server/tests/vte_outside_lock.rs
+++ b/services/rttx-server/tests/vte_outside_lock.rs
@@ -1,0 +1,46 @@
+//! Integration test: VTE parsing outside the mutex still propagates
+//! CWD and title changes correctly.
+//!
+//! Verifies that the two-phase `accept_output`/`parse_and_extract` split
+//! (issue #823) does not regress metadata extraction.
+
+mod common;
+
+use common::{TestClient, send_input, start_test_server};
+use rttx_proto::proto;
+use std::time::Duration;
+
+async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
+    client.handshake().await;
+    let runtime_id =
+        common::create_runtime(client, "vte-test", proto::RuntimePolicy::Persistent).await;
+    let pane_id = common::create_pane(client, &runtime_id).await;
+    common::attach_rw(client, &runtime_id).await;
+    (runtime_id, pane_id)
+}
+
+#[tokio::test]
+async fn title_and_cwd_propagated_after_two_phase_parsing() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&sock).await;
+    let (runtime_id, pane_id) = setup_attached_pane(&mut client).await;
+
+    // Emit OSC 0 (title) and OSC 7 (CWD) in a single printf.
+    let cmd = "printf '\\033]0;my-project\\007\\033]7;file://localhost/tmp/project\\007'\n";
+    send_input(&mut client, &runtime_id, &pane_id, cmd.as_bytes()).await;
+
+    let msgs = client.drain(Duration::from_secs(5)).await;
+
+    let title_msg = msgs.iter().find_map(|m| match &m.msg {
+        Some(proto::server_message::Msg::TitleChanged(t)) => Some(t.title.clone()),
+        _ => None,
+    });
+    let cwd_msg = msgs.iter().find_map(|m| match &m.msg {
+        Some(proto::server_message::Msg::CwdChanged(c)) => Some(c.cwd.clone()),
+        _ => None,
+    });
+
+    assert_eq!(title_msg.as_deref(), Some("my-project"), "title should propagate");
+    assert_eq!(cwd_msg.as_deref(), Some("/tmp/project"), "CWD should propagate");
+}


### PR DESCRIPTION
## What changed and why

Moves the expensive byte-by-byte VTE parsing out of the server mutex critical section in the PTY read loop. Previously, `pane.feed_output(&data)` ran the full VTE state machine (up to 64 KB byte-by-byte) while holding the global `tokio::sync::Mutex<Server>`, creating a convoy effect that starved client input processing and other pane read loops.

### Approach

Split the operation into three phases:

1. **Phase 1 (under lock, fast):** `pane.accept_output(&data)` stores raw bytes in the scrollback buffer and pending flush, increments `output_seq`, and `pane.take_screen()` moves the screen out of the pane via `mem::replace`.
2. **Phase 2 (outside lock, expensive):** `screen.parse(&data)` runs the VTE state machine on the taken screen — no lock held.
3. **Phase 3 (under lock, fast):** `pane.return_screen(screen)` puts the screen back and extracts metadata changes (CWD, title, DSR replies).

### API additions

- `PaneScreen::accept_raw(data)` — stores raw bytes without VTE parsing
- `PaneScreen::parse(data)` — runs VTE parser without storing raw bytes
- `Pane::accept_output(data)` — stores raw bytes + pending flush + seq increment
- `Pane::take_screen()` / `return_screen(screen)` — temporarily extract screen for out-of-lock parsing
- `Pane::parse_and_extract(data)` — runs VTE + extracts metadata (for callers that don't need the take/return pattern)

The existing `feed_output` and `PaneScreen::feed` methods are preserved as convenience wrappers.

## How to manually verify

1. Run the daemon with multiple panes producing continuous output (e.g., `yes` or `cat /dev/urandom | xxd`)
2. Verify that input echo latency in an idle pane remains low
3. Check that CWD, title, and terminal modes are still correctly tracked

## Tests added

### screen.rs (4 tests)
- `accept_raw_stores_bytes_without_parsing` — verifies raw bytes stored without VTE side effects
- `parse_advances_vte_state_machine` — verifies VTE parsing updates cursor/title
- `accept_raw_then_parse_equivalent_to_feed` — verifies split API produces identical results to `feed`
- `accept_raw_caps_at_max_bytes` — verifies scrollback cap works in accept_raw

### pane.rs (6 tests)
- `accept_output_stores_raw_bytes_without_vte_parsing` — verifies no VTE parsing in accept phase
- `parse_and_extract_runs_vte_after_accept` — verifies metadata extraction after deferred parse
- `take_screen_and_return_screen_equivalent_to_feed_output` — verifies two-phase path matches single-call path
- `take_screen_returns_screen_with_accumulated_state` — verifies taken screen has full state
- `return_screen_restores_screen_state` — verifies screen is properly restored
- `accept_output_increments_seq_each_call` — verifies seq counter behavior

## Tests run

- `cargo build --workspace --no-default-features --features vte-0_76` ✅
- `cargo test --workspace --no-default-features --features vte-0_76` ✅ (395 server lib tests, all pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `cargo test -p rttx-server --tests` ✅ (all integration tests pass)

Fixes #823