### PR TITLE
feat(cli): add `rttx-server kill <runtime-id>` command

### DIFF
--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -34,6 +34,11 @@ enum Command {
     Status,
     /// Remove all runtimes with no connected clients
     Clean,
+    /// Terminate a specific runtime by ID
+    Kill {
+        /// Runtime ID (UUID) to terminate
+        runtime_id: String,
+    },
     /// Serve one client over stdin/stdout (for SSH)
     AttachStdio,
     /// Show the path to the daemon log file
@@ -52,6 +57,7 @@ fn main() -> anyhow::Result<()> {
         Command::Stop => stop(),
         Command::Status => status(),
         Command::Clean => clean(),
+        Command::Kill { runtime_id } => kill(&runtime_id),
         Command::AttachStdio => attach_stdio(),
         Command::Logs => {
             logs();
@@ -555,6 +561,85 @@ fn clean() -> anyhow::Result<()> {
     })
 }
 
+fn kill(runtime_id_str: &str) -> anyhow::Result<()> {
+    use bytes::BytesMut;
+    use rttx_proto::{decode_frame, encode_frame};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let runtime_id: uuid::Uuid = runtime_id_str
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid runtime ID: not a valid UUID"))?;
+
+    let os = UnixOs;
+    let socket_path = os.runtime_dir().join("rttx-server.sock");
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        if !ipc::is_server_running(&socket_path).await {
+            eprintln!("Daemon is not running");
+            std::process::exit(1);
+        }
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path).await?;
+        let mut buf = BytesMut::new();
+        let mut read_buf = BytesMut::with_capacity(8192);
+
+        // Hello handshake.
+        let hello = proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::Hello(proto::Hello {
+                protocol_version: rttx_proto::PROTOCOL_VERSION,
+                client_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
+            })),
+        };
+        encode_frame(&hello, &mut buf)?;
+        stream.write_all(&buf).await?;
+        stream.flush().await?;
+
+        loop {
+            stream.read_buf(&mut read_buf).await?;
+            if decode_frame::<proto::ServerMessage>(&mut read_buf).is_ok() {
+                break;
+            }
+        }
+
+        // TerminateRuntime.
+        buf.clear();
+        encode_frame(
+            &proto::ClientMessage {
+                msg: Some(proto::client_message::Msg::TerminateRuntime(proto::TerminateRuntime {
+                    runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
+                })),
+            },
+            &mut buf,
+        )?;
+        stream.write_all(&buf).await?;
+        stream.flush().await?;
+
+        // Wait for RuntimeTerminated or Error.
+        let resp: proto::ServerMessage = loop {
+            stream.read_buf(&mut read_buf).await?;
+            match decode_frame::<proto::ServerMessage>(&mut read_buf) {
+                Ok(msg) => break msg,
+                Err(rttx_proto::FrameError::Incomplete) => {}
+                Err(e) => anyhow::bail!("decode error: {e}"),
+            }
+        };
+
+        match resp.msg {
+            Some(proto::server_message::Msg::RuntimeTerminated(_)) => {
+                println!("Runtime terminated.");
+            }
+            Some(proto::server_message::Msg::Error(e)) => {
+                eprintln!("Error: {}", e.message);
+                std::process::exit(1);
+            }
+            _ => anyhow::bail!("unexpected response from daemon"),
+        }
+
+        Ok(())
+    })
+}
+
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max { s.to_string() } else { format!("{}…", &s[..max - 1]) }
 }
