### PR TITLE
fix(ux): make header bar workspace buttons icon-only and consistent

### DIFF
--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -123,26 +123,24 @@ mod imp {
             toggle_sidebar.set_active(true);
             header.pack_start(&toggle_sidebar);
 
-            self.new_button.set_label("New");
-            self.new_button.set_tooltip_text(Some("New workspace"));
             self.new_button.set_icon_name("list-add-symbolic");
+            self.new_button.set_tooltip_text(Some("New workspace"));
             self.new_button.add_css_class("flat");
             self.new_button.update_property(&[gtk4::accessible::Property::Label("New workspace")]);
             header.pack_start(&self.new_button);
 
-            self.connect_button.set_label("Connect");
-            self.connect_button.set_tooltip_text(Some("Connect to existing workspace"));
             self.connect_button.set_icon_name("network-server-symbolic");
+            self.connect_button.set_tooltip_text(Some("Connect to existing workspace"));
             self.connect_button.add_css_class("flat");
             self.connect_button
                 .update_property(&[gtk4::accessible::Property::Label("Connect to existing")]);
             header.pack_start(&self.connect_button);
 
-            self.new_direct_button.set_label("Direct");
-            self.new_direct_button.set_tooltip_text(Some("New direct workspace"));
+            self.new_direct_button.set_icon_name("utilities-terminal-symbolic");
+            self.new_direct_button.set_tooltip_text(Some("New direct terminal"));
             self.new_direct_button.add_css_class("flat");
             self.new_direct_button
-                .update_property(&[gtk4::accessible::Property::Label("New direct workspace")]);
+                .update_property(&[gtk4::accessible::Property::Label("New direct terminal")]);
             header.pack_start(&self.new_direct_button);
 
             if let Some(label) = config::badge_label() {

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2994,18 +2994,9 @@ fn header_bar_workspace_buttons_are_icon_only() {
     );
 
     // All buttons must have tooltips for discoverability.
-    assert!(
-        imp.new_button.tooltip_text().is_some(),
-        "New button must have a tooltip"
-    );
-    assert!(
-        imp.connect_button.tooltip_text().is_some(),
-        "Connect button must have a tooltip"
-    );
-    assert!(
-        imp.new_direct_button.tooltip_text().is_some(),
-        "Direct button must have a tooltip"
-    );
+    assert!(imp.new_button.tooltip_text().is_some(), "New button must have a tooltip");
+    assert!(imp.connect_button.tooltip_text().is_some(), "Connect button must have a tooltip");
+    assert!(imp.new_direct_button.tooltip_text().is_some(), "Direct button must have a tooltip");
 
     window.close();
     remove_env("RTTX_DISABLE_SHELL_SPAWN");

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2940,3 +2940,74 @@ fn find_action_row_by_title(group: &adw::PreferencesGroup, title: &str) -> Optio
     }
     None
 }
+
+/// Regression for #887: header bar workspace buttons must be icon-only and consistent.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn header_bar_workspace_buttons_are_icon_only() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    set_env("XDG_CONFIG_HOME", tmp.path());
+    set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.header-button-style-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = rttx::window::Window::new(&app);
+    window.present();
+    pump_events(50);
+
+    let imp = window.imp();
+
+    // All buttons must have an icon.
+    assert_eq!(
+        imp.new_button.icon_name().as_deref(),
+        Some("list-add-symbolic"),
+        "New button must use list-add-symbolic icon"
+    );
+    assert_eq!(
+        imp.connect_button.icon_name().as_deref(),
+        Some("network-server-symbolic"),
+        "Connect button must use network-server-symbolic icon"
+    );
+    assert_eq!(
+        imp.new_direct_button.icon_name().as_deref(),
+        Some("utilities-terminal-symbolic"),
+        "Direct button must use utilities-terminal-symbolic icon"
+    );
+
+    // No button should have a text label (icon-only style).
+    assert!(
+        imp.new_button.label().is_none_or(|l| l.is_empty()),
+        "New button must not have a text label"
+    );
+    assert!(
+        imp.connect_button.label().is_none_or(|l| l.is_empty()),
+        "Connect button must not have a text label"
+    );
+    assert!(
+        imp.new_direct_button.label().is_none_or(|l| l.is_empty()),
+        "Direct button must not have a text label"
+    );
+
+    // All buttons must have tooltips for discoverability.
+    assert!(
+        imp.new_button.tooltip_text().is_some(),
+        "New button must have a tooltip"
+    );
+    assert!(
+        imp.connect_button.tooltip_text().is_some(),
+        "Connect button must have a tooltip"
+    );
+    assert!(
+        imp.new_direct_button.tooltip_text().is_some(),
+        "Direct button must have a tooltip"
+    );
+
+    window.close();
+    remove_env("RTTX_DISABLE_SHELL_SPAWN");
+    remove_env("XDG_CONFIG_HOME");
+}


### PR DESCRIPTION
## What changed and why

The three header bar buttons for creating workspaces (New, Connect, Direct) were inconsistent:
- **New** and **Connect** had both icon AND text label
- **Direct** had text label only, no icon

This violated GNOME HIG which recommends icon-only buttons in the header bar. The fix removes text labels from all three buttons and adds an icon to the Direct button, making them all follow the same icon-only style with descriptive tooltips.

### Button mapping:
| Button | Icon | Tooltip |
|--------|------|---------|
| New workspace | `list-add-symbolic` | "New workspace" |
| Connect to existing | `network-server-symbolic` | "Connect to existing workspace" |
| New direct terminal | `utilities-terminal-symbolic` | "New direct terminal" |

## Manual verification

1. Build and run: `cargo build -p rttx --no-default-features --features vte-0_76 && RTTX_DEV_MODE=1 ./target/debug/rttx`
2. Observe the header bar — all three buttons should show icons only, no text
3. Hover each button to verify tooltips appear
4. Click each button to verify functionality is preserved

## Tests added

- `header_bar_workspace_buttons_are_icon_only` — GTK widget test verifying:
  - All three buttons have the correct icon name
  - No button has a text label
  - All buttons have tooltips for discoverability

## Tests run

- `cargo test --workspace` (proto + server) — all pass
- `cargo test -p rttx --no-default-features --features vte-0_76` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — 2928 tests pass, including the new GTK test

Fixes #887