### PR TITLE
fix: implement StreamOverflow recovery via resync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.21"
+version = "0.4.22"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -89,6 +89,11 @@ pub enum EndpointEvent {
         endpoint: RuntimeEndpoint,
         message: v3::ServerEnvelope,
     },
+    WorkspaceResynced {
+        workspace_id: String,
+        runtime_id: String,
+        snapshot: v3::RuntimeSnapshot,
+    },
     WorkspaceError {
         workspace_id: String,
         operation: ManagerOperation,
@@ -159,6 +164,10 @@ enum EndpointCommand {
         runtime_id: String,
         runtime_pane_id: String,
         no_persist: bool,
+    },
+    ResyncRuntime {
+        workspace_id: String,
+        runtime_id: String,
     },
     Shutdown,
 }
@@ -1218,6 +1227,40 @@ impl EndpointActor {
                 };
                 let _ = self.send_message(&env).await;
             }
+            EndpointCommand::ResyncRuntime { workspace_id, runtime_id } => {
+                let Ok(runtime_uuid) = runtime_id.parse::<Uuid>() else {
+                    return;
+                };
+                let resync = rttx_proto::v3_resync::build_resync_runtime(runtime_uuid);
+                let msg = v3::client_envelope::Command::ResyncRuntime(resync);
+                match self.send_and_read(msg, false).await {
+                    Ok(response) => match response.payload {
+                        Some(v3::server_envelope::Payload::RuntimeSnapshot(snapshot)) => {
+                            let _ = self.event_tx.try_send(EndpointEvent::WorkspaceResynced {
+                                workspace_id,
+                                runtime_id,
+                                snapshot,
+                            });
+                        }
+                        Some(v3::server_envelope::Payload::Error(e)) => {
+                            tracing::warn!(
+                                "Resync failed for workspace {workspace_id}: {}",
+                                e.message
+                            );
+                        }
+                        _ => {
+                            tracing::warn!(
+                                "Unexpected resync response for workspace {workspace_id}"
+                            );
+                        }
+                    },
+                    Err(error) => {
+                        tracing::warn!(
+                            "Resync request failed for workspace {workspace_id}: {error}"
+                        );
+                    }
+                }
+            }
             EndpointCommand::ForgetWorkspace { workspace_id } => {
                 self.tracked_workspaces.remove(&workspace_id);
             }
@@ -1495,10 +1538,38 @@ impl EndpointActor {
                         tracked_runtime_id != &runtime_id.to_string()
                     });
                 }
+                if let Some(v3::server_envelope::Payload::StreamOverflow(overflow)) = &env.payload {
+                    self.handle_stream_overflow(overflow);
+                    return;
+                }
                 self.forward_push(env);
             }
             Ok(None) | Err(_) => self.handle_disconnect(),
         }
