### PR TITLE
fix(ux): increase New Workspace dialog height for better visibility

### DIFF
--- a/clients/rttx/src/new_workspace_dialog.rs
+++ b/clients/rttx/src/new_workspace_dialog.rs
@@ -12,7 +12,8 @@ use crate::window::Window;
 /// host. The user picks a place to create a new daemon-backed workspace.
 pub fn show(window: &Window, host: &Host) {
     let title = format!("New Workspace: {}", host.name);
-    let dialog = adw::Dialog::builder().title(&title).content_width(400).content_height(450).build();
+    let dialog =
+        adw::Dialog::builder().title(&title).content_width(400).content_height(450).build();
 
     let header = adw::HeaderBar::new();
 

--- a/clients/rttx/src/new_workspace_dialog.rs
+++ b/clients/rttx/src/new_workspace_dialog.rs
@@ -12,7 +12,7 @@ use crate::window::Window;
 /// host. The user picks a place to create a new daemon-backed workspace.
 pub fn show(window: &Window, host: &Host) {
     let title = format!("New Workspace: {}", host.name);
-    let dialog = adw::Dialog::builder().title(&title).content_width(400).build();
+    let dialog = adw::Dialog::builder().title(&title).content_width(400).content_height(450).build();
 
     let header = adw::HeaderBar::new();
 
@@ -32,7 +32,7 @@ pub fn show(window: &Window, host: &Host) {
     let scroll = gtk4::ScrolledWindow::builder()
         .hscrollbar_policy(gtk4::PolicyType::Never)
         .vexpand(true)
-        .min_content_height(200)
+        .min_content_height(300)
         .child(&list_box)
         .build();
 


### PR DESCRIPTION
## What changed and why

The New Workspace dialog was too short, requiring users to scroll to see available places. This adds an explicit `content_height(450)` to the dialog and increases the scroll area's `min_content_height` from 200 to 300.

## How to manually verify

1. Open rttx
2. Click the New Workspace button (or Ctrl+Shift+T)
3. The dialog should be noticeably taller, showing more places without scrolling

## Tests

No new tests added — this is a pure sizing change to an `adw::Dialog` builder property. A test asserting `content_height == 450` would be tautological.

Existing tests verified:
- `new_workspace_dialog::tests::*` (all 9 unit tests pass)
- `gtk_widget_tests::new_workspace_dialog_*` (all 3 GTK widget tests pass)
- Full quality test suite passes
- Clippy passes

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✓
- `cargo test -p rttx --no-default-features --features vte-0_76` ✓
- `cargo test -p rttx-proto -p rttx-server` ✓
- `bash .github/scripts/run-clippy.sh` ✓
- `bash .github/scripts/run-quality-tests.sh` ✓

Fixes #889