### PR TITLE
feat(profiling): instrument PTY read, VTE parse, and serialization I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.4.32"
+version = "0.4.33"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.4.32"
+version = "0.4.33"
 dependencies = [
  "bytes",
  "proptest",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.4.32"
+version = "0.4.33"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.32"
+version = "0.4.33"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.4.32',
+  version: '0.4.33',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/src/crash_report.rs
+++ b/services/rttx-server/src/crash_report.rs
@@ -121,6 +121,9 @@ fn write_metrics_snapshot(out: &mut String, metrics: &DaemonMetrics) {
     write_histogram(out, "  dispatch_latency_us", &metrics.dispatch_latency_us);
     write_histogram(out, "  pty_read_latency_us", &metrics.pty_read_latency_us);
     write_histogram(out, "  client_write_latency_us", &metrics.client_write_latency_us);
+    write_histogram(out, "  vte_parse_latency_us", &metrics.vte_parse_latency_us);
+    write_histogram(out, "  serialization_tick_latency_us", &metrics.serialization_tick_latency_us);
+    write_histogram(out, "  io_flush_latency_us", &metrics.io_flush_latency_us);
 }
 
 fn write_histogram(out: &mut String, label: &str, h: &crate::metrics::LatencyHistogram) {

--- a/services/rttx-server/src/diagnostics.rs
+++ b/services/rttx-server/src/diagnostics.rs
@@ -190,7 +190,14 @@ mod tests {
                 PathBuf::from("/tmp/test-state/rttx/daemon")
             }
         }
-        Server::new(Box::new(TestOs), std::sync::Arc::new(crate::metrics::DaemonMetrics::new()))
+        let dir = tempfile::TempDir::new().unwrap();
+        let ring = std::sync::Arc::new(crate::flight::RingWriter::open(dir.path()).unwrap());
+        std::mem::forget(dir);
+        Server::new(
+            Box::new(TestOs),
+            std::sync::Arc::new(crate::metrics::DaemonMetrics::new()),
+            ring,
+        )
     }
 
     #[test]