+    }
+
+    fn handle_stream_overflow(&self, overflow: &v3::StreamOverflow) {
+        let Ok(runtime_id) = rttx_proto::bytes_to_uuid(&overflow.runtime_id) else {
+            return;
+        };
+        let runtime_id_str = runtime_id.to_string();
+        let Some(workspace_id) = self
+            .tracked_workspaces
+            .iter()
+            .find(|(_, rid)| *rid == &runtime_id_str)
+            .map(|(wid, _)| wid.clone())
+        else {
+            return;
+        };
+        tracing::warn!(
+            workspace_id,
+            %runtime_id,
+            dropped = overflow.dropped_count,
+            "StreamOverflow received, requesting resync"
+        );
+        let _ = self
+            .self_tx
+            .try_send(EndpointCommand::ResyncRuntime { workspace_id, runtime_id: runtime_id_str });
     }
 
     fn forward_push(&self, message: v3::ServerEnvelope) {
@@ -2955,5 +3026,180 @@ mod tests {
             2,
             "all workspaces must remain tracked after partial reconnect failure"
         );
+    }
+
+    #[test]
+    fn handle_stream_overflow_queues_resync_command() {
+        let ((reader, writer), _server) = split_duplex_connection();
+        let (event_tx, _event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
+        let (self_tx, mut cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let mut actor = EndpointActor {
+            endpoint: RuntimeEndpoint::Local,
+            event_tx,
+            self_tx,
+            cmd_rx: mpsc::channel(1).1,
+            connection: None,
+            reader: Some(reader),
+            writer: Some(writer),
+            ssh_handle: None,
+            tracked_workspaces: HashMap::new(),
+            reconnect_attempt: 0,
+            heartbeat: HeartbeatMonitor::default(),
+            heartbeat_deadline: new_heartbeat_deadline(),
+            daemon_start_attempted: false,
+            auto_start_daemon: true,
+            reconnect_delay_secs: 10,
+            next_request_id: 1,
+        };
+
+        let runtime_id = Uuid::new_v4();
+        actor.tracked_workspaces.insert("ws-1".into(), runtime_id.to_string());
+
+        let overflow = v3::StreamOverflow {
+            runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
+            pane_id: None,
+            dropped_count: 5,
+        };
+        actor.handle_stream_overflow(&overflow);
+
+        match cmd_rx.try_recv() {
+            Ok(EndpointCommand::ResyncRuntime { workspace_id, runtime_id: rid }) => {
+                assert_eq!(workspace_id, "ws-1");
+                assert_eq!(rid, runtime_id.to_string());
+            }
+            other => panic!("expected ResyncRuntime command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn handle_stream_overflow_ignores_unknown_runtime() {
+        let ((reader, writer), _server) = split_duplex_connection();
+        let (event_tx, _event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
+        let (self_tx, mut cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let actor = EndpointActor {
+            endpoint: RuntimeEndpoint::Local,
+            event_tx,
+            self_tx,
+            cmd_rx: mpsc::channel(1).1,
+            connection: None,
+            reader: Some(reader),
+            writer: Some(writer),
+            ssh_handle: None,
+            tracked_workspaces: HashMap::new(),
+            reconnect_attempt: 0,
+            heartbeat: HeartbeatMonitor::default(),
+            heartbeat_deadline: new_heartbeat_deadline(),
+            daemon_start_attempted: false,
+            auto_start_daemon: true,
+            reconnect_delay_secs: 10,
+            next_request_id: 1,
+        };
+
+        let overflow = v3::StreamOverflow {
+            runtime_id: rttx_proto::uuid_to_bytes(Uuid::new_v4()),
+            pane_id: None,
+            dropped_count: 3,
+        };
+        actor.handle_stream_overflow(&overflow);
+
+        assert!(matches!(cmd_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn resync_command_sends_request_and_emits_event() {
+        let ((reader, writer), mut server_stream) = split_duplex_connection();
+        let (mut actor, mut event_rx) = make_actor_with_events(reader, writer);
+
+        let runtime_id = Uuid::new_v4();
+        actor.tracked_workspaces.insert("ws-1".into(), runtime_id.to_string());
+
+        let server = tokio::spawn(async move {
+            let mut read_buf = BytesMut::new();
+            let request = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            match request.command {
+                Some(v3::client_envelope::Command::ResyncRuntime(resync)) => {
+                    assert_eq!(rttx_proto::bytes_to_uuid(&resync.runtime_id).unwrap(), runtime_id);
+                }
+                other => panic!("expected ResyncRuntime, got {other:?}"),
+            }
+            let pane_id = Uuid::new_v4();
+            let snap = rttx_proto::v3_snapshot::build_runtime_snapshot(
+                runtime_id,
+                42,
+                v3::RuntimeClientRole::Writer,
+                vec![rttx_proto::v3_snapshot::build_pane_snapshot(
+                    rttx_proto::v3_snapshot::PaneSnapshotParams {
+                        pane_id,
+                        pane_output_seq: 100,
+                        title: "bash".into(),
+                        cwd: "/home".into(),
+                        cols: 80,
+                        rows: 24,
+                        exit_status: None,
+                        terminal_modes: v3::TerminalModeState::default(),
+                        scrollback_tail: bytes::Bytes::from_static(b"$ "),
+                        total_scrollback_bytes: 2,
+                    },
+                )],
+            );
+            send_server_envelope(
+                &mut server_stream,
+                &rttx_proto::v3_resync::build_resync_response(request.request_id, snap),
+            )
+            .await;
+        });
+
+        actor
+            .handle_command(EndpointCommand::ResyncRuntime {
+                workspace_id: "ws-1".into(),
+                runtime_id: runtime_id.to_string(),
+            })
+            .await;
+
+        server.await.expect("server task should complete");
+
+        match event_rx.try_recv() {
+            Ok(EndpointEvent::WorkspaceResynced { workspace_id, runtime_id: rid, snapshot }) => {
+                assert_eq!(workspace_id, "ws-1");
+                assert_eq!(rid, runtime_id.to_string());
+                assert_eq!(snapshot.panes.len(), 1);
+            }
+            other => panic!("expected WorkspaceResynced event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resync_command_handles_error_response() {
+        let ((reader, writer), mut server_stream) = split_duplex_connection();
+        let (mut actor, mut event_rx) = make_actor_with_events(reader, writer);
+
+        let runtime_id = Uuid::new_v4();
+        actor.tracked_workspaces.insert("ws-1".into(), runtime_id.to_string());
+
+        let server = tokio::spawn(async move {
+            let mut read_buf = BytesMut::new();
+            let request = recv_client_envelope(&mut server_stream, &mut read_buf).await;
+            let err = rttx_proto::v3_error::build_error(
+                v3::ErrorKind::Internal,
+                "resync failed",
+                "ResyncRuntime",
+            );
+            send_server_envelope(
+                &mut server_stream,
+                &rttx_proto::v3_error::build_error_response(request.request_id, err),
+            )
+            .await;
+        });
+
+        actor
+            .handle_command(EndpointCommand::ResyncRuntime {
+                workspace_id: "ws-1".into(),
+                runtime_id: runtime_id.to_string(),
+            })
+            .await;
+
+        server.await.expect("server task should complete");
+
+        assert!(matches!(event_rx.try_recv(), Err(TryRecvError::Empty)));
     }
 }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -639,6 +639,16 @@ impl Window {
                     self.apply_endpoint_event_transition(&transition);
                 }
             }
+            EndpointEvent::WorkspaceResynced { .. } => {
+                let transition = {
+                    let mut state = self.imp().state.borrow_mut();
+                    state.reconcile_endpoint_event(&event)
+                };
+                self.apply_endpoint_event_transition(&transition);
+                if !transition.pane_snapshot_restores.is_empty() {
+                    self.show_toast("Terminal resynced — some output may have been lost");
+                }
+            }
             other => {
                 let transition = {
                     let mut state = self.imp().state.borrow_mut();

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -7119,3 +7119,100 @@ fn rename_focused_pane_direct_sets_custom_title() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn workspace_resynced_event_restores_pane_content() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.workspace-resynced-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    let runtime_id = uuid::Uuid::new_v4();
+    let pane_id = uuid::Uuid::new_v4();
+    let session_state = crate::test_helpers::managed_session_with_runtime(
+        "workspace-resync",
+        "Resync Workspace",
+        LayoutNode::new_terminal_with_uuid(&pane_id.to_string()),
+        RuntimeEndpoint::Local,
+        WorkspacePolicy::Persistent,
+        Some(&runtime_id.to_string()),
+    );
+    window.imp().state.borrow_mut().workspaces.push(session_state.clone());
+    window.build_session(&session_state, false);
+
+    // First, open the workspace so bindings are established.
+    window.handle_endpoint_event(crate::daemon_bridge::EndpointEvent::WorkspaceOpened {
+        workspace_id: session_state.uuid.clone(),
+        runtime_id: runtime_id.to_string(),
+        snapshot: rttx_proto::v3::RuntimeSnapshot {
+            runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
+            runtime_revision: 7,
+            client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
+            panes: vec![rttx_proto::v3::PaneSnapshot {
+                pane_id: rttx_proto::uuid_to_bytes(pane_id),
+                pane_output_seq: 10,
+                title: "bash".into(),
+                cwd: "/home".into(),
+                cols: 80,
+                rows: 24,
+                exit_status: None,
+                terminal_modes: None,
+                scrollback_tail: bytes::Bytes::from_static(b"initial"),
+                total_scrollback_bytes: 7,
+                scrollback_complete: true,
+            }],
+        },
+    });
+    pump_events(50);
+
+    // Now simulate a resync with updated content.
+    window.handle_endpoint_event(crate::daemon_bridge::EndpointEvent::WorkspaceResynced {
+        workspace_id: session_state.uuid.clone(),
+        runtime_id: runtime_id.to_string(),
+        snapshot: rttx_proto::v3::RuntimeSnapshot {
+            runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
+            runtime_revision: 8,
+            client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
+            panes: vec![rttx_proto::v3::PaneSnapshot {
+                pane_id: rttx_proto::uuid_to_bytes(pane_id),
+                pane_output_seq: 50,
+                title: "bash".into(),
+                cwd: "/home/project".into(),
+                cols: 80,
+                rows: 24,
+                exit_status: None,
+                terminal_modes: None,
+                scrollback_tail: bytes::Bytes::from_static(b"resynced output"),
+                total_scrollback_bytes: 15,
+                scrollback_complete: true,
+            }],
+        },
+    });
+    pump_events(50);
+
+    // Verify the pane is still connected and the CWD was updated.
+    let pane = window
+        .imp()
+        .persistent_terminals
+        .borrow()
+        .get(&pane_id.to_string())
+        .cloned()
+        .expect("pane should be present after resync");
+    assert!(pane.input_enabled_for_test());
+    assert_eq!(pane.current_directory().as_deref(), Some("/home/project"));
+
+    // Verify the layout was not rebuilt (workspace count unchanged).
+    let state = window.imp().state.borrow();
+    assert_eq!(state.workspaces.len(), 2); // default + our workspace
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -215,6 +215,10 @@ impl WindowState {
                 }
                 transition.persist_window_state = true;
             }
+            EndpointEvent::WorkspaceResynced { workspace_id, snapshot, .. } => {
+                let restores = self.build_resync_restores(workspace_id, snapshot);
+                transition.pane_snapshot_restores = restores;
+            }
             EndpointEvent::RuntimeMessage { .. } | EndpointEvent::WorkspaceError { .. } => {}
         }
 
@@ -520,6 +524,42 @@ impl WindowState {
             skipped_runtime_panes,
             previous_layout_terminals: layout_terminal_uuids,
         })
+    }
+
+    /// Build snapshot restores for a resync without rebuilding the layout.
+    fn build_resync_restores(
+        &self,
+        workspace_id: &str,
+        snapshot: &v3::RuntimeSnapshot,
+    ) -> Vec<WorkspacePaneRestore> {
+        let Some(session) = self.workspaces.iter().find(|s| s.uuid == workspace_id) else {
+            return Vec::new();
+        };
+        let layout_by_runtime_pane: BTreeMap<_, _> = session
+            .runtime
+            .pane_bindings
+            .iter()
+            .map(|(layout_uuid, runtime_pane_id)| (runtime_pane_id.clone(), layout_uuid.clone()))
+            .collect();
+        snapshot
+            .panes
+            .iter()
+            .filter_map(|pane_snapshot| {
+                let runtime_pane_id = snapshot_pane_id(pane_snapshot)?;
+                let layout_terminal_uuid = layout_by_runtime_pane.get(&runtime_pane_id)?.clone();
+                Some(WorkspacePaneRestore {
+                    layout_terminal_uuid,
+                    title: pane_snapshot.title.clone(),
+                    cwd: pane_snapshot.cwd.clone(),
+                    pane_output_seq: pane_snapshot.pane_output_seq,
+                    scrollback_tail: pane_snapshot.scrollback_tail.clone(),
+                    scrollback_complete: pane_snapshot.scrollback_complete,
+                    cols: pane_snapshot.cols as u16,
+                    rows: pane_snapshot.rows as u16,
+                    terminal_modes: pane_snapshot.terminal_modes,
+                })
+            })
+            .collect()
     }
 }
 
@@ -1947,6 +1987,139 @@ mod tests {
             state.dismissed_runtime_ids.contains(&live_id),
             "live dismissed ID should be retained"
         );
+    }
+
+    // ── Resync (StreamOverflow recovery) ──
+
+    #[test]
+    fn resync_produces_snapshot_restores_for_bound_panes() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let pane_uuid = uuid::Uuid::new_v4().to_string();
+        let mut state = window_state(vec![managed_session("ws-1", "Workspace", term(&pane_uuid))]);
+        // Simulate an opened workspace so bindings exist.
+        let _ = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(
+                &runtime_id,
+                vec![pane_snapshot(&pane_uuid, "bash", "/home", b"initial")],
+            ),
+        });
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceResynced {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(
+                &runtime_id,
+                vec![pane_snapshot(&pane_uuid, "bash", "/home/project", b"resynced output")],
+            ),
+        });
+
+        assert_eq!(transition.pane_snapshot_restores.len(), 1);
+        let restore = &transition.pane_snapshot_restores[0];
+        assert_eq!(restore.layout_terminal_uuid, pane_uuid);
+        assert_eq!(restore.cwd, "/home/project");
+        assert_eq!(restore.scrollback_tail, bytes::Bytes::from_static(b"resynced output"));
+    }
+
+    #[test]
+    fn resync_ignores_unknown_workspace() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let mut state = window_state(vec![]);
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceResynced {
+            workspace_id: "nonexistent".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(&runtime_id, vec![]),
+        });
+
+        assert!(transition.pane_snapshot_restores.is_empty());
+    }
+
+    #[test]
+    fn resync_skips_unbound_runtime_panes() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let pane_uuid = uuid::Uuid::new_v4().to_string();
+        let extra_pane = uuid::Uuid::new_v4().to_string();
+        let mut state = window_state(vec![managed_session("ws-1", "Workspace", term(&pane_uuid))]);
+        let _ = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(&runtime_id, vec![pane_snapshot(&pane_uuid, "bash", "/home", b"")]),
+        });
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceResynced {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(
+                &runtime_id,
+                vec![
+                    pane_snapshot(&pane_uuid, "bash", "/home", b"resynced"),
+                    pane_snapshot(&extra_pane, "zsh", "/tmp", b"extra"),
+                ],
+            ),
+        });
+
+        assert_eq!(transition.pane_snapshot_restores.len(), 1);
+        assert_eq!(transition.pane_snapshot_restores[0].layout_terminal_uuid, pane_uuid);
+    }
+
+    #[test]
+    fn resync_does_not_rebuild_layout() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let pane_uuid = uuid::Uuid::new_v4().to_string();
+        let mut state = window_state(vec![managed_session("ws-1", "Workspace", term(&pane_uuid))]);
+        let _ = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(&runtime_id, vec![pane_snapshot(&pane_uuid, "bash", "/home", b"")]),
+        });
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceResynced {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(
+                &runtime_id,
+                vec![pane_snapshot(&pane_uuid, "bash", "/home", b"resynced")],
+            ),
+        });
+
+        assert!(transition.rebuilt_workspaces.is_empty());
+        assert!(transition.recovered_workspaces.is_empty());
+        assert!(transition.pane_create_requests.is_empty());
+    }
+
+    #[test]
+    fn resync_carries_terminal_modes() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let pane_uuid = uuid::Uuid::new_v4().to_string();
+        let mut state = window_state(vec![managed_session("ws-1", "Workspace", term(&pane_uuid))]);
+        let _ = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(&runtime_id, vec![pane_snapshot(&pane_uuid, "bash", "/home", b"")]),
+        });
+
+        let mut snap = pane_snapshot(&pane_uuid, "vim", "/home", b"vim content");
+        snap.terminal_modes = Some(v3::TerminalModeState {
+            bracketed_paste: true,
+            application_cursor_keys: true,
+            ..Default::default()
+        });
+
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceResynced {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(&runtime_id, vec![snap]),
+        });
+
+        assert_eq!(transition.pane_snapshot_restores.len(), 1);
+        let modes = transition.pane_snapshot_restores[0]
+            .terminal_modes
+            .as_ref()
+            .expect("modes should be present");
+        assert!(modes.bracketed_paste);
+        assert!(modes.application_cursor_keys);
     }
 
     #[test]

