### PR TITLE
fix(daemon): Handle SIGHUP and log signal number on shutdown

### DIFF
--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -52,7 +52,7 @@ serde_json.workspace = true
 
 # Process management
 daemonix = "0.1"
-nix = { version = "0.29", features = ["fs"] }
+nix = { version = "0.29", features = ["fs", "signal"] }
 signal-hook = { version = "0.3", features = ["iterator"] }
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -709,4 +709,12 @@ mod tests {
         // Verify the daemonix API surface we rely on compiles and builds correctly.
         let _daemon = daemonix::Daemonize::new().pid_file(&pid_path).working_directory("/");
     }
+
+    #[test]
+    fn signal_handler_registers_sighup() {
+        use signal_hook::consts::{SIGHUP, SIGINT, SIGTERM};
+        use signal_hook::iterator::Signals;
+        let signals = Signals::new([SIGTERM, SIGINT, SIGHUP]);
+        assert!(signals.is_ok(), "SIGTERM, SIGINT, SIGHUP must all be registerable");
+    }
 }

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -645,17 +645,17 @@ fn truncate(s: &str, max: usize) -> String {
 }
 
 async fn handle_signals(server: Arc<Mutex<Server>>) {
-    use signal_hook::consts::{SIGINT, SIGTERM};
+    use signal_hook::consts::{SIGINT, SIGTERM, SIGHUP};
     use signal_hook_tokio::Signals;
     use tokio_stream::StreamExt;
 
-    let Ok(mut signals) = Signals::new([SIGTERM, SIGINT]) else {
+    let Ok(mut signals) = Signals::new([SIGTERM, SIGINT, SIGHUP]) else {
         tracing::error!("Failed to register signal handlers");
         return;
     };
 
-    if signals.next().await.is_some() {
-        tracing::info!("Received OS shutdown signal, triggering cooperative shutdown");
+    if let Some(sig) = signals.next().await {
+        tracing::info!(signal = sig, "Received signal, triggering cooperative shutdown");
         let s = server.lock().await;
         s.request_shutdown();
     }

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -661,7 +661,6 @@ async fn handle_signals(server: Arc<Mutex<Server>>) {
     }
 }
 
-#[cfg(test)]
 mod tests {
     use super::*;
     use clap::Parser;
@@ -709,16 +708,5 @@ mod tests {
         let pid_path = dir.path().join("test.pid");
         // Verify the daemonix API surface we rely on compiles and builds correctly.
         let _daemon = daemonix::Daemonize::new().pid_file(&pid_path).working_directory("/");
-    }
-}
-
-#[cfg(test)]
-mod signal_tests {
-    #[test]
-    fn signal_handler_includes_sighup() {
-        use signal_hook::consts::{SIGHUP, SIGINT, SIGTERM};
-        // Verify all three signals can be registered (no panic).
-        let signals = signal_hook::iterator::Signals::new([SIGTERM, SIGINT, SIGHUP]);
-        assert!(signals.is_ok(), "must be able to register SIGTERM, SIGINT, SIGHUP");
     }
 }

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -661,6 +661,7 @@ async fn handle_signals(server: Arc<Mutex<Server>>) {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
     use clap::Parser;

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -645,7 +645,7 @@ fn truncate(s: &str, max: usize) -> String {
 }
 
 async fn handle_signals(server: Arc<Mutex<Server>>) {
-    use signal_hook::consts::{SIGINT, SIGTERM, SIGHUP};
+    use signal_hook::consts::{SIGHUP, SIGINT, SIGTERM};
     use signal_hook_tokio::Signals;
     use tokio_stream::StreamExt;
 
@@ -709,5 +709,16 @@ mod tests {
         let pid_path = dir.path().join("test.pid");
         // Verify the daemonix API surface we rely on compiles and builds correctly.
         let _daemon = daemonix::Daemonize::new().pid_file(&pid_path).working_directory("/");
+    }
+}
+
+#[cfg(test)]
+mod signal_tests {
+    #[test]
+    fn signal_handler_includes_sighup() {
+        use signal_hook::consts::{SIGHUP, SIGINT, SIGTERM};
+        // Verify all three signals can be registered (no panic).
+        let signals = signal_hook::iterator::Signals::new([SIGTERM, SIGINT, SIGHUP]);
+        assert!(signals.is_ok(), "must be able to register SIGTERM, SIGINT, SIGHUP");
     }
 }

--- a/services/rttx-server/tests/sighup_shutdown.rs
+++ b/services/rttx-server/tests/sighup_shutdown.rs
@@ -1,0 +1,56 @@
+//! Test that the daemon handles SIGHUP gracefully (shuts down instead of dying silently).
+
+use std::process::Stdio;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::process::Command;
+
+#[tokio::test]
+async fn sighup_triggers_graceful_shutdown() {
+    let tmp = TempDir::new().unwrap();
+    let runtime_dir = tmp.path().join("runtime");
+    let cache_dir = tmp.path().join("cache");
+    let state_dir = tmp.path().join("state");
+    tokio::fs::create_dir_all(&runtime_dir).await.unwrap();
+    tokio::fs::create_dir_all(&cache_dir).await.unwrap();
+    tokio::fs::create_dir_all(&state_dir).await.unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_rttx-server");
+    let mut child = Command::new(bin)
+        .arg("start")
+        .arg("--foreground")
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("XDG_CACHE_HOME", &cache_dir)
+        .env("XDG_STATE_HOME", &state_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+
+    let socket = runtime_dir.join("rttx-server").join("v1").join("rttx-server.sock");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        if socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(socket.exists(), "daemon socket must appear");
+
+    // Send SIGHUP.
+    let pid = child.id().expect("child pid");
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid as i32),
+        nix::sys::signal::Signal::SIGHUP,
+    )
+    .expect("kill SIGHUP");
+
+    // Daemon should exit gracefully within a few seconds.
+    let status = tokio::time::timeout(Duration::from_secs(10), child.wait())
+        .await
+        .expect("daemon must exit within 10s after SIGHUP")
+        .expect("wait failed");
+
+    assert!(status.success(), "daemon must exit cleanly on SIGHUP, got: {status}");
+}


### PR DESCRIPTION
Handle SIGHUP so the daemon shuts down gracefully when the terminal is lost. Log the actual signal number to aid crash investigation.