### PR TITLE
fix(daemon): expand tilde and resolve relative CWD paths before is_dir check

### DIFF
--- a/services/rttx-server/src/pty.rs
+++ b/services/rttx-server/src/pty.rs
@@ -63,7 +63,12 @@ impl Pty {
             // OSC 7 (CWD reporting) which is set up by vte-2.91.sh.
             cmd = cmd.arg0(format!("-{}", basename(&config.command[0])));
         }
-        let effective_cwd = config.cwd.clone().or_else(home_dir).filter(|p| p.is_dir());
+        let effective_cwd = config
+            .cwd
+            .as_ref()
+            .map(resolve_cwd)
+            .or_else(home_dir)
+            .filter(|p| p.is_dir());
         if let Some(ref cwd) = effective_cwd {
             cmd = cmd.current_dir(cwd);
         }
@@ -146,6 +151,26 @@ fn basename(path: &str) -> &str {
 /// Resolve the user's home directory from the environment.
 fn home_dir() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+/// Expand a CWD path so it can be validated and used with `current_dir`.
+///
+/// - `~/…` → `$HOME/…`
+/// - bare `~` → `$HOME`
+/// - relative paths (no leading `/`) → `$HOME/path`
+/// - absolute paths → unchanged
+fn resolve_cwd(path: &PathBuf) -> PathBuf {
+    let s = path.to_string_lossy();
+    if s == "~" {
+        return home_dir().unwrap_or_else(|| path.clone());
+    }
+    if let Some(rest) = s.strip_prefix("~/") {
+        return home_dir().map_or_else(|| path.clone(), |h| h.join(rest));
+    }
+    if path.is_relative() {
+        return home_dir().map_or_else(|| path.clone(), |h| h.join(path));
+    }
+    path.clone()
 }
 
 #[cfg(test)]
@@ -253,5 +278,52 @@ mod tests {
         assert_eq!(basename("/bin/bash"), "bash");
         assert_eq!(basename("/usr/local/bin/zsh"), "zsh");
         assert_eq!(basename("sh"), "sh");
+    }
+
+    // ── resolve_cwd unit tests ──────────────────────────────────
+
+    #[test]
+    fn resolve_cwd_expands_bare_tilde() {
+        let home = std::env::var("HOME").expect("HOME must be set");
+        assert_eq!(resolve_cwd(&PathBuf::from("~")), PathBuf::from(&home));
+    }
+
+    #[test]
+    fn resolve_cwd_expands_tilde_prefix() {
+        let home = std::env::var("HOME").expect("HOME must be set");
+        let resolved = resolve_cwd(&PathBuf::from("~/projects"));
+        assert_eq!(resolved, PathBuf::from(format!("{home}/projects")));
+    }
+
+    #[test]
+    fn resolve_cwd_resolves_relative_path_against_home() {
+        let home = std::env::var("HOME").expect("HOME must be set");
+        let resolved = resolve_cwd(&PathBuf::from("projects/myapp"));
+        assert_eq!(resolved, PathBuf::from(format!("{home}/projects/myapp")));
+    }
+
+    #[test]
+    fn resolve_cwd_preserves_absolute_path() {
+        let resolved = resolve_cwd(&PathBuf::from("/tmp/test"));
+        assert_eq!(resolved, PathBuf::from("/tmp/test"));
+    }
+
+    // ── PTY spawn with tilde CWD ────────────────────────────────
+
+    #[test]
+    fn tilde_cwd_expands_to_home() {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        rt.block_on(async {
+            let home = std::env::var("HOME").expect("HOME must be set");
+            let config = PtyConfig {
+                command: vec!["/bin/sh".into(), "-c".into(), "pwd".into()],
+                cwd: Some(PathBuf::from("~")),
+                ..PtyConfig::default()
+            };
+            let mut pty = Pty::spawn(Uuid::new_v4(), &config).expect("spawn must succeed");
+            let output = read_pty_output(&mut pty).await;
+            let cwd = output.trim();
+            assert_eq!(cwd, home, "PTY with cwd=~ must start in $HOME, got {cwd}");
+        });
     }
 }

