### PR TITLE
feat: add "Reconnect All from Host" context menu option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "bytes",
  "proptest",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.26"
+version = "0.4.27"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -395,6 +395,7 @@ pub fn present_workspace_actions(
 pub struct WorkspaceMenuItems {
     pub show_edit_connection: bool,
     pub show_reconnect: bool,
+    pub show_reconnect_host: bool,
     pub show_detach: bool,
 }
 
@@ -406,6 +407,7 @@ pub struct WorkspaceMenuContext {
     pub is_persistent: bool,
     pub is_attached: bool,
     pub is_disconnected: bool,
+    pub has_other_disconnected_from_same_host: bool,
 }
 
 /// Determine which context menu items are relevant for a workspace.
@@ -414,6 +416,9 @@ pub const fn workspace_menu_items(ctx: &WorkspaceMenuContext) -> WorkspaceMenuIt
     WorkspaceMenuItems {
         show_edit_connection: ctx.is_remote,
         show_reconnect: ctx.is_managed && ctx.is_disconnected,
+        show_reconnect_host: ctx.is_managed
+            && ctx.is_disconnected
+            && ctx.has_other_disconnected_from_same_host,
         show_detach: ctx.is_persistent && ctx.is_attached,
     }
 }
@@ -1193,9 +1198,11 @@ mod tests {
             is_persistent: true,
             is_attached: true,
             is_disconnected: false,
+            has_other_disconnected_from_same_host: false,
         });
         assert!(!items.show_edit_connection);
         assert!(!items.show_reconnect);
+        assert!(!items.show_reconnect_host);
         assert!(items.show_detach);
     }
 
@@ -1207,9 +1214,11 @@ mod tests {
             is_persistent: true,
             is_attached: true,
             is_disconnected: true,
+            has_other_disconnected_from_same_host: false,
         });
         assert!(items.show_edit_connection);
         assert!(items.show_reconnect);
+        assert!(!items.show_reconnect_host);
         assert!(items.show_detach);
     }
 
@@ -1221,9 +1230,11 @@ mod tests {
             is_persistent: false,
             is_attached: true,
             is_disconnected: false,
+            has_other_disconnected_from_same_host: false,
         });
         assert!(!items.show_edit_connection);
         assert!(!items.show_reconnect);
+        assert!(!items.show_reconnect_host);
         assert!(!items.show_detach);
     }
 
@@ -1235,8 +1246,10 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: true,
+            has_other_disconnected_from_same_host: false,
         });
         assert!(items.show_reconnect);
+        assert!(!items.show_reconnect_host);
         assert!(!items.show_detach);
     }
 
@@ -1248,10 +1261,39 @@ mod tests {
             is_persistent: false,
             is_attached: false,
             is_disconnected: false,
+            has_other_disconnected_from_same_host: false,
         });
         assert!(!items.show_edit_connection);
         assert!(!items.show_reconnect);
+        assert!(!items.show_reconnect_host);
         assert!(!items.show_detach);
+    }
+
+    #[test]
+    fn menu_items_reconnect_host_shown_when_multiple_disconnected() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: true,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: false,
+            is_disconnected: true,
+            has_other_disconnected_from_same_host: true,
+        });
+        assert!(items.show_reconnect);
+        assert!(items.show_reconnect_host);
+    }
+
+    #[test]
+    fn menu_items_reconnect_host_hidden_when_connected() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: true,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: true,
+            is_disconnected: false,
+            has_other_disconnected_from_same_host: true,
+        });
+        assert!(!items.show_reconnect_host);
     }
 
     // ── SessionMissing state ────────────────────────────────────
