### PR TITLE
fix: increase Connect to Existing dialog height for better item visibility

### DIFF
--- a/clients/rttx/src/connect_existing_dialog.rs
+++ b/clients/rttx/src/connect_existing_dialog.rs
@@ -6,6 +6,10 @@ use rttx_proto::v3;
 use crate::host::Host;
 use crate::window::Window;
 
+pub const DIALOG_CONTENT_WIDTH: i32 = 400;
+pub const DIALOG_CONTENT_HEIGHT: i32 = 450;
+pub const SCROLL_MIN_CONTENT_HEIGHT: i32 = 300;
+
 /// Classification of a daemon session for the Connect to Existing dialog.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeAvailability {
@@ -79,7 +83,11 @@ pub fn matches_query(entry: &RuntimeEntry, query: &str) -> bool {
 /// Show the Connect to Existing dialog for a specific host.
 pub fn show(window: &Window, host: &Host, runtimes: &[v3::RuntimeInfo]) {
     let title = format!("Connect to Existing: {}", host.name);
-    let dialog = adw::Dialog::builder().title(&title).content_width(400).build();
+    let dialog = adw::Dialog::builder()
+        .title(&title)
+        .content_width(DIALOG_CONTENT_WIDTH)
+        .content_height(DIALOG_CONTENT_HEIGHT)
+        .build();
 
     let header = adw::HeaderBar::new();
 
@@ -99,7 +107,7 @@ pub fn show(window: &Window, host: &Host, runtimes: &[v3::RuntimeInfo]) {
     let scroll = gtk4::ScrolledWindow::builder()
         .hscrollbar_policy(gtk4::PolicyType::Never)
         .vexpand(true)
-        .min_content_height(200)
+        .min_content_height(SCROLL_MIN_CONTENT_HEIGHT)
         .child(&list_box)
         .build();
 

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -2017,6 +2017,27 @@ fn connect_existing_dialog_search_filters_sessions() {
     );
 }
 
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn connect_existing_dialog_has_sufficient_height_for_item_visibility() {
+    require_display!();
+
+    assert_eq!(rttx::connect_existing_dialog::DIALOG_CONTENT_HEIGHT, 450);
+    assert_eq!(rttx::connect_existing_dialog::SCROLL_MIN_CONTENT_HEIGHT, 300);
+
+    let dialog = libadwaita::Dialog::builder()
+        .content_width(rttx::connect_existing_dialog::DIALOG_CONTENT_WIDTH)
+        .content_height(rttx::connect_existing_dialog::DIALOG_CONTENT_HEIGHT)
+        .build();
+    assert_eq!(dialog.content_height(), 450);
+    assert_eq!(dialog.content_width(), 400);
+
+    let scroll = gtk4::ScrolledWindow::builder()
+        .min_content_height(rttx::connect_existing_dialog::SCROLL_MIN_CONTENT_HEIGHT)
+        .build();
+    assert_eq!(scroll.min_content_height(), 300);
+}
+
 // ── Mouse reporting vs gestures (#459) ──────────────────────────
 
 /// The link click gesture on a direct terminal must use capture phase so it


### PR DESCRIPTION
## What changed and why

The Connect to Existing Workspace dialog was too short, making it hard to see and select from the list of available runtimes. Increased the dialog height to show more items.

**Changes:**
- Added `content_height(450)` to the dialog builder (previously had no explicit height)
- Increased `min_content_height` on the scroll area from 200 to 300
- Extracted dimension values as public constants for testability

These values match the pattern used in the New Workspace dialog (`new_workspace_dialog.rs`).

## Manual verification

1. Open rttx with multiple daemon-backed workspaces running
2. Press Ctrl+Shift+A to open the Connect to Existing dialog
3. Verify the dialog is taller and shows more items without scrolling

## Tests added

- `connect_existing_dialog_has_sufficient_height_for_item_visibility` — GTK widget test verifying dialog and scroll dimensions

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (new test confirmed passing)
- `cargo test -p rttx-proto -p rttx-server` ✅

Fixes #891