### PR TITLE
feat(profiling): custom tracing subscriber layer for ring buffer + metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "2"
 # Logging
 tracing = "0.1"
 tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 
 # Dev/test
 tempfile = "3"

--- a/services/rttx-server/src/lib.rs
+++ b/services/rttx-server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod logging;
 pub mod metrics;
 pub mod os;
 pub mod pane;
+pub mod profiling;
 pub mod protocol;
 pub mod pty;
 pub mod runtime;

--- a/services/rttx-server/src/logging.rs
+++ b/services/rttx-server/src/logging.rs
@@ -1,12 +1,21 @@
 //! File logging with daily rotation and automatic cleanup.
 
 use std::path::Path;
-use tracing_subscriber::EnvFilter;
+use std::sync::Arc;
 
-/// Initialize file-based logging with daily rotation.
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+use crate::flight::RingWriter;
+use crate::metrics::DaemonMetrics;
+use crate::profiling::ProfilingLayer;
+
+/// Initialize file-based logging with daily rotation and profiling layer.
 ///
-/// Logs are written to `log_dir/<prefix>.log.<date>`. Old log files beyond
-/// `keep_days` are removed on startup.
+/// Composes the file-logging layer with the `ProfilingLayer` via the
+/// tracing subscriber registry. The profiling layer records span events
+/// to the ring buffer and updates `DaemonMetrics` histograms.
 pub fn init_file_logging(log_dir: &Path, prefix: &str, dev_mode: bool) {
     let default_level = if dev_mode { "debug" } else { "info" };
     let filter =
@@ -16,11 +25,35 @@ pub fn init_file_logging(log_dir: &Path, prefix: &str, dev_mode: bool) {
     let file_appender = tracing_appender::rolling::daily(log_dir, format!("{prefix}.log"));
     cleanup_old_logs(log_dir, &format!("{prefix}.log"), 3);
 
-    tracing_subscriber::fmt()
-        .with_writer(file_appender)
-        .with_env_filter(filter)
-        .with_ansi(false)
-        .init();
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(file_appender).with_ansi(false);
+
+    tracing_subscriber::registry().with(filter).with(fmt_layer).init();
+}
+
+/// Initialize file-based logging composed with the profiling layer.
+///
+/// The profiling layer writes span events to the ring buffer and updates
+/// latency histograms in `DaemonMetrics`.
+pub fn init_logging_with_profiling(
+    log_dir: &Path,
+    prefix: &str,
+    dev_mode: bool,
+    metrics: Arc<DaemonMetrics>,
+    ring: Arc<RingWriter>,
+) {
+    let default_level = if dev_mode { "debug" } else { "info" };
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    let _ = std::fs::create_dir_all(log_dir);
+    let file_appender = tracing_appender::rolling::daily(log_dir, format!("{prefix}.log"));
+    cleanup_old_logs(log_dir, &format!("{prefix}.log"), 3);
+
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(file_appender).with_ansi(false);
+
+    let profiling_layer = ProfilingLayer::new(metrics, ring);
+
+    tracing_subscriber::registry().with(filter).with(fmt_layer).with(profiling_layer).init();
 }
 
 /// Remove rotated log files older than `keep_days`.

--- a/services/rttx-server/src/profiling.rs
+++ b/services/rttx-server/src/profiling.rs
@@ -1,0 +1,352 @@
+//! Custom tracing subscriber layer for profiling.
+//!
+//! Writes span events to the ring buffer flight recorder and updates
+//! `DaemonMetrics` latency histograms. Only processes spans with
+//! `target = "rttx_profile"` — all other tracing output is ignored.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Instant;
+
+use tracing::Subscriber;
+use tracing::span;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::flight::{EventType, FlightEvent, RingWriter, SpanKind};
+use crate::metrics::DaemonMetrics;
+
+/// Target string that profiling spans must use to be recorded.
+const PROFILE_TARGET: &str = "rttx_profile";
+
+/// Tracing layer that records span enter/exit events to the ring buffer
+/// and updates latency histograms in `DaemonMetrics`.
+pub struct ProfilingLayer {
+    metrics: Arc<DaemonMetrics>,
+    ring: Arc<RingWriter>,
+    epoch: Instant,
+    next_span_id: AtomicU32,
+}
+
+impl ProfilingLayer {
+    #[must_use]
+    pub fn new(metrics: Arc<DaemonMetrics>, ring: Arc<RingWriter>) -> Self {
+        Self { metrics, ring, epoch: Instant::now(), next_span_id: AtomicU32::new(1) }
+    }
+
+    fn timestamp_ns(&self) -> u64 {
+        self.epoch.elapsed().as_nanos() as u64
+    }
+
+    fn allocate_span_id(&self) -> u32 {
+        self.next_span_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+/// Per-span data stored in the tracing registry extensions.
+struct SpanData {
+    span_id: u32,
+    span_kind: SpanKind,
+    enter_time: Option<Instant>,
+}
+
+/// Parse the `span_kind` field from span attributes.
+fn parse_span_kind(attrs: &span::Attributes<'_>) -> SpanKind {
+    struct KindVisitor(SpanKind);
+
+    impl tracing::field::Visit for KindVisitor {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "span_kind" {
+                self.0 = match value {
+                    "mutex_acquire" => SpanKind::MutexAcquire,
+                    "pty_read" => SpanKind::PtyRead,
+                    "vte_parse" => SpanKind::VteParse,
+                    "client_dispatch" => SpanKind::ClientDispatch,
+                    "client_write" => SpanKind::ClientWrite,
+                    "channel_send" => SpanKind::ChannelSend,
+                    "serialization_tick" => SpanKind::SerializationTick,
+                    "io_flush" => SpanKind::IoFlush,
+                    "client_session" => SpanKind::ClientSession,
+                    _ => SpanKind::Shutdown,
+                };
+            }
+        }
+
+        fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+    }
+
+    let mut visitor = KindVisitor(SpanKind::Shutdown);
+    attrs.record(&mut visitor);
+    visitor.0
+}
+
+impl<S> tracing_subscriber::Layer<S> for ProfilingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        if attrs.metadata().target() != PROFILE_TARGET {
+            return;
+        }
+
+        let span_kind = parse_span_kind(attrs);
+        let data = SpanData { span_id: self.allocate_span_id(), span_kind, enter_time: None };
+
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(data);
+        }
+    }
+
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let Some((sid, kind)) = ({
+            let mut ext = span.extensions_mut();
+            ext.get_mut::<SpanData>().map(|d| {
+                d.enter_time = Some(Instant::now());
+                (d.span_id, d.span_kind)
+            })
+        }) else {
+            return;
+        };
+
+        self.ring.record(&FlightEvent {
+            timestamp_ns: self.timestamp_ns(),
+            span_id: sid,
+            event_type: EventType::Enter,
+            span_kind: kind,
+            context: [0; 16],
+            value: 0,
+        });
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let Some((sid, kind, duration_ns)) = ({
+            let mut ext = span.extensions_mut();
+            ext.get_mut::<SpanData>().map(|d| {
+                let dur = d.enter_time.map_or(0, |t| t.elapsed().as_nanos() as u64);
+                (d.span_id, d.span_kind, dur)
+            })
+        }) else {
+            return;
+        };
+
+        let duration_us = duration_ns / 1_000;
+
+        self.ring.record(&FlightEvent {
+            timestamp_ns: self.timestamp_ns(),
+            span_id: sid,
+            event_type: EventType::Exit,
+            span_kind: kind,
+            context: [0; 16],
+            value: duration_ns,
+        });
+
+        match kind {
+            SpanKind::MutexAcquire => self.metrics.mutex_wait_us.record(duration_us),
+            SpanKind::PtyRead => self.metrics.pty_read_latency_us.record(duration_us),
+            SpanKind::ClientDispatch => self.metrics.dispatch_latency_us.record(duration_us),
+            SpanKind::ClientWrite => self.metrics.client_write_latency_us.record(duration_us),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flight::RingReader;
+    use tempfile::TempDir;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    fn setup() -> (Arc<DaemonMetrics>, Arc<RingWriter>, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let metrics = Arc::new(DaemonMetrics::new());
+        let ring = Arc::new(RingWriter::open(dir.path()).unwrap());
+        (metrics, ring, dir)
+    }
+
+    #[test]
+    fn profiling_span_records_enter_and_exit() {
+        let (metrics, ring, dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "test_op",
+                span_kind = "pty_read"
+            );
+            let _guard = span.enter();
+            std::thread::sleep(std::time::Duration::from_micros(100));
+        });
+
+        let reader = RingReader::open(&dir.path().join("flight.bin")).unwrap();
+        let events = reader.read_all();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, EventType::Enter);
+        assert_eq!(events[0].span_kind, SpanKind::PtyRead);
+        assert_eq!(events[1].event_type, EventType::Exit);
+        assert_eq!(events[1].span_kind, SpanKind::PtyRead);
+        assert!(events[1].value > 0, "exit event should have non-zero duration");
+    }
+
+    #[test]
+    fn non_profile_spans_are_ignored() {
+        let (metrics, ring, dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(
+                target: "some_other_target",
+                tracing::Level::INFO,
+                "ignored_op",
+                span_kind = "pty_read"
+            );
+            let _guard = span.enter();
+        });
+
+        let reader = RingReader::open(&dir.path().join("flight.bin")).unwrap();
+        let events = reader.read_all();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn exit_updates_correct_histogram() {
+        let (metrics, ring, _dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "mutex_op",
+                span_kind = "mutex_acquire"
+            );
+            let _guard = span.enter();
+            std::thread::sleep(std::time::Duration::from_micros(50));
+        });
+
+        let snap = metrics.mutex_wait_us.snapshot();
+        let total: u64 = snap.iter().sum();
+        assert_eq!(total, 1, "mutex_wait_us should have exactly one sample");
+    }
+
+    #[test]
+    fn span_kind_dispatch_updates_dispatch_histogram() {
+        let (metrics, ring, _dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "dispatch",
+                span_kind = "client_dispatch"
+            );
+            let _guard = span.enter();
+        });
+
+        let snap = metrics.dispatch_latency_us.snapshot();
+        let total: u64 = snap.iter().sum();
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn span_kind_client_write_updates_write_histogram() {
+        let (metrics, ring, _dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "write",
+                span_kind = "client_write"
+            );
+            let _guard = span.enter();
+            std::thread::sleep(std::time::Duration::from_micros(10));
+        });
+
+        let snap = metrics.client_write_latency_us.snapshot();
+        let total: u64 = snap.iter().sum();
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn multiple_spans_accumulate_in_ring_buffer() {
+        let (metrics, ring, dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            for _ in 0..5 {
+                let span = tracing::span!(
+                    target: "rttx_profile",
+                    tracing::Level::INFO,
+                    "op",
+                    span_kind = "io_flush"
+                );
+                let _guard = span.enter();
+            }
+        });
+
+        let reader = RingReader::open(&dir.path().join("flight.bin")).unwrap();
+        let events = reader.read_all();
+        // 5 spans × 2 events (enter + exit) = 10
+        assert_eq!(events.len(), 10);
+    }
+
+    #[test]
+    fn span_ids_are_sequential() {
+        let (metrics, ring, dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            for _ in 0..3 {
+                let span = tracing::span!(
+                    target: "rttx_profile",
+                    tracing::Level::INFO,
+                    "op",
+                    span_kind = "pty_read"
+                );
+                let _guard = span.enter();
+            }
+        });
+
+        let reader = RingReader::open(&dir.path().join("flight.bin")).unwrap();
+        let events = reader.read_all();
+        // Enter events at indices 0, 2, 4 should have sequential span_ids
+        assert_eq!(events[0].span_id, 1);
+        assert_eq!(events[2].span_id, 2);
+        assert_eq!(events[4].span_id, 3);
+    }
+
+    #[test]
+    fn unknown_span_kind_defaults_to_shutdown() {
+        let (metrics, ring, dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "op",
+                span_kind = "unknown_kind"
+            );
+            let _guard = span.enter();
+        });
+
+        let reader = RingReader::open(&dir.path().join("flight.bin")).unwrap();
+        let events = reader.read_all();
+        assert_eq!(events[0].span_kind, SpanKind::Shutdown);
+    }
+}

