### PR TITLE
feat: F2 keyboard shortcut for workspace rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "proptest",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/shortcuts.rs
+++ b/clients/rttx/src/shortcuts.rs
@@ -105,6 +105,7 @@ pub static DEFAULT_SHORTCUTS: &[ShortcutDef] = &[
         label: "Commands leader key",
         default_accels: &["<Ctrl>semicolon"],
     },
+    ShortcutDef { action: "rename-workspace", label: "Rename workspace", default_accels: &["F2"] },
 ];
 
 /// Look up the effective accelerators for an action, checking user overrides
@@ -243,5 +244,11 @@ mod tests {
     fn repair_terminal_shortcut_registered() {
         let accels = default_accels("repair-terminal");
         assert_eq!(accels, vec!["<Ctrl><Shift>X"]);
+    }
+
+    #[test]
+    fn rename_workspace_shortcut_registered() {
+        let accels = default_accels("rename-workspace");
+        assert_eq!(accels, vec!["F2"]);
     }
 }

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -42,6 +42,7 @@ impl Window {
             ("rotate-layout", Self::rotate_layout),
             ("repair-terminal", Self::repair_focused_terminal),
             ("rename-pane", Self::rename_focused_pane),
+            ("rename-workspace", Self::rename_active_workspace),
             ("new-session", Self::add_session),
             ("new-ephemeral-workspace", Self::add_ephemeral_session),
             ("new-remote-workspace", Self::show_new_remote_workspace_dialog),
@@ -299,6 +300,19 @@ impl Window {
             && let Some(terminal) = self.terminal_handle(&uuid)
         {
             self.show_rename_pane_dialog(&uuid, &terminal);
+        }
+    }
+
+    fn rename_active_workspace(&self) {
+        let imp = self.imp();
+        if let Some(row) = imp
+            .sidebar_list
+            .selected_row()
+            .and_then(|r| r.child())
+            .and_then(|c| c.downcast::<WorkspaceRow>().ok())
+        {
+            let uuid = row.uuid();
+            self.show_rename_runtime_popover(&row, &uuid);
         }
     }
 

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -3023,3 +3023,23 @@ fn header_bar_workspace_buttons_are_icon_only() {
     remove_env("RTTX_DISABLE_SHELL_SPAWN");
     remove_env("XDG_CONFIG_HOME");
 }
+
+/// The window must expose a `rename-workspace` action bound to F2.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn window_has_rename_workspace_action() {
+    require_display!();
+
+    let app = adw::Application::builder()
+        .application_id("io.github.IllyaYalovyy.rttx.test.rename_workspace_action")
+        .build();
+    app.register(None::<&gtk4::gio::Cancellable>).unwrap();
+
+    let window = rttx::window::Window::new(&app);
+    let action_group: gtk4::gio::ActionGroup = window.clone().upcast();
+    assert!(
+        action_group.has_action("rename-workspace"),
+        "window must have rename-workspace action"
+    );
+    window.close();
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.5.1',
+  version: '0.5.2',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Adds F2 as a keyboard shortcut to rename the active workspace. This is a standard desktop convention (F2 = rename in file managers, spreadsheets, etc.) that makes workspace renaming more discoverable and faster.

The implementation registers a `rename-workspace` action in the window's action map, bound to F2 via the existing shortcut system. When triggered, it finds the selected workspace row in the sidebar and shows the existing rename popover.

## Manual verification

1. Launch rttx
2. Create or select a workspace in the sidebar
3. Press F2
4. The rename popover appears on the active workspace row
5. Type a new name and press Enter — workspace is renamed

## Tests added

- `shortcuts::tests::rename_workspace_shortcut_registered` — unit test verifying F2 is the default accelerator for `rename-workspace`
- `window_has_rename_workspace_action` — GTK widget test verifying the window exposes the action

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76`) ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (both new tests confirmed passing)

## Version bump

0.5.1 → 0.5.2 (UX-affecting change: new keyboard shortcut)

Fixes #933