### PR TITLE
fix(client): implement StreamOverflow recovery via resync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.21"
+version = "0.4.22"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -14,7 +14,7 @@ use crate::runtime::{
 };
 use rttx_proto::v3;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
@@ -89,6 +89,12 @@ pub enum EndpointEvent {
         endpoint: RuntimeEndpoint,
         message: v3::ServerEnvelope,
     },
+    ResyncCompleted {
+        endpoint: RuntimeEndpoint,
+        runtime_id: String,
+        snapshot: v3::RuntimeSnapshot,
+        dropped_count: u64,
+    },
     WorkspaceError {
         workspace_id: String,
         operation: ManagerOperation,
@@ -159,6 +165,10 @@ enum EndpointCommand {
         runtime_id: String,
         runtime_pane_id: String,
         no_persist: bool,
+    },
+    ResyncRuntime {
+        runtime_id: String,
+        dropped_count: u64,
     },
     Shutdown,
 }
@@ -416,6 +426,8 @@ struct EndpointActor {
     auto_start_daemon: bool,
     reconnect_delay_secs: u32,
     next_request_id: u64,
+    /// Runtime IDs with a pending resync request (debounce guard).
+    pending_resyncs: HashSet<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -508,6 +520,7 @@ impl EndpointActor {
             auto_start_daemon,
             reconnect_delay_secs,
             next_request_id: 1,
+            pending_resyncs: HashSet::new(),
         }
     }
 
@@ -627,6 +640,20 @@ impl EndpointActor {
             && let Ok(runtime_id) = rttx_proto::bytes_to_uuid(&terminated.runtime_id)
         {
             self.tracked_workspaces.retain(|_, tracked| tracked != &runtime_id.to_string());
+        }
+        if let Some(v3::server_envelope::Payload::StreamOverflow(overflow)) = &env.payload {
+            if let Ok(runtime_id) = rttx_proto::bytes_to_uuid(&overflow.runtime_id) {
+                let rid = runtime_id.to_string();
+                if self.pending_resyncs.insert(rid) {
+                    let _ = self.self_tx.try_send(EndpointCommand::ResyncRuntime {
+                        runtime_id: runtime_id.to_string(),
+                        dropped_count: overflow.dropped_count,
+                    });
+                }
+            }
+            // Don't forward StreamOverflow to the GTK thread — the resync
+            // response will carry the corrective snapshot.
+            return;
         }
         self.forward_push(env);
     }
@@ -1221,6 +1248,39 @@ impl EndpointActor {
             EndpointCommand::ForgetWorkspace { workspace_id } => {
                 self.tracked_workspaces.remove(&workspace_id);
             }
+            EndpointCommand::ResyncRuntime { runtime_id, dropped_count } => {
+                let Some(runtime_uuid) = Uuid::parse_str(&runtime_id).ok() else {
+                    self.pending_resyncs.remove(&runtime_id);
+                    return;
+                };
+                if self.writer.is_none() {
+                    self.pending_resyncs.remove(&runtime_id);
+                    return;
+                }
+                let msg = v3::client_envelope::Command::ResyncRuntime(v3::ResyncRuntime {
+                    runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
+                });
+                match self.send_and_read(msg, false).await {
+                    Ok(response) => {
+                        if let Some(v3::server_envelope::Payload::RuntimeSnapshot(snapshot)) =
+                            response.payload
+                        {
+                            let _ = self.event_tx.try_send(EndpointEvent::ResyncCompleted {
+                                endpoint: self.endpoint.clone(),
+                                runtime_id: runtime_id.clone(),
+                                snapshot,
+                                dropped_count,
+                            });
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            "ResyncRuntime failed for runtime {runtime_id}: {error}"
+                        );
+                    }
+                }
+                self.pending_resyncs.remove(&runtime_id);
+            }
             EndpointCommand::Shutdown => {}
         }
     }
@@ -1553,6 +1613,7 @@ impl EndpointActor {
         self.writer = None;
         self.ssh_handle = None;
         self.heartbeat.reset();
+        self.pending_resyncs.clear();
         if self.tracked_workspaces.is_empty() {
             return;
         }
@@ -1742,6 +1803,7 @@ mod tests {
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
             next_request_id: 1,
+            pending_resyncs: HashSet::new(),
         }
     }
 