--- a/services/rttx-server/tests/profiling_layer.rs
+++ b/services/rttx-server/tests/profiling_layer.rs
@@ -1,0 +1,171 @@
+//! Integration test: `ProfilingLayer` records spans to ring buffer and metrics.
+//!
+//! Verifies end-to-end behavior of the profiling layer when composed with
+//! the tracing subscriber registry — spans appear in the ring buffer and
+//! the correct histograms are updated.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use rttx_server::flight::{EventType, RingReader, RingWriter, SpanKind};
+use rttx_server::metrics::DaemonMetrics;
+use rttx_server::profiling::ProfilingLayer;
+use tempfile::TempDir;
+use tracing_subscriber::layer::SubscriberExt;
+
+#[test]
+fn profiling_layer_end_to_end() {
+    let dir = TempDir::new().unwrap();
+    let metrics = Arc::new(DaemonMetrics::new());
+    let ring = Arc::new(RingWriter::open(dir.path()).unwrap());
+
+    let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        // Profile span — should be recorded
+        let span = tracing::span!(
+            target: "rttx_profile",
+            tracing::Level::INFO,
+            "pty_read_op",
+            span_kind = "pty_read"
+        );
+        {
+            let _guard = span.enter();
+            std::thread::sleep(std::time::Duration::from_micros(200));
+        }
+
+        // Non-profile span — should be ignored
+        tracing::info!("regular log message");
+        let ignored = tracing::span!(
+            target: "rttx_server",
+            tracing::Level::INFO,
+            "normal_span"
+        );
+        let _g = ignored.enter();
+    });
+
+    // Verify ring buffer
+    let reader = RingReader::open(&dir.path().join("flight.bin")).unwrap();
+    let events = reader.read_all();
+    assert_eq!(events.len(), 2, "expected Enter + Exit events");
+    assert_eq!(events[0].event_type, EventType::Enter);
+    assert_eq!(events[0].span_kind, SpanKind::PtyRead);
+    assert_eq!(events[1].event_type, EventType::Exit);
+    assert_eq!(events[1].span_kind, SpanKind::PtyRead);
+    assert!(events[1].value > 0, "exit should carry duration_ns");
+    assert!(events[1].timestamp_ns >= events[0].timestamp_ns);
+
+    // Verify metrics
+    let snap = metrics.pty_read_latency_us.snapshot();
+    let total: u64 = snap.iter().sum();
+    assert_eq!(total, 1, "pty_read histogram should have one sample");
+}
+
+#[test]
+fn profiling_layer_multiple_span_kinds_update_correct_histograms() {
+    let dir = TempDir::new().unwrap();
+    let metrics = Arc::new(DaemonMetrics::new());
+    let ring = Arc::new(RingWriter::open(dir.path()).unwrap());
+
+    let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        for kind in &["mutex_acquire", "pty_read", "client_dispatch", "client_write"] {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "op",
+                span_kind = *kind
+            );
+            let _guard = span.enter();
+        }
+    });
+
+    // Each kind should have exactly one sample in its histogram
+    let mutex_total: u64 = metrics.mutex_wait_us.snapshot().iter().sum();
+    let pty_total: u64 = metrics.pty_read_latency_us.snapshot().iter().sum();
+    let dispatch_total: u64 = metrics.dispatch_latency_us.snapshot().iter().sum();
+    let write_total: u64 = metrics.client_write_latency_us.snapshot().iter().sum();
+
+    assert_eq!(mutex_total, 1);
+    assert_eq!(pty_total, 1);
+    assert_eq!(dispatch_total, 1);
+    assert_eq!(write_total, 1);
+
+    // Ring buffer should have 8 events (4 enter + 4 exit)
+    let reader = RingReader::open(&dir.path().join("flight.bin")).unwrap();
+    assert_eq!(reader.read_all().len(), 8);
+}
+
+#[test]
+fn profiling_layer_concurrent_spans() {
+    use tracing::Dispatch;
+
+    let dir = TempDir::new().unwrap();
+    let metrics = Arc::new(DaemonMetrics::new());
+    let ring = Arc::new(RingWriter::open(dir.path()).unwrap());
+
+    let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let dispatch = Dispatch::new(subscriber);
+
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let d = dispatch.clone();
+        handles.push(std::thread::spawn(move || {
+            let _guard = tracing::dispatcher::set_default(&d);
+            for _ in 0..100 {
+                let span = tracing::span!(
+                    target: "rttx_profile",
+                    tracing::Level::INFO,
+                    "concurrent_op",
+                    span_kind = "pty_read"
+                );
+                let _g = span.enter();
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // 4 threads × 100 spans = 400 histogram samples
+    let snap = metrics.pty_read_latency_us.snapshot();
+    let total: u64 = snap.iter().sum();
+    assert_eq!(total, 400);
+
+    // 400 spans × 2 events = 800 ring buffer events
+    assert_eq!(ring.write_pos(), 800);
+}
+
+#[test]
+fn profiling_layer_does_not_interfere_with_counters() {
+    let dir = TempDir::new().unwrap();
+    let metrics = Arc::new(DaemonMetrics::new());
+    let ring = Arc::new(RingWriter::open(dir.path()).unwrap());
+
+    // Manually increment a counter before layer usage
+    metrics.messages_dispatched.fetch_add(42, Ordering::Relaxed);
+
+    let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        let span = tracing::span!(
+            target: "rttx_profile",
+            tracing::Level::INFO,
+            "op",
+            span_kind = "client_dispatch"
+        );
+        let _guard = span.enter();
+    });
+
+    // Counter should be untouched by the layer
+    assert_eq!(metrics.messages_dispatched.load(Ordering::Relaxed), 42);
+    // But histogram should have the sample
+    let snap = metrics.dispatch_latency_us.snapshot();
+    let total: u64 = snap.iter().sum();
+    assert_eq!(total, 1);
+}


### PR DESCRIPTION
## Summary

Implements a custom `ProfilingLayer` (`tracing_subscriber::Layer`) that writes span events to the ring buffer flight recorder and updates `DaemonMetrics` latency histograms. This is Phase 2 of the profiling infrastructure (RFC-028), building on #894 (DaemonMetrics) and #895 (ring buffer).

Fixes #896

## What changed

- **New `profiling.rs` module** — `ProfilingLayer` implementing `tracing_subscriber::Layer`:
  - Filters only spans with `target = "rttx_profile"` (ignores all other tracing output)
  - On span enter: writes Enter event to ring buffer with timestamp + span metadata
  - On span exit: computes duration (exit - enter), writes Exit event, updates the relevant `LatencyHistogram` based on `span_kind` field
  - Holds `Arc<DaemonMetrics>` and `Arc<RingWriter>` for lock-free recording
  - Sequential span IDs via atomic counter

- **Refactored `logging.rs`** — `init_file_logging` now uses layered subscriber composition (`tracing_subscriber::registry().with(...)`). Added `init_logging_with_profiling` that composes the file layer with the profiling layer.

- **Workspace `Cargo.toml`** — added `registry` feature to `tracing-subscriber`

## How to verify manually

```rust
use tracing::span;

// This span will be recorded by the profiling layer:
let span = tracing::span!(
    target: "rttx_profile",
    tracing::Level::INFO,
    "my_operation",
    span_kind = "pty_read"
);
let _guard = span.enter();
// ... work ...
// On drop: duration recorded to pty_read_latency_us histogram + ring buffer
```

## Tests added

**Unit tests** (8 in `profiling::tests`):
- `profiling_span_records_enter_and_exit` — verifies Enter/Exit events in ring buffer
- `non_profile_spans_are_ignored` — non-`rttx_profile` spans produce no events
- `exit_updates_correct_histogram` — mutex_acquire → mutex_wait_us
- `span_kind_dispatch_updates_dispatch_histogram` — client_dispatch → dispatch_latency_us
- `span_kind_client_write_updates_write_histogram` — client_write → client_write_latency_us
- `multiple_spans_accumulate_in_ring_buffer` — 5 spans → 10 events
- `span_ids_are_sequential` — atomic counter produces 1, 2, 3...
- `unknown_span_kind_defaults_to_shutdown` — graceful fallback

**Integration tests** (4 in `tests/profiling_layer.rs`):
- `profiling_layer_end_to_end` — full span lifecycle with timing verification
- `profiling_layer_multiple_span_kinds_update_correct_histograms` — all 4 histogram-mapped kinds
- `profiling_layer_concurrent_spans` — 4 threads × 100 spans, verifies atomicity
- `profiling_layer_does_not_interfere_with_counters` — layer only touches histograms

## Tests run

- `cargo test -p rttx-server --lib --tests` — 450 lib + all integration tests pass
- `cargo clippy -p rttx-server --tests -- -D warnings` — clean
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass including profiling tests