### PR TITLE
perf(server): eliminate double strip_client_queries processing

### DIFF
--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -101,12 +101,21 @@ impl Pane {
     /// Store raw PTY bytes without running the VTE parser.
     ///
     /// Updates `pending_flush`, `output_seq`, and the screen's raw-byte
-    /// buffer. This is a fast memcpy suitable for calling inside a
-    /// contended mutex. Call [`parse_and_extract`] afterwards (potentially
-    /// after releasing the lock) to run the expensive VTE state machine.
+    /// buffer. The screen receives raw bytes for accurate VTE parsing,
+    /// while `pending_flush` receives stripped bytes (terminal query
+    /// sequences removed) so that `flush_scrollback` can write directly
+    /// without re-stripping. The fast path (no ESC byte) avoids any
+    /// allocation beyond the `extend_from_slice` memcpy.
+    ///
+    /// Call [`parse_and_extract`] afterwards (potentially after releasing
+    /// the lock) to run the expensive VTE state machine.
     pub fn accept_output(&mut self, data: &[u8]) {
         self.screen.accept_raw(data);
-        self.pending_flush.extend_from_slice(data);
+        if data.contains(&0x1b) {
+            self.pending_flush.extend_from_slice(&strip_client_queries(data));
+        } else {
+            self.pending_flush.extend_from_slice(data);
+        }
         self.output_seq += 1;
         if self.pending_flush.len() > DEFAULT_MAX_SCROLLBACK {
             let excess = self.pending_flush.len() - DEFAULT_MAX_SCROLLBACK;
@@ -313,18 +322,18 @@ impl Pane {
     }
 }
 
-/// Write scrollback data to disk: strip client queries, append, and rotate.
+/// Write scrollback data to disk: append and rotate.
 ///
-/// This is the I/O-only counterpart of [`Pane::flush_scrollback`]. It can
-/// be called outside the server mutex after draining pending bytes with
-/// [`Pane::take_pending_flush`].
+/// Data is expected to be pre-stripped (terminal query sequences already
+/// removed by [`Pane::accept_output`]). This is the I/O-only counterpart
+/// of [`Pane::flush_scrollback`]. It can be called outside the server
+/// mutex after draining pending bytes with [`Pane::take_pending_flush`].
 pub fn write_scrollback_to_disk(path: &Path, data: &[u8]) -> Result<(), std::io::Error> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let clean = strip_client_queries(data);
     let mut file = std::fs::OpenOptions::new().create(true).append(true).open(path)?;
-    file.write_all(&clean)?;
+    file.write_all(data)?;
     rotate_scrollback_log(path, DEFAULT_MAX_SCROLLBACK_LOG, SCROLLBACK_ROTATE_KEEP)
 }
 
@@ -1021,10 +1030,10 @@ mod tests {
     }
 
     #[test]
-    fn write_scrollback_to_disk_creates_file_and_strips_queries() {
+    fn write_scrollback_to_disk_writes_pre_stripped_data() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("scrollback").join("test.log");
-        let data = b"line1\r\n\x1b[6nline2\r\n";
+        let data = b"line1\r\nline2\r\n";
 
         write_scrollback_to_disk(&path, data).unwrap();
 
@@ -1075,6 +1084,29 @@ mod tests {
         // VTE not parsed — CWD not extracted yet.
         assert!(pane.cwd.is_none());
         assert!(pane.screen.cwd().is_none());
+    }
+
+    #[test]
+    fn accept_output_strips_queries_from_pending_flush() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let data = b"hello\x1b[6nworld\x1b[c";
+        pane.accept_output(data);
+
+        // Screen gets raw bytes (needed for accurate VTE parsing).
+        assert_eq!(pane.screen.raw_bytes(), data);
+        // Pending flush gets stripped bytes (no double strip on disk write).
+        let flushed = pane.take_pending_flush();
+        assert_eq!(flushed, b"helloworld");
+    }
+
+    #[test]
+    fn accept_output_pending_flush_unchanged_without_queries() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let data = b"plain text output\r\n";
+        pane.accept_output(data);
+
+        let flushed = pane.take_pending_flush();
+        assert_eq!(flushed, data);
     }
 
     #[test]

