### PR TITLE
feat: implement export configuration file dialog and write action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "bytes",
  "proptest",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.25"
+version = "0.4.26"
 license = "GPL-3.0-or-later"

--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -273,10 +273,13 @@ pub fn run() -> glib::ExitCode {
     });
     app.add_action(&save_state_action);
 
-    // Data management actions (placeholders — logic in subsequent tasks).
+    // Data management actions.
     let export_action = gtk4::gio::SimpleAction::new("export-config", None);
-    export_action.connect_activate(|_, _| {
-        tracing::info!("export-config action triggered (not yet implemented)");
+    let app_ref = app.clone();
+    export_action.connect_activate(move |_, _| {
+        let Some(win) = app_ref.active_window() else { return };
+        let Some(win) = win.downcast_ref::<Window>() else { return };
+        export_config_dialog(win);
     });
     app.add_action(&export_action);
 
@@ -295,9 +298,87 @@ pub fn run() -> glib::ExitCode {
     app.run()
 }
 
+fn today_date_string() -> String {
+    use std::time::SystemTime;
+    let secs = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let days = secs / 86400;
+    let (year, month, day) = crate::store::envelope::days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+fn export_config_dialog(win: &Window) {
+    let filter = gtk4::FileFilter::new();
+    filter.add_suffix("json");
+    filter.set_name(Some("JSON files"));
+
+    let filters = gtk4::gio::ListStore::new::<gtk4::FileFilter>();
+    filters.append(&filter);
+
+    let dialog = gtk4::FileDialog::builder()
+        .title("Export Configuration")
+        .initial_name(format!("rttx-config-{}.json", today_date_string()))
+        .default_filter(&filter)
+        .filters(&filters)
+        .build();
+
+    let win_clone = win.clone();
+    dialog.save(Some(win), gtk4::gio::Cancellable::NONE, move |result| {
+        let file = match result {
+            Ok(f) => f,
+            Err(e) => {
+                if !e.matches(gtk4::gio::IOErrorEnum::Cancelled) {
+                    win_clone.show_toast(&format!("Export failed: {e}"));
+                }
+                return;
+            }
+        };
+
+        let Some(path) = file.path() else {
+            win_clone.show_toast("Export failed: invalid file path");
+            return;
+        };
+
+        let store = crate::store::default_store();
+        let bundle = store.export_bundle();
+        let envelope = crate::store::models::export::ExportEnvelope::new(bundle);
+
+        let json = match serde_json::to_string_pretty(&envelope) {
+            Ok(j) => j,
+            Err(e) => {
+                win_clone.show_toast(&format!("Export failed: {e}"));
+                return;
+            }
+        };
+
+        if let Err(e) = std::fs::write(&path, json) {
+            win_clone.show_toast(&format!("Export failed: {e}"));
+            return;
+        }
+
+        win_clone.show_toast("Configuration exported");
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn today_date_string_matches_yyyy_mm_dd_format() {
+        let date = today_date_string();
+        assert_eq!(date.len(), 10);
+        assert_eq!(&date[4..5], "-");
+        assert_eq!(&date[7..8], "-");
+        let year: u32 = date[..4].parse().unwrap();
+        let month: u32 = date[5..7].parse().unwrap();
+        let day: u32 = date[8..10].parse().unwrap();
+        assert!(year >= 2024);
+        assert!((1..=12).contains(&month));
+        assert!((1..=31).contains(&day));
+    }
 
     #[test]
     fn cleanup_old_logs_keeps_recent_files() {

--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -300,10 +300,8 @@ pub fn run() -> glib::ExitCode {
 
 fn today_date_string() -> String {
     use std::time::SystemTime;
-    let secs = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let secs =
+        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs();
     let days = secs / 86400;
     let (year, month, day) = crate::store::envelope::days_to_ymd(days);
     format!("{year:04}-{month:02}-{day:02}")

--- a/clients/rttx/src/store/envelope.rs
+++ b/clients/rttx/src/store/envelope.rs
@@ -134,7 +134,7 @@ pub(crate) fn now_iso8601() -> String {
     format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
 }
 
-const fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
+pub(crate) const fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
     // Algorithm from Howard Hinnant's `civil_from_days`.
     days += 719_468;
     let era = days / 146_097;

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -4,7 +4,7 @@
 //! `version`, and diagnostic fields. Writes are atomic (temp + fsync + rename).
 //! Loads recover from malformed files by falling back to the last-good backup.
 
-mod envelope;
+pub(crate) mod envelope;
 mod io;
 pub mod models;
 mod paths;

--- a/clients/rttx/tests/export_action.rs
+++ b/clients/rttx/tests/export_action.rs
@@ -1,0 +1,113 @@
+//! Integration tests for the export configuration action (issue #856).
+//!
+//! These tests verify the export-to-file flow: serialization, file writing,
+//! and round-trip validation through `parse_export_file`.
+
+use rttx::store::models::export::{ExportBundle, ExportEnvelope, parse_export_file};
+use rttx::store::models::preferences::PreferencesV1;
+
+#[test]
+fn export_envelope_serializes_to_valid_json_file() {
+    let bundle = ExportBundle {
+        preferences: Some(PreferencesV1::default()),
+        library: None,
+        hosts: None,
+        workspaces: None,
+    };
+    let envelope = ExportEnvelope::new(bundle);
+    let json = serde_json::to_string_pretty(&envelope).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("rttx-config-2026-05-08.json");
+    std::fs::write(&path, &json).unwrap();
+
+    let contents = std::fs::read_to_string(&path).unwrap();
+    let parsed = parse_export_file(&contents).unwrap();
+    assert!(parsed.preferences.is_some());
+}
+
+#[test]
+fn export_file_contains_schema_and_version_fields() {
+    let envelope = ExportEnvelope::new(ExportBundle::default());
+    let json = serde_json::to_string_pretty(&envelope).unwrap();
+
+    assert!(json.contains("\"schema\": \"rttx.client.export\""));
+    assert!(json.contains("\"version\": 1"));
+    assert!(json.contains("\"app_version\""));
+    assert!(json.contains("\"exported_at\""));
+}
+
+#[test]
+fn export_default_filename_contains_date() {
+    let filename = format!("rttx-config-{}.json", "2026-05-08");
+    assert!(filename.starts_with("rttx-config-"));
+    assert!(std::path::Path::new(&filename)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("json")));
+    assert_eq!(filename.len(), "rttx-config-YYYY-MM-DD.json".len());
+}
+
+#[test]
+fn export_write_failure_on_readonly_path() {
+    let bundle = ExportBundle::default();
+    let envelope = ExportEnvelope::new(bundle);
+    let json = serde_json::to_string_pretty(&envelope).unwrap();
+
+    let result = std::fs::write("/proc/nonexistent/export.json", &json);
+    assert!(result.is_err());
+}
+
+#[test]
+fn export_full_bundle_round_trips_through_file() {
+    use rttx::store::models::hosts::{HostCatalog, HostKind, HostRecord};
+    use rttx::store::models::library::{CommandRecord, Library, PlaceRecord};
+    use rttx::store::models::commands::RunMode;
+
+    let bundle = ExportBundle {
+        preferences: Some(PreferencesV1::default()),
+        library: Some(Library {
+            places: vec![PlaceRecord {
+                id: "p1".into(),
+                name: "Projects".into(),
+                path: "~/projects".into(),
+                host_tags: vec![],
+            }],
+            commands: vec![CommandRecord {
+                id: "c1".into(),
+                title: "Test".into(),
+                body: "cargo test".into(),
+                default_run_mode: RunMode::Run,
+                host_tags: vec![],
+                parameters: vec![],
+                description: String::new(),
+                labels: vec![],
+                shortcut_keys: vec![],
+            }],
+        }),
+        hosts: Some(HostCatalog {
+            hosts: vec![HostRecord {
+                key: "dev-server".into(),
+                name: "Dev Server".into(),
+                kind: HostKind::default(),
+                ssh_target: Some("user@dev.example.com".into()),
+                labels: vec![],
+            }],
+        }),
+        workspaces: None,
+    };
+
+    let envelope = ExportEnvelope::new(bundle.clone());
+    let json = serde_json::to_string_pretty(&envelope).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("full-export.json");
+    std::fs::write(&path, &json).unwrap();
+
+    let contents = std::fs::read_to_string(&path).unwrap();
+    let parsed = parse_export_file(&contents).unwrap();
+
+    assert_eq!(parsed.preferences, bundle.preferences);
+    assert_eq!(parsed.library, bundle.library);
+    assert_eq!(parsed.hosts, bundle.hosts);
+    assert_eq!(parsed.workspaces, bundle.workspaces);
+}

--- a/clients/rttx/tests/export_action.rs
+++ b/clients/rttx/tests/export_action.rs
@@ -41,9 +41,11 @@ fn export_file_contains_schema_and_version_fields() {
 fn export_default_filename_contains_date() {
     let filename = format!("rttx-config-{}.json", "2026-05-08");
     assert!(filename.starts_with("rttx-config-"));
-    assert!(std::path::Path::new(&filename)
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("json")));
+    assert!(
+        std::path::Path::new(&filename)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+    );
     assert_eq!(filename.len(), "rttx-config-YYYY-MM-DD.json".len());
 }
 
@@ -59,9 +61,9 @@ fn export_write_failure_on_readonly_path() {
 
 #[test]
 fn export_full_bundle_round_trips_through_file() {
+    use rttx::store::models::commands::RunMode;
     use rttx::store::models::hosts::{HostCatalog, HostKind, HostRecord};
     use rttx::store::models::library::{CommandRecord, Library, PlaceRecord};
-    use rttx::store::models::commands::RunMode;
 
     let bundle = ExportBundle {
         preferences: Some(PreferencesV1::default()),

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.25',
+  version: '0.4.26',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Implements issue #856: wires the "Export Configuration..." button in the Preferences Data section to a working export flow.

**Behavior:**
1. Clicking "Export Configuration..." opens a `gtk4::FileDialog` save picker
2. Default filename: `rttx-config-YYYY-MM-DD.json`
3. File filter: `*.json` (JSON files)
4. On confirm: calls `ClientStore::export_bundle()`, wraps in `ExportEnvelope`, serializes to pretty JSON, writes to chosen path
5. On success: shows toast "Configuration exported"
6. On I/O error or serialization error: shows error toast
7. On cancel: silently returns (no toast)

## Manual verification

1. Open Preferences → Data section
2. Click "Export Configuration..."
3. Verify file dialog opens with default name `rttx-config-2026-05-08.json`
4. Save to a location → verify toast "Configuration exported" appears
5. Open the saved file → verify valid JSON with schema `rttx.client.export`
6. Cancel the dialog → verify no toast or error

## Tests added

**Unit tests:**
- `application::tests::today_date_string_matches_yyyy_mm_dd_format` — validates date format

**Integration tests** (`tests/export_action.rs`):
- `export_envelope_serializes_to_valid_json_file` — write + round-trip
- `export_file_contains_schema_and_version_fields` — envelope structure
- `export_default_filename_contains_date` — filename pattern
- `export_write_failure_on_readonly_path` — I/O error path
- `export_full_bundle_round_trips_through_file` — full bundle with all domains

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (all 12 unit + integration tests pass)
- `cargo test -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass including data group tests)

Fixes #856