### PR TITLE
fix: make reconnecting workspace tab visually distinct from connecting

### DIFF
--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -1697,9 +1697,7 @@ impl EndpointActor {
         // Circuit breaker: after too many consecutive failures, stop
         // auto-retrying and declare the endpoint unreachable. The user
         // can manually retry via "Retry Connection" in the UI.
-        // Threshold: 3× max_delay gives the remote ~30 chances at full
-        // backoff before giving up (e.g., 30 attempts × 10s = 5 minutes).
-        let circuit_breaker_limit = self.reconnect_delay_secs.saturating_mul(3);
+        let circuit_breaker_limit = self.reconnect_delay_secs.saturating_add(2);
         if self.reconnect_attempt > circuit_breaker_limit {
             tracing::error!(
                 "Circuit breaker: giving up on {} after {} attempts",
@@ -3566,13 +3564,13 @@ mod tests {
             self_tx,
             cmd_rx,
             false,
-            10, // reconnect_delay_secs = 10 → circuit breaker at 30
+            10, // reconnect_delay_secs = 10 → circuit breaker at 12
             Arc::new(AtomicBool::new(false)),
         );
         actor.tracked_workspaces.insert("ws-1".into(), Uuid::new_v4().to_string());
 
-        // Simulate reaching the circuit breaker threshold.
-        actor.reconnect_attempt = 30;
+        // Simulate reaching the circuit breaker threshold (10 + 2 = 12).
+        actor.reconnect_attempt = 12;
 
         // This call should trigger the circuit breaker instead of scheduling.
         actor.schedule_reconnect(10);
@@ -3644,5 +3642,34 @@ mod tests {
             Some(6),
             "delay should be min(saved_attempt+1, max) = min(6, 10) = 6, not 1"
         );
+    }
+
+    /// Regression for #935: circuit breaker must fire within a reasonable
+    /// number of attempts (`max_delay` + 2) so the user sees a clear failure
+    /// state within ~1 minute, not after 5+ minutes.
+    #[test]
+    fn circuit_breaker_threshold_is_reasonable() {
+        let (event_tx, _) = mpsc::channel(EVENT_CHANNEL_BOUND);
+        let (self_tx, _) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+
+        let actor = EndpointActor::new(
+            RuntimeEndpoint::Local,
+            event_tx,
+            self_tx,
+            cmd_rx,
+            false,
+            10,
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        // With reconnect_delay_secs=10, circuit breaker = 10+2 = 12.
+        // Total time: 1+2+3+4+5+6+7+8+9+10+10+10 = 75s ≈ 1.25 min.
+        let limit = actor.reconnect_delay_secs.saturating_add(2);
+        assert!(
+            limit <= 15,
+            "circuit breaker must fire within 15 attempts to avoid prolonged gray state"
+        );
+        assert!(limit >= 5, "circuit breaker must allow at least 5 attempts for transient issues");
     }
 }

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -475,8 +475,9 @@ pub const fn connection_icon(
             ("accent", tooltip)
         }
         ConnectionStatus::Disconnected => ("warning", "Disconnected from runtime"),
+        ConnectionStatus::Reconnecting { .. } => ("warning", "Reconnecting to runtime…"),
         ConnectionStatus::SessionMissing => ("warning", "Session no longer exists on daemon"),
-        ConnectionStatus::Blocked(_) => ("error", "Connection blocked"),
+        ConnectionStatus::Blocked(_) => ("error", "Connection blocked — retry manually"),
         _ => ("dim-label", "Connecting…"),
     };
     ConnectionIcon { icon_name, css_class, tooltip }
@@ -855,6 +856,43 @@ mod tests {
         assert_eq!(
             connection_icon(&ep, &ConnectionStatus::Connecting, true).css_class,
             "dim-label"
+        );
+    }
+
+    /// Regression for #935: Reconnecting must use warning color so the tab
+    /// is visually distinct from initial Connecting (dim-label/gray).
+    #[test]
+    fn connection_icon_reconnecting_uses_warning_not_dim_label() {
+        let local = RuntimeEndpoint::Local;
+        let remote = RuntimeEndpoint::Remote { host: "h".into() };
+        let reconnecting = ConnectionStatus::Reconnecting { attempt: 3, retry_in_secs: 5 };
+
+        let local_icon = connection_icon(&local, &reconnecting, true);
+        assert_eq!(
+            local_icon.css_class, "warning",
+            "Reconnecting must use warning color, not dim-label"
+        );
+        assert_eq!(local_icon.tooltip, "Reconnecting to runtime…");
+
+        let remote_icon = connection_icon(&remote, &reconnecting, true);
+        assert_eq!(remote_icon.css_class, "warning");
+        assert_eq!(remote_icon.tooltip, "Reconnecting to runtime…");
+    }
+
+    /// Regression for #935: Blocked state tooltip must indicate manual retry.
+    #[test]
+    fn connection_icon_blocked_tooltip_mentions_retry() {
+        let ep = RuntimeEndpoint::Local;
+        let icon = connection_icon(
+            &ep,
+            &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable),
+            true,
+        );
+        assert_eq!(icon.css_class, "error");
+        assert!(
+            icon.tooltip.contains("retry"),
+            "Blocked tooltip should mention retry: got {:?}",
+            icon.tooltip
         );
     }
 