--- a/services/rttx-server/src/pty.rs
+++ b/services/rttx-server/src/pty.rs
@@ -63,12 +63,8 @@ impl Pty {
             // OSC 7 (CWD reporting) which is set up by vte-2.91.sh.
             cmd = cmd.arg0(format!("-{}", basename(&config.command[0])));
         }
-        let effective_cwd = config
-            .cwd
-            .as_ref()
-            .map(resolve_cwd)
-            .or_else(home_dir)
-            .filter(|p| p.is_dir());
+        let effective_cwd =
+            config.cwd.as_ref().map(resolve_cwd).or_else(home_dir).filter(|p| p.is_dir());
         if let Some(ref cwd) = effective_cwd {
             cmd = cmd.current_dir(cwd);
         }

--- a/services/rttx-server/tests/split_cwd.rs
+++ b/services/rttx-server/tests/split_cwd.rs
@@ -299,9 +299,7 @@ async fn create_pane_with_tilde_cwd_expands_to_home() {
             }
         }
     }
-    panic!(
-        "tilde CWD pane should start in $HOME ({home:?}) within timeout.\nOutput: {output}"
-    );
+    panic!("tilde CWD pane should start in $HOME ({home:?}) within timeout.\nOutput: {output}");
 }
 
 /// Pane created with a tilde-prefixed CWD (`~/subdir`) should expand to

--- a/services/rttx-server/tests/split_cwd.rs
+++ b/services/rttx-server/tests/split_cwd.rs
@@ -307,25 +307,13 @@ async fn create_pane_with_tilde_cwd_expands_to_home() {
 #[tokio::test]
 async fn create_pane_with_tilde_prefix_cwd_expands_correctly() {
     let home = std::env::var("HOME").expect("HOME must be set");
-    // Use a subdirectory that exists under $HOME — pick one that's very
-    // likely to exist on any Linux system.
-    let subdir = std::path::Path::new(&home)
-        .read_dir()
-        .ok()
-        .and_then(|mut entries| {
-            entries.find_map(|e| {
-                let e = e.ok()?;
-                if e.file_type().ok()?.is_dir() {
-                    Some(e.file_name().to_string_lossy().into_owned())
-                } else {
-                    None
-                }
-            })
-        })
-        .expect("$HOME must contain at least one subdirectory");
+    // Create a temporary subdirectory under $HOME for the test.
+    let subdir_name = format!("rttx-test-{}", uuid::Uuid::new_v4());
+    let subdir_path = std::path::PathBuf::from(&home).join(&subdir_name);
+    std::fs::create_dir(&subdir_path).expect("create test subdir under $HOME");
 
-    let tilde_path = format!("~/{subdir}");
-    let expected_abs = format!("{home}/{subdir}");
+    let tilde_path = format!("~/{subdir_name}");
+    let expected_abs = subdir_path.to_string_lossy().to_string();
 
     let tmp = tempfile::tempdir().unwrap();
     let (socket_path, _handle) = start_test_server(tmp.path()).await;
@@ -378,10 +366,12 @@ async fn create_pane_with_tilde_prefix_cwd_expands_correctly() {
         {
             output.push_str(&String::from_utf8_lossy(&delta.data));
             if output.contains(&expected_abs) {
+                let _ = std::fs::remove_dir(&subdir_path);
                 return;
             }
         }
     }
+    let _ = std::fs::remove_dir(&subdir_path);
     panic!(
         "tilde-prefix CWD pane should start in {expected_abs:?} within timeout.\nOutput: {output}"
     );

--- a/services/rttx-server/tests/split_cwd.rs
+++ b/services/rttx-server/tests/split_cwd.rs
@@ -238,3 +238,153 @@ async fn create_pane_without_cwd_inherits_sibling_cwd() {
         "second pane pwd should contain sibling CWD {target_str:?} within timeout.\nOutput: {output}"
     );
 }
+
+/// Pane created with a tilde CWD (`~`) should expand to $HOME. Regression
+/// test for #905.
+#[tokio::test]
+async fn create_pane_with_tilde_cwd_expands_to_home() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "tilde-cwd-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let runtime_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+
+    let pane_id = create_pane_with_cwd(&mut client, &runtime_id, Some("~".into())).await;
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
+            runtime_id: runtime_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(_)) => break,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    }
+
+    let input = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            runtime_id: runtime_id.clone(),
+            pane_id: pane_id.clone(),
+            data: bytes::Bytes::from_static(b"pwd\n"),
+        })),
+    };
+    client.send(&input).await;
+
+    let home = std::env::var("HOME").expect("HOME must be set");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut output = String::new();
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(delta)) = msg.msg
+        {
+            output.push_str(&String::from_utf8_lossy(&delta.data));
+            if output.contains(&home) {
+                return;
+            }
+        }
+    }
+    panic!(
+        "tilde CWD pane should start in $HOME ({home:?}) within timeout.\nOutput: {output}"
+    );
+}
+
+/// Pane created with a tilde-prefixed CWD (`~/subdir`) should expand to
+/// `$HOME/subdir`. Regression test for #905.
+#[tokio::test]
+async fn create_pane_with_tilde_prefix_cwd_expands_correctly() {
+    let home = std::env::var("HOME").expect("HOME must be set");
+    // Use a subdirectory that exists under $HOME — pick one that's very
+    // likely to exist on any Linux system.
+    let subdir = std::path::Path::new(&home)
+        .read_dir()
+        .ok()
+        .and_then(|mut entries| {
+            entries.find_map(|e| {
+                let e = e.ok()?;
+                if e.file_type().ok()?.is_dir() {
+                    Some(e.file_name().to_string_lossy().into_owned())
+                } else {
+                    None
+                }
+            })
+        })
+        .expect("$HOME must contain at least one subdirectory");
+
+    let tilde_path = format!("~/{subdir}");
+    let expected_abs = format!("{home}/{subdir}");
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (socket_path, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&socket_path).await;
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "tilde-prefix-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let runtime_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+
+    let pane_id = create_pane_with_cwd(&mut client, &runtime_id, Some(tilde_path)).await;
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
+            runtime_id: runtime_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::Snapshot(_)) => break,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    }
+
+    let input = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::Input(proto::Input {
+            runtime_id: runtime_id.clone(),
+            pane_id: pane_id.clone(),
+            data: bytes::Bytes::from_static(b"pwd\n"),
+        })),
+    };
+    client.send(&input).await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut output = String::new();
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(delta)) = msg.msg
+        {
+            output.push_str(&String::from_utf8_lossy(&delta.data));
+            if output.contains(&expected_abs) {
+                return;
+            }
+        }
+    }
+    panic!(
+        "tilde-prefix CWD pane should start in {expected_abs:?} within timeout.\nOutput: {output}"
+    );
+}


