### PR TITLE
feat(cli): add `rttx-server config` command

### DIFF
--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -40,6 +40,8 @@ enum Command {
     Logs,
     /// Show runtime memory diagnostics
     Diagnostics,
+    /// Show resolved paths and configuration
+    Config,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -56,6 +58,10 @@ fn main() -> anyhow::Result<()> {
             Ok(())
         }
         Command::Diagnostics => diagnostics(),
+        Command::Config => {
+            config();
+            Ok(())
+        }
     }
 }
 
@@ -165,6 +171,24 @@ fn logs() {
     let os = UnixOs;
     let log_dir = os.cache_dir();
     println!("{}", log_dir.display());
+}
+
+fn config() {
+    let dev_mode = rttx_server::os::unix::dev_mode_enabled();
+    let os = UnixOs;
+
+    let mode = if dev_mode { "development" } else { "production" };
+    let socket = os.runtime_dir().join("rttx-server.sock");
+    let state = os.state_dir();
+    let scrollback = os.state_dir().join("runtimes");
+    let log_dir = os.cache_dir();
+
+    println!("Mode: {mode}");
+    println!("Socket: {}", socket.display());
+    println!("State: {}", state.display());
+    println!("Scrollback: {}", scrollback.display());
+    println!("Logs: {}", log_dir.display());
+    println!("Protocol version: {}", rttx_proto::PROTOCOL_VERSION);
 }
 
 fn diagnostics() -> anyhow::Result<()> {
@@ -567,6 +591,12 @@ mod tests {
     fn cli_parses_diagnostics_command() {
         let cli = Cli::try_parse_from(["rttx-server", "diagnostics"]).unwrap();
         assert!(matches!(cli.command, Some(Command::Diagnostics)));
+    }
+
+    #[test]
+    fn cli_parses_config_command() {
+        let cli = Cli::try_parse_from(["rttx-server", "config"]).unwrap();
+        assert!(matches!(cli.command, Some(Command::Config)));
     }
 
     #[test]

--- a/services/rttx-server/tests/config_command.rs
+++ b/services/rttx-server/tests/config_command.rs
@@ -1,0 +1,45 @@
+//! Integration test for `rttx-server config` subcommand.
+
+use std::process::Command;
+
+fn server_binary() -> std::path::PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // remove test binary name
+    path.pop(); // remove `deps/`
+    path.push("rttx-server");
+    path
+}
+
+#[test]
+fn config_prints_expected_fields() {
+    let output = Command::new(server_binary())
+        .arg("config")
+        .env("RTTX_DEV_MODE", "")
+        .output()
+        .expect("failed to run rttx-server config");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains("Mode: production"));
+    assert!(stdout.contains("Socket:"));
+    assert!(stdout.contains("State:"));
+    assert!(stdout.contains("Scrollback:"));
+    assert!(stdout.contains("Logs:"));
+    assert!(stdout.contains("Protocol version:"));
+}
+
+#[test]
+fn config_dev_mode_shows_development() {
+    let output = Command::new(server_binary())
+        .arg("config")
+        .env("RTTX_DEV_MODE", "1")
+        .output()
+        .expect("failed to run rttx-server config");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains("Mode: development"));
+    assert!(stdout.contains("rttx-server-devel"));
+}


### PR DESCRIPTION
## What changed and why

Adds a new `rttx-server config` subcommand that prints all resolved paths and configuration, helping users troubleshoot path resolution issues — especially when running in dev mode.

Output example:
```
Mode: production
Socket: /run/user/1000/rttx-server/v1/rttx-server.sock
State: /home/user/.local/state/rttx/daemon
Scrollback: /home/user/.local/state/rttx/daemon/runtimes
Logs: /home/user/.cache/rttx-server
Protocol version: 2
```

## Manual verification

```bash
cargo build -p rttx-server
./target/debug/rttx-server config
RTTX_DEV_MODE=1 ./target/debug/rttx-server config
./target/debug/rttx-server --help  # shows config in command list
```

## Tests added

- `cli_parses_config_command` — verifies clap parses the new subcommand

## Tests run

- `cargo build --workspace --no-default-features --features vte-0_76` ✅
- `cargo test --workspace --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #275