### PR TITLE
feat(config): Add Data section to Preferences with export/import/reset buttons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.24"
+version = "0.4.25"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -273,6 +273,25 @@ pub fn run() -> glib::ExitCode {
     });
     app.add_action(&save_state_action);
 
+    // Data management actions (placeholders — logic in subsequent tasks).
+    let export_action = gtk4::gio::SimpleAction::new("export-config", None);
+    export_action.connect_activate(|_, _| {
+        tracing::info!("export-config action triggered (not yet implemented)");
+    });
+    app.add_action(&export_action);
+
+    let import_action = gtk4::gio::SimpleAction::new("import-config", None);
+    import_action.connect_activate(|_, _| {
+        tracing::info!("import-config action triggered (not yet implemented)");
+    });
+    app.add_action(&import_action);
+
+    let reset_action = gtk4::gio::SimpleAction::new("reset-config", None);
+    reset_action.connect_activate(|_, _| {
+        tracing::info!("reset-config action triggered (not yet implemented)");
+    });
+    app.add_action(&reset_action);
+
     app.run()
 }
 

--- a/clients/rttx/src/preferences_window.rs
+++ b/clients/rttx/src/preferences_window.rs
@@ -214,6 +214,8 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
         keyboard_group.add(&row);
     }
 
+    let data_group = build_data_group(&window);
+
     let page = adw::PreferencesPage::new();
     page.set_icon_name(Some("preferences-system-symbolic"));
     page.set_title("General");
@@ -221,6 +223,7 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
     page.add(&terminal_group);
     page.add(&session_group);
     page.add(&keyboard_group);
+    page.add(&data_group);
     window.add(&page);
 
     let parent_window = parent.as_ref().clone();
@@ -278,6 +281,58 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
     });
 
     window.present();
+}
+
+#[must_use]
+pub fn build_data_group(window: &adw::PreferencesWindow) -> adw::PreferencesGroup {
+    let group = adw::PreferencesGroup::new();
+    group.set_title("Data");
+
+    let export_row = adw::ActionRow::builder()
+        .title("Export Configuration\u{2026}")
+        .subtitle("Save all settings, bookmarks, and hosts to a file")
+        .activatable(true)
+        .build();
+    let export_icon = gtk4::Image::from_icon_name("document-save-symbolic");
+    export_icon.set_valign(gtk4::Align::Center);
+    export_row.add_suffix(&export_icon);
+    let window_ref = window.clone();
+    export_row.connect_activated(move |_| {
+        window_ref.activate_action("app.export-config", None).ok();
+    });
+    group.add(&export_row);
+
+    let import_row = adw::ActionRow::builder()
+        .title("Import Configuration\u{2026}")
+        .subtitle("Replace current settings from a previously exported file")
+        .activatable(true)
+        .build();
+    import_row.add_css_class("destructive-action");
+    let import_icon = gtk4::Image::from_icon_name("document-open-symbolic");
+    import_icon.set_valign(gtk4::Align::Center);
+    import_row.add_suffix(&import_icon);
+    let window_ref = window.clone();
+    import_row.connect_activated(move |_| {
+        window_ref.activate_action("app.import-config", None).ok();
+    });
+    group.add(&import_row);
+
+    let reset_row = adw::ActionRow::builder()
+        .title("Reset to Defaults")
+        .subtitle("Restore all preferences to their original values")
+        .activatable(true)
+        .build();
+    reset_row.add_css_class("destructive-action");
+    let reset_icon = gtk4::Image::from_icon_name("edit-clear-all-symbolic");
+    reset_icon.set_valign(gtk4::Align::Center);
+    reset_row.add_suffix(&reset_icon);
+    let window_ref = window.clone();
+    reset_row.connect_activated(move |_| {
+        window_ref.activate_action("app.reset-config", None).ok();
+    });
+    group.add(&reset_row);
+
+    group
 }
 
 fn load_scheme_names() -> Vec<String> {

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -17,6 +17,7 @@ use gtk4::gio::prelude::*;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::ObjectSubclassIsExt;
 use libadwaita as adw;
+use libadwaita::prelude::*;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Once;
@@ -2771,4 +2772,136 @@ fn menu_model_contains_label(model: &gtk4::gio::MenuModel, label: &str) -> bool 
         }
     }
     false