--- a/clients/rttx/tests/stream_overflow_resync.rs
+++ b/clients/rttx/tests/stream_overflow_resync.rs
@@ -1,0 +1,195 @@
+//! Integration test for #825: `StreamOverflow` recovery via resync.
+//!
+//! Verifies that `WorkspaceResynced` events produce correct snapshot
+//! restores without rebuilding the layout, and that the resync path
+//! handles multi-pane workspaces and terminal mode preservation.
+
+use rttx::daemon_bridge::EndpointEvent;
+use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy, WorkspaceRuntime};
+use rttx::workspace::*;
+
+fn term(id: &str) -> LayoutNode {
+    LayoutNode::Terminal { uuid: id.to_string(), profile: None, cwd: None, custom_title: None }
+}
+
+fn hsplit(first: LayoutNode, second: LayoutNode) -> LayoutNode {
+    LayoutNode::Split {
+        orientation: SplitOrientation::Horizontal,
+        ratio: 0.5,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+fn pane_snapshot(
+    pane_id: &str,
+    title: &str,
+    cwd: &str,
+    scrollback: &[u8],
+) -> rttx_proto::v3::PaneSnapshot {
+    rttx_proto::v3::PaneSnapshot {
+        pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),
+        pane_output_seq: 0,
+        title: title.to_string(),
+        cwd: cwd.to_string(),
+        cols: 120,
+        rows: 40,
+        exit_status: None,
+        terminal_modes: None,
+        scrollback_tail: bytes::Bytes::copy_from_slice(scrollback),
+        total_scrollback_bytes: scrollback.len() as u64,
+        scrollback_complete: true,
+    }
+}
+
+fn snapshot(
+    runtime_id: &str,
+    panes: Vec<rttx_proto::v3::PaneSnapshot>,
+) -> rttx_proto::v3::RuntimeSnapshot {
+    rttx_proto::v3::RuntimeSnapshot {
+        runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
+        panes,
+        runtime_revision: 1,
+        client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
+    }
+}
+
+fn managed_workspace(id: &str, layout: LayoutNode, runtime_id: Option<&str>) -> WorkspaceState {
+    let terminal_uuids = layout.terminal_uuids();
+    let terminal_recovery = terminal_uuids
+        .iter()
+        .cloned()
+        .map(|uuid| (uuid, rttx::workspace::PaneRecovery::empty_shell()))
+        .collect();
+    let active_terminal_uuid = terminal_uuids.first().cloned();
+    let mut session = WorkspaceState {
+        uuid: id.to_string(),
+        name: id.to_string(),
+        layout,
+        terminal_recovery,
+        active_terminal_uuid,
+        input_sync: false,
+        runtime: WorkspaceRuntime {
+            managed: true,
+            endpoint: RuntimeEndpoint::Local,
+            policy: WorkspacePolicy::Persistent,
+            runtime_id: runtime_id.map(str::to_string),
+            pane_bindings: std::collections::BTreeMap::default(),
+            pending_layout_panes: std::collections::BTreeSet::default(),
+        },
+        color: WorkspaceColor::default(),
+        zoomed_terminal_uuid: None,
+        user_renamed: false,
+    };
+    session.runtime.ensure_placeholder_bindings(&terminal_uuids);
+    session
+}
+
+/// Resync on a multi-pane workspace restores all bound panes without
+/// altering the layout structure.
+#[test]
+fn resync_multi_pane_workspace_restores_all_panes() {
+    let runtime_id = uuid::Uuid::new_v4().to_string();
+    let pane_a = uuid::Uuid::new_v4().to_string();
+    let pane_b = uuid::Uuid::new_v4().to_string();
+
+    let layout = hsplit(term(&pane_a), term(&pane_b));
+    let mut state = WindowState {
+        workspaces: vec![managed_workspace("ws-1", layout, None)],
+        ..WindowState::default()
+    };
+
+    // Open workspace to establish bindings.
+    let _ = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+        workspace_id: "ws-1".into(),
+        runtime_id: runtime_id.clone(),
+        snapshot: snapshot(
+            &runtime_id,
+            vec![
+                pane_snapshot(&pane_a, "bash", "/home", b"initial-a"),
+                pane_snapshot(&pane_b, "zsh", "/tmp", b"initial-b"),
+            ],
+        ),
+    });
+
+    let layout_before = state.workspaces[0].layout.terminal_uuids();
+
+    // Resync with updated content.
+    let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceResynced {
+        workspace_id: "ws-1".into(),
+        runtime_id: runtime_id.clone(),
+        snapshot: snapshot(
+            &runtime_id,
+            vec![
+                pane_snapshot(&pane_a, "bash", "/home/project", b"resynced-a"),
+                pane_snapshot(&pane_b, "zsh", "/var/log", b"resynced-b"),
+            ],
+        ),
+    });
+
+    // Both panes should have snapshot restores.
+    assert_eq!(transition.pane_snapshot_restores.len(), 2);
+
+    let restore_a = transition
+        .pane_snapshot_restores
+        .iter()
+        .find(|r| r.scrollback_tail == bytes::Bytes::from_static(b"resynced-a"))
+        .expect("pane A should be restored");
+    assert_eq!(restore_a.cwd, "/home/project");
+
+    let restore_b = transition
+        .pane_snapshot_restores
+        .iter()
+        .find(|r| r.scrollback_tail == bytes::Bytes::from_static(b"resynced-b"))
+        .expect("pane B should be restored");
+    assert_eq!(restore_b.cwd, "/var/log");
+
+    // Layout must not change.
+    assert_eq!(state.workspaces[0].layout.terminal_uuids(), layout_before);
+    assert!(transition.rebuilt_workspaces.is_empty());
+    assert!(transition.pane_create_requests.is_empty());
+}
+
+/// Repeated resyncs do not accumulate state or corrupt bindings.
+#[test]
+fn repeated_resyncs_are_idempotent() {
+    let runtime_id = uuid::Uuid::new_v4().to_string();
+    let pane_uuid = uuid::Uuid::new_v4().to_string();
+
+    let mut state = WindowState {
+        workspaces: vec![managed_workspace("ws-1", term(&pane_uuid), None)],
+        ..WindowState::default()
+    };
+
+    let _ = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+        workspace_id: "ws-1".into(),
+        runtime_id: runtime_id.clone(),
+        snapshot: snapshot(
+            &runtime_id,
+            vec![pane_snapshot(&pane_uuid, "bash", "/home", b"initial")],
+        ),
+    });
+
+    for i in 0..5 {
+        let content = format!("resync-{i}");
+        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceResynced {
+            workspace_id: "ws-1".into(),
+            runtime_id: runtime_id.clone(),
+            snapshot: snapshot(
+                &runtime_id,
+                vec![pane_snapshot(&pane_uuid, "bash", "/home", content.as_bytes())],
+            ),
+        });
+
+        assert_eq!(transition.pane_snapshot_restores.len(), 1);
+        assert_eq!(
+            transition.pane_snapshot_restores[0].scrollback_tail,
+            bytes::Bytes::from(content)
+        );
+        assert!(transition.rebuilt_workspaces.is_empty());
+    }
+
+    // Layout and bindings unchanged after 5 resyncs.
+    assert_eq!(state.workspaces[0].layout.terminal_uuids().len(), 1);
+    assert_eq!(state.workspaces[0].runtime.pane_bindings.len(), 1);
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.21',
+  version: '0.4.22',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

