### PR TITLE
perf: add indexed lookups for message dispatch and sidebar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.22"
+version = "0.4.23"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/test_helpers.rs
+++ b/clients/rttx/src/test_helpers.rs
@@ -134,7 +134,9 @@ pub fn managed_session_with_runtime(
 /// Build a window state from workspaces.
 #[must_use]
 pub fn window_state(workspaces: Vec<WorkspaceState>) -> WindowState {
-    WindowState { active_workspace_index: 0, workspaces, ..WindowState::default() }
+    let mut state = WindowState { active_workspace_index: 0, workspaces, ..WindowState::default() };
+    state.rebuild_pane_reverse_index();
+    state
 }
 
 // ── Color scheme builder ─────────────────────────────────────────

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -634,16 +634,8 @@ impl Window {
             manager.rename_runtime(session_uuid, &endpoint, &runtime_id, new_name);
         }
 
-        let mut idx = 0;
-        while let Some(row) = self.imp().sidebar_list.row_at_index(idx) {
-            if let Some(session_row) =
-                row.child().and_then(|child| child.downcast::<WorkspaceRow>().ok())
-                && session_row.uuid() == session_uuid
-            {
-                session_row.set_workspace_name(new_name);
-                return;
-            }
-            idx += 1;
+        if let Some(session_row) = self.sidebar_workspace_row(session_uuid) {
+            session_row.set_workspace_name(new_name);
         }
     }
 

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -78,6 +78,8 @@ mod imp {
         pub host_selector_keys: RefCell<Vec<String>>,
         pub leader_keys: RefCell<Vec<String>>,
         pub leader_timeout_source: RefCell<Option<glib::SourceId>>,
+        /// Workspace UUID → sidebar row index for O(1) sidebar lookups.
+        pub sidebar_row_index: RefCell<HashMap<String, i32>>,
     }
 
     #[glib::object_subclass]
@@ -393,7 +395,7 @@ impl Window {
             .as_ref()
             .and_then(|id| workspaces.iter().position(|ws| ws.uuid == *id))
             .unwrap_or(0);
-        let state = if workspaces.is_empty() {
+        let mut state = if workspaces.is_empty() {
             WindowState::default()
         } else {
             WindowState {
@@ -405,8 +407,10 @@ impl Window {
                 left_sidebar_width: ui.left_sidebar_width,
                 right_sidebar_width: ui.right_sidebar_width,
                 dismissed_runtime_ids: cache.dismissed_runtime_ids,
+                pane_reverse_index: std::collections::HashMap::new(),
             }
         };
+        state.rebuild_pane_reverse_index();
 
         let active_index =
             state.active_workspace_index.min(state.workspaces.len().saturating_sub(1));
@@ -782,6 +786,7 @@ impl Window {
         let list_row = gtk4::ListBoxRow::new();
         list_row.set_child(Some(&row));
         imp.sidebar_list.append(&list_row);
+        self.rebuild_sidebar_row_index();
     }
 
     fn sync_sidebar_to_visible_session(&self) {
@@ -1034,6 +1039,7 @@ impl Window {
             drop(session);
             let new_index = pos.min(state.workspaces.len() - 1);
             state.active_workspace_index = new_index;
+            state.rebuild_pane_reverse_index();
             (uuids, new_index, info)
         };
 
@@ -1097,6 +1103,7 @@ impl Window {
                 {
                     state.dismissed_runtime_ids.insert(runtime_id.clone());
                 }
+                state.rebuild_pane_reverse_index();
                 drop(state);
                 if let Some((endpoint, runtime_id)) = managed_runtime
                     && let Some(manager) = imp.connection_manager.borrow().as_ref()
@@ -1121,6 +1128,7 @@ impl Window {
             };
             let new_index = pos.min(state.workspaces.len() - 1);
             state.active_workspace_index = new_index;
+            state.rebuild_pane_reverse_index();
             (uuids, new_index, managed_runtime)
         };
 
@@ -1174,6 +1182,27 @@ impl Window {
         self.renumber_session_rows();
     }
 
+    /// Rebuild the sidebar row index from the current `ListBox` contents.
+    pub(super) fn rebuild_sidebar_row_index(&self) {
+        let imp = self.imp();
+        let mut index = HashMap::new();
+        let mut idx = 0;
+        while let Some(row) = imp.sidebar_list.row_at_index(idx) {
+            if let Some(session_row) = row.child().and_then(|c| c.downcast::<WorkspaceRow>().ok()) {
+                index.insert(session_row.uuid(), idx);
+            }
+            idx += 1;
+        }
+        imp.sidebar_row_index.replace(index);
+    }
+
+    /// Look up the sidebar `WorkspaceRow` for a workspace UUID via the index.
+    fn sidebar_workspace_row(&self, workspace_uuid: &str) -> Option<WorkspaceRow> {
+        let imp = self.imp();
+        let idx = *imp.sidebar_row_index.borrow().get(workspace_uuid)?;
+        imp.sidebar_list.row_at_index(idx)?.child().and_then(|c| c.downcast::<WorkspaceRow>().ok())
+    }
+
     fn remove_sidebar_row(&self, session_uuid: &str) {
         let imp = self.imp();
         // Clear the stored popover — its parent (the ListBoxRow) is about
@@ -1189,6 +1218,7 @@ impl Window {
                 && sr.uuid() == session_uuid
             {
                 imp.sidebar_list.remove(&r);
+                self.rebuild_sidebar_row_index();
                 return;
             }
             idx += 1;

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -895,17 +895,8 @@ impl Window {
             connection_icon(&session.runtime.endpoint, status, session.uses_managed_runtime());
         drop(state);
 
-        let list = &self.imp().sidebar_list;
-        let mut idx = 0;
-        while let Some(row) = list.row_at_index(idx) {
-            if let Some(session_row) =
-                row.child().and_then(|child| child.downcast::<WorkspaceRow>().ok())
-                && session_row.uuid() == workspace_id
-            {
-                session_row.set_connection_icon(&icon);
-                break;
-            }
-            idx += 1;
+        if let Some(session_row) = self.sidebar_workspace_row(workspace_id) {
+            session_row.set_connection_icon(&icon);
         }
     }
 
@@ -1168,16 +1159,8 @@ impl Window {
     }
 
     fn update_sidebar_row_name(&self, session_uuid: &str, name: &str) {
-        let mut idx = 0;
-        while let Some(row) = self.imp().sidebar_list.row_at_index(idx) {
-            if let Some(session_row) =
-                row.child().and_then(|child| child.downcast::<WorkspaceRow>().ok())
-                && session_row.uuid() == session_uuid
-            {
-                session_row.set_workspace_name(name);
-                return;
-            }
-            idx += 1;
+        if let Some(session_row) = self.sidebar_workspace_row(session_uuid) {
+            session_row.set_workspace_name(name);
         }
     }
 

--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -573,16 +573,8 @@ impl Window {
             .map(|s| s.uuid.clone());
         drop(state);
         let Some(session_uuid) = session_uuid else { return };
-        let list = &imp.sidebar_list;
-        let mut idx = 0;
-        while let Some(row) = list.row_at_index(idx) {
-            if let Some(session_row) = row.child().and_then(|c| c.downcast::<WorkspaceRow>().ok())
-                && session_row.uuid() == session_uuid
-            {
-                session_row.mark_activity();
-                break;
-            }
-            idx += 1;
+        if let Some(session_row) = self.sidebar_workspace_row(&session_uuid) {
+            session_row.mark_activity();
         }
     }
 
@@ -631,15 +623,8 @@ impl Window {
             });
             workspace_connection_summary(endpoint, pane_info.as_deref())
         };
-        let mut idx = 0;
-        while let Some(row) = imp.sidebar_list.row_at_index(idx) {
-            if let Some(session_row) = row.child().and_then(|c| c.downcast::<WorkspaceRow>().ok())
-                && session_row.uuid() == session_uuid
-            {
-                session_row.set_subtitle(&subtitle);
-                return;
-            }
-            idx += 1;
+        if let Some(session_row) = self.sidebar_workspace_row(session_uuid) {
+            session_row.set_subtitle(&subtitle);
         }
     }
 

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -22,7 +22,7 @@ fn load_saved_window_state() -> WindowState {
         .as_ref()
         .and_then(|id| workspaces.iter().position(|ws| ws.uuid == *id))
         .unwrap_or(0);
-    WindowState {
+    let mut state = WindowState {
         workspaces,
         active_workspace_index,
         width: ui.window_width,
@@ -31,7 +31,10 @@ fn load_saved_window_state() -> WindowState {
         left_sidebar_width: ui.left_sidebar_width,
         right_sidebar_width: ui.right_sidebar_width,
         dismissed_runtime_ids: cache.dismissed_runtime_ids,
-    }
+        pane_reverse_index: std::collections::HashMap::new(),
+    };
+    state.rebuild_pane_reverse_index();
+    state
 }
 
 /// Save a `WindowState` through the `ClientStore` for test setup.

--- a/clients/rttx/src/workspace/state.rs
+++ b/clients/rttx/src/workspace/state.rs
@@ -248,7 +248,7 @@ const fn default_right_sidebar_width() -> i32 {
 }
 
 /// Persistent state of the entire application window.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WindowState {
     pub workspaces: Vec<WorkspaceState>,
     pub active_workspace_index: usize,
@@ -263,6 +263,50 @@ pub struct WindowState {
     /// resurrection until the daemon actually removes the runtime.
     #[serde(default)]
     pub dismissed_runtime_ids: std::collections::BTreeSet<String>,
+    /// Reverse index: `"endpoint_key\0runtime_pane_id"` → `(workspace_id, layout_terminal_uuid)`.
+    /// Derived from pane bindings; not persisted.
+    #[serde(skip)]
+    pub pane_reverse_index: std::collections::HashMap<String, (String, String)>,
+}
+
+impl PartialEq for WindowState {
+    fn eq(&self, other: &Self) -> bool {
+        self.workspaces == other.workspaces
+            && self.active_workspace_index == other.active_workspace_index
+            && self.width == other.width
+            && self.height == other.height
+            && self.is_maximized == other.is_maximized
+            && self.left_sidebar_width == other.left_sidebar_width
+            && self.right_sidebar_width == other.right_sidebar_width
+            && self.dismissed_runtime_ids == other.dismissed_runtime_ids
+    }
+}
+
+impl Eq for WindowState {}
+
+impl WindowState {
+    /// Composite key for the pane reverse index.
+    pub(crate) fn pane_index_key(endpoint_key: &str, runtime_pane_id: &str) -> String {
+        format!("{endpoint_key}\0{runtime_pane_id}")
+    }
+
+    /// Rebuild the reverse index from all workspace pane bindings.
+    pub fn rebuild_pane_reverse_index(&mut self) {
+        self.pane_reverse_index.clear();
+        for session in &self.workspaces {
+            if !session.uses_managed_runtime() {
+                continue;
+            }
+            let endpoint_key = session.runtime.endpoint.key();
+            for (layout_uuid, runtime_pane_id) in &session.runtime.pane_bindings {
+                if session.runtime.is_layout_pane_pending(layout_uuid) {
+                    continue;
+                }
+                let key = Self::pane_index_key(&endpoint_key, runtime_pane_id);
+                self.pane_reverse_index.insert(key, (session.uuid.clone(), layout_uuid.clone()));
+            }
+        }
+    }
 }
 
 impl Default for WindowState {
@@ -276,6 +320,7 @@ impl Default for WindowState {
             left_sidebar_width: default_left_sidebar_width(),
             right_sidebar_width: default_right_sidebar_width(),
             dismissed_runtime_ids: std::collections::BTreeSet::new(),
+            pane_reverse_index: std::collections::HashMap::new(),
         }
     }
 }

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -258,6 +258,10 @@ impl WindowState {
             recovered.push(session);
         }
 
+        if !recovered.is_empty() {
+            self.rebuild_pane_reverse_index();
+        }
+
         recovered
     }
 
@@ -339,21 +343,8 @@ impl WindowState {
         endpoint: &RuntimeEndpoint,
         runtime_pane_id: &str,
     ) -> Option<(String, String)> {
-        let session = self.workspaces.iter().find(|session| {
-            session.uses_managed_runtime()
-                && &session.runtime.endpoint == endpoint
-                && session
-                    .runtime
-                    .pane_bindings
-                    .values()
-                    .any(|bound_runtime_pane_id| bound_runtime_pane_id == runtime_pane_id)
-        })?;
-        session
-            .runtime
-            .pane_bindings
-            .iter()
-            .find(|(_, bound_runtime_pane_id)| *bound_runtime_pane_id == runtime_pane_id)
-            .map(|(layout_terminal_uuid, _)| (session.uuid.clone(), layout_terminal_uuid.clone()))
+        let key = Self::pane_index_key(&endpoint.key(), runtime_pane_id);
+        self.pane_reverse_index.get(&key).cloned()
     }
 
     /// Apply the state mutation for a daemon pane-create acknowledgement.
@@ -374,6 +365,7 @@ impl WindowState {
 
         session.runtime.runtime_id = Some(runtime_id.to_string());
         session.runtime.bind_runtime_pane(layout_terminal_uuid, runtime_pane_id);
+        self.rebuild_pane_reverse_index();
         true
     }
 
@@ -391,7 +383,9 @@ impl WindowState {
         session.runtime.ensure_placeholder_bindings(&layout_terminal_uuids);
         session.prune_recovery();
         session.normalize_active_terminal();
-        Some(session.clone())
+        let result = session.clone();
+        self.rebuild_pane_reverse_index();
+        Some(result)
     }
 
     /// Apply the state mutation for attaching/reconciling a managed runtime snapshot.
@@ -517,8 +511,11 @@ impl WindowState {
             }
         }
 
+        let session_state = session.clone();
+        self.rebuild_pane_reverse_index();
+
         Some(ManagedWorkspaceOpenResult {
-            session_state: session.clone(),
+            session_state,
             panes_to_create,
             snapshot_restores,
             skipped_runtime_panes,
@@ -2139,5 +2136,219 @@ mod tests {
         assert_eq!(round_tripped.scrollback_lines, 5000);
         assert!(round_tripped.smart_clipboard);
         assert_eq!(round_tripped.paste_guard_threshold, 512);
+    }
+
+    // ── Reverse index tests ──────────────────────────────────────
+
+    #[test]
+    fn reverse_index_matches_linear_scan_for_bound_pane() {
+        let endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
+        let runtime_pane_id = "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26";
+        let mut session = managed_session_with_runtime(
+            "workspace-1",
+            "Workspace",
+            term("pane-1"),
+            endpoint.clone(),
+            WorkspacePolicy::Persistent,
+            Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
+        );
+        session.runtime.bind_runtime_pane("pane-1", runtime_pane_id);
+        let state = window_state(vec![session]);
+
+        assert_eq!(
+            state.runtime_pane_target(&endpoint, runtime_pane_id),
+            Some(("workspace-1".into(), "pane-1".into())),
+        );
+    }
+
+    #[test]
+    fn reverse_index_excludes_pending_placeholder_bindings() {
+        let state = window_state(vec![managed_session("workspace-1", "Workspace", term("pane-1"))]);
+
+        // Placeholder bindings (self-bindings) are pending — not in the index.
+        assert!(
+            state.runtime_pane_target(&RuntimeEndpoint::Local, "pane-1").is_none(),
+            "pending placeholder bindings must not appear in the reverse index",
+        );
+    }
+
+    #[test]
+    fn reverse_index_consistent_after_pane_create() {
+        let mut state =
+            window_state(vec![managed_session("workspace-1", "Workspace", term("pane-1"))]);
+
+        state.apply_managed_pane_created(
+            "workspace-1",
+            "pane-1",
+            "d7d04564-b2bf-4302-9495-e65c4df12ac6",
+            "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26",
+        );
+
+        assert_eq!(
+            state.runtime_pane_target(
+                &RuntimeEndpoint::Local,
+                "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"
+            ),
+            Some(("workspace-1".into(), "pane-1".into())),
+        );
+    }
+
+    #[test]
+    fn reverse_index_consistent_after_pane_close() {
+        let mut session = managed_session_with_runtime(
+            "workspace-1",
+            "Workspace",
+            hsplit(term("left"), term("right")),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
+        );
+        session.runtime.bind_runtime_pane("left", "07fa83b4-9ae3-4354-a1c5-1f685ffab370");
+        session.runtime.bind_runtime_pane("right", "0d88f17f-626d-40b8-a1d3-6a42af628ac9");
+        let mut state = window_state(vec![session]);
+
+        state.apply_managed_pane_closed("workspace-1", "left");
+
+        assert!(
+            state
+                .runtime_pane_target(
+                    &RuntimeEndpoint::Local,
+                    "07fa83b4-9ae3-4354-a1c5-1f685ffab370"
+                )
+                .is_none(),
+            "closed pane must be removed from the reverse index",
+        );
+        assert_eq!(
+            state.runtime_pane_target(
+                &RuntimeEndpoint::Local,
+                "0d88f17f-626d-40b8-a1d3-6a42af628ac9"
+            ),
+            Some(("workspace-1".into(), "right".into())),
+        );
+    }
+
+    #[test]
+    fn reverse_index_consistent_after_workspace_opened_reconciliation() {
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+        let runtime_pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+        let runtime_pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
+        let mut state = window_state(vec![managed_session(
+            "workspace-1",
+            "Workspace",
+            hsplit(term("left"), term("right")),
+        )]);
+
+        state.apply_managed_workspace_opened(
+            "workspace-1",
+            runtime_id,
+            &snapshot(
+                runtime_id,
+                vec![
+                    pane_snapshot(runtime_pane_a, "Shell", "/home", b""),
+                    pane_snapshot(runtime_pane_b, "Logs", "/var", b""),
+                ],
+            ),
+        );
+
+        assert_eq!(
+            state.runtime_pane_target(&RuntimeEndpoint::Local, runtime_pane_a),
+            Some(("workspace-1".into(), "left".into())),
+        );
+        assert_eq!(
+            state.runtime_pane_target(&RuntimeEndpoint::Local, runtime_pane_b),
+            Some(("workspace-1".into(), "right".into())),
+        );
+    }
+
+    #[test]
+    fn reverse_index_consistent_after_inventory_recovery() {
+        let runtime_id = uuid::Uuid::new_v4().to_string();
+        let pane_id = uuid::Uuid::new_v4().to_string();
+        let mut state = WindowState::default_for_test();
+
+        state.recover_managed_workspaces_from_inventory(
+            &RuntimeEndpoint::Local,
+            &[rt_info(
+                &runtime_id,
+                "Recovered",
+                v3::RuntimePolicy::Persistent,
+                vec![pane_info(&pane_id, "Shell", "/home")],
+                Some(&pane_id),
+            )],
+        );
+
+        // Inventory recovery creates self-bindings that are NOT pending
+        // (the pane IDs come from the daemon), so they should be in the index.
+        assert_eq!(
+            state.runtime_pane_target(&RuntimeEndpoint::Local, &pane_id),
+            Some((format!("inventory:local:{runtime_id}"), pane_id.clone())),
+        );
+    }
+
+    #[test]
+    fn reverse_index_not_serialized() {
+        let mut session = managed_session_with_runtime(
+            "ws-1",
+            "Work",
+            term("t1"),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
+        );
+        session.runtime.bind_runtime_pane("t1", "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26");
+        let state = window_state(vec![session]);
+
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(
+            !json.contains("pane_reverse_index"),
+            "reverse index must not appear in serialized JSON",
+        );
+
+        let deserialized: WindowState = serde_json::from_str(&json).unwrap();
+        assert!(
+            deserialized.pane_reverse_index.is_empty(),
+            "deserialized state must have empty reverse index",
+        );
+    }
+
+    #[test]
+    fn reverse_index_multi_workspace_multi_endpoint() {
+        let local_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+        let remote_pane = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
+        let remote_endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
+
+        let mut local_session = managed_session_with_runtime(
+            "ws-local",
+            "Local",
+            term("local-t1"),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
+        );
+        local_session.runtime.bind_runtime_pane("local-t1", local_pane);
+
+        let mut remote_session = managed_session_with_runtime(
+            "ws-remote",
+            "Remote",
+            term("remote-t1"),
+            remote_endpoint.clone(),
+            WorkspacePolicy::Persistent,
+            Some("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
+        );
+        remote_session.runtime.bind_runtime_pane("remote-t1", remote_pane);
+
+        let state = window_state(vec![local_session, remote_session]);
+
+        assert_eq!(
+            state.runtime_pane_target(&RuntimeEndpoint::Local, local_pane),
+            Some(("ws-local".into(), "local-t1".into())),
+        );
+        assert_eq!(
+            state.runtime_pane_target(&remote_endpoint, remote_pane),
+            Some(("ws-remote".into(), "remote-t1".into())),
+        );
+        // Cross-endpoint lookup must not match.
+        assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, remote_pane).is_none());
+        assert!(state.runtime_pane_target(&remote_endpoint, local_pane).is_none());
     }
 }

--- a/clients/rttx/tests/pane_reverse_index.rs
+++ b/clients/rttx/tests/pane_reverse_index.rs
@@ -1,0 +1,222 @@
+//! Integration tests for the pane reverse index.
+//!
+//! Verifies that `runtime_pane_target()` returns correct results through
+//! full workspace lifecycle scenarios: create, bind, reconcile, close.
+
+use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy, WorkspaceRuntime};
+use rttx::workspace::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+fn term(id: &str) -> LayoutNode {
+    LayoutNode::Terminal { uuid: id.to_string(), profile: None, cwd: None, custom_title: None }
+}
+
+fn hsplit(first: LayoutNode, second: LayoutNode) -> LayoutNode {
+    LayoutNode::Split {
+        orientation: SplitOrientation::Horizontal,
+        ratio: 0.5,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+fn managed_session(
+    id: &str,
+    name: &str,
+    layout: LayoutNode,
+    endpoint: RuntimeEndpoint,
+    policy: WorkspacePolicy,
+    runtime_id: Option<&str>,
+) -> WorkspaceState {
+    let terminal_uuids = layout.terminal_uuids();
+    let terminal_recovery =
+        terminal_uuids.iter().cloned().map(|uuid| (uuid, PaneRecovery::empty_shell())).collect();
+    let active_terminal_uuid = terminal_uuids.first().cloned();
+    let mut session = WorkspaceState {
+        uuid: id.to_string(),
+        name: name.to_string(),
+        layout,
+        terminal_recovery,
+        active_terminal_uuid,
+        input_sync: false,
+        runtime: WorkspaceRuntime {
+            managed: true,
+            endpoint,
+            policy,
+            runtime_id: runtime_id.map(str::to_string),
+            pane_bindings: BTreeMap::default(),
+            pending_layout_panes: BTreeSet::default(),
+        },
+        color: WorkspaceColor::default(),
+        zoomed_terminal_uuid: None,
+        user_renamed: false,
+    };
+    session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
+    session
+}
+
+fn window_state(workspaces: Vec<WorkspaceState>) -> WindowState {
+    let mut state = WindowState { workspaces, active_workspace_index: 0, ..WindowState::default() };
+    state.rebuild_pane_reverse_index();
+    state
+}
+
+fn pane_snapshot(pane_id: &str, title: &str, cwd: &str) -> rttx_proto::v3::PaneSnapshot {
+    rttx_proto::v3::PaneSnapshot {
+        pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),
+        pane_output_seq: 0,
+        title: title.to_string(),
+        cwd: cwd.to_string(),
+        cols: 120,
+        rows: 40,
+        exit_status: None,
+        terminal_modes: None,
+        scrollback_tail: bytes::Bytes::new(),
+        total_scrollback_bytes: 0,
+        scrollback_complete: true,
+    }
+}
+
+fn snapshot(
+    runtime_id: &str,
+    panes: Vec<rttx_proto::v3::PaneSnapshot>,
+) -> rttx_proto::v3::RuntimeSnapshot {
+    rttx_proto::v3::RuntimeSnapshot {
+        runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
+        panes,
+        runtime_revision: 1,
+        client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
+    }
+}
+
+/// Full lifecycle: create workspace → bind panes → close pane → verify index.
+#[test]
+fn lifecycle_create_bind_close_keeps_index_consistent() {
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+    let pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
+
+    let mut state = window_state(vec![managed_session(
+        "ws-1",
+        "Workspace",
+        hsplit(term("left"), term("right")),
+        RuntimeEndpoint::Local,
+        WorkspacePolicy::Persistent,
+        None,
+    )]);
+
+    // Before binding: no lookups should resolve.
+    assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, pane_a).is_none());
+
+    // Bind panes via apply_managed_pane_created.
+    state.apply_managed_pane_created("ws-1", "left", runtime_id, pane_a);
+    state.apply_managed_pane_created("ws-1", "right", runtime_id, pane_b);
+
+    // Both panes should resolve.
+    assert_eq!(
+        state.runtime_pane_target(&RuntimeEndpoint::Local, pane_a),
+        Some(("ws-1".into(), "left".into())),
+    );
+    assert_eq!(
+        state.runtime_pane_target(&RuntimeEndpoint::Local, pane_b),
+        Some(("ws-1".into(), "right".into())),
+    );
+
+    // Close one pane.
+    state.apply_managed_pane_closed("ws-1", "left");
+
+    // Closed pane should no longer resolve.
+    assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, pane_a).is_none());
+    // Remaining pane should still resolve.
+    assert_eq!(
+        state.runtime_pane_target(&RuntimeEndpoint::Local, pane_b),
+        Some(("ws-1".into(), "right".into())),
+    );
+}
+
+/// Reconciliation through `workspace_opened` replaces stale bindings and
+/// the index reflects the new state.
+#[test]
+fn reconciliation_updates_index_after_daemon_restart() {
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let old_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+    let new_pane = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+    let mut session = managed_session(
+        "ws-1",
+        "Workspace",
+        term("t1"),
+        RuntimeEndpoint::Local,
+        WorkspacePolicy::Persistent,
+        Some(runtime_id),
+    );
+    session.runtime.bind_runtime_pane("t1", old_pane);
+    let mut state = window_state(vec![session]);
+
+    // Old pane resolves.
+    assert_eq!(
+        state.runtime_pane_target(&RuntimeEndpoint::Local, old_pane),
+        Some(("ws-1".into(), "t1".into())),
+    );
+
+    // Daemon restarts with a new pane ID.
+    state.apply_managed_workspace_opened(
+        "ws-1",
+        runtime_id,
+        &snapshot(runtime_id, vec![pane_snapshot(new_pane, "Shell", "/home")]),
+    );
+
+    // Old pane should no longer resolve.
+    assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, old_pane).is_none());
+    // New pane should resolve.
+    assert_eq!(
+        state.runtime_pane_target(&RuntimeEndpoint::Local, new_pane),
+        Some(("ws-1".into(), "t1".into())),
+    );
+}
+
+/// Multiple workspaces on different endpoints maintain isolated indexes.
+#[test]
+fn multi_endpoint_isolation_through_full_lifecycle() {
+    let local_runtime = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let remote_runtime = "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26";
+    let local_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+    let remote_pane = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
+    let remote_endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
+
+    let mut state = window_state(vec![
+        managed_session(
+            "ws-local",
+            "Local",
+            term("local-t1"),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            None,
+        ),
+        managed_session(
+            "ws-remote",
+            "Remote",
+            term("remote-t1"),
+            remote_endpoint.clone(),
+            WorkspacePolicy::Persistent,
+            None,
+        ),
+    ]);
+
+    // Bind local pane.
+    state.apply_managed_pane_created("ws-local", "local-t1", local_runtime, local_pane);
+    // Bind remote pane.
+    state.apply_managed_pane_created("ws-remote", "remote-t1", remote_runtime, remote_pane);
+
+    // Each pane resolves only on its own endpoint.
+    assert_eq!(
+        state.runtime_pane_target(&RuntimeEndpoint::Local, local_pane),
+        Some(("ws-local".into(), "local-t1".into())),
+    );
+    assert_eq!(
+        state.runtime_pane_target(&remote_endpoint, remote_pane),
+        Some(("ws-remote".into(), "remote-t1".into())),
+    );
+    assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, remote_pane).is_none());
+    assert!(state.runtime_pane_target(&remote_endpoint, local_pane).is_none());
+}

