### PR TITLE
fix(daemon): Log peer PID on Shutdown + strip CPR responses (#920)

### DIFF
--- a/services/rttx-server/src/ipc.rs
+++ b/services/rttx-server/src/ipc.rs
@@ -44,9 +44,10 @@ impl Listener {
     }
 
     /// Accept the next client connection.
-    pub async fn accept(&self) -> Result<ClientConnection<UnixStream>, IpcError> {
+    pub async fn accept(&self) -> Result<(ClientConnection<UnixStream>, Option<u32>), IpcError> {
         let (stream, _addr) = self.inner.accept().await?;
-        Ok(ClientConnection::new(stream))
+        let peer_pid = stream.peer_cred().ok().and_then(|c| c.pid().map(|p| p as u32));
+        Ok((ClientConnection::new(stream), peer_pid))
     }
 
     /// Return the socket path.
@@ -360,7 +361,7 @@ mod tests {
             conn.stream.write_all(&buf).await.unwrap();
         });
 
-        let mut server_conn = listener.accept().await.unwrap();
+        let (mut server_conn, _) = listener.accept().await.unwrap();
         let msg = server_conn.read_message().await.unwrap().unwrap();
         assert!(msg.msg.is_some());
         if let Some(proto::client_message::Msg::Hello(hello)) = msg.msg {
@@ -383,7 +384,7 @@ mod tests {
             let _stream = UnixStream::connect(&path_clone).await.unwrap();
         });
 
-        let mut server_conn = listener.accept().await.unwrap();
+        let (mut server_conn, _) = listener.accept().await.unwrap();
         client_task.await.unwrap();
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -505,8 +505,18 @@ fn csi_query_len(data: &[u8]) -> Option<usize> {
     let seq_len = pos + 1;
 
     match final_byte {
-        // DSR: CSI 5 n, CSI 6 n
-        b'n' if intermediates.is_empty() && matches!(params, b"5" | b"6") => Some(seq_len),
+        // DSR: CSI 5 n, CSI 6 n, CSI ? 5 n, CSI ? 6 n
+        b'n' if intermediates.is_empty() && matches!(params, b"5" | b"6" | b"?5" | b"?6") => {
+            Some(seq_len)
+        }
+        // CPR (Cursor Position Report): CSI <digits> ; <digits> R
+        // These are responses to DSR queries — never useful as display output.
+        b'R' if intermediates.is_empty()
+            && !params.is_empty()
+            && params.iter().all(|&b| b.is_ascii_digit() || b == b';') =>
+        {
+            Some(seq_len)
+        }
         // DA1: CSI c, CSI 0 c
         b'c' if intermediates.is_empty() && matches!(params, b"" | b"0") => Some(seq_len),
         // DA2: ESC [ > c or ESC [ > 0 c
@@ -1245,6 +1255,20 @@ mod tests {
     #[test]
     fn strip_removes_dsr_operating_status() {
         assert_eq!(strip_client_queries(b"before\x1b[5nafter"), b"beforeafter");
+    }
+
+    #[test]
+    fn strip_removes_cpr_response() {
+        // CSI 63;1 R — cursor position report (row 63, col 1)
+        assert_eq!(strip_client_queries(b"before\x1b[63;1Rafter"), b"beforeafter");
+        // Multiple CPR responses in sequence
+        assert_eq!(strip_client_queries(b"\x1b[63;1R\x1b[63;2R\x1b[30;1R"), b"");
+    }
+
+    #[test]
+    fn strip_removes_decxcpr_query() {
+        // CSI ? 6 n — extended cursor position query
+        assert_eq!(strip_client_queries(b"before\x1b[?6nafter"), b"beforeafter");
     }
 
     #[test]

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -2834,7 +2834,7 @@ pub async fn run(server: Arc<Mutex<Server>>) -> anyhow::Result<()> {
     loop {
         tokio::select! {
             result = listener.accept() => {
-                let conn = result?;
+                let (conn, peer_pid) = result?;
                 let Ok(permit) = connection_limit.clone().try_acquire_owned() else {
                     tracing::warn!("Connection limit reached ({MAX_CONCURRENT_CLIENTS}), rejecting client");
                     continue;
@@ -2842,7 +2842,7 @@ pub async fn run(server: Arc<Mutex<Server>>) -> anyhow::Result<()> {
                 let server = Arc::clone(&server);
                 tokio::spawn(async move {
                     let _permit = permit;
-                    let _ = handle_client(server, conn).await;
+                    let _ = handle_client(server, conn, peer_pid).await;
                 });
             }
             _ = shutdown_rx.changed() => {
@@ -2911,19 +2911,27 @@ const fn v3_msg_type(envelope: &v3::ClientEnvelope) -> &'static str {
 pub async fn handle_stdio_client(server: Arc<Mutex<Server>>) -> anyhow::Result<()> {
     let stream = crate::ipc::StdioStream::new();
     let conn = ClientConnection::new(stream);
-    handle_client(server, conn).await
+    handle_client(server, conn, None).await
 }
 
 #[allow(clippy::significant_drop_tightening)]
 async fn handle_client<S>(
     server: Arc<Mutex<Server>>,
     mut conn: ClientConnection<S>,
+    peer_pid: Option<u32>,
 ) -> anyhow::Result<()>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
     let client_id = Uuid::new_v4();
     let client_short = short_id(client_id);
+    let peer_info = peer_pid.map_or_else(
+        || "stdio".to_string(),
+        |pid| {
+            let name = std::fs::read_to_string(format!("/proc/{pid}/comm")).unwrap_or_default();
+            format!("pid={pid} ({})", name.trim())
+        },
+    );
 
     let (tx, rx) = mpsc::channel(PUSH_CHANNEL_BOUND);
     let (resp_tx, resp_rx) = mpsc::channel::<ClientMsg>(RESP_CHANNEL_BOUND);
@@ -2984,6 +2992,7 @@ where
             resp_tx,
             &raw_frame,
             metrics.clone(),
+            &peer_info,
         )
         .await
     };
@@ -3107,6 +3116,7 @@ where
 /// The first frame was already read during protocol detection and is passed
 /// in as `first_frame`. It is decoded as a v2 `ClientMessage` and processed
 /// before entering the normal read loop.
+#[allow(clippy::too_many_arguments)]
 async fn v2_client_reader(
     server: Arc<Mutex<Server>>,
     client_id: Uuid,
@@ -3115,6 +3125,7 @@ async fn v2_client_reader(
     resp_tx: mpsc::Sender<ClientMsg>,
     first_frame: &[u8],
     metrics: Arc<crate::metrics::DaemonMetrics>,
+    peer_info: &str,
 ) -> (anyhow::Result<()>, bool) {
     use prost::Message;
 
@@ -3135,7 +3146,10 @@ async fn v2_client_reader(
 
     // Process the first message (Hello).
     if matches!(msg.msg, Some(proto::client_message::Msg::Shutdown(_))) {
-        tracing::info!("Shutdown requested by client {client_short}");
+        tracing::warn!(
+            peer = %peer_info,
+            "Shutdown requested by client {client_short}"
+        );
         crate::instrument::lock_server(&server, &metrics).await.request_shutdown();
         return (Ok(()), true);
     }
@@ -3170,7 +3184,7 @@ async fn v2_client_reader(
         };
 
         if matches!(msg.msg, Some(proto::client_message::Msg::Shutdown(_))) {
-            tracing::info!("Shutdown requested by client {client_short}");
+            tracing::warn!("Shutdown requested by client {client_short} (v2 reader loop)");
             crate::instrument::lock_server(&server, &metrics).await.request_shutdown();
             return (Ok(()), true);
         }
@@ -3217,7 +3231,7 @@ async fn v3_client_reader(
 
         // Check for Shutdown (fire-and-forget).
         if matches!(envelope.command, Some(v3::client_envelope::Command::Shutdown(_))) {
-            tracing::info!("Shutdown requested by client {client_short}");
+            tracing::warn!("Shutdown requested by client {client_short} (v3)");
             crate::instrument::lock_server(&server, &metrics).await.request_shutdown();
             return (Ok(()), true);
         }

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1692,7 +1692,7 @@ async fn probe_connection_logs_at_debug_not_info() {
     let conn = crate::ipc::ClientConnection::new(server_half);
 
     // handle_client will see EOF immediately (no Hello sent).
-    let _ = super::handle_client(server, conn).await;
+    let _ = super::handle_client(server, conn, None).await;
 
     // Probe should be logged at debug level, not info.
     assert!(logs_contain("Client probe from"));
@@ -1709,7 +1709,7 @@ async fn real_client_logs_connected_and_disconnected_at_info() {
 
     // Spawn handle_client in background.
     let handle = tokio::spawn(async move {
-        let _ = super::handle_client(server, conn).await;
+        let _ = super::handle_client(server, conn, None).await;
     });
 
     // Send a Hello message from the client side.
@@ -2304,7 +2304,7 @@ async fn connection_limit_rejects_excess_clients() {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     });
 
-    let conn1 = listener.accept().await.unwrap();
+    let (conn1, _) = listener.accept().await.unwrap();
     let permit1 = connection_limit.clone().try_acquire_owned();
     assert!(permit1.is_ok(), "first connection should get a permit");
 
@@ -2314,7 +2314,7 @@ async fn connection_limit_rejects_excess_clients() {
         let _stream = UnixStream::connect(&path2).await.unwrap();
     });
 
-    let _conn2 = listener.accept().await.unwrap();
+    let (_conn2, _) = listener.accept().await.unwrap();
     assert!(
         connection_limit.try_acquire().is_err(),
         "second connection should be rejected at limit=1"

--- a/services/rttx-server/tests/cpr_stripping.rs
+++ b/services/rttx-server/tests/cpr_stripping.rs
@@ -1,0 +1,60 @@
+//! Regression test: CPR responses (ESC[row;colR) are stripped from output
+//! sent to clients, preventing garbage text after daemon restart.
+
+mod common;
+
+use common::{TestClient, send_input, start_test_server};
+use rttx_proto::proto;
+use std::time::Duration;
+
+#[tokio::test]
+async fn cpr_responses_stripped_from_client_output() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let runtime_id =
+        common::create_runtime(&mut client, "cpr-test", proto::RuntimePolicy::Persistent).await;
+    let pane_id = common::create_pane(&mut client, &runtime_id).await;
+    common::attach_rw(&mut client, &runtime_id).await;
+
+    // Make the shell emit a CPR response by sending ESC[6n (cursor position query).
+    // The shell's terminal driver responds with ESC[row;colR.
+    // This response must NOT appear in the Delta messages sent to the client.
+    send_input(&mut client, &runtime_id, &pane_id, b"printf '\\033[6n'; cat\n").await;
+
+    let msgs = client.drain(Duration::from_secs(5)).await;
+
+    // Check that no Delta contains a raw CPR response pattern.
+    for msg in &msgs {
+        if let Some(proto::server_message::Msg::Delta(delta)) = &msg.msg {
+            let data = &delta.data;
+            // CPR response: ESC [ <digits> ; <digits> R
+            // Should have been stripped by strip_client_queries.
+            let has_cpr = data.windows(3).any(|w| {
+                w[0] == 0x1b
+                    && w[1] == b'['
+                    && data[w.as_ptr() as usize - data.as_ptr() as usize..]
+                        .iter()
+                        .skip(2)
+                        .take_while(|&&b| b.is_ascii_digit() || b == b';')
+                        .count()
+                        > 0
+                    && data
+                        .get(
+                            w.as_ptr() as usize - data.as_ptr() as usize
+                                + 2
+                                + data[w.as_ptr() as usize - data.as_ptr() as usize..]
+                                    .iter()
+                                    .skip(2)
+                                    .take_while(|&&b| b.is_ascii_digit() || b == b';')
+                                    .count(),
+                        )
+                        .copied()
+                        == Some(b'R')
+            });
+            assert!(!has_cpr, "Delta should not contain CPR response (ESC[row;colR)");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #920

## Changes
1. Log peer PID and process name on Shutdown requests (WARN level)
2. Strip CPR responses from client output (prevents garbage after restart)
3. Strip DECXCPR queries (ESC[?6n) from scrollback

## Tests
- 517 lib tests pass
- New integration test: cpr_stripping
- Clippy clean
- Runtime behavior gate passes

## Verification
- `cargo test -p rttx-server` — all pass
- `cargo clippy -p rttx-server` — clean
- Runtime behavior gate — pass