@@ -597,6 +682,25 @@ mod tests {
     fn cli_parses_config_command() {
         let cli = Cli::try_parse_from(["rttx-server", "config"]).unwrap();
         assert!(matches!(cli.command, Some(Command::Config)));
+    }
+
+    #[test]
+    fn cli_parses_kill_command_with_uuid() {
+        let cli =
+            Cli::try_parse_from(["rttx-server", "kill", "d7d04564-b2bf-4302-9495-e65c4df12ac6"])
+                .unwrap();
+        match cli.command {
+            Some(Command::Kill { runtime_id }) => {
+                assert_eq!(runtime_id, "d7d04564-b2bf-4302-9495-e65c4df12ac6");
+            }
+            _ => panic!("expected Kill command"),
+        }
+    }
+
+    #[test]
+    fn cli_kill_requires_runtime_id_argument() {
+        let result = Cli::try_parse_from(["rttx-server", "kill"]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/services/rttx-server/tests/kill_command.rs
+++ b/services/rttx-server/tests/kill_command.rs
@@ -1,0 +1,92 @@
+//! Integration tests for the `rttx-server kill <runtime-id>` command.
+
+mod common;
+
+use common::{TestClient, start_test_server};
+use rttx_proto::proto;
+
+#[tokio::test]
+async fn kill_terminates_existing_runtime() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let runtime_id =
+        common::create_runtime(&mut client, "target", proto::RuntimePolicy::Persistent).await;
+
+    // Verify it exists.
+    let runtimes = common::list_runtimes(&mut client).await;
+    assert_eq!(runtimes.len(), 1);
+
+    // Terminate via the same protocol path the kill command uses.
+    common::terminate_runtime(&mut client, &runtime_id).await;
+
+    // Verify it's gone.
+    let runtimes = common::list_runtimes(&mut client).await;
+    assert!(runtimes.is_empty());
+}
+
+#[tokio::test]
+async fn kill_nonexistent_runtime_returns_error() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let fake_id = rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4());
+
+    let msg = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::TerminateRuntime(proto::TerminateRuntime {
+            runtime_id: fake_id,
+        })),
+    };
+    client.send(&msg).await;
+
+    let resp = client.recv().await;
+    match resp.msg {
+        Some(proto::server_message::Msg::Error(e)) => {
+            assert!(e.message.contains("not found"), "expected 'not found', got: {}", e.message);
+        }
+        other => panic!("expected Error, got: {other:?}"),
+    }
+}
+
+/// Binary-level test: `rttx-server kill` with invalid UUID exits with error.
+#[test]
+fn kill_invalid_uuid_exits_with_error() {
+    let bin = env!("CARGO_BIN_EXE_rttx-server");
+
+    let output = std::process::Command::new(bin)
+        .args(["kill", "not-a-uuid"])
+        .output()
+        .expect("failed to run kill");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid runtime ID"),
+        "expected 'invalid runtime ID' in stderr, got: {stderr}"
+    );
+}
+
+/// Binary-level test: `rttx-server kill` reports daemon not running.
+#[test]
+fn kill_reports_not_running_without_daemon() {
+    let bin = env!("CARGO_BIN_EXE_rttx-server");
+    let tmp = tempfile::TempDir::new().unwrap();
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+
+    let output = std::process::Command::new(bin)
+        .args(["kill", "d7d04564-b2bf-4302-9495-e65c4df12ac6"])
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .output()
+        .expect("failed to run kill");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not running"), "should report daemon not running, got: {stderr}");
+}


### PR DESCRIPTION
## What changed and why

Adds a `kill` subcommand to `rttx-server` that terminates a specific runtime by UUID. This gives users a way to clean up stuck or zombie runtimes from the command line without needing the GUI.

Usage:
```
rttx-server kill d7d04564-b2bf-4302-9495-e65c4df12ac6
Runtime terminated.
```

The command:
- Validates the UUID argument before connecting
- Connects to the running daemon via the Unix socket
- Sends `TerminateRuntime` and waits for confirmation
- Reports the daemon's error message if the runtime doesn't exist or is owned by another client
- Exits non-zero when the daemon is not running or the runtime cannot be terminated

## How to manually verify

1. Start the daemon: `rttx-server start --foreground`
2. Create a runtime via the GUI or another client
3. Run `rttx-server status` to get the runtime UUID
4. Run `rttx-server kill <uuid>` — should print "Runtime terminated."
5. Run `rttx-server status` — runtime should be gone
6. Run `rttx-server kill <same-uuid>` — should print error about runtime not found

## Tests added

- `cli_parses_kill_command_with_uuid` — unit test for CLI parsing
- `cli_kill_requires_runtime_id_argument` — unit test for missing argument
- `kill_terminates_existing_runtime` — integration test with live daemon
- `kill_nonexistent_runtime_returns_error` — integration test for error path
- `kill_invalid_uuid_exits_with_error` — binary-level test for invalid input
- `kill_reports_not_running_without_daemon` — binary-level test for offline daemon

## Tests run

- `cargo build --workspace --no-default-features --features vte-0_76` ✅
- `cargo test --workspace --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 6 kill tests confirmed passing)

Fixes #276