### PR TITLE
fix(commands): Fix parameter persistence — recursive ListBox search (#922)

### DIFF
--- a/clients/rttx/src/commands_window.rs
+++ b/clients/rttx/src/commands_window.rs
@@ -311,18 +311,7 @@ fn extract_parameters(list: &gtk4::ListBox) -> Result<Vec<CommandParameter>, Str
 
 fn collect_entry_rows(group: &adw::PreferencesGroup) -> Vec<adw::EntryRow> {
     let mut entries = Vec::new();
-    let listbox = group.first_child().and_then(|c| {
-        // PreferencesGroup wraps content in a Box > ListBox
-        let mut child = Some(c);
-        while let Some(c) = child {
-            if let Ok(lb) = c.clone().downcast::<gtk4::ListBox>() {
-                return Some(lb);
-            }
-            child = c.next_sibling();
-        }
-        None
-    });
-    if let Some(lb) = listbox {
+    if let Some(lb) = find_listbox_recursive(group.first_child()) {
         let mut i = 0;
         while let Some(row) = lb.row_at_index(i) {
             if let Ok(entry) = row.downcast::<adw::EntryRow>() {
@@ -332,6 +321,26 @@ fn collect_entry_rows(group: &adw::PreferencesGroup) -> Vec<adw::EntryRow> {
         }
     }
     entries
+}
+
+/// Recursively search the widget tree for a `gtk4::ListBox`.
+///
+/// `adw::PreferencesGroup` nests its content `ListBox` inside an internal
+/// container (`Box` > `ListBox` in libadwaita 1.5). A flat sibling traversal
+/// misses it — we must descend into children.
+fn find_listbox_recursive(start: Option<gtk4::Widget>) -> Option<gtk4::ListBox> {
+    let mut stack: Vec<gtk4::Widget> = start.into_iter().collect();
+    while let Some(widget) = stack.pop() {
+        if let Ok(lb) = widget.clone().downcast::<gtk4::ListBox>() {
+            return Some(lb);
+        }
+        let mut child = widget.first_child();
+        while let Some(c) = child {
+            stack.push(c.clone());
+            child = c.next_sibling();
+        }
+    }
+    None
 }
 
 const fn run_mode_from_index(index: u32) -> CommandRunMode {

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -590,13 +590,15 @@ mod tests {
             default_run_mode: crate::commands::CommandRunMode::Run,
             host_tags: vec![],
             parameters: vec![
-                crate::commands::CommandParameter { description: String::new(),
+                crate::commands::CommandParameter {
+                    description: String::new(),
                     name: "ENV".into(),
                     label: "Environment".into(),
                     choices: vec!["staging".into(), "prod".into()],
                     default: Some("staging".into()),
                 },
-                crate::commands::CommandParameter { description: String::new(),
+                crate::commands::CommandParameter {
+                    description: String::new(),
                     name: "REGION".into(),
                     label: "Region".into(),
                     choices: vec!["us-east-1".into(), "eu-west-1".into()],
@@ -621,7 +623,8 @@ mod tests {
     #[test]
     fn duplicate_command_preserves_parameters() {
         let mut cmd = SavedCommand::new("Deploy", "deploy --env $ENV");
-        cmd.parameters = vec![crate::commands::CommandParameter { description: String::new(),
+        cmd.parameters = vec![crate::commands::CommandParameter {
+            description: String::new(),
             name: "ENV".into(),
             label: "Environment".into(),
             choices: vec!["staging".into(), "prod".into()],

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -580,6 +580,60 @@ mod tests {
         assert_eq!(commands[0].default_run_mode, crate::commands::CommandRunMode::Insert);
     }
 
+    #[test]
+    fn library_preserves_command_parameters() {
+        let (_tmp, store) = test_store();
+        let cmd = SavedCommand {
+            uuid: "param-test".into(),
+            title: "Deploy".into(),
+            body: "deploy --env $ENV".into(),
+            default_run_mode: crate::commands::CommandRunMode::Run,
+            host_tags: vec![],
+            parameters: vec![
+                crate::commands::CommandParameter {
+                    name: "ENV".into(),
+                    label: "Environment".into(),
+                    choices: vec!["staging".into(), "prod".into()],
+                    default: Some("staging".into()),
+                },
+                crate::commands::CommandParameter {
+                    name: "REGION".into(),
+                    label: "Region".into(),
+                    choices: vec!["us-east-1".into(), "eu-west-1".into()],
+                    default: None,
+                },
+            ],
+            description: String::new(),
+            labels: vec![],
+            shortcut_keys: vec![],
+        };
+        store.save_commands(&[cmd]).unwrap();
+        let loaded = store.load_commands();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].parameters.len(), 2);
+        assert_eq!(loaded[0].parameters[0].name, "ENV");
+        assert_eq!(loaded[0].parameters[0].choices, vec!["staging", "prod"]);
+        assert_eq!(loaded[0].parameters[0].default, Some("staging".into()));
+        assert_eq!(loaded[0].parameters[1].name, "REGION");
+        assert_eq!(loaded[0].parameters[1].default, None);
+    }
+
+    #[test]
+    fn duplicate_command_preserves_parameters() {
+        let mut cmd = SavedCommand::new("Deploy", "deploy --env $ENV");
+        cmd.parameters = vec![crate::commands::CommandParameter {
+            name: "ENV".into(),
+            label: "Environment".into(),
+            choices: vec!["staging".into(), "prod".into()],
+            default: Some("staging".into()),
+        }];
+        let copy = cmd.duplicate();
+        assert_eq!(copy.parameters.len(), 1);
+        assert_eq!(copy.parameters[0].name, "ENV");
+        assert_eq!(copy.parameters[0].choices, vec!["staging", "prod"]);
+        assert_ne!(copy.uuid, cmd.uuid, "duplicate must have a new UUID");
+    }
+
     // ── LoadOutcome::map ────────────────────────────────────
 
     #[test]

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -590,13 +590,13 @@ mod tests {
             default_run_mode: crate::commands::CommandRunMode::Run,
             host_tags: vec![],
             parameters: vec![
-                crate::commands::CommandParameter {
+                crate::commands::CommandParameter { description: String::new(),
                     name: "ENV".into(),
                     label: "Environment".into(),
                     choices: vec!["staging".into(), "prod".into()],
                     default: Some("staging".into()),
                 },
-                crate::commands::CommandParameter {
+                crate::commands::CommandParameter { description: String::new(),
                     name: "REGION".into(),
                     label: "Region".into(),
                     choices: vec!["us-east-1".into(), "eu-west-1".into()],
@@ -621,7 +621,7 @@ mod tests {
     #[test]
     fn duplicate_command_preserves_parameters() {
         let mut cmd = SavedCommand::new("Deploy", "deploy --env $ENV");
-        cmd.parameters = vec![crate::commands::CommandParameter {
+        cmd.parameters = vec![crate::commands::CommandParameter { description: String::new(),
             name: "ENV".into(),
             label: "Environment".into(),
             choices: vec!["staging".into(), "prod".into()],


### PR DESCRIPTION
Fixes #922

## Root Cause

`collect_entry_rows` used flat sibling traversal to find ListBox inside `adw::PreferencesGroup`. In libadwaita 1.5, the ListBox is nested inside an internal GtkBox. Traversal found nothing → `extract_parameters` returned empty → parameters silently lost on save.

## Fix

Replace with recursive depth-first search (`find_listbox_recursive`).

## Tests Added

- `library_preserves_command_parameters` — store round-trip with 2 parameters
- `duplicate_command_preserves_parameters` — verifies `.duplicate()` preserves params

## Verification

- `cargo test -p rttx-server --lib` — 517 pass
- Cannot run client tests locally (missing VTE) — CI will verify