@@ -1848,6 +1910,7 @@ mod tests {
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
             next_request_id: 1,
+            pending_resyncs: HashSet::new(),
         };
         (actor, event_rx)
     }
@@ -2189,6 +2252,7 @@ mod tests {
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
             next_request_id: 1,
+            pending_resyncs: HashSet::new(),
         };
 
         let stale_runtime = Uuid::new_v4();
@@ -2271,6 +2335,7 @@ mod tests {
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
             next_request_id: 1,
+            pending_resyncs: HashSet::new(),
         };
 
         let runtime_id = Uuid::new_v4();
@@ -2478,6 +2543,7 @@ mod tests {
             auto_start_daemon: true,
             reconnect_delay_secs: 10,
             next_request_id: 1,
+            pending_resyncs: HashSet::new(),
         };
 
         // Server: drop the connection immediately to cause I/O errors.
@@ -2955,5 +3021,204 @@ mod tests {
             2,
             "all workspaces must remain tracked after partial reconnect failure"
         );
+    }
+
+    #[test]
+    fn dispatch_push_intercepts_stream_overflow_and_queues_resync() {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            let ((reader, writer), _server_stream) = split_duplex_connection();
+            let (event_tx, mut event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
+            let (self_tx, mut cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+            let mut actor = EndpointActor {
+                endpoint: RuntimeEndpoint::Local,
+                event_tx,
+                self_tx,
+                cmd_rx: mpsc::channel(CMD_CHANNEL_BOUND).1,
+                connection: None,
+                reader: Some(reader),
+                writer: Some(writer),
+                ssh_handle: None,
+                tracked_workspaces: HashMap::new(),
+                reconnect_attempt: 0,
+                heartbeat: HeartbeatMonitor::default(),
+                heartbeat_deadline: new_heartbeat_deadline(),
+                daemon_start_attempted: false,
+                auto_start_daemon: true,
+                reconnect_delay_secs: 10,
+                next_request_id: 1,
+                pending_resyncs: HashSet::new(),
+            };
+
+            let runtime_id = Uuid::new_v4();
+            let overflow = rttx_proto::v3_resync::build_stream_overflow(runtime_id, None, 5);
+            let env = rttx_proto::v3_resync::build_stream_overflow_envelope(overflow);
+
+            actor.dispatch_push(env);
+
+            // StreamOverflow must NOT be forwarded to the GTK thread.
+            assert!(event_rx.try_recv().is_err());
+
+            // A ResyncRuntime command must be queued.
+            let cmd = cmd_rx.try_recv().expect("should queue ResyncRuntime");
+            match cmd {
+                EndpointCommand::ResyncRuntime { dropped_count, .. } => {
+                    assert_eq!(dropped_count, 5);
+                }
+                other => panic!("expected ResyncRuntime, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn dispatch_push_debounces_duplicate_stream_overflow() {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            let ((reader, writer), _server_stream) = split_duplex_connection();
+            let (event_tx, _event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
+            let (self_tx, mut cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+            let mut actor = EndpointActor {
+                endpoint: RuntimeEndpoint::Local,
+                event_tx,
+                self_tx,
+                cmd_rx: mpsc::channel(CMD_CHANNEL_BOUND).1,
+                connection: None,
+                reader: Some(reader),
+                writer: Some(writer),
+                ssh_handle: None,
+                tracked_workspaces: HashMap::new(),
+                reconnect_attempt: 0,
+                heartbeat: HeartbeatMonitor::default(),
+                heartbeat_deadline: new_heartbeat_deadline(),
+                daemon_start_attempted: false,
+                auto_start_daemon: true,
+                reconnect_delay_secs: 10,
+                next_request_id: 1,
+                pending_resyncs: HashSet::new(),
+            };
+
+            let runtime_id = Uuid::new_v4();
+            let overflow1 = rttx_proto::v3_resync::build_stream_overflow(runtime_id, None, 3);
+            let env1 = rttx_proto::v3_resync::build_stream_overflow_envelope(overflow1);
+            let overflow2 = rttx_proto::v3_resync::build_stream_overflow(runtime_id, None, 7);
+            let env2 = rttx_proto::v3_resync::build_stream_overflow_envelope(overflow2);
+
+            actor.dispatch_push(env1);
+            actor.dispatch_push(env2);
+
+            // Only one ResyncRuntime command should be queued.
+            let _cmd = cmd_rx.try_recv().expect("first resync queued");
+            assert!(cmd_rx.try_recv().is_err(), "duplicate resync must be suppressed");
+        });
+    }
+
+    #[test]
+    fn disconnect_clears_pending_resyncs() {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            let ((reader, writer), _server_stream) = split_duplex_connection();
+            let (event_tx, _event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
+            let (self_tx, _cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+            let mut actor = EndpointActor {
+                endpoint: RuntimeEndpoint::Local,
+                event_tx,
+                self_tx,
+                cmd_rx: mpsc::channel(CMD_CHANNEL_BOUND).1,
+                connection: None,
+                reader: Some(reader),
+                writer: Some(writer),
+                ssh_handle: None,
+                tracked_workspaces: HashMap::new(),
+                reconnect_attempt: 0,
+                heartbeat: HeartbeatMonitor::default(),
+                heartbeat_deadline: new_heartbeat_deadline(),
+                daemon_start_attempted: false,
+                auto_start_daemon: true,
+                reconnect_delay_secs: 10,
+                next_request_id: 1,
+                pending_resyncs: HashSet::new(),
+            };
+
+            actor.pending_resyncs.insert("some-runtime".into());
+            assert!(!actor.pending_resyncs.is_empty());
+
+            actor.handle_disconnect();
+
+            assert!(actor.pending_resyncs.is_empty());
+        });
+    }
+
+    #[tokio::test]
+    async fn resync_runtime_command_sends_request_and_forwards_snapshot() {
+        let ((reader, writer), mut server_stream) = split_duplex_connection();
+        let (mut actor, mut event_rx) = make_actor_with_events(reader, writer);
+
+        let runtime_id = Uuid::new_v4();
+        let pane_id = Uuid::new_v4();
+        actor.pending_resyncs.insert(runtime_id.to_string());
+
+        let server = tokio::spawn(async move {
+            let mut read_buf = BytesMut::new();
+            let msg = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            match msg.command {
+                Some(v3::client_envelope::Command::ResyncRuntime(req)) => {
+                    assert_eq!(
+                        rttx_proto::bytes_to_uuid(&req.runtime_id).unwrap(),
+                        runtime_id
+                    );
+                }
+                other => panic!("expected ResyncRuntime, got {other:?}"),
+            }
+
+            let pane_snap = rttx_proto::v3_snapshot::build_pane_snapshot(
+                rttx_proto::v3_snapshot::PaneSnapshotParams {
+                    pane_id,
+                    pane_output_seq: 100,
+                    title: "bash".into(),
+                    cwd: "/home".into(),
+                    cols: 80,
+                    rows: 24,
+                    exit_status: None,
+                    terminal_modes: v3::TerminalModeState::default(),
+                    scrollback_tail: bytes::Bytes::from_static(b"$ "),
+                    total_scrollback_bytes: 2,
+                },
+            );
+            let snapshot = rttx_proto::v3_snapshot::build_runtime_snapshot(
+                runtime_id,
+                42,
+                v3::RuntimeClientRole::Writer,
+                vec![pane_snap],
+            );
+            let response = rttx_proto::v3_resync::build_resync_response(msg.request_id, snapshot);
+            send_server_envelope(&mut server_stream, &response).await;
+        });
+
+        actor
+            .handle_command(EndpointCommand::ResyncRuntime {
+                runtime_id: runtime_id.to_string(),
+                dropped_count: 10,
+            })
+            .await;
+
+        server.await.expect("server task");
+
+        let event = event_rx.try_recv().expect("should emit ResyncCompleted");
+        match event {
+            EndpointEvent::ResyncCompleted {
+                runtime_id: rid,
+                snapshot,
+                dropped_count,
+                ..
+            } => {
+                assert_eq!(rid, runtime_id.to_string());
+                assert_eq!(dropped_count, 10);
+                assert_eq!(snapshot.panes.len(), 1);
+            }
+            other => panic!("expected ResyncCompleted, got {other:?}"),
+        }
+
+        // pending_resyncs must be cleared after completion.
+        assert!(actor.pending_resyncs.is_empty());
     }
 }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -614,6 +614,9 @@ impl Window {
                     self.show_toast(&detail);
                 }
             }
+            EndpointEvent::ResyncCompleted { endpoint, runtime_id, snapshot, .. } => {
+                self.apply_resync_snapshot(&endpoint, &runtime_id, &snapshot);
+            }
             EndpointEvent::InventoryLoaded { endpoint, runtimes }
                 if self.imp().pending_connect_existing.borrow().is_some() =>
             {
@@ -740,6 +743,58 @@ impl Window {
         let (cols, rows) = pane.terminal_size();
         if cols > 0 && rows > 0 && (cols != restore.cols || rows != restore.rows) {
             self.send_managed_terminal_resize(&restore.layout_terminal_uuid, cols, rows);
+        }
+    }
+
+    /// Apply a resync snapshot received after a `StreamOverflow`.
+    ///
+    /// Resets each affected pane's VTE and feeds the fresh snapshot data,
+    /// then shows a toast so the user knows output may have been lost.
+    pub(super) fn apply_resync_snapshot(
+        &self,
+        endpoint: &RuntimeEndpoint,
+        runtime_id: &str,
+        snapshot: &v3::RuntimeSnapshot,
+    ) {
+        let state = self.imp().state.borrow();
+        let Some(workspace_id) = state.workspace_for_runtime(endpoint, runtime_id) else {
+            return;
+        };
+        let session = state.workspaces.iter().find(|s| s.uuid == workspace_id);
+        let Some(session) = session else { return };
+        let bindings = session.runtime.pane_bindings.clone();
+        drop(state);
+
+        let mut resynced = 0u32;
+        for pane_snap in &snapshot.panes {
+            let Ok(pane_uuid) = rttx_proto::bytes_to_uuid(&pane_snap.pane_id) else {
+                continue;
+            };
+            let runtime_pane_id = pane_uuid.to_string();
+            let Some(layout_terminal_uuid) = bindings
+                .iter()
+                .find(|(_, rpid)| **rpid == runtime_pane_id)
+                .map(|(ltid, _)| ltid.clone())
+            else {
+                continue;
+            };
+            let restore = WorkspacePaneRestore {
+                layout_terminal_uuid,
+                title: pane_snap.title.clone(),
+                cwd: pane_snap.cwd.clone(),
+                pane_output_seq: pane_snap.pane_output_seq,
+                scrollback_tail: pane_snap.scrollback_tail.clone(),
+                scrollback_complete: pane_snap.scrollback_complete,
+                cols: pane_snap.cols as u16,
+                rows: pane_snap.rows as u16,
+                terminal_modes: pane_snap.terminal_modes,
+            };
+            self.restore_managed_snapshot(&restore);
+            resynced += 1;
+        }
+
+        if resynced > 0 {
+            self.show_toast("Terminal resynced — some output may have been lost");
         }
     }
 

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -7119,3 +7119,100 @@ fn rename_focused_pane_direct_sets_custom_title() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+/// `apply_resync_snapshot` resets VTE and feeds fresh snapshot data for
+/// each pane in the runtime, then shows a toast. Verifies the full
+/// StreamOverflow → resync → snapshot application path on the GTK side.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn apply_resync_snapshot_resets_and_feeds_panes() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.resync-snapshot-test").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    let layout_uuid = "resync-pane-1";
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let runtime_pane_id = uuid::Uuid::new_v4().to_string();
+
+    let mut session_state = crate::test_helpers::managed_session_with_runtime(
+        "ws-resync",
+        "Resync Test",
+        LayoutNode::new_terminal_with_uuid(layout_uuid),
+        RuntimeEndpoint::Local,
+        WorkspacePolicy::Persistent,
+        Some(runtime_id),
+    );
+    // Replace placeholder binding with a real runtime pane ID.
+    session_state.runtime.pane_bindings.clear();
+    session_state
+        .runtime
+        .pane_bindings
+        .insert(layout_uuid.to_string(), runtime_pane_id.clone());
+
+    window.imp().state.borrow_mut().workspaces.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    // Feed some initial content so we can verify the reset.
+    {
+        let pane = window
+            .imp()
+            .persistent_terminals
+            .borrow()
+            .get(layout_uuid)
+            .cloned()
+            .expect("pane should exist");
+        pane.feed_output(b"old content that should be replaced\r\n");
+    }
+
+    // Build a snapshot as the daemon would send after ResyncRuntime.
+    let pane_uuid: uuid::Uuid = runtime_pane_id.parse().unwrap();
+    let pane_snap = rttx_proto::v3_snapshot::build_pane_snapshot(
+        rttx_proto::v3_snapshot::PaneSnapshotParams {
+            pane_id: pane_uuid,
+            pane_output_seq: 200,
+            title: "zsh".into(),
+            cwd: "/tmp/resync".into(),
+            cols: 80,
+            rows: 24,
+            exit_status: None,
+            terminal_modes: rttx_proto::v3::TerminalModeState::default(),
+            scrollback_tail: bytes::Bytes::from_static(b"$ echo resynced\r\nresynced\r\n"),
+            total_scrollback_bytes: 26,
+        },
+    );
+    let runtime_uuid: uuid::Uuid = runtime_id.parse().unwrap();
+    let snapshot = rttx_proto::v3_snapshot::build_runtime_snapshot(
+        runtime_uuid,
+        99,
+        rttx_proto::v3::RuntimeClientRole::Writer,
+        vec![pane_snap],
+    );
+
+    window.apply_resync_snapshot(&RuntimeEndpoint::Local, runtime_id, &snapshot);
+
+    let pane = window
+        .imp()
+        .persistent_terminals
+        .borrow()
+        .get(layout_uuid)
+        .cloned()
+        .expect("pane should exist after resync");
+
+    assert_eq!(
+        pane.current_directory().as_deref(),
+        Some("/tmp/resync"),
+        "resync should update CWD"
+    );
+    assert_eq!(pane.status_label_text_for_test(), "Connected", "resync marks pane connected");
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -215,7 +215,9 @@ impl WindowState {
                 }
                 transition.persist_window_state = true;
             }
-            EndpointEvent::RuntimeMessage { .. } | EndpointEvent::WorkspaceError { .. } => {}
+            EndpointEvent::RuntimeMessage { .. }
+            | EndpointEvent::ResyncCompleted { .. }
+            | EndpointEvent::WorkspaceError { .. } => {}
         }
 
         transition

--- a/clients/rttx/tests/resync_overflow_recovery.rs
+++ b/clients/rttx/tests/resync_overflow_recovery.rs
@@ -1,0 +1,192 @@
+//! Integration test for #825: `StreamOverflow` recovery via resync.
+//!
+//! Verifies that `ResyncCompleted` events are correctly handled by the
+//! workspace state reconciliation layer and that the snapshot-to-restore
+//! mapping produces correct results for bound and unbound panes.
+
+use rttx::daemon_bridge::EndpointEvent;
+use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy, WorkspaceRuntime};
+use rttx::workspace::*;
+use rttx::workspace_state::WorkspacePaneRestore;
+use std::collections::BTreeMap;
+
+fn term(id: &str) -> LayoutNode {
+    LayoutNode::Terminal { uuid: id.to_string(), profile: None, cwd: None, custom_title: None }
+}
+
+fn hsplit(first: LayoutNode, second: LayoutNode) -> LayoutNode {
+    LayoutNode::Split {
+        orientation: SplitOrientation::Horizontal,
+        ratio: 0.5,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+fn pane_snapshot(pane_id: &str, title: &str, cwd: &str) -> rttx_proto::v3::PaneSnapshot {
+    rttx_proto::v3::PaneSnapshot {
+        pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),
+        pane_output_seq: 200,
+        title: title.to_string(),
+        cwd: cwd.to_string(),
+        cols: 80,
+        rows: 24,
+        exit_status: None,
+        terminal_modes: None,
+        scrollback_tail: bytes::Bytes::from_static(b"$ echo resynced\r\n"),
+        total_scrollback_bytes: 17,
+        scrollback_complete: true,
+    }
+}
+
+fn snapshot(
+    runtime_id: &str,
+    panes: Vec<rttx_proto::v3::PaneSnapshot>,
+) -> rttx_proto::v3::RuntimeSnapshot {
+    rttx_proto::v3::RuntimeSnapshot {
+        runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
+        panes,
+        runtime_revision: 42,
+        client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
+    }
+}
+
+/// `ResyncCompleted` is a no-op in `reconcile_endpoint_event` — it does not
+/// mutate workspace state. The snapshot application happens in the window
+/// layer, not the state layer.
+#[test]
+fn resync_completed_does_not_mutate_workspace_state() {
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let pane_id_1 = "a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5";
+
+    let mut session =
+        WorkspaceState::new_managed_local("Home".into(), WorkspacePolicy::Persistent, None);
+    session.uuid = "ws-1".into();
+    session.layout = term("left");
+    session.runtime = WorkspaceRuntime::managed_local(
+        WorkspacePolicy::Persistent,
+        &session.layout.terminal_uuids(),
+    );
+    session.runtime.runtime_id = Some(runtime_id.into());
+    session.runtime.pane_bindings = BTreeMap::from([("left".into(), pane_id_1.into())]);
+
+    let mut state = WindowState {
+        active_workspace_index: 0,
+        workspaces: vec![session],
+        ..WindowState::default()
+    };
+
+    let state_before = state.workspaces[0].clone();
+
+    let snap = snapshot(runtime_id, vec![pane_snapshot(pane_id_1, "bash", "/tmp")]);
+    let transition = state.reconcile_endpoint_event(&EndpointEvent::ResyncCompleted {
+        endpoint: RuntimeEndpoint::Local,
+        runtime_id: runtime_id.into(),
+        snapshot: snap,
+        dropped_count: 5,
+    });
+
+    // State must be unchanged — resync is handled in the window layer.
+    assert_eq!(state.workspaces[0], state_before);
+    assert!(transition.pane_snapshot_restores.is_empty());
+    assert!(transition.rebuilt_workspaces.is_empty());
+    assert!(transition.recovered_workspaces.is_empty());
+}
+
+/// Verify that a resync snapshot can be decomposed into the correct
+/// `WorkspacePaneRestore` structs for each bound pane.
+#[test]
+fn resync_snapshot_maps_to_pane_restores() {
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let pane_id_1 = "a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5";
+    let pane_id_2 = "b2b2b2b2-c3c3-d4d4-e5e5-f6f6f6f6f6f6";
+
+    let mut session =
+        WorkspaceState::new_managed_local("Home".into(), WorkspacePolicy::Persistent, None);
+    session.uuid = "ws-1".into();
+    session.layout = hsplit(term("left"), term("right"));
+    session.runtime = WorkspaceRuntime::managed_local(
+        WorkspacePolicy::Persistent,
+        &session.layout.terminal_uuids(),
+    );
+    session.runtime.runtime_id = Some(runtime_id.into());
+    session.runtime.pane_bindings =
+        BTreeMap::from([("left".into(), pane_id_1.into()), ("right".into(), pane_id_2.into())]);
+
+    let snap = snapshot(
+        runtime_id,
+        vec![pane_snapshot(pane_id_1, "bash", "/home"), pane_snapshot(pane_id_2, "vim", "/tmp")],
+    );
+
+    // Simulate the mapping logic from apply_resync_snapshot.
+    let bindings = &session.runtime.pane_bindings;
+    let mut restores = Vec::new();
+    for pane_snap in &snap.panes {
+        let pane_uuid = rttx_proto::bytes_to_uuid(&pane_snap.pane_id).unwrap();
+        let runtime_pane_id = pane_uuid.to_string();
+        if let Some((layout_uuid, _)) = bindings.iter().find(|(_, rpid)| **rpid == runtime_pane_id)
+        {
+            restores.push(WorkspacePaneRestore {
+                layout_terminal_uuid: layout_uuid.clone(),
+                title: pane_snap.title.clone(),
+                cwd: pane_snap.cwd.clone(),
+                pane_output_seq: pane_snap.pane_output_seq,
+                scrollback_tail: pane_snap.scrollback_tail.clone(),
+                scrollback_complete: pane_snap.scrollback_complete,
+                cols: pane_snap.cols as u16,
+                rows: pane_snap.rows as u16,
+                terminal_modes: pane_snap.terminal_modes,
+            });
+        }
+    }
+
+    assert_eq!(restores.len(), 2);
+    assert_eq!(restores[0].layout_terminal_uuid, "left");
+    assert_eq!(restores[0].cwd, "/home");
+    assert_eq!(restores[0].title, "bash");
+    assert_eq!(restores[1].layout_terminal_uuid, "right");
+    assert_eq!(restores[1].cwd, "/tmp");
+    assert_eq!(restores[1].title, "vim");
+}
+
+/// Unbound panes in the snapshot (e.g. panes created after the last
+/// reconciliation) are silently skipped during resync.
+#[test]
+fn resync_snapshot_skips_unbound_panes() {
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let pane_id_1 = "a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5";
+    let unbound_pane = "cccccccc-dddd-eeee-ffff-000000000000";
+
+    let mut session =
+        WorkspaceState::new_managed_local("Home".into(), WorkspacePolicy::Persistent, None);
+    session.uuid = "ws-1".into();
+    session.layout = term("left");
+    session.runtime = WorkspaceRuntime::managed_local(
+        WorkspacePolicy::Persistent,
+        &session.layout.terminal_uuids(),
+    );
+    session.runtime.runtime_id = Some(runtime_id.into());
+    session.runtime.pane_bindings = BTreeMap::from([("left".into(), pane_id_1.into())]);
+
+    let snap = snapshot(
+        runtime_id,
+        vec![
+            pane_snapshot(pane_id_1, "bash", "/home"),
+            pane_snapshot(unbound_pane, "orphan", "/tmp"),
+        ],
+    );
+
+    let bindings = &session.runtime.pane_bindings;
+    let mut restores = Vec::new();
+    for pane_snap in &snap.panes {
+        let pane_uuid = rttx_proto::bytes_to_uuid(&pane_snap.pane_id).unwrap();
+        let runtime_pane_id = pane_uuid.to_string();
+        if let Some((layout_uuid, _)) = bindings.iter().find(|(_, rpid)| **rpid == runtime_pane_id)
+        {
+            restores.push(layout_uuid.clone());
+        }
+    }
+
+    assert_eq!(restores.len(), 1);
+    assert_eq!(restores[0], "left");
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.21',
+  version: '0.4.22',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

When the daemon detects push channel overflow and sends `StreamOverflow`, the client previously silently ignored it, leaving terminal output permanently corrupted. Now the client:

1. Intercepts `StreamOverflow` in the daemon bridge actor
2. Sends a `ResyncRuntime` request to get a fresh `RuntimeSnapshot`
3. Applies the snapshot to all affected panes (VTE reset + scrollback feed)
4. Shows a toast: "Terminal resynced — some output may have been lost"

Debouncing via a `pending_resyncs` set prevents multiple concurrent resyncs for the same runtime. The set is cleared on disconnect.

## Manual verification

1. Build with heavy output (e.g. `yes | head -100000`) in a daemon-backed workspace
2. If push channel overflows, the client should resync and show a toast
3. Terminal content should match the daemon's screen state after resync

## Tests added

### Unit tests (daemon_bridge)
- `dispatch_push_intercepts_stream_overflow_and_queues_resync` — verifies StreamOverflow is intercepted and ResyncRuntime command is queued
- `dispatch_push_debounces_duplicate_stream_overflow` — verifies duplicate overflows for the same runtime are suppressed
- `disconnect_clears_pending_resyncs` — verifies pending_resyncs is cleared on disconnect
- `resync_runtime_command_sends_request_and_forwards_snapshot` — integration test: sends ResyncRuntime to mock server, receives snapshot, emits ResyncCompleted event

### GTK widget test
- `apply_resync_snapshot_resets_and_feeds_panes` — verifies VTE reset + snapshot feed + CWD update + connected status after resync

## Tests run

- `cargo test -p rttx --lib` — 714 passed, 200 ignored
- `cargo test -p rttx-proto` — 342 passed
- `cargo test -p rttx-server --lib` — 395 passed
- `cargo test -p rttx-server --tests` — all passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed, including GTK test via Broadway

Fixes #825