### PR TITLE
feat(config): implement import configuration action

### DIFF
--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -1,6 +1,7 @@
 use gtk4::glib;
 use gtk4::prelude::*;
 use libadwaita as adw;
+use libadwaita::prelude::*;
 
 use crate::config;
 use crate::window::Window;
@@ -284,8 +285,11 @@ pub fn run() -> glib::ExitCode {
     app.add_action(&export_action);
 
     let import_action = gtk4::gio::SimpleAction::new("import-config", None);
-    import_action.connect_activate(|_, _| {
-        tracing::info!("import-config action triggered (not yet implemented)");
+    let app_ref = app.clone();
+    import_action.connect_activate(move |_, _| {
+        let Some(win) = app_ref.active_window() else { return };
+        let Some(win) = win.downcast_ref::<Window>() else { return };
+        import_config_confirm(win);
     });
     app.add_action(&import_action);
 
@@ -358,6 +362,99 @@ fn export_config_dialog(win: &Window) {
 
         win_clone.show_toast("Configuration exported");
     });
+}
+
+fn import_config_confirm(win: &Window) {
+    let dialog = adw::AlertDialog::builder()
+        .heading("Replace Configuration?")
+        .body(
+            "This will replace all current settings, bookmarks, hosts, and workspaces \
+             with the contents of the imported file. This cannot be undone.",
+        )
+        .close_response("cancel")
+        .default_response("cancel")
+        .build();
+    dialog.add_response("cancel", "Cancel");
+    dialog.add_response("replace", "Replace");
+    dialog.set_response_appearance("replace", adw::ResponseAppearance::Destructive);
+
+    let win_clone = win.clone();
+    dialog.connect_response(None, move |_, response| {
+        if response == "replace" {
+            import_config_file_dialog(&win_clone);
+        }
+    });
+    dialog.present(Some(win));
+}
+
+fn import_config_file_dialog(win: &Window) {
+    let filter = gtk4::FileFilter::new();
+    filter.add_suffix("json");
+    filter.set_name(Some("JSON files"));
+
+    let filters = gtk4::gio::ListStore::new::<gtk4::FileFilter>();
+    filters.append(&filter);
+
+    let dialog = gtk4::FileDialog::builder()
+        .title("Import Configuration")
+        .default_filter(&filter)
+        .filters(&filters)
+        .build();
+
+    let win_clone = win.clone();
+    dialog.open(Some(win), gtk4::gio::Cancellable::NONE, move |result| {
+        let file = match result {
+            Ok(f) => f,
+            Err(e) => {
+                if !e.matches(gtk4::gio::IOErrorEnum::Cancelled) {
+                    show_error_dialog(&win_clone, &format!("Import failed: {e}"));
+                }
+                return;
+            }
+        };
+
+        let Some(path) = file.path() else {
+            show_error_dialog(&win_clone, "Import failed: invalid file path");
+            return;
+        };
+
+        let json = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                show_error_dialog(&win_clone, &format!("Could not read the file: {e}"));
+                return;
+            }
+        };
+
+        let bundle = match crate::store::models::export::parse_export_file(&json) {
+            Ok(b) => b,
+            Err(e) => {
+                show_error_dialog(&win_clone, &e.to_string());
+                return;
+            }
+        };
+
+        if let Err(e) = crate::store::default_store().import_bundle(&bundle) {
+            show_error_dialog(&win_clone, &format!("Import failed: {e}"));
+            return;
+        }
+
+        win_clone.show_toast("Configuration imported. Please restart rttx.");
+        glib::timeout_add_seconds_local_once(2, move || {
+            std::process::exit(0);
+        });
+    });
+}
+
+fn show_error_dialog(win: &Window, message: &str) {
+    let dialog = adw::AlertDialog::builder()
+        .heading("Import Error")
+        .body(message)
+        .close_response("ok")
+        .default_response("ok")
+        .build();
+    dialog.add_response("ok", "OK");
+    dialog.present(Some(win));
 }
 
 #[cfg(test)]