+}
+
+// ── Preferences Data section tests ──────────────────────────────────────────
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn preferences_data_group_has_three_rows() {
+    require_display!();
+
+    let window = adw::PreferencesWindow::new();
+    let group = rttx::preferences_window::build_data_group(&window);
+
+    let mut row_count = 0;
+    let mut child = group.first_child();
+    while let Some(widget) = child {
+        if widget.downcast_ref::<adw::ActionRow>().is_some() {
+            row_count += 1;
+        }
+        // ActionRows are inside a GtkListBox inside the group
+        if let Some(list_box) = widget.downcast_ref::<gtk4::ListBox>() {
+            let mut row_child = list_box.first_child();
+            while let Some(row_widget) = row_child {
+                if row_widget.downcast_ref::<adw::ActionRow>().is_some() {
+                    row_count += 1;
+                }
+                row_child = row_widget.next_sibling();
+            }
+        }
+        child = widget.next_sibling();
+    }
+    assert_eq!(row_count, 3, "Data group should contain exactly 3 action rows");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn preferences_data_group_export_row_has_no_destructive_class() {
+    require_display!();
+
+    let window = adw::PreferencesWindow::new();
+    let group = rttx::preferences_window::build_data_group(&window);
+
+    let first_row = find_action_row_by_title(&group, "Export Configuration\u{2026}");
+    assert!(first_row.is_some(), "Export row should exist");
+    let row = first_row.unwrap();
+    assert!(
+        !row.has_css_class("destructive-action"),
+        "Export row should NOT have destructive-action class"
+    );
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn preferences_data_group_import_row_has_destructive_class() {
+    require_display!();
+
+    let window = adw::PreferencesWindow::new();
+    let group = rttx::preferences_window::build_data_group(&window);
+
+    let row = find_action_row_by_title(&group, "Import Configuration\u{2026}");
+    assert!(row.is_some(), "Import row should exist");
+    assert!(
+        row.unwrap().has_css_class("destructive-action"),
+        "Import row should have destructive-action class"
+    );
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn preferences_data_group_reset_row_has_destructive_class() {
+    require_display!();
+
+    let window = adw::PreferencesWindow::new();
+    let group = rttx::preferences_window::build_data_group(&window);
+
+    let row = find_action_row_by_title(&group, "Reset to Defaults");
+    assert!(row.is_some(), "Reset row should exist");
+    assert!(
+        row.unwrap().has_css_class("destructive-action"),
+        "Reset row should have destructive-action class"
+    );
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn preferences_data_group_rows_have_subtitles() {
+    require_display!();
+
+    let window = adw::PreferencesWindow::new();
+    let group = rttx::preferences_window::build_data_group(&window);
+
+    let export = find_action_row_by_title(&group, "Export Configuration\u{2026}").unwrap();
+    assert!(export.subtitle().is_some_and(|s| !s.is_empty()), "Export row should have a subtitle");
+
+    let import = find_action_row_by_title(&group, "Import Configuration\u{2026}").unwrap();
+    assert!(import.subtitle().is_some_and(|s| !s.is_empty()), "Import row should have a subtitle");
+
+    let reset = find_action_row_by_title(&group, "Reset to Defaults").unwrap();
+    assert!(reset.subtitle().is_some_and(|s| !s.is_empty()), "Reset row should have a subtitle");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn preferences_data_group_title_is_data() {
+    require_display!();
+
+    let window = adw::PreferencesWindow::new();
+    let group = rttx::preferences_window::build_data_group(&window);
+    assert_eq!(group.title().as_str(), "Data");
+}
+
+fn find_action_row_by_title(group: &adw::PreferencesGroup, title: &str) -> Option<adw::ActionRow> {
+    let mut child = group.first_child();
+    while let Some(widget) = child {
+        if let Some(row) = widget.downcast_ref::<adw::ActionRow>()
+            && row.title().as_str() == title
+        {
+            return Some(row.clone());
+        }
+        if let Some(list_box) = widget.downcast_ref::<gtk4::ListBox>() {
+            let mut row_child = list_box.first_child();
+            while let Some(row_widget) = row_child {
+                if let Some(row) = row_widget.downcast_ref::<adw::ActionRow>()
+                    && row.title().as_str() == title
+                {
+                    return Some(row.clone());
+                }
+                row_child = row_widget.next_sibling();
+            }
+        }
+        child = widget.next_sibling();
+    }
+    None
 }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.24',
+  version: '0.4.25',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds a "Data" `PreferencesGroup` at the bottom of the Preferences window with three activatable `ActionRow` buttons:

1. **Export Configuration…** — normal style, triggers `app.export-config`
2. **Import Configuration…** — `destructive-action` CSS class, triggers `app.import-config`
3. **Reset to Defaults** — `destructive-action` CSS class, triggers `app.reset-config`

Each row has a descriptive subtitle. The GActions are registered as placeholders (log-only) — actual export/import/reset logic will be implemented in subsequent tasks per RFC-029.

## Manual verification

1. Run `RTTX_DEV_MODE=1 cargo run -p rttx --no-default-features --features vte-0_76`
2. Open Preferences (Ctrl+,)
3. Scroll to the bottom — "Data" section should be visible with three rows
4. Click each row — check terminal logs for the action trigger messages

## Tests added

6 GTK widget tests in `gtk_widget_tests.rs`:
- `preferences_data_group_has_three_rows`
- `preferences_data_group_export_row_has_no_destructive_class`
- `preferences_data_group_import_row_has_destructive_class`
- `preferences_data_group_reset_row_has_destructive_class`
- `preferences_data_group_rows_have_subtitles`
- `preferences_data_group_title_is_data`

## Tests run

- `cargo test --workspace` — all pass (756 passed, 0 failed)
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all 6 new GTK tests pass via Broadway

Fixes #855