### PR TITLE
build: complete DEB and RPM packaging with daemon binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,11 @@ jobs:
       - name: Install cargo-deb
         run: cargo install cargo-deb
 
-      - name: Build release binary
-        run: cargo build --release -p rttx
+      - name: Build release binaries
+        run: cargo build --release -p rttx -p rttx-server
+
+      - name: Strip binaries
+        run: strip target/release/rttx target/release/rttx-server
 
       - name: Build DEB
         working-directory: clients/rttx
@@ -130,11 +133,11 @@ jobs:
       - name: Install cargo-generate-rpm
         run: cargo install cargo-generate-rpm
 
-      - name: Build release binary
-        run: cargo build --release -p rttx
+      - name: Build release binaries
+        run: cargo build --release -p rttx -p rttx-server
 
-      - name: Strip binary
-        run: strip target/release/rttx
+      - name: Strip binaries
+        run: strip target/release/rttx target/release/rttx-server
 
       - name: Build RPM
         working-directory: clients/rttx

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ sudo dnf install rttx
 
 Launch from the app grid or run `rttx` in a terminal. To remove: `sudo dnf remove rttx`.
 
+### Debian / Ubuntu (DEB)
+
+Download the `.deb` package from the
+[latest GitHub release](https://github.com/IllyaYalovyy/rttx/releases/latest):
+
+```bash
+sudo apt install ./rttx_<version>_amd64.deb
+```
+
+The package includes both the GUI (`rttx`) and the daemon (`rttx-server`). Launch from the app
+grid or run `rttx` in a terminal. To remove: `sudo apt remove rttx`.
+
 ### Flatpak
 
 Flatpak works on any Linux distribution. The bundle includes everything rttx needs.

--- a/clients/rttx/Cargo.toml
+++ b/clients/rttx/Cargo.toml
@@ -64,6 +64,7 @@ section = "utils"
 priority = "optional"
 assets = [
     ["../../target/release/rttx", "usr/bin/", "755"],
+    ["../../target/release/rttx-server", "usr/bin/", "755"],
     ["data/io.github.IllyaYalovyy.rttx.desktop", "usr/share/applications/", "644"],
     ["data/io.github.IllyaYalovyy.rttx.metainfo.xml", "usr/share/metainfo/", "644"],
     ["data/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg", "usr/share/icons/hicolor/scalable/apps/", "644"],
@@ -72,6 +73,7 @@ assets = [
 [package.metadata.generate-rpm]
 assets = [
     { source = "../../target/release/rttx", dest = "/usr/bin/rttx", mode = "755" },
+    { source = "../../target/release/rttx-server", dest = "/usr/bin/rttx-server", mode = "755" },
     { source = "data/io.github.IllyaYalovyy.rttx.desktop", dest = "/usr/share/applications/io.github.IllyaYalovyy.rttx.desktop", mode = "644" },
     { source = "data/io.github.IllyaYalovyy.rttx.metainfo.xml", dest = "/usr/share/metainfo/io.github.IllyaYalovyy.rttx.metainfo.xml", mode = "644" },
     { source = "data/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg", dest = "/usr/share/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg", mode = "644" },

--- a/packaging/rttx/deb/build-deb.sh
+++ b/packaging/rttx/deb/build-deb.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a .deb package for rttx (client + daemon).
+# Requires: cargo-deb (`cargo install cargo-deb`)
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${repo_root}"
+
+echo "Building release binaries..."
+cargo build --release -p rttx -p rttx-server
+
+echo "Stripping binaries..."
+strip target/release/rttx target/release/rttx-server
+
+echo "Building DEB package..."
+cargo deb -p rttx --no-build
+
+deb_file=$(ls -1 target/debian/*.deb 2>/dev/null | head -1)
+if [[ -n "${deb_file}" ]]; then
+    echo "DEB package built: ${deb_file}"
+    dpkg-deb --info "${deb_file}"
+else
+    echo "ERROR: No .deb file found in target/debian/" >&2
+    exit 1
+fi

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -39,6 +39,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/io.github
 %license LICENSE
 %doc clients/rttx/README.md
 %{_bindir}/rttx
+%{_bindir}/rttx-server
 %{_datadir}/applications/io.github.IllyaYalovyy.rttx.desktop
 %{_datadir}/metainfo/io.github.IllyaYalovyy.rttx.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg


### PR DESCRIPTION
## What changed and why

Completes issue #87 by including `rttx-server` in the DEB and RPM packages and adding a local build script.

Previously, the DEB/RPM metadata (added in #873) only packaged the `rttx` GUI binary. Since the daemon must be on `$PATH` for workspace functionality, users installing from a `.deb` or `.rpm` would get a broken experience without manually building and installing `rttx-server` separately.

## Changes

- **`clients/rttx/Cargo.toml`**: Add `rttx-server` to both `[package.metadata.deb]` and `[package.metadata.generate-rpm]` asset lists
- **`packaging/rttx/rttx.spec`**: Add `rttx-server` to `%files` section
- **`.github/workflows/release.yml`**: Build both `rttx` and `rttx-server` before DEB/RPM packaging; add strip step for DEB
- **`packaging/rttx/deb/build-deb.sh`**: New local build script (analogous to `flatpak/build-bundle.sh`)
- **`README.md`**: Add Debian/Ubuntu installation section

## Manual verification

1. Verified `cargo build -p rttx -p rttx-server` succeeds
2. Verified the asset paths in Cargo.toml point to correct binary locations
3. Verified the release workflow builds both binaries before packaging
4. Verified the build script is executable and follows the same pattern as `build-bundle.sh`

## Tests

This is a packaging/CI change with no source code modifications. All existing tests pass:
- `cargo test -p rttx-proto` — 9 passed
- `cargo test -p rttx-server` — all passed
- `cargo test -p rttx` — 12 passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed

## Limitations

- The DEB uses `$auto` for dependencies which relies on `dpkg-shlibdeps` at build time — this works correctly in the CI Ubuntu environment
- No APT repository is set up yet (users download from GitHub Releases)

Fixes #87