--- a/clients/rttx/tests/import_action.rs
+++ b/clients/rttx/tests/import_action.rs
@@ -1,0 +1,115 @@
+//! Integration tests for the import configuration action (issue #857).
+//!
+//! These tests verify the import flow: file reading, validation, store write,
+//! and error handling. The GTK dialog interactions (confirmation, file picker)
+//! cannot be tested without a display, but the underlying logic is exercised.
+
+use rttx::store::models::export::{ExportBundle, ExportEnvelope, parse_export_file};
+use rttx::store::models::preferences::PreferencesV1;
+use rttx::store::{ClientStore, StorePaths};
+
+fn test_store() -> (tempfile::TempDir, ClientStore) {
+    let dir = tempfile::tempdir().unwrap();
+    let config_dir = dir.path().join("config");
+    let state_dir = dir.path().join("state");
+    let cache_dir = dir.path().join("cache");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    let paths = StorePaths::new(config_dir, state_dir, cache_dir);
+    let store = ClientStore::new(paths);
+    (dir, store)
+}
+
+#[test]
+fn import_flow_reads_file_validates_and_writes_to_store() {
+    let (dir, store) = test_store();
+
+    let bundle = ExportBundle {
+        preferences: Some(PreferencesV1 { font: "Monospace 14".into(), ..Default::default() }),
+        library: None,
+        hosts: None,
+        workspaces: None,
+    };
+    let envelope = ExportEnvelope::new(bundle);
+    let json = serde_json::to_string_pretty(&envelope).unwrap();
+
+    let file_path = dir.path().join("import.json");
+    std::fs::write(&file_path, &json).unwrap();
+
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    let parsed = parse_export_file(&contents).unwrap();
+    store.import_bundle(&parsed).unwrap();
+
+    let loaded = store.load_preferences().into_value().unwrap_or_default();
+    assert_eq!(loaded.font, "Monospace 14");
+}
+
+#[test]
+fn import_flow_rejects_invalid_file_content() {
+    let result = parse_export_file("this is not json");
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("not valid JSON"));
+}
+
+#[test]
+fn import_flow_rejects_wrong_schema_file() {
+    let json = r#"{"schema": "something.else", "version": 1, "data": {}}"#;
+    let result = parse_export_file(json);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("not an rttx configuration export"));
+}
+
+#[test]
+fn import_flow_rejects_unsupported_version() {
+    let json = r#"{
+        "schema": "rttx.client.export",
+        "version": 99,
+        "app_version": "9.0.0",
+        "exported_at": "2026-01-01T00:00:00Z",
+        "data": {}
+    }"#;
+    let result = parse_export_file(json);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("newer version"));
+}
+
+#[test]
+fn import_flow_handles_io_error_on_missing_file() {
+    let result = std::fs::read_to_string("/nonexistent/path/config.json");
+    assert!(result.is_err());
+}
+
+#[test]
+fn import_flow_overwrites_existing_preferences() {
+    let (_dir, store) = test_store();
+
+    let initial_bundle = ExportBundle {
+        preferences: Some(PreferencesV1 { font: "Initial Font 12".into(), ..Default::default() }),
+        library: None,
+        hosts: None,
+        workspaces: None,
+    };
+    store.import_bundle(&initial_bundle).unwrap();
+
+    let loaded = store.load_preferences().into_value().unwrap_or_default();
+    assert_eq!(loaded.font, "Initial Font 12");
+
+    let bundle = ExportBundle {
+        preferences: Some(PreferencesV1 { font: "Imported Font 16".into(), ..Default::default() }),
+        library: None,
+        hosts: None,
+        workspaces: None,
+    };
+    let envelope = ExportEnvelope::new(bundle);
+    let json = serde_json::to_string_pretty(&envelope).unwrap();
+
+    let parsed = parse_export_file(&json).unwrap();
+    store.import_bundle(&parsed).unwrap();
+
+    let loaded = store.load_preferences().into_value().unwrap_or_default();
+    assert_eq!(loaded.font, "Imported Font 16");
+}


### PR DESCRIPTION
## What changed and why

Implements the import configuration action (issue #857). When the user clicks "Import Configuration..." in Preferences > Data:

1. A confirmation dialog warns that this is a destructive operation
2. On confirm: a file picker opens (filtered to *.json)
3. The selected file is read and validated via `parse_export_file()`
4. On validation error: an error dialog shows the user-facing message
5. On valid file: `ClientStore::import_bundle()` writes the configuration
6. On success: a toast says "Configuration imported. Please restart rttx." and the app exits after 2 seconds
7. On I/O error: an error dialog is shown

## Manual verification

1. Open Preferences > Data section
2. Click "Import Configuration..."
3. Verify confirmation dialog appears with "Replace Configuration?" heading
4. Click Cancel → nothing happens
5. Click Replace → file picker opens
6. Select a valid export file → config is imported, toast shown, app exits
7. Select an invalid file → error dialog with appropriate message

## Tests added

- `tests/import_action.rs` — 6 integration tests:
  - `import_flow_reads_file_validates_and_writes_to_store`
  - `import_flow_rejects_invalid_file_content`
  - `import_flow_rejects_wrong_schema_file`
  - `import_flow_rejects_unsupported_version`
  - `import_flow_handles_io_error_on_missing_file`
  - `import_flow_overwrites_existing_preferences`

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (12 passed)
- `cargo test -p rttx --no-default-features --features vte-0_76 --test import_action` ✅ (6 passed)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all import_action tests confirmed passing)

## Dependencies

All dependencies are resolved:
- #853 (ClientStore::import_bundle) — closed
- #854 (parse_export_file validation) — closed
- #855 (UI buttons) — closed

Fixes #857