--- a/services/rttx-server/src/instrument.rs
+++ b/services/rttx-server/src/instrument.rs
@@ -196,8 +196,13 @@ mod tests {
     async fn lock_server_returns_working_guard() {
         let metrics = Arc::new(DaemonMetrics::new());
         let os = crate::os::unix::UnixOs;
-        let server =
-            tokio::sync::Mutex::new(crate::server::Server::new(Box::new(os), Arc::clone(&metrics)));
+        let dir = tempfile::TempDir::new().unwrap();
+        let ring = Arc::new(crate::flight::RingWriter::open(dir.path()).unwrap());
+        let server = tokio::sync::Mutex::new(crate::server::Server::new(
+            Box::new(os),
+            Arc::clone(&metrics),
+            ring,
+        ));
 
         let guard = lock_server(&server, &metrics).await;
         assert!(!guard.server_id.is_nil());

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -195,7 +195,11 @@ fn start(foreground: bool) -> anyhow::Result<()> {
 
     let rt = tokio::runtime::Runtime::new()?;
     let result = rt.block_on(async {
-        let server = Arc::new(Mutex::new(Server::new(Box::new(os), Arc::clone(&metrics))));
+        let server = Arc::new(Mutex::new(Server::new(
+            Box::new(os),
+            Arc::clone(&metrics),
+            Arc::clone(&ring),
+        )));
 
         {
             let mut s = server.lock().await;

--- a/services/rttx-server/src/metrics.rs
+++ b/services/rttx-server/src/metrics.rs
@@ -94,6 +94,9 @@ impl LatencyHistogram {
 /// All fields use atomic operations — no locks required for reads or writes.
 #[derive(Debug)]
 pub struct DaemonMetrics {
+    // Epoch for ring buffer timestamps
+    pub epoch: std::time::Instant,
+
     // Gauges
     pub connected_clients: AtomicU32,
     pub active_panes: AtomicU32,
@@ -114,6 +117,9 @@ pub struct DaemonMetrics {
     pub dispatch_latency_us: LatencyHistogram,
     pub pty_read_latency_us: LatencyHistogram,
     pub client_write_latency_us: LatencyHistogram,
+    pub vte_parse_latency_us: LatencyHistogram,
+    pub serialization_tick_latency_us: LatencyHistogram,
+    pub io_flush_latency_us: LatencyHistogram,
 }
 
 impl Default for DaemonMetrics {
@@ -124,8 +130,10 @@ impl Default for DaemonMetrics {
 
 impl DaemonMetrics {
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
+            epoch: std::time::Instant::now(),
+
             connected_clients: AtomicU32::new(0),
             active_panes: AtomicU32::new(0),
             total_channel_depth: AtomicU64::new(0),
@@ -143,6 +151,9 @@ impl DaemonMetrics {
             dispatch_latency_us: LatencyHistogram::new(),
             pty_read_latency_us: LatencyHistogram::new(),
             client_write_latency_us: LatencyHistogram::new(),
+            vte_parse_latency_us: LatencyHistogram::new(),
+            serialization_tick_latency_us: LatencyHistogram::new(),
+            io_flush_latency_us: LatencyHistogram::new(),
         }
     }
 }

--- a/services/rttx-server/src/profile.rs
+++ b/services/rttx-server/src/profile.rs
@@ -53,6 +53,9 @@ pub struct ProfileReport {
     pub dispatch_latency: LatencyStats,
     pub pty_read_latency: LatencyStats,
     pub client_write_latency: LatencyStats,
+    pub vte_parse_latency: LatencyStats,
+    pub serialization_tick_latency: LatencyStats,
+    pub io_flush_latency: LatencyStats,
     pub contention: ContentionStats,
     pub slow_ops: Vec<SlowOp>,
 }
@@ -125,6 +128,10 @@ pub fn build_report(events: &[FlightEvent], pid: Option<u32>) -> ProfileReport {
     let dispatch_latency = compute_latency_stats(durations.get(&SpanKind::ClientDispatch));
     let pty_read_latency = compute_latency_stats(durations.get(&SpanKind::PtyRead));
     let client_write_latency = compute_latency_stats(durations.get(&SpanKind::ClientWrite));
+    let vte_parse_latency = compute_latency_stats(durations.get(&SpanKind::VteParse));
+    let serialization_tick_latency =
+        compute_latency_stats(durations.get(&SpanKind::SerializationTick));
+    let io_flush_latency = compute_latency_stats(durations.get(&SpanKind::IoFlush));
 
     ProfileReport {
         pid,
@@ -134,6 +141,9 @@ pub fn build_report(events: &[FlightEvent], pid: Option<u32>) -> ProfileReport {
         dispatch_latency,
         pty_read_latency,
         client_write_latency,
+        vte_parse_latency,
+        serialization_tick_latency,
+        io_flush_latency,
         contention,
         slow_ops,
     }
@@ -211,7 +221,10 @@ impl fmt::Display for ProfileReport {
         write_latency_line(f, "Mutex wait", &self.mutex_latency)?;
         write_latency_line(f, "Message dispatch", &self.dispatch_latency)?;
         write_latency_line(f, "PTY read batch", &self.pty_read_latency)?;
+        write_latency_line(f, "VTE parse", &self.vte_parse_latency)?;
         write_latency_line(f, "Client write", &self.client_write_latency)?;
+        write_latency_line(f, "Serialization tick", &self.serialization_tick_latency)?;
+        write_latency_line(f, "IO flush", &self.io_flush_latency)?;
 
         // Contention section
         writeln!(f)?;
@@ -340,6 +353,9 @@ pub struct JsonLatency {
     pub dispatch: JsonLatencyStats,
     pub pty_read: JsonLatencyStats,
     pub client_write: JsonLatencyStats,
+    pub vte_parse: JsonLatencyStats,
+    pub serialization_tick: JsonLatencyStats,
+    pub io_flush: JsonLatencyStats,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -375,6 +391,9 @@ impl From<&ProfileReport> for JsonReport {
                 dispatch: (&r.dispatch_latency).into(),
                 pty_read: (&r.pty_read_latency).into(),
                 client_write: (&r.client_write_latency).into(),
+                vte_parse: (&r.vte_parse_latency).into(),
+                serialization_tick: (&r.serialization_tick_latency).into(),
+                io_flush: (&r.io_flush_latency).into(),
             },
             contention: JsonContention {
                 mutex_contentions: r.contention.mutex_contentions,
@@ -700,5 +719,57 @@ mod tests {
         ];
         let report = build_report(&events, None);
         assert_eq!(report.contention.channel_overflows, 2);
+    }
+
+    #[test]
+    fn vte_parse_latency_computed() {
+        let events = vec![make_exit_event(1_000_000, SpanKind::VteParse, 200_000)]; // 200µs
+        let report = build_report(&events, None);
+        assert_eq!(report.vte_parse_latency.count, 1);
+        assert_eq!(report.vte_parse_latency.p50_us, 200);
+    }
+
+    #[test]
+    fn serialization_tick_latency_computed() {
+        let events = vec![make_exit_event(1_000_000, SpanKind::SerializationTick, 5_000_000)]; // 5ms
+        let report = build_report(&events, None);
+        assert_eq!(report.serialization_tick_latency.count, 1);
+        assert_eq!(report.serialization_tick_latency.p50_us, 5_000);
+    }
+
+    #[test]
+    fn io_flush_latency_computed() {
+        let events = vec![make_exit_event(1_000_000, SpanKind::IoFlush, 1_000_000)]; // 1ms
+        let report = build_report(&events, None);
+        assert_eq!(report.io_flush_latency.count, 1);
+        assert_eq!(report.io_flush_latency.p50_us, 1_000);
+    }
+
+    #[test]
+    fn display_format_includes_new_latency_lines() {
+        let events = vec![
+            make_exit_event(1_000_000, SpanKind::VteParse, 100_000),
+            make_exit_event(2_000_000, SpanKind::SerializationTick, 5_000_000),
+            make_exit_event(3_000_000, SpanKind::IoFlush, 2_000_000),
+        ];
+        let report = build_report(&events, None);
+        let output = report.to_string();
+        assert!(output.contains("VTE parse"), "report should show VTE parse latency");
+        assert!(output.contains("Serialization tick"), "report should show serialization tick");
+        assert!(output.contains("IO flush"), "report should show IO flush latency");
+    }
+
+    #[test]
+    fn json_report_includes_new_latency_fields() {
+        let events = vec![
+            make_exit_event(1_000_000, SpanKind::VteParse, 100_000),
+            make_exit_event(2_000_000, SpanKind::SerializationTick, 5_000_000),
+        ];
+        let report = build_report(&events, None);
+        let json: JsonReport = (&report).into();
+        let serialized = serde_json::to_string(&json).unwrap();
+        assert!(serialized.contains("\"vte_parse\""));
+        assert!(serialized.contains("\"serialization_tick\""));
+        assert!(serialized.contains("\"io_flush\""));
     }
 }

--- a/services/rttx-server/src/profiling.rs
+++ b/services/rttx-server/src/profiling.rs
@@ -146,8 +146,13 @@ where
         match kind {
             SpanKind::MutexAcquire => self.metrics.mutex_wait_us.record(duration_us),
             SpanKind::PtyRead => self.metrics.pty_read_latency_us.record(duration_us),
+            SpanKind::VteParse => self.metrics.vte_parse_latency_us.record(duration_us),
             SpanKind::ClientDispatch => self.metrics.dispatch_latency_us.record(duration_us),
             SpanKind::ClientWrite => self.metrics.client_write_latency_us.record(duration_us),
+            SpanKind::SerializationTick => {
+                self.metrics.serialization_tick_latency_us.record(duration_us);
+            }
+            SpanKind::IoFlush => self.metrics.io_flush_latency_us.record(duration_us),
             _ => {}
         }
     }
@@ -349,5 +354,70 @@ mod tests {
         let reader = RingReader::open(&dir.path().join("flight.bin")).unwrap();
         let events = reader.read_all();
         assert_eq!(events[0].span_kind, SpanKind::Shutdown);
+    }
+
+    #[test]
+    fn vte_parse_span_updates_histogram() {
+        let (metrics, ring, _dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "vte.parse",
+                span_kind = "vte_parse"
+            );
+            let _guard = span.enter();
+            std::thread::sleep(std::time::Duration::from_micros(10));
+        });
+
+        let snap = metrics.vte_parse_latency_us.snapshot();
+        let total: u64 = snap.iter().sum();
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn serialization_tick_span_updates_histogram() {
+        let (metrics, ring, _dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "serialization.tick",
+                span_kind = "serialization_tick"
+            );
+            let _guard = span.enter();
+        });
+
+        let snap = metrics.serialization_tick_latency_us.snapshot();
+        let total: u64 = snap.iter().sum();
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn io_flush_span_updates_histogram() {
+        let (metrics, ring, _dir) = setup();
+        let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "io.flush",
+                span_kind = "io_flush"
+            );
+            let _guard = span.enter();
+            std::thread::sleep(std::time::Duration::from_micros(10));
+        });
+
+        let snap = metrics.io_flush_latency_us.snapshot();
+        let total: u64 = snap.iter().sum();
+        assert_eq!(total, 1);
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -190,6 +190,8 @@ pub struct Server {
     pub os: Box<dyn OsInterface>,
     /// Always-on profiling metrics shared with the profiling layer.
     pub metrics: Arc<crate::metrics::DaemonMetrics>,
+    /// Ring buffer writer for direct flight event recording.
+    pub ring: Arc<crate::flight::RingWriter>,
     /// Per-client bounded push channels for server-initiated messages (Deltas, etc.).
     client_senders: HashMap<Uuid, mpsc::Sender<ClientMsg>>,
     /// Per-client response channels for request/response messages.
@@ -207,7 +209,11 @@ pub struct Server {
 impl Server {
     /// Create a new server with the native engine.
     #[must_use]
-    pub fn new(os: Box<dyn OsInterface>, metrics: Arc<crate::metrics::DaemonMetrics>) -> Self {
+    pub fn new(
+        os: Box<dyn OsInterface>,
+        metrics: Arc<crate::metrics::DaemonMetrics>,
+        ring: Arc<crate::flight::RingWriter>,
+    ) -> Self {
         let (shutdown_tx, _) = watch::channel(false);
         Self {
             runtimes: HashMap::new(),
@@ -215,6 +221,7 @@ impl Server {
             engine: Box::new(NativeEngine),
             os,
             metrics,
+            ring,
             client_senders: HashMap::new(),
             client_resp_senders: HashMap::new(),
             client_protocols: HashMap::new(),
@@ -501,6 +508,10 @@ impl Server {
                         child,
                         kill_rx,
                         Arc::clone(&metrics),
+                        {
+                            let s = crate::instrument::lock_server(server, &metrics).await;
+                            Arc::clone(&s.ring)
+                        },
                     );
                     tracing::info!("Reconstructed pane {pane_short} in runtime {runtime_label}");
                 }
@@ -992,7 +1003,7 @@ impl Server {
                         let child_pid = pty.pid();
                         let (reader, writer, mut child) = pty.into_parts();
                         let (kill_tx, kill_rx) = oneshot::channel();
-                        let (revision, runtime_name, metrics) = {
+                        let (revision, runtime_name, metrics, ring) = {
                             let mut s = crate::instrument::lock_server(server, metrics).await;
                             let Some(rt_lock) = s.runtimes.get(&runtime_id) else {
                                 let _ = child.start_kill();
@@ -1014,7 +1025,8 @@ impl Server {
                                 .insert(pane_id, Arc::new(tokio::sync::Mutex::new(writer)));
                             s.pty_kill_senders.insert(pane_id, kill_tx);
                             let m = s.metrics.clone();
-                            (revision, name, m)
+                            let r = Arc::clone(&s.ring);
+                            (revision, name, m, r)
                         };
                         spawn_pty_read_loop(
                             Arc::clone(server),
@@ -1025,6 +1037,7 @@ impl Server {
                             child,
                             kill_rx,
                             metrics,
+                            ring,
                         );
                         tracing::info!(
                             "Pane {} created in runtime \"{}\" ({})",
@@ -1967,7 +1980,7 @@ impl Server {
                 let child_pid = pty.pid();
                 let (reader, writer, mut child) = pty.into_parts();
                 let (kill_tx, kill_rx) = oneshot::channel();
-                let (revision, runtime_name, metrics) = {
+                let (revision, runtime_name, metrics, ring) = {
                     let mut s = crate::instrument::lock_server(server, metrics).await;
                     let Some(rt_lock) = s.runtimes.get(&runtime_id) else {
                         let _ = child.start_kill();
@@ -1992,7 +2005,8 @@ impl Server {
                     s.pty_writers.insert(pane_id, Arc::new(tokio::sync::Mutex::new(writer)));
                     s.pty_kill_senders.insert(pane_id, kill_tx);
                     let m = s.metrics.clone();
-                    (revision, name, m)
+                    let r = Arc::clone(&s.ring);
+                    (revision, name, m, r)
                 };
                 spawn_pty_read_loop(
                     Arc::clone(server),
@@ -2003,6 +2017,7 @@ impl Server {
                     child,
                     kill_rx,
                     metrics,
+                    ring,
                 );
                 tracing::info!(
                     "Pane {} created in runtime \"{}\" ({})",
@@ -2269,6 +2284,7 @@ fn spawn_pty_read_loop(
     mut child: tokio::process::Child,
     mut kill_rx: oneshot::Receiver<()>,
     metrics: Arc<crate::metrics::DaemonMetrics>,
+    ring: Arc<crate::flight::RingWriter>,
 ) {
     let runtime_label = format!("\"{}\" ({})", runtime_name, short_id(runtime_id));
     let pane_short = short_id(pane_id);
@@ -2310,6 +2326,11 @@ fn spawn_pty_read_loop(
                             }
 
                             let data = batch.split().freeze();
+                            let batch_len = data.len() as u64;
+                            metrics.bytes_read_from_pty.fetch_add(batch_len, std::sync::atomic::Ordering::Relaxed);
+                            let pty_batch_start = std::time::Instant::now();
+                            let mut pane_context = [0u8; 16];
+                            pane_context[..16].copy_from_slice(pane_id.as_bytes());
 
                             // Phase 1: accept raw bytes under the per-runtime lock
                             // (fast memcpy, no VTE parsing).  The server mutex is
@@ -2350,6 +2371,13 @@ fn spawn_pty_read_loop(
 
                             // Phase 2: VTE parsing outside any lock.
                             if let Some(ref mut screen) = taken_screen {
+                                let _vte_span = tracing::info_span!(
+                                    target: "rttx_profile",
+                                    "vte.parse",
+                                    span_kind = "vte_parse",
+                                    pane_id = %pane_short,
+                                    bytes_parsed = batch_len,
+                                ).entered();
                                 screen.parse(&data);
                             }
 
@@ -2421,6 +2449,16 @@ fn spawn_pty_read_loop(
                                 let mut s = crate::instrument::lock_server(&server, &metrics).await;
                                 s.handle_push_overflows(&all_overflows, runtime_id);
                             }
+
+                            metrics.pty_read_latency_us.record(pty_batch_start.elapsed().as_micros() as u64);
+                            ring.record(&crate::flight::FlightEvent {
+                                timestamp_ns: metrics.epoch.elapsed().as_nanos() as u64,
+                                span_id: 0,
+                                event_type: crate::flight::EventType::Exit,
+                                span_kind: crate::flight::SpanKind::PtyRead,
+                                context: pane_context,
+                                value: pty_batch_start.elapsed().as_nanos() as u64,
+                            });
                         }
                         Err(e) => {
                             tracing::error!("PTY read error for pane {pane_short} in runtime {runtime_label}: {e}");
@@ -2527,6 +2565,7 @@ pub async fn serialization_loop(
     server: Arc<Mutex<Server>>,
     interval: Duration,
     shutdown_rx: &mut watch::Receiver<bool>,
+    ring: Arc<crate::flight::RingWriter>,
 ) {
     let metrics = { server.lock().await.metrics.clone() };
     let mut ticker = tokio::time::interval(interval);
@@ -2540,6 +2579,9 @@ pub async fn serialization_loop(
                 return;
             }
         }
+
+        metrics.serialization_ticks.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tick_start = std::time::Instant::now();
 
         let s = crate::instrument::lock_server(&server, &metrics).await;
         let state_dir = s.os.state_dir();
@@ -2596,6 +2638,13 @@ pub async fn serialization_loop(
 
         // Phase 2: flush scrollback to disk outside the lock.
         for (path, data) in &flush_jobs {
+            let _flush_span = tracing::info_span!(
+                target: "rttx_profile",
+                "io.flush",
+                span_kind = "io_flush",
+                path = %path.display(),
+            )
+            .entered();
             if let Err(e) = crate::pane::write_scrollback_to_disk(path, data) {
                 tracing::error!("Failed to flush scrollback to {}: {e}", path.display());
             }
@@ -2603,6 +2652,13 @@ pub async fn serialization_loop(
 
         // Write v2 daemon index only when runtime IDs changed.
         if index_changed {
+            let _flush_span = tracing::info_span!(
+                target: "rttx_profile",
+                "io.flush",
+                span_kind = "io_flush",
+                path = %state_dir.join("index.json").display(),
+            )
+            .entered();
             if let Err(e) = crate::state::persistence::save_daemon_index(&state_dir, &current_ids) {
                 tracing::error!("Failed to write v2 daemon index: {e}");
             } else {
@@ -2613,6 +2669,13 @@ pub async fn serialization_loop(
         // Write only dirty runtimes.
         let written_ids: Vec<Uuid> = dirty_runtime_files.iter().map(|rf| rf.spec.id).collect();
         for rf in &dirty_runtime_files {
+            let _flush_span = tracing::info_span!(
+                target: "rttx_profile",
+                "io.flush",
+                span_kind = "io_flush",
+                path = %state_dir.join("runtimes").join(rf.spec.id.to_string()).display(),
+            )
+            .entered();
             if let Err(e) = crate::state::persistence::save_runtime(&state_dir, rf) {
                 tracing::error!("Failed to write v2 runtime {}: {e}", short_id(rf.spec.id));
             }
@@ -2620,6 +2683,12 @@ pub async fn serialization_loop(
 
         // Write screen snapshots for dirty runtimes.
         for (runtime_id, snap) in &screen_snapshots {
+            let _flush_span = tracing::info_span!(
+                target: "rttx_profile",
+                "io.flush",
+                span_kind = "io_flush",
+                path = %state_dir.join("runtimes").join(runtime_id.to_string()).join("screen").display(),
+            ).entered();
             if let Err(e) =
                 crate::state::persistence::save_screen_snapshot(&state_dir, *runtime_id, snap)
             {
@@ -2641,6 +2710,16 @@ pub async fn serialization_loop(
                 }
             }
         }
+
+        metrics.serialization_tick_latency_us.record(tick_start.elapsed().as_micros() as u64);
+        ring.record(&crate::flight::FlightEvent {
+            timestamp_ns: metrics.epoch.elapsed().as_nanos() as u64,
+            span_id: 0,
+            event_type: crate::flight::EventType::Exit,
+            span_kind: crate::flight::SpanKind::SerializationTick,
+            context: [0; 16],
+            value: tick_start.elapsed().as_nanos() as u64,
+        });
     }
 }
 
@@ -2742,9 +2821,11 @@ pub async fn run(server: Arc<Mutex<Server>>) -> anyhow::Result<()> {
 
     // Start serialization loop.
     let ser_server = Arc::clone(&server);
+    let ser_ring = { server.lock().await.ring.clone() };
     let mut ser_shutdown_rx = shutdown_rx.clone();
     tokio::spawn(async move {
-        serialization_loop(ser_server, Duration::from_secs(1), &mut ser_shutdown_rx).await;
+        serialization_loop(ser_server, Duration::from_secs(1), &mut ser_shutdown_rx, ser_ring)
+            .await;
     });
 
     let connection_limit = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_CLIENTS));

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -22,10 +22,22 @@ impl OsInterface for StubOs {
 }
 
 fn new_server() -> Arc<Mutex<Server>> {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ring = Arc::new(crate::flight::RingWriter::open(dir.path()).unwrap());
+    // Leak the TempDir so it lives for the test duration.
+    std::mem::forget(dir);
     Arc::new(Mutex::new(Server::new(
         Box::new(StubOs),
         Arc::new(crate::metrics::DaemonMetrics::new()),
+        ring,
     )))
+}
+
+fn test_ring() -> Arc<crate::flight::RingWriter> {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ring = Arc::new(crate::flight::RingWriter::open(dir.path()).unwrap());
+    std::mem::forget(dir);
+    ring
 }
 
 fn test_metrics() -> Arc<crate::metrics::DaemonMetrics> {
@@ -70,7 +82,8 @@ fn short_id_returns_first_eight_characters() {
 
 #[test]
 fn runtime_label_includes_name_and_short_id() {
-    let mut server = Server::new(Box::new(StubOs), Arc::new(crate::metrics::DaemonMetrics::new()));
+    let mut server =
+        Server::new(Box::new(StubOs), Arc::new(crate::metrics::DaemonMetrics::new()), test_ring());
     let rt = Runtime::new("my-workspace".into());
     let runtime_id = rt.id;
     server.runtimes.insert(runtime_id, Arc::new(Mutex::new(rt)));
@@ -83,7 +96,8 @@ fn runtime_label_includes_name_and_short_id() {
 
 #[test]
 fn runtime_label_falls_back_for_unknown_runtime() {
-    let server = Server::new(Box::new(StubOs), Arc::new(crate::metrics::DaemonMetrics::new()));
+    let server =
+        Server::new(Box::new(StubOs), Arc::new(crate::metrics::DaemonMetrics::new()), test_ring());
     let unknown_id = Uuid::new_v4();
     let label = server.runtime_label(unknown_id);
     assert!(label.starts_with('('), "got: {label}");
@@ -2104,7 +2118,8 @@ async fn terminate_runtime_removes_state_directory() {
     let tmp = tempfile::TempDir::new().unwrap();
     let os = temp_os(tmp.path());
     let state_dir = os.state_dir();
-    let mut server = Server::new(Box::new(os), Arc::new(crate::metrics::DaemonMetrics::new()));
+    let mut server =
+        Server::new(Box::new(os), Arc::new(crate::metrics::DaemonMetrics::new()), test_ring());
 
     let mut rt = Runtime::new("cleanup-test".into());
     let runtime_id = rt.id;
@@ -2163,7 +2178,8 @@ fn load_persisted_state_sweeps_orphans() {
     // Save daemon index referencing only the known runtime.
     crate::state::persistence::save_daemon_index(&state_dir, &[known_id]).unwrap();
 
-    let mut server = Server::new(Box::new(os), Arc::new(crate::metrics::DaemonMetrics::new()));
+    let mut server =
+        Server::new(Box::new(os), Arc::new(crate::metrics::DaemonMetrics::new()), test_ring());
     server.load_persisted_state();
 
     // Known runtime should be loaded.
@@ -2181,7 +2197,8 @@ fn fresh_start_log_includes_state_directory_path() {
     let tmp = tempfile::TempDir::new().unwrap();
     let os = temp_os(tmp.path());
     let expected_state_dir = os.state_dir().to_string_lossy().to_string();
-    let mut server = Server::new(Box::new(os), Arc::new(crate::metrics::DaemonMetrics::new()));
+    let mut server =
+        Server::new(Box::new(os), Arc::new(crate::metrics::DaemonMetrics::new()), test_ring());
     server.load_persisted_state();
 
     assert!(
@@ -2222,7 +2239,8 @@ fn v1_state_json_in_cache_dir_is_ignored() {
     )
     .unwrap();
 
-    let mut server = Server::new(Box::new(os), Arc::new(crate::metrics::DaemonMetrics::new()));
+    let mut server =
+        Server::new(Box::new(os), Arc::new(crate::metrics::DaemonMetrics::new()), test_ring());
     server.load_persisted_state();
 
     assert!(

--- a/services/rttx-server/src/watchdog.rs
+++ b/services/rttx-server/src/watchdog.rs
@@ -195,6 +195,14 @@ fn build_hang_report(metrics: &DaemonMetrics, consecutive_timeouts: u32) -> Stri
         "Client write latency (µs): {:?}",
         metrics.client_write_latency_us.snapshot()
     );
+    let _ =
+        writeln!(report, "VTE parse latency (µs): {:?}", metrics.vte_parse_latency_us.snapshot());
+    let _ = writeln!(
+        report,
+        "Serialization tick latency (µs): {:?}",
+        metrics.serialization_tick_latency_us.snapshot()
+    );
+    let _ = writeln!(report, "IO flush latency (µs): {:?}", metrics.io_flush_latency_us.snapshot());
     report
 }
 
@@ -490,6 +498,11 @@ mod tests {
                 PathBuf::from("/tmp/test-state/rttx/daemon")
             }
         }
-        Server::new(Box::new(TestOs), Arc::new(DaemonMetrics::new()))
+        Server::new(Box::new(TestOs), Arc::new(DaemonMetrics::new()), {
+            let dir = tempfile::TempDir::new().unwrap();
+            let ring = std::sync::Arc::new(crate::flight::RingWriter::open(dir.path()).unwrap());
+            std::mem::forget(dir);
+            ring
+        })
     }
 }

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -124,7 +124,8 @@ pub async fn start_test_server(
 
     let os = TestOs { runtime_dir, cache_dir };
     let metrics = Arc::new(rttx_server::metrics::DaemonMetrics::new());
-    let server = Arc::new(Mutex::new(Server::new(Box::new(os), metrics)));
+    let ring = Arc::new(rttx_server::flight::RingWriter::open(tmp_dir).unwrap());
+    let server = Arc::new(Mutex::new(Server::new(Box::new(os), metrics, ring)));
 
     // Load persisted state and reconstruct sessions (if any).
     {

--- a/services/rttx-server/tests/io_instrumentation.rs
+++ b/services/rttx-server/tests/io_instrumentation.rs
@@ -1,0 +1,91 @@
+//! Integration test: I/O instrumentation spans for PTY read, VTE parse,
+//! serialization tick, and IO flush are recorded to the ring buffer and
+//! update the correct histograms.
+
+use std::sync::Arc;
+
+use rttx_server::flight::{EventType, RingReader, RingWriter, SpanKind};
+use rttx_server::metrics::DaemonMetrics;
+use rttx_server::profiling::ProfilingLayer;
+use tempfile::TempDir;
+use tracing_subscriber::layer::SubscriberExt;
+
+#[test]
+fn io_span_kinds_update_correct_histograms() {
+    let dir = TempDir::new().unwrap();
+    let metrics = Arc::new(DaemonMetrics::new());
+    let ring = Arc::new(RingWriter::open(dir.path()).unwrap());
+
+    let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        for kind in &["vte_parse", "serialization_tick", "io_flush"] {
+            let span = tracing::span!(
+                target: "rttx_profile",
+                tracing::Level::INFO,
+                "io_op",
+                span_kind = *kind
+            );
+            let _guard = span.enter();
+            std::thread::sleep(std::time::Duration::from_micros(10));
+        }
+    });
+
+    let vte: u64 = metrics.vte_parse_latency_us.snapshot().iter().sum();
+    let ser: u64 = metrics.serialization_tick_latency_us.snapshot().iter().sum();
+    let flush: u64 = metrics.io_flush_latency_us.snapshot().iter().sum();
+
+    assert_eq!(vte, 1, "vte_parse histogram should have one sample");
+    assert_eq!(ser, 1, "serialization_tick histogram should have one sample");
+    assert_eq!(flush, 1, "io_flush histogram should have one sample");
+
+    // Ring buffer: 3 spans × 2 events (enter + exit)
+    let reader = RingReader::open(&dir.path().join("flight.bin")).unwrap();
+    let events = reader.read_all();
+    assert_eq!(events.len(), 6);
+
+    let exit_events: Vec<_> = events.iter().filter(|e| e.event_type == EventType::Exit).collect();
+    assert_eq!(exit_events.len(), 3);
+    assert_eq!(exit_events[0].span_kind, SpanKind::VteParse);
+    assert_eq!(exit_events[1].span_kind, SpanKind::SerializationTick);
+    assert_eq!(exit_events[2].span_kind, SpanKind::IoFlush);
+
+    // Each exit event should carry a non-zero duration
+    for ev in &exit_events {
+        assert!(ev.value > 0, "exit event for {:?} should have duration", ev.span_kind);
+    }
+}
+
+#[test]
+fn io_instrumentation_does_not_affect_other_histograms() {
+    let dir = TempDir::new().unwrap();
+    let metrics = Arc::new(DaemonMetrics::new());
+    let ring = Arc::new(RingWriter::open(dir.path()).unwrap());
+
+    let layer = ProfilingLayer::new(Arc::clone(&metrics), Arc::clone(&ring));
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        let span = tracing::span!(
+            target: "rttx_profile",
+            tracing::Level::INFO,
+            "io_op",
+            span_kind = "io_flush"
+        );
+        let _guard = span.enter();
+    });
+
+    // Only io_flush should be updated
+    let flush: u64 = metrics.io_flush_latency_us.snapshot().iter().sum();
+    assert_eq!(flush, 1);
+
+    let pty: u64 = metrics.pty_read_latency_us.snapshot().iter().sum();
+    let vte: u64 = metrics.vte_parse_latency_us.snapshot().iter().sum();
+    let ser: u64 = metrics.serialization_tick_latency_us.snapshot().iter().sum();
+    let mutex: u64 = metrics.mutex_wait_us.snapshot().iter().sum();
+    assert_eq!(pty, 0);
+    assert_eq!(vte, 0);
+    assert_eq!(ser, 0);
+    assert_eq!(mutex, 0);
+}

--- a/services/rttx-server/tests/watchdog_hang_detection.rs
+++ b/services/rttx-server/tests/watchdog_hang_detection.rs
@@ -33,7 +33,10 @@ fn create_test_server() -> Server {
             PathBuf::from("/tmp/test-state/rttx/daemon")
         }
     }
-    Server::new(Box::new(TestOs), Arc::new(DaemonMetrics::new()))
+    let dir = tempfile::TempDir::new().unwrap();
+    let ring = Arc::new(rttx_server::flight::RingWriter::open(dir.path()).unwrap());
+    std::mem::forget(dir);
+    Server::new(Box::new(TestOs), Arc::new(DaemonMetrics::new()), ring)
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Adds profiling spans and metrics to the daemon's I/O hot paths (RFC-028 Phase 6). Answers: "is it a slow pane or slow disk?"

Fixes #901

## What changed

- **PTY read loop**: record `bytes_read_from_pty` counter and `pty_read_latency_us` histogram per coalesced batch; emit `PtyRead` flight event with pane context bytes
- **VTE parsing**: tracing span around `screen.parse()` with `pane_id` and `bytes_parsed`; `vte_parse_latency_us` histogram
- **Serialization loop**: record `serialization_ticks` counter and `serialization_tick_latency_us` histogram per tick; emit `SerializationTick` flight event
- **Disk I/O**: tracing span around each scrollback flush and state file write; `io_flush_latency_us` histogram
- **Crash/hang reports**: include new histograms in both crash reports and watchdog hang reports
- **Server::new()**: now accepts a `RingWriter` Arc for direct flight recording from the PTY read loop and serialization loop
- Version bump to 0.4.33

## Manual verification

1. `RTTX_DEV_MODE=1 cargo run -p rttx-server -- start --foreground` — daemon starts
2. Open a pane, type commands — PTY read spans appear in ring buffer
3. `rttx-server profile` shows VTE parse, serialization tick, and IO flush latency percentiles

## Tests added

### Profiling layer tests (`profiling.rs`)
- `vte_parse_span_updates_histogram` — VTE parse span records to histogram
- `serialization_tick_span_updates_histogram` — serialization tick span records
- `io_flush_span_updates_histogram` — IO flush span records to histogram

### Profile report tests (`profile.rs`)
- `vte_parse_latency_computed` — report computes VTE parse stats
- `serialization_tick_latency_computed` — report computes serialization stats
- `io_flush_latency_computed` — report computes IO flush stats
- `display_format_includes_new_latency_lines` — text output includes new lines
- `json_report_includes_new_latency_fields` — JSON output includes new fields

## Tests run

- `cargo build -p rttx-server -p rttx-proto` ✅
- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-server --lib` — 510 passed ✅
- `cargo test -p rttx-server --tests` — all integration tests passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — 763 passed ✅