### PR TITLE
build: add [workspace.dependencies] to centralize shared deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,33 @@ resolver = "3"
 [workspace.package]
 version = "0.4.26"
 license = "GPL-3.0-or-later"
+
+[workspace.dependencies]
+# Internal
+rttx-proto = { path = "protocols/rttx-proto" }
+
+# Protocol serialization
+prost = { version = "0.13", features = ["std", "prost-derive"] }
+prost-build = "0.13"
+bytes = "1"
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Async runtime
+tokio = { version = "1" }
+
+# Utilities
+uuid = { version = "1", features = ["v4"] }
+thiserror = "2"
+
+# Logging
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Dev/test
+tempfile = "3"
+pretty_assertions = "1"
+proptest = "1"

--- a/clients/rttx/Cargo.toml
+++ b/clients/rttx/Cargo.toml
@@ -42,17 +42,17 @@ vte-0_78 = ["vte4/v0_78"]
 gtk4 = { version = "0.9", features = ["v4_14"] }
 libadwaita = { version = "0.7", features = ["v1_5"] }
 vte4 = "0.8"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-uuid = { version = "1", features = ["v4"] }
-tracing = "0.1"
-tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-rttx-proto = { path = "../../protocols/rttx-proto" }
-prost = "0.13"
-bytes = "1"
-tokio = { version = "1", features = ["net", "io-util", "sync", "rt", "rt-multi-thread", "macros", "process", "time"] }
-thiserror = "2"
+serde.workspace = true
+serde_json.workspace = true
+uuid.workspace = true
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-subscriber.workspace = true
+rttx-proto.workspace = true
+prost.workspace = true
+bytes.workspace = true
+tokio = { workspace = true, features = ["net", "io-util", "sync", "rt", "rt-multi-thread", "macros", "process", "time"] }
+thiserror.workspace = true
 
 [package.metadata.deb]
 maintainer = "Illya Yalovyy <yalovoy@gmail.com>"
@@ -85,7 +85,7 @@ libadwaita = ">= 1.5"
 vte291-gtk4 = ">= 0.76"
 
 [dev-dependencies]
-tempfile = "3"
-pretty_assertions = "1"
+tempfile.workspace = true
+pretty_assertions.workspace = true
 rstest = "0.23"
-proptest = "1"
+proptest.workspace = true

--- a/protocols/rttx-proto/Cargo.toml
+++ b/protocols/rttx-proto/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2024"
 license.workspace = true
 
 [dependencies]
-prost = { version = "0.13", features = ["std", "prost-derive"] }
-bytes = "1"
-uuid = { version = "1", features = ["v4"] }
-thiserror = "2"
+prost.workspace = true
+bytes.workspace = true
+uuid.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-proptest = "1"
+proptest.workspace = true
 
 [build-dependencies]
-prost-build = "0.13"
+prost-build.workspace = true

--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -30,14 +30,14 @@ todo = "warn"
 dbg_macro = "warn"
 
 [dependencies]
-rttx-proto = { path = "../../protocols/rttx-proto" }
+rttx-proto.workspace = true
 
 # Protocol serialization
-prost = "0.13"
-bytes = "1"
+prost.workspace = true
+bytes.workspace = true
 
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 tokio-stream = "0.1"
 
 # PTY
@@ -47,8 +47,8 @@ pty-process = { version = "0.5", features = ["async"] }
 vte = "0.13"
 
 # Serialization (state persistence)
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 
 # Process management
 daemonix = "0.1"
@@ -60,11 +60,11 @@ signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 clap = { version = "4", features = ["derive"] }
 
 # Utilities
-uuid = { version = "1", features = ["v4", "serde"] }
-tracing = "0.1"
-tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-thiserror = "2"
+uuid = { workspace = true, features = ["serde"] }
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-subscriber.workspace = true
+thiserror.workspace = true
 anyhow = "1"
 
 [[bin]]
@@ -72,7 +72,7 @@ name = "pty-exerciser"
 path = "src/bin/pty_exerciser.rs"
 
 [dev-dependencies]
-tempfile = "3"
-pretty_assertions = "1"
+tempfile.workspace = true
+pretty_assertions.workspace = true
 tracing-test = "0.2"
-proptest = "1"
+proptest.workspace = true


### PR DESCRIPTION
## What changed and why

Adds a `[workspace.dependencies]` table to the root `Cargo.toml` and converts all workspace members to use `dep.workspace = true` for the 13 dependencies that were duplicated across 2-3 crates.

This prevents version drift, reduces Cargo.toml noise, and makes dependency bumps a one-line change. Completes the modern Rust workspace setup alongside the existing `resolver = "3"`.

**Centralized dependencies:**
- `rttx-proto`, `prost`, `prost-build`, `bytes`
- `serde`, `serde_json`, `tokio`, `uuid`, `thiserror`
- `tracing`, `tracing-appender`, `tracing-subscriber`
- `tempfile`, `pretty_assertions`, `proptest` (dev)

**Feature handling:** Base features are defined in the workspace table; members add per-crate features (e.g., tokio `full` in server, selective features in client; uuid `serde` in server).

## How to verify

```bash
cargo build --workspace  # (use --no-default-features --features vte-0_76 for client on VTE 0.76)
cargo test --workspace
bash .github/scripts/run-clippy.sh
bash .github/scripts/run-quality-tests.sh
```

## Tests

No new tests needed — this is a build-system-only change with no behavioral impact. All existing tests pass unchanged.

## Tests run

- `cargo build -p rttx-proto -p rttx-server` ✅
- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (757 passed, 0 failed)

Fixes #335