When the daemon's push channel overflows and drops messages, the client previously silently ignored the `StreamOverflow` notification, leaving terminal output permanently corrupted with no recovery path.

Now the client:
1. Intercepts `StreamOverflow` in the daemon bridge's `handle_runtime_message`
2. Looks up the affected workspace via `tracked_workspaces`
3. Queues a `ResyncRuntime` command via `self_tx`
4. Sends a `ResyncRuntime` request to the daemon and receives a fresh `RuntimeSnapshot`
5. Emits a `WorkspaceResynced` event to the GTK layer
6. Reconciles the event by re-feeding pane content (`vte.reset + feed_snapshot`) without rebuilding the layout
7. Shows a toast: "Terminal resynced — some output may have been lost"

The protocol layer (`OPT_RESYNC`, `StreamOverflow`, `ResyncRuntime`, `RuntimeSnapshot`) was already fully implemented — this change wires the client to actually use it.

## Manual verification

1. Build and run with `RTTX_DEV_MODE=1`
2. Produce heavy terminal output (e.g., `yes | head -100000`)
3. If overflow occurs, verify the terminal resyncs and a toast appears
4. Verify other panes in the same workspace are unaffected

## Tests added

### Unit tests (workspace_state.rs)
- `resync_produces_snapshot_restores_for_bound_panes` — verifies resync produces correct snapshot restores
- `resync_ignores_unknown_workspace` — verifies no-op for unknown workspace
- `resync_skips_unbound_runtime_panes` — verifies unbound panes are skipped
- `resync_does_not_rebuild_layout` — verifies layout is not rebuilt during resync
- `resync_carries_terminal_modes` — verifies terminal modes are preserved

### Integration tests (daemon_bridge.rs)
- `handle_stream_overflow_queues_resync_command` — verifies overflow triggers resync command
- `handle_stream_overflow_ignores_unknown_runtime` — verifies no-op for unknown runtime
- `resync_command_sends_request_and_emits_event` — verifies full resync request/response flow
- `resync_command_handles_error_response` — verifies error handling

### GTK test (window/tests.rs)
- `workspace_resynced_event_restores_pane_content` — verifies pane content and CWD are restored after resync

## Tests run

- `cargo test --workspace` (VTE 0.76) — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass including GTK test via Broadway

## Version bump

0.4.21 → 0.4.22 (4 source files changed, affects user experience via toast)

Fixes #825