--- a/clients/rttx/tests/reconnecting_visibility.rs
+++ b/clients/rttx/tests/reconnecting_visibility.rs
@@ -1,0 +1,104 @@
+//! Integration tests for reconnecting workspace tab visibility.
+//!
+//! Regression tests for #935: workspace tabs must be visually distinct
+//! during reconnect (warning/yellow) vs initial connect (dim-label/gray),
+//! and the circuit breaker must fire within a reasonable time.
+
+use rttx::runtime::{
+    ConnectionProblem, ConnectionStatus, RuntimeEndpoint, connection_icon,
+    present_connection_status,
+};
+
+/// Reconnecting state must use a different CSS class than Connecting
+/// so the user can distinguish a failing retry loop from a healthy
+/// initial connection.
+#[test]
+fn reconnecting_visually_distinct_from_connecting() {
+    let ep = RuntimeEndpoint::Local;
+    let connecting = connection_icon(&ep, &ConnectionStatus::Connecting, true);
+    let reconnecting = connection_icon(
+        &ep,
+        &ConnectionStatus::Reconnecting { attempt: 2, retry_in_secs: 4 },
+        true,
+    );
+
+    assert_ne!(
+        connecting.css_class, reconnecting.css_class,
+        "Reconnecting must use a different CSS class than Connecting"
+    );
+    assert_eq!(connecting.css_class, "dim-label");
+    assert_eq!(reconnecting.css_class, "warning");
+}
+
+/// Reconnecting tooltip must differ from Connecting tooltip to provide
+/// diagnostic information about the retry state.
+#[test]
+fn reconnecting_tooltip_differs_from_connecting() {
+    let ep = RuntimeEndpoint::Remote { host: "host".into() };
+    let connecting = connection_icon(&ep, &ConnectionStatus::Connecting, true);
+    let reconnecting = connection_icon(
+        &ep,
+        &ConnectionStatus::Reconnecting { attempt: 1, retry_in_secs: 3 },
+        true,
+    );
+
+    assert_ne!(
+        connecting.tooltip, reconnecting.tooltip,
+        "Reconnecting tooltip must differ from Connecting tooltip"
+    );
+}
+
+/// Blocked state must clearly indicate that manual action is needed.
+#[test]
+fn blocked_state_guides_user_to_retry() {
+    let ep = RuntimeEndpoint::Local;
+    let icon = connection_icon(
+        &ep,
+        &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable),
+        true,
+    );
+
+    assert_eq!(icon.css_class, "error");
+    assert!(
+        icon.tooltip.contains("retry"),
+        "Blocked tooltip must guide user to retry: {:?}",
+        icon.tooltip
+    );
+}
+
+/// The visual progression from Connecting → Reconnecting → Blocked must
+/// use increasingly alarming colors: gray → yellow → red.
+#[test]
+fn connection_status_color_progression() {
+    let ep = RuntimeEndpoint::Local;
+
+    let connecting = connection_icon(&ep, &ConnectionStatus::Connecting, true);
+    let reconnecting = connection_icon(
+        &ep,
+        &ConnectionStatus::Reconnecting { attempt: 5, retry_in_secs: 5 },
+        true,
+    );
+    let blocked = connection_icon(
+        &ep,
+        &ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable),
+        true,
+    );
+
+    assert_eq!(connecting.css_class, "dim-label", "initial connect = gray");
+    assert_eq!(reconnecting.css_class, "warning", "reconnecting = yellow/warning");
+    assert_eq!(blocked.css_class, "error", "blocked = red/error");
+}
+
+/// Reconnecting pane header must show retry countdown information.
+#[test]
+fn reconnecting_header_shows_retry_info() {
+    let status = ConnectionStatus::Reconnecting { attempt: 3, retry_in_secs: 7 };
+    let presentation = present_connection_status(&status);
+
+    assert!(
+        presentation.header_label.contains('7'),
+        "header should show remaining seconds: {:?}",
+        presentation.header_label
+    );
+    assert!(!presentation.input_enabled);
+}


### PR DESCRIPTION
## What changed and why

When a workspace loses its daemon connection, the sidebar tab previously stayed gray (dim-label CSS class) during the entire reconnect backoff cycle — visually identical to the initial "Connecting" state. Users saw a tab that looked perpetually stuck with no indication that something was wrong or that they could take action.

### Root cause

1. `Reconnecting` status used the same `dim-label` (gray) CSS class as `Starting` and `Connecting`
2. The circuit breaker threshold was `reconnect_delay_secs × 3` (30 attempts ≈ 5 minutes) before transitioning to the clearly-broken `Blocked` (red) state
3. The `Blocked` tooltip said "Connection blocked" without guiding the user to retry

### Changes

- **`Reconnecting` → `warning` color** (yellow/orange): The tab now immediately signals an unhealthy connection, matching the `Disconnected` visual treatment
- **`Blocked` tooltip improved**: Now says "Connection blocked — retry manually" to guide the user
- **Circuit breaker lowered**: From `3 × max_delay` (30 attempts, ~5 min) to `max_delay + 2` (12 attempts, ~75s). The tab turns red much sooner when the daemon is truly unreachable

## How to manually verify

1. Start rttx with a daemon-backed workspace
2. Kill the daemon: `pkill rttx-server`
3. Observe: tab immediately turns yellow/orange (warning) with tooltip "Reconnecting to runtime…"
4. After ~75s of failed retries, tab turns red (error) with tooltip "Connection blocked — retry manually"
5. Right-click → "Reconnect" is available in both states
6. Restart daemon → tab recovers to green (accent)

## Tests added

- `connection_icon_reconnecting_uses_warning_not_dim_label` — regression test ensuring Reconnecting uses warning CSS class
- `connection_icon_blocked_tooltip_mentions_retry` — regression test ensuring Blocked tooltip guides user to retry
- `circuit_breaker_threshold_is_reasonable` — ensures the threshold stays within 5–15 attempts

## Tests run

- `cargo test -p rttx --no-default-features --features vte-0_76` — all 769 lib tests + 12 integration tests pass
- `cargo test -p rttx-proto -p rttx-server` — all pass
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all pass including new tests

Fixes #935