--- a/clients/rttx/tests/workspace_persistence_e2e.rs
+++ b/clients/rttx/tests/workspace_persistence_e2e.rs
@@ -414,6 +414,7 @@ fn full_roundtrip_through_file_persistence() {
         left_sidebar_width: 200,
         right_sidebar_width: 350,
         dismissed_runtime_ids: dismissed,
+        pane_reverse_index: std::collections::HashMap::new(),
     };
 
     let loaded = save_and_load(&state);

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.22',
+  version: '0.4.23',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Fixes #832

`runtime_pane_target()` performed an O(W×P) linear scan of all workspaces and pane bindings for every incoming daemon message (OutputDelta, CwdChanged, TitleChanged, PaneExited). With 50 workspaces × 5 panes, that's 250 comparisons per message at 8000 messages/sec.

Similarly, `mark_session_activity()`, `refresh_workspace_row_status()`, `refresh_sidebar_subtitle()`, and `update_sidebar_row_name()` each performed O(N) linear scans of the sidebar ListBox rows.

### Changes

1. **Pane reverse index on `WindowState`**: Added a `HashMap<String, (String, String)>` mapping `"endpoint_key\0runtime_pane_id"` → `(workspace_id, layout_terminal_uuid)`. The index is:
   - Rebuilt after every binding mutation (`apply_managed_pane_created`, `apply_managed_pane_closed`, `apply_managed_workspace_opened`, `recover_managed_workspaces_from_inventory`, workspace close/detach)
   - Rebuilt on state load from disk
   - Not persisted (`#[serde(skip)]`)
   - Excluded from `PartialEq` (manual impl)
   - Skips pending placeholder bindings (consistent with the old linear scan behavior)

