### PR TITLE
build: add local RPM build script

### DIFF
--- a/packaging/rttx/rpm/build-rpm.sh
+++ b/packaging/rttx/rpm/build-rpm.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build an .rpm package for rttx (client + daemon).
+# Requires: cargo-generate-rpm (`cargo install cargo-generate-rpm`)
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${repo_root}"
+
+echo "Building release binaries..."
+cargo build --release -p rttx -p rttx-server
+
+echo "Stripping binaries..."
+strip target/release/rttx target/release/rttx-server
+
+echo "Building RPM package..."
+cargo generate-rpm -p clients/rttx
+
+rpm_file=$(find target/generate-rpm -name '*.rpm' 2>/dev/null | head -1)
+if [[ -n "${rpm_file}" ]]; then
+    echo "RPM package built: ${rpm_file}"
+    rpm -qip "${rpm_file}" 2>/dev/null || true
+else
+    echo "ERROR: No .rpm file found in target/generate-rpm/" >&2
+    exit 1
+fi


### PR DESCRIPTION
## What changed and why

Add `packaging/rttx/rpm/build-rpm.sh` — a local RPM build script for developers, matching the existing `packaging/rttx/deb/build-deb.sh`.

The RPM repository (Fedora COPR) is already fully functional via the release workflow's `copr-submit` job. This script completes the local developer experience for RPM packaging.

Fixes #86

## Manual verification

```bash
# Requires: cargo install cargo-generate-rpm
bash packaging/rttx/rpm/build-rpm.sh
```

## Tests added

No code changes — this is a shell script for packaging. Verified:
- Script is executable
- Workspace builds cleanly
- All existing tests pass

## Tests run

- `cargo build --workspace` ✓
- `cargo test --workspace` ✓
- `bash .github/scripts/run-clippy.sh` ✓
- `bash .github/scripts/run-quality-tests.sh` ✓

## Context

Issue #86 asked for an RPM repository. The COPR submission workflow (added in #873/#875) already publishes RPMs to `illya/rttx` on Fedora COPR, and the README documents installation via `dnf copr enable illya/rttx`. This PR adds the missing local build convenience script.