### PR TITLE
build: add cargo-deb and cargo-generate-rpm metadata

### DIFF
--- a/clients/rttx/Cargo.toml
+++ b/clients/rttx/Cargo.toml
@@ -54,6 +54,34 @@ bytes = "1"
 tokio = { version = "1", features = ["net", "io-util", "sync", "rt", "rt-multi-thread", "macros", "process", "time"] }
 thiserror = "2"
 
+[package.metadata.deb]
+maintainer = "Illya Yalovyy <yalovoy@gmail.com>"
+copyright = "2024-2026, Illya Yalovyy"
+license-file = ["../../LICENSE", "0"]
+extended-description = "A tiling terminal emulator for GNOME built with Rust, GTK4, and Libadwaita. Features split-screen terminals, workspace management, session persistence, and input synchronization."
+depends = "$auto"
+section = "utils"
+priority = "optional"
+assets = [
+    ["../../target/release/rttx", "usr/bin/", "755"],
+    ["data/io.github.IllyaYalovyy.rttx.desktop", "usr/share/applications/", "644"],
+    ["data/io.github.IllyaYalovyy.rttx.metainfo.xml", "usr/share/metainfo/", "644"],
+    ["data/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg", "usr/share/icons/hicolor/scalable/apps/", "644"],
+]
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "../../target/release/rttx", dest = "/usr/bin/rttx", mode = "755" },
+    { source = "data/io.github.IllyaYalovyy.rttx.desktop", dest = "/usr/share/applications/io.github.IllyaYalovyy.rttx.desktop", mode = "644" },
+    { source = "data/io.github.IllyaYalovyy.rttx.metainfo.xml", dest = "/usr/share/metainfo/io.github.IllyaYalovyy.rttx.metainfo.xml", mode = "644" },
+    { source = "data/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg", dest = "/usr/share/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg", mode = "644" },
+]
+
+[package.metadata.generate-rpm.requires]
+gtk4 = ">= 4.14"
+libadwaita = ">= 1.5"
+vte291-gtk4 = ">= 0.76"
+
 [dev-dependencies]
 tempfile = "3"
 pretty_assertions = "1"

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -1,5 +1,5 @@
 Name:           rttx
-Version:        0.4.1
+Version:        0.4.26
 Release:        1%{?dist}
 Summary:        A tiling terminal emulator for GNOME
 


### PR DESCRIPTION
## What changed and why

Adds `[package.metadata.deb]` and `[package.metadata.generate-rpm]` sections to `clients/rttx/Cargo.toml`, enabling the existing release pipeline (`.github/workflows/release.yml`) to produce DEB and RPM artifacts when a version tag is pushed.

Also syncs `packaging/rttx/rttx.spec` version to 0.4.26 (used by COPR builds).

Fixes #107, Fixes #108.

## Manual verification

1. `cargo metadata --format-version 1 --no-deps` shows both `deb` and `generate-rpm` metadata sections correctly parsed.
2. All workspace tests pass.
3. Clippy and format checks pass.
4. Version consistency check passes.

## Tests added

None — this is a build metadata change with no source code modifications. The existing CI quality gate and Flatpak manifest validation job cover the packaging paths.

## Tests run

- `cargo build --workspace --no-default-features --features vte-0_76` ✅
- `cargo test --workspace --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `bash .github/scripts/check-version-consistency.sh` ✅
- `cargo fmt --check` ✅

## Limitations

- Actual DEB/RPM generation cannot be tested locally without `cargo-deb` and `cargo-generate-rpm` installed. The metadata format is validated by `cargo metadata` parsing.
- COPR submission requires repository secrets (`COPR_LOGIN`, `COPR_USERNAME`, `COPR_TOKEN`) to be configured separately.