2. **Sidebar row index on Window imp**: Added a `HashMap<String, i32>` mapping workspace UUID → sidebar row index. Rebuilt whenever sidebar rows are added, removed, or reordered.

3. **`runtime_pane_target()`** now does a single HashMap lookup — O(1).

4. **Sidebar lookups** in `mark_session_activity`, `refresh_workspace_row_status`, `refresh_sidebar_subtitle`, `update_sidebar_row_name`, and the rename dialog now use the indexed lookup — O(1).

### How to manually verify

1. Create multiple workspaces (local and remote)
2. Split panes in each workspace
3. Verify terminal output flows correctly to all panes
4. Verify sidebar activity indicators work when switching between workspaces
5. Verify connection status icons update correctly
6. Verify workspace rename updates the sidebar
7. Close workspaces and verify cleanup

### Tests added

8 new unit tests for the reverse index:
- `reverse_index_matches_linear_scan_for_bound_pane` — basic correctness
- `reverse_index_excludes_pending_placeholder_bindings` — pending panes excluded
- `reverse_index_consistent_after_pane_create` — index updated after daemon pane ack
- `reverse_index_consistent_after_pane_close` — index updated after pane removal
- `reverse_index_consistent_after_workspace_opened_reconciliation` — index updated after reconciliation
- `reverse_index_consistent_after_inventory_recovery` — index updated after inventory recovery
- `reverse_index_not_serialized` — index excluded from JSON serialization
- `reverse_index_multi_workspace_multi_endpoint` — cross-endpoint isolation

### Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76`) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` — 732 passed, 0 failed ✅
- `cargo test -p rttx-proto -p rttx-server` — all passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests passed ✅

### Limitations

- The sidebar row index is not used for the `renumber_session_rows` or `remove_sidebar_row` methods since they iterate all rows by design (not on the hot path).
- The pane reverse index is rebuilt from scratch on each mutation rather than incrementally updated. This is simpler and still fast (O(W×P) rebuild happens only on binding changes, not on every message).