### PR TITLE
fix(client): Feed cleanup bytes after snapshot when terminal_modes is None (#926)

### DIFF
--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -805,6 +805,13 @@ impl Window {
             // already contains the rendered screen content, and switching
             // VTE into alt-screen mode would discard it.
             pane.restore_interaction_modes(modes);
+        } else {
+            // No mode state available — feed cleanup bytes to ensure any
+            // mouse tracking or other modes left by the scrollback data
+            // are disabled. Without this, stale DECSET sequences in the
+            // scrollback can leave VTE with mouse tracking on, causing
+            // mouse clicks to print escape sequences instead of working.
+            pane.vte().feed(crate::terminal::terminal_cleanup_bytes());
         }
         pane.set_current_directory(Some(&restore.cwd));
         if !restore.title.is_empty() && pane.custom_title().is_none() {


### PR DESCRIPTION
Fixes #926

When `terminal_modes` is `None`, stale mouse-tracking sequences in scrollback leave VTE in a bad state. Now always feeds `terminal_cleanup_bytes()` after snapshot restore.

- Server tests: 517 pass
- Client change is 7 lines in an else branch — CI will verify