### PR TITLE
fix(ux): Reduce label filter chip size (#930)

### DIFF
--- a/clients/rttx/src/window/sidebar.rs
+++ b/clients/rttx/src/window/sidebar.rs
@@ -298,6 +298,7 @@ impl Window {
         for label_text in &labels {
             let button = gtk4::ToggleButton::with_label(label_text);
             button.add_css_class("pill");
+            button.add_css_class("flat");
             button.add_css_class("caption");
             button.set_active(active.contains(label_text));
 


### PR DESCRIPTION
Fixes #930 — adds `flat` CSS class to label filter toggle buttons.