--- a/services/rttx-server/tests/scrollback_pre_stripped.rs
+++ b/services/rttx-server/tests/scrollback_pre_stripped.rs
@@ -1,0 +1,92 @@
+//! Integration test: scrollback stores pre-stripped data (#831).
+//!
+//! Verifies that `accept_output` strips terminal query sequences before
+//! storing bytes in `pending_flush`, so `write_scrollback_to_disk` writes
+//! clean data without a redundant second strip pass.
+
+mod common;
+
+use common::{TestClient, start_test_server, wait_for_scrollback_log};
+use rttx_proto::proto;
+use std::time::Duration;
+
+/// Scrollback log must not contain DSR queries even though stripping
+/// now happens at accept time rather than at flush time.
+#[tokio::test]
+async fn scrollback_pre_stripped_at_accept_time() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut c = TestClient::connect(&sock).await;
+    c.handshake().await;
+
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "pre-strip-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    })
+    .await;
+    let runtime_id = match c.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            runtime_id: runtime_id.clone(),
+            cwd: None,
+            dark_background: None,
+            cols: 0,
+            rows: 0,
+            no_persist: None,
+        })),
+    })
+    .await;
+    let pane_id = match c.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
+            runtime_id: runtime_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    })
+    .await;
+    match c.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+    c.drain(Duration::from_millis(500)).await;
+
+    // Emit DSR + DA1 queries interleaved with a marker.
+    c.send(&proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            runtime_id: runtime_id.clone(),
+            pane_id: pane_id.clone(),
+            data: bytes::Bytes::from_static(
+                b"printf 'PRE_STRIP\\033[6n\\033[cMARKER'\n",
+            ),
+        })),
+    })
+    .await;
+
+    let logs = wait_for_scrollback_log(tmp.path(), Duration::from_secs(15)).await;
+    assert!(!logs.is_empty(), "scrollback log should exist");
+
+    let content = std::fs::read(&logs[0]).unwrap();
+    let text = String::from_utf8_lossy(&content);
+    assert!(text.contains("PRE_STRIP"), "marker should be in scrollback: {text}");
+
+    // DSR and DA1 queries must have been stripped at accept time.
+    assert!(
+        !content.windows(4).any(|w| w == b"\x1b[6n"),
+        "DSR query must not appear in scrollback log",
+    );
+    assert!(
+        !content.windows(3).any(|w| w == b"\x1b[c"),
+        "DA1 query must not appear in scrollback log",
+    );
+}

--- a/services/rttx-server/tests/scrollback_pre_stripped.rs
+++ b/services/rttx-server/tests/scrollback_pre_stripped.rs
@@ -66,9 +66,7 @@ async fn scrollback_pre_stripped_at_accept_time() {
         msg: Some(proto::client_message::Msg::Input(proto::Input {
             runtime_id: runtime_id.clone(),
             pane_id: pane_id.clone(),
-            data: bytes::Bytes::from_static(
-                b"printf 'PRE_STRIP\\033[6n\\033[cMARKER'\n",
-            ),
+            data: bytes::Bytes::from_static(b"printf 'PRE_STRIP\\033[6n\\033[cMARKER'\n"),
         })),
     })
     .await;


### PR DESCRIPTION
## What changed and why

Eliminates redundant `strip_client_queries()` processing in the PTY output path. Previously, the same data was stripped twice:

1. In the PTY read loop (Phase 5) before broadcasting to clients
2. In `write_scrollback_to_disk()` before writing to the scrollback log

Now `accept_output()` strips terminal query sequences before storing bytes in `pending_flush`, so `write_scrollback_to_disk()` writes directly without re-stripping. The screen still receives raw bytes for accurate VTE parsing.

The fast path (no ESC byte in the batch — the common case for normal terminal output) avoids any allocation beyond the existing `extend_from_slice` memcpy.

Fixes #831

## How to manually verify

1. Run `rttx` with a daemon, produce output containing DSR queries (e.g. `printf '\e[6n'`)
2. Check scrollback log files under `~/.local/state/rttx/daemon/runtimes/*/scrollback/` — they should not contain DSR/DA1/DA2 query sequences
3. Client output should remain clean (no `;1R` garbage)

## Tests added

- `accept_output_strips_queries_from_pending_flush` — verifies screen gets raw bytes while pending_flush gets stripped bytes
- `accept_output_pending_flush_unchanged_without_queries` — verifies fast path (no ESC) passes data through unchanged
- Updated `write_scrollback_to_disk_writes_pre_stripped_data` — reflects that `write_scrollback_to_disk` now expects pre-stripped data

## Tests run

- `cargo test -p rttx-server --lib` — 402 passed, 0 failed
- `cargo test -p rttx-server --tests` — all integration tests passed
- `cargo test -p rttx-server --test property_robustness` — 13 passed
- `cargo test -p rttx-proto` — 9 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed, 0 failures