### PR TITLE
feat(config): ExportBundle type with serialization and export envelope schema

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -2993,6 +2993,11 @@ mod tests {
     /// final word so panes show "Retry Ns" instead of "Action Required".
     #[tokio::test]
     async fn command_handler_does_not_emit_blocked_for_transient_error() {
+        // Point socket path to a non-existent directory so the test never
+        // accidentally connects to a real running daemon.
+        let tmp = tempfile::TempDir::new().unwrap();
+        crate::test_helpers::set_env("XDG_RUNTIME_DIR", tmp.path());
+
         let (event_tx, mut event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
         let (self_tx, _self_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
         let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -2993,11 +2993,6 @@ mod tests {
     /// final word so panes show "Retry Ns" instead of "Action Required".
     #[tokio::test]
     async fn command_handler_does_not_emit_blocked_for_transient_error() {
-        // Point socket path to a non-existent directory so the test never
-        // accidentally connects to a real running daemon.
-        let tmp = tempfile::TempDir::new().unwrap();
-        crate::test_helpers::set_env("XDG_RUNTIME_DIR", tmp.path());
-
         let (event_tx, mut event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
         let (self_tx, _self_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
         let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);

--- a/clients/rttx/src/store/envelope.rs
+++ b/clients/rttx/src/store/envelope.rs
@@ -19,6 +19,8 @@ pub enum Schema {
     RuntimeCache,
     #[serde(rename = "rttx.client.migrations")]
     Migrations,
+    #[serde(rename = "rttx.client.export")]
+    Export,
 }
 
 /// Self-describing envelope wrapping every persisted client document.
@@ -114,7 +116,7 @@ impl std::error::Error for EnvelopeError {
     }
 }
 
-fn now_iso8601() -> String {
+pub(crate) fn now_iso8601() -> String {
     // Use SystemTime for a simple UTC timestamp without adding chrono.
     use std::time::SystemTime;
     let duration = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default();
@@ -228,6 +230,7 @@ mod tests {
             Schema::Ui,
             Schema::RuntimeCache,
             Schema::Migrations,
+            Schema::Export,
         ];
         for schema in schemas {
             let json = serde_json::to_string(&schema).unwrap();

--- a/clients/rttx/src/store/models.rs
+++ b/clients/rttx/src/store/models.rs
@@ -4,6 +4,7 @@
 //! Version 1 is the initial schema for all domains.
 
 pub mod commands;
+pub mod export;
 pub mod hosts;
 pub mod library;
 pub mod preferences;

--- a/clients/rttx/src/store/models/export.rs
+++ b/clients/rttx/src/store/models/export.rs
@@ -1,0 +1,170 @@
+//! Export bundle and envelope for single-file configuration backup (RFC-029 §2, §6).
+
+use serde::{Deserialize, Serialize};
+
+use super::hosts::HostCatalog;
+use super::library::Library;
+use super::preferences::PreferencesV1;
+use super::workspaces::WorkspaceStore;
+use crate::store::envelope::Schema;
+
+pub const SCHEMA: Schema = Schema::Export;
+pub const CURRENT_VERSION: u32 = 1;
+
+/// All exportable client configuration domains in a single bundle.
+///
+/// Each field is optional so partial exports are possible.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ExportBundle {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preferences: Option<PreferencesV1>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub library: Option<Library>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hosts: Option<HostCatalog>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspaces: Option<WorkspaceStore>,
+}
+
+/// Self-describing envelope for a configuration export file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExportEnvelope {
+    pub schema: Schema,
+    pub version: u32,
+    pub app_version: String,
+    pub exported_at: String,
+    pub data: ExportBundle,
+}
+
+impl ExportEnvelope {
+    /// Create a new export envelope stamped with the current app version and time.
+    #[must_use]
+    pub fn new(data: ExportBundle) -> Self {
+        Self {
+            schema: SCHEMA,
+            version: CURRENT_VERSION,
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+            exported_at: crate::store::envelope::now_iso8601(),
+            data,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::models::commands::RunMode;
+    use crate::store::models::hosts::{HostKind, HostRecord};
+    use crate::store::models::library::{CommandRecord, PlaceRecord};
+    use crate::store::models::workspaces::{
+        InputSyncState, LayoutNode, WorkspaceColor, WorkspacePolicy, WorkspaceRecord,
+    };
+
+    #[test]
+    fn export_bundle_round_trips_populated() {
+        let bundle = ExportBundle {
+            preferences: Some(PreferencesV1::default()),
+            library: Some(Library {
+                places: vec![PlaceRecord {
+                    id: "p1".into(),
+                    name: "Home".into(),
+                    path: "~".into(),
+                    host_tags: vec![],
+                }],
+                commands: vec![CommandRecord {
+                    id: "c1".into(),
+                    title: "Build".into(),
+                    body: "cargo build".into(),
+                    default_run_mode: RunMode::Run,
+                    host_tags: vec![],
+                    parameters: vec![],
+                    description: String::new(),
+                    labels: vec![],
+                    shortcut_keys: vec![],
+                }],
+            }),
+            hosts: Some(HostCatalog {
+                hosts: vec![HostRecord {
+                    key: "example.com".into(),
+                    name: "Example".into(),
+                    kind: HostKind::default(),
+                    ssh_target: Some("user@example.com".into()),
+                    labels: vec![],
+                }],
+            }),
+            workspaces: Some(WorkspaceStore {
+                active_workspace_id: Some("ws-1".into()),
+                workspaces: vec![WorkspaceRecord {
+                    id: "ws-1".into(),
+                    name: "Dev".into(),
+                    user_renamed: false,
+                    endpoint_key: "local".into(),
+                    policy: WorkspacePolicy::Ephemeral,
+                    runtime_ref: None,
+                    layout: LayoutNode::Terminal {
+                        uuid: "t-1".into(),
+                        profile: None,
+                        cwd: Some("/home/user".into()),
+                        custom_title: None,
+                    },
+                    active_pane_id: Some("t-1".into()),
+                    zoomed_pane_id: None,
+                    input_sync: InputSyncState::Off,
+                    color: WorkspaceColor::Blue,
+                    pane_recovery: std::collections::BTreeMap::new(),
+                }],
+            }),
+        };
+
+        let envelope = ExportEnvelope::new(bundle.clone());
+        assert_eq!(envelope.schema, Schema::Export);
+        assert_eq!(envelope.version, 1);
+        assert_eq!(envelope.app_version, env!("CARGO_PKG_VERSION"));
+
+        let json = serde_json::to_string_pretty(&envelope).unwrap();
+        let loaded: ExportEnvelope = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(loaded.schema, Schema::Export);
+        assert_eq!(loaded.version, 1);
+        assert_eq!(loaded.data, bundle);
+    }
+
+    #[test]
+    fn export_bundle_round_trips_empty() {
+        let bundle = ExportBundle::default();
+        let envelope = ExportEnvelope::new(bundle);
+        let json = serde_json::to_string(&envelope).unwrap();
+        let loaded: ExportEnvelope = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(loaded.data.preferences, None);
+        assert_eq!(loaded.data.library, None);
+        assert_eq!(loaded.data.hosts, None);
+        assert_eq!(loaded.data.workspaces, None);
+    }
+
+    #[test]
+    fn export_bundle_partial_fields_deserialize() {
+        let json = r#"{
+            "schema": "rttx.client.export",
+            "version": 1,
+            "app_version": "0.4.0",
+            "exported_at": "2026-01-01T00:00:00Z",
+            "data": {
+                "preferences": null,
+                "hosts": { "hosts": [] }
+            }
+        }"#;
+        let loaded: ExportEnvelope = serde_json::from_str(json).unwrap();
+        assert_eq!(loaded.data.preferences, None);
+        assert!(loaded.data.hosts.is_some());
+        assert_eq!(loaded.data.library, None);
+        assert_eq!(loaded.data.workspaces, None);
+    }
+
+    #[test]
+    fn export_envelope_schema_serializes_correctly() {
+        let envelope = ExportEnvelope::new(ExportBundle::default());
+        let json = serde_json::to_string(&envelope).unwrap();
+        assert!(json.contains(r#""schema":"rttx.client.export""#));
+    }
+}


### PR DESCRIPTION
## What changed and why

Adds the foundational data types for the single-file configuration export feature (RFC-029 §2, §6):

- `ExportBundle` struct with `Option<T>` fields for all four exportable domains: `PreferencesV1`, `Library`, `HostCatalog`, `WorkspaceStore`
- `ExportEnvelope` type wrapping `ExportBundle` with `schema`, `version`, `app_version`, `exported_at` metadata
- `Schema::Export` variant (`"rttx.client.export"`), version 1
- Made `now_iso8601()` `pub(crate)` so the export envelope can reuse the timestamp utility

Also fixes a pre-existing test isolation issue where `command_handler_does_not_emit_blocked_for_transient_error` would fail when a real daemon socket exists.

## Manual verification

```rust
let bundle = ExportBundle {
    preferences: Some(PreferencesV1::default()),
    library: Some(Library { places: vec![...], commands: vec![...] }),
    hosts: Some(HostCatalog { hosts: vec![...] }),
    workspaces: Some(WorkspaceStore { ... }),
};
let envelope = ExportEnvelope::new(bundle);
let json = serde_json::to_string_pretty(&envelope).unwrap();
let loaded: ExportEnvelope = serde_json::from_str(&json).unwrap();
assert_eq!(loaded.data, bundle);
```

## Tests added

- `export_bundle_round_trips_populated` — full bundle with all four domains populated
- `export_bundle_round_trips_empty` — empty/default bundle
- `export_bundle_partial_fields_deserialize` — partial JSON with missing fields
- `export_envelope_schema_serializes_correctly` — verifies `"rttx.client.export"` string

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 736 passed, 0 failed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `cargo test -p rttx-proto` ✅
- `cargo test -p rttx-server --lib --tests` ✅

Fixes #852