@@ -1307,6 +1349,7 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: false,
+            has_other_disconnected_from_same_host: false,
         });
         assert!(!items.show_reconnect);
     }

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -437,17 +437,30 @@ impl Window {
             let Some(session) = state.workspaces.iter().find(|s| s.uuid == session_uuid) else {
                 return;
             };
-            let disconnected =
-                self.imp().workspace_connection_status.borrow().get(session_uuid).is_some_and(
-                    |s| {
+            let statuses = self.imp().workspace_connection_status.borrow();
+            let disconnected = statuses.get(session_uuid).is_some_and(|s| {
+                matches!(
+                    s,
+                    ConnectionStatus::Disconnected
+                        | ConnectionStatus::Reconnecting { .. }
+                        | ConnectionStatus::Blocked(_)
+                )
+            });
+            let endpoint_key = session.runtime.endpoint.key();
+            let has_other_disconnected = state.workspaces.iter().any(|s| {
+                s.uuid != session_uuid
+                    && s.uses_managed_runtime()
+                    && s.runtime.endpoint.key() == endpoint_key
+                    && statuses.get(&s.uuid).is_some_and(|st| {
                         matches!(
-                            s,
+                            st,
                             ConnectionStatus::Disconnected
                                 | ConnectionStatus::Reconnecting { .. }
                                 | ConnectionStatus::Blocked(_)
                         )
-                    },
-                );
+                    })
+            });
+            drop(statuses);
             crate::runtime::workspace_menu_items(&crate::runtime::WorkspaceMenuContext {
                 is_remote: matches!(session.runtime.endpoint, RuntimeEndpoint::Remote { .. }),
                 is_managed: session.uses_managed_runtime(),
@@ -455,6 +468,7 @@ impl Window {
                     && matches!(session.runtime.policy, WorkspacePolicy::Persistent),
                 is_attached: session.runtime.runtime_id.is_some(),
                 is_disconnected: disconnected,
+                has_other_disconnected_from_same_host: has_other_disconnected,
             })
         };
 
@@ -465,6 +479,9 @@ impl Window {
         }
         if items.show_reconnect {
             menu.append(Some("Reconnect"), Some("win.ctx-reconnect"));
+        }
+        if items.show_reconnect_host {
+            menu.append(Some("Reconnect All from Host"), Some("win.ctx-reconnect-host"));
         }
         if items.show_detach {
             menu.append(Some("Detach"), Some("win.ctx-detach"));
@@ -505,6 +522,16 @@ impl Window {
                 w.retry_workspace_connection(&u);
             });
             self.add_action(&reconnect_action);
+        }
+
+        if items.show_reconnect_host {
+            let w = self.clone();
+            let u = session_uuid.to_string();
+            let reconnect_host_action = gtk4::gio::SimpleAction::new("ctx-reconnect-host", None);
+            reconnect_host_action.connect_activate(move |_, _| {
+                w.retry_all_workspaces_for_endpoint(&u);
+            });
+            self.add_action(&reconnect_host_action);
         }
 
         if items.show_detach {

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -471,6 +471,47 @@ impl Window {
         self.connect_managed_workspace(&session_state);
     }
 
+    /// Reconnect all managed workspaces sharing the same endpoint as the given workspace.
+    pub(super) fn retry_all_workspaces_for_endpoint(&self, workspace_id: &str) {
+        let targets: Vec<WorkspaceState> = {
+            let state = self.imp().state.borrow();
+            let Some(origin) = state.workspaces.iter().find(|s| s.uuid == workspace_id) else {
+                return;
+            };
+            let endpoint_key = origin.runtime.endpoint.key();
+            let statuses = self.imp().workspace_connection_status.borrow();
+            state
+                .workspaces
+                .iter()
+                .filter(|s| {
+                    s.uses_managed_runtime()
+                        && s.runtime.endpoint.key() == endpoint_key
+                        && statuses.get(&s.uuid).is_some_and(|st| {
+                            matches!(
+                                st,
+                                ConnectionStatus::Disconnected
+                                    | ConnectionStatus::Reconnecting { .. }
+                                    | ConnectionStatus::Blocked(_)
+                            )
+                        })
+                })
+                .cloned()
+                .collect()
+        };
+        if let Some(first) = targets.first()
+            && let Some(manager) = self.imp().connection_manager.borrow().as_ref()
+        {
+            manager.reset_endpoint(&first.runtime.endpoint);
+        }
+        for session_state in &targets {
+            self.set_workspace_connection_status(
+                &session_state.uuid,
+                &ConnectionStatus::Connecting,
+            );
+            self.connect_managed_workspace(session_state);
+        }
+    }
+
     pub(super) fn send_managed_terminal_input(&self, terminal_uuid: &str, data: &[u8]) {
         let (primary, sync_targets) = {
             let state = self.imp().state.borrow();

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -7495,3 +7495,181 @@ fn command_crud_duplicate_adds_copy_to_sidebar() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn reconnect_host_action_shown_when_multiple_disconnected_from_same_host() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.reconnect-host-test").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    let ws1 = crate::test_helpers::managed_session_with_runtime(
+        "ws-remote-1",
+        "Remote 1",
+        LayoutNode::new_terminal_with_uuid("pane-r1"),
+        RuntimeEndpoint::Remote { host: "server.example.com".into() },
+        WorkspacePolicy::Persistent,
+        Some("rt-1"),
+    );
+    let ws2 = crate::test_helpers::managed_session_with_runtime(
+        "ws-remote-2",
+        "Remote 2",
+        LayoutNode::new_terminal_with_uuid("pane-r2"),
+        RuntimeEndpoint::Remote { host: "server.example.com".into() },
+        WorkspacePolicy::Persistent,
+        Some("rt-2"),
+    );
+
+    window.imp().state.borrow_mut().workspaces.push(ws1.clone());
+    window.build_session(&ws1, false);
+    window.imp().state.borrow_mut().workspaces.push(ws2.clone());
+    window.build_session(&ws2, false);
+    pump_events(50);
+
+    // Mark both as disconnected.
+    window.set_workspace_connection_status(&ws1.uuid, &ConnectionStatus::Disconnected);
+    window.set_workspace_connection_status(&ws2.uuid, &ConnectionStatus::Disconnected);
+
+    let row = session_row_for_uuid(&window, &ws1.uuid);
+    window.show_workspace_popover_menu(&row, &ws1.uuid);
+
+    assert!(
+        window.lookup_action("ctx-reconnect-host").is_some(),
+        "reconnect-host action should be registered when multiple workspaces from same host are disconnected"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn reconnect_host_action_hidden_when_only_one_disconnected() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.reconnect-host-single-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    let ws1 = crate::test_helpers::managed_session_with_runtime(
+        "ws-solo-1",
+        "Solo Remote",
+        LayoutNode::new_terminal_with_uuid("pane-solo"),
+        RuntimeEndpoint::Remote { host: "solo.example.com".into() },
+        WorkspacePolicy::Persistent,
+        Some("rt-solo"),
+    );
+
+    window.imp().state.borrow_mut().workspaces.push(ws1.clone());
+    window.build_session(&ws1, false);
+    pump_events(50);
+
+    window.set_workspace_connection_status(&ws1.uuid, &ConnectionStatus::Disconnected);
+
+    let row = session_row_for_uuid(&window, &ws1.uuid);
+    window.show_workspace_popover_menu(&row, &ws1.uuid);
+
+    assert!(
+        window.lookup_action("ctx-reconnect-host").is_none(),
+        "reconnect-host action should NOT be registered when only one workspace is disconnected"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn reconnect_host_reconnects_all_disconnected_workspaces_from_same_endpoint() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.reconnect-host-all-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+
+    let ws1 = crate::test_helpers::managed_session_with_runtime(
+        "ws-host-a1",
+        "Host A - 1",
+        LayoutNode::new_terminal_with_uuid("pane-a1"),
+        RuntimeEndpoint::Remote { host: "host-a.example.com".into() },
+        WorkspacePolicy::Persistent,
+        Some("rt-a1"),
+    );
+    let ws2 = crate::test_helpers::managed_session_with_runtime(
+        "ws-host-a2",
+        "Host A - 2",
+        LayoutNode::new_terminal_with_uuid("pane-a2"),
+        RuntimeEndpoint::Remote { host: "host-a.example.com".into() },
+        WorkspacePolicy::Persistent,
+        Some("rt-a2"),
+    );
+    let ws3 = crate::test_helpers::managed_session_with_runtime(
+        "ws-host-b1",
+        "Host B - 1",
+        LayoutNode::new_terminal_with_uuid("pane-b1"),
+        RuntimeEndpoint::Remote { host: "host-b.example.com".into() },
+        WorkspacePolicy::Persistent,
+        Some("rt-b1"),
+    );
+
+    window.imp().state.borrow_mut().workspaces.push(ws1.clone());
+    window.build_session(&ws1, false);
+    window.imp().state.borrow_mut().workspaces.push(ws2.clone());
+    window.build_session(&ws2, false);
+    window.imp().state.borrow_mut().workspaces.push(ws3.clone());
+    window.build_session(&ws3, false);
+    pump_events(50);
+
+    // Mark all three as disconnected.
+    window.set_workspace_connection_status(&ws1.uuid, &ConnectionStatus::Disconnected);
+    window.set_workspace_connection_status(&ws2.uuid, &ConnectionStatus::Disconnected);
+    window.set_workspace_connection_status(&ws3.uuid, &ConnectionStatus::Disconnected);
+
+    // Trigger reconnect-all for host-a endpoint via ws1.
+    window.retry_all_workspaces_for_endpoint(&ws1.uuid);
+    pump_events(50);
+
+    // ws1 and ws2 (same host) should now be Connecting.
+    let statuses = window.imp().workspace_connection_status.borrow();
+    assert_eq!(
+        statuses.get(&ws1.uuid),
+        Some(&ConnectionStatus::Connecting),
+        "ws1 should be reconnecting"
+    );
+    assert_eq!(
+        statuses.get(&ws2.uuid),
+        Some(&ConnectionStatus::Connecting),
+        "ws2 should be reconnecting (same host)"
+    );
+    // ws3 (different host) should remain Disconnected.
+    assert_eq!(
+        statuses.get(&ws3.uuid),
+        Some(&ConnectionStatus::Disconnected),
+        "ws3 should remain disconnected (different host)"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -1026,6 +1026,7 @@ fn workspace_menu_items_contract() {
         is_persistent: true,
         is_attached: true,
         is_disconnected: true,
+        has_other_disconnected_from_same_host: false,
     });
     assert!(all.show_edit_connection);
     assert!(all.show_reconnect);
@@ -1038,6 +1039,7 @@ fn workspace_menu_items_contract() {
         is_persistent: false,
         is_attached: true,
         is_disconnected: false,
+        has_other_disconnected_from_same_host: false,
     });
     assert!(!minimal.show_edit_connection);
     assert!(!minimal.show_reconnect);
@@ -1109,4 +1111,43 @@ fn contract_rotate_preserves_structure_and_serializes() {
     let json = serde_json::to_string(&rotated).unwrap();
     let restored: LayoutNode = serde_json::from_str(&json).unwrap();
     assert_eq!(restored, rotated);
+}
+
+/// Reconnect-host menu item requires both disconnected state and sibling workspaces.
+#[test]
+fn workspace_menu_reconnect_host_requires_sibling_disconnected() {
+    use rttx::runtime::{WorkspaceMenuContext, workspace_menu_items};
+
+    // Disconnected with other disconnected siblings → show reconnect-host.
+    let with_siblings = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: true,
+        is_managed: true,
+        is_persistent: true,
+        is_attached: false,
+        is_disconnected: true,
+        has_other_disconnected_from_same_host: true,
+    });
+    assert!(with_siblings.show_reconnect_host);
+
+    // Disconnected without siblings → hide reconnect-host.
+    let without_siblings = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: true,
+        is_managed: true,
+        is_persistent: true,
+        is_attached: false,
+        is_disconnected: true,
+        has_other_disconnected_from_same_host: false,
+    });
+    assert!(!without_siblings.show_reconnect_host);
+
+    // Connected with siblings → hide reconnect-host.
+    let connected = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: true,
+        is_managed: true,
+        is_persistent: true,
+        is_attached: true,
+        is_disconnected: false,
+        has_other_disconnected_from_same_host: true,
+    });
+    assert!(!connected.show_reconnect_host);
 }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.26',