### PR DESCRIPTION
## What changed and why

`Pty::spawn()` in `pty.rs` applied `.filter(|p| p.is_dir())` on the raw CWD path without expanding `~` or resolving relative paths against `$HOME`. This caused:

- Tilde paths (`~/projects`) to fail the `is_dir()` check because `PathBuf` doesn't understand shell tilde expansion
- Relative paths (`projects/myapp`) to be checked against the daemon's working directory instead of the user's home

The path was silently dropped and the PTY fell back to `$HOME`.

### Fix

Added `resolve_cwd()` helper that:
1. Expands bare `~` to `$HOME`
2. Expands `~/…` to `$HOME/…`
3. Resolves relative paths against `$HOME`
4. Leaves absolute paths unchanged

The `is_dir()` validation now runs on the resolved absolute path.

## Manual verification

1. Create a Place with path `~/projects` (or any tilde-prefixed path to an existing directory)
2. Open it as a new workspace → pane starts in the correct directory
3. Create a Place with a relative path like `Documents` → pane starts in `$HOME/Documents`

## Tests added

### Unit tests (`pty.rs`)
- `resolve_cwd_expands_bare_tilde`
- `resolve_cwd_expands_tilde_prefix`
- `resolve_cwd_resolves_relative_path_against_home`
- `resolve_cwd_preserves_absolute_path`
- `tilde_cwd_expands_to_home` (PTY spawn integration)

### Integration tests (`split_cwd.rs`)
- `create_pane_with_tilde_cwd_expands_to_home`
- `create_pane_with_tilde_prefix_cwd_expands_correctly`

## Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `cargo test -p rttx-server` ✅ (all 410+ lib tests + all integration tests)

Fixes #905