+  version: '0.4.27',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds a "Reconnect All from Host" option to the workspace context menu in the sidebar. When a remote host connection fails, all workspaces connected to that host enter a disconnected state. Previously, users had to reconnect each workspace individually. This option triggers reconnection for all disconnected workspaces sharing the same endpoint at once.

The menu item only appears when:
- The workspace is managed (daemon-backed)
- The workspace is disconnected
- At least one other workspace from the same host is also disconnected

## How to manually verify

1. Create 2+ workspaces connected to the same remote host
2. Disconnect the host (e.g., kill the remote daemon or break SSH)
3. Right-click any disconnected workspace in the sidebar
4. Verify "Reconnect All from Host" appears in the context menu
5. Click it and verify all workspaces from that host begin reconnecting
6. Verify workspaces from other hosts remain unaffected

## Tests added

### Unit tests (runtime.rs)
- `menu_items_reconnect_host_shown_when_multiple_disconnected` — verifies the menu item appears when conditions are met
- `menu_items_reconnect_host_hidden_when_connected` — verifies it's hidden when workspace is connected

### GTK widget tests (window/tests.rs)
- `reconnect_host_action_shown_when_multiple_disconnected_from_same_host` — verifies the action is registered in the popover menu
- `reconnect_host_action_hidden_when_only_one_disconnected` — verifies the action is NOT registered when only one workspace is disconnected
- `reconnect_host_reconnects_all_disconnected_workspaces_from_same_endpoint` — verifies the reconnect logic targets only workspaces from the same host

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76` — all 759 pass, 209 ignored (GTK)
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests pass including the 3 new ones
- `cargo test -p rttx-server` — pass
- `cargo test -p rttx-proto` — pass

## Limitations

- The option only appears when there are 2+ disconnected workspaces from the same host. If only one workspace is disconnected, the regular "Reconnect" option suffices.

Fixes #881