### PR TITLE
fix: keep window open with fresh workspace on Close All

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "proptest",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -96,14 +96,10 @@ impl Window {
     }
 
     pub(super) fn confirm_close_all(&self) {
-        let all_uuids: Vec<String> = {
-            let state = self.imp().state.borrow();
-            state.workspaces.iter().map(|s| s.uuid.clone()).collect()
-        };
-        if all_uuids.is_empty() {
+        let count = self.imp().state.borrow().workspaces.len();
+        if count == 0 {
             return;
         }
-        let count = all_uuids.len();
         let body = format!(
             "Close {count} workspace{}? All panes and running processes will be stopped.",
             if count == 1 { "" } else { "s" }
@@ -117,9 +113,7 @@ impl Window {
         alert.set_close_response("cancel");
         alert.connect_response(None, move |_, response| {
             if response == "close" {
-                for uuid in &all_uuids {
-                    win.close_session(uuid);
-                }
+                win.close_all_sessions();
             }
         });
         alert.present(Some(self));

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -1099,6 +1099,79 @@ impl Window {
         self.renumber_session_rows();
     }
 
+    /// Close every workspace and replace them with a single fresh direct
+    /// terminal. Keeps the window open — used by "Close All".
+    pub(crate) fn close_all_sessions(&self) {
+        let imp = self.imp();
+
+        let all_uuids: Vec<String> = {
+            let state = imp.state.borrow();
+            state.workspaces.iter().map(|s| s.uuid.clone()).collect()
+        };
+
+        // Tear down each workspace without triggering window close.
+        for uuid in &all_uuids {
+            let (terminal_uuids, managed_runtime) = {
+                let mut state = imp.state.borrow_mut();
+                let Some(pos) = state.workspaces.iter().position(|s| s.uuid == *uuid) else {
+                    continue;
+                };
+                let session = state.workspaces.remove(pos);
+                let uuids = session.layout.terminal_uuids();
+                let managed = if session.uses_managed_runtime() {
+                    Some((session.runtime.endpoint.clone(), session.runtime.runtime_id))
+                } else {
+                    None
+                };
+                state.rebuild_pane_reverse_index();
+                (uuids, managed)
+            };
+
+            {
+                let terminals = imp.terminals.borrow();
+                for tuuid in &terminal_uuids {
+                    if let Some(term) = terminals.get(tuuid) {
+                        term.disconnect_child_exited();
+                    }
+                }
+            }
+            {
+                let mut terminals = imp.terminals.borrow_mut();
+                for tuuid in &terminal_uuids {
+                    terminals.remove(tuuid);
+                }
+            }
+            {
+                let mut panes = imp.persistent_terminals.borrow_mut();
+                for tuuid in &terminal_uuids {
+                    panes.remove(tuuid);
+                }
+            }
+
+            if let Some((endpoint, runtime_id)) = managed_runtime
+                && let Some(manager) = imp.connection_manager.borrow().as_ref()
+            {
+                if let Some(ref runtime_id) = runtime_id {
+                    manager.terminate_runtime(uuid, &endpoint, runtime_id);
+                }
+                manager.forget_workspace(&endpoint, uuid);
+                imp.workspace_connection_status.borrow_mut().remove(uuid.as_str());
+                if let Some(runtime_id) = runtime_id {
+                    imp.state.borrow_mut().dismissed_runtime_ids.insert(runtime_id);
+                }
+            }
+            self.clear_workspace_reconnect_countdown(uuid);
+
+            if let Some(child) = imp.session_stack.child_by_name(uuid) {
+                imp.session_stack.remove(&child);
+            }
+            self.remove_sidebar_row(uuid);
+        }
+
+        // Create a fresh direct terminal workspace.
+        self.add_direct_session();
+    }
+
     pub(crate) fn close_session(&self, session_uuid: &str) {
         let imp = self.imp();
 

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -7673,3 +7673,61 @@ fn reconnect_host_reconnects_all_disconnected_workspaces_from_same_endpoint() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+/// Regression test for #939: "Close All" should keep the window open with a
+/// fresh direct workspace instead of closing the application.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn close_all_keeps_window_open_with_fresh_workspace() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("XDG_STATE_HOME", tmp.path());
+    crate::test_helpers::set_env("XDG_CACHE_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.close-all-fresh-test")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.set_default_size(1200, 800);
+    window.present();
+    pump_events(100);
+
+    // Ensure we start with exactly one workspace (from default state), then add a second.
+    let initial_count = window.imp().state.borrow().workspaces.len();
+    assert!(initial_count >= 1, "should have at least one workspace after init");
+
+    let second = WorkspaceState::new("Second".into());
+    window.imp().state.borrow_mut().workspaces.push(second.clone());
+    window.build_session(&second, false);
+    pump_events(50);
+
+    let pre_close_count = window.imp().state.borrow().workspaces.len();
+    assert!(pre_close_count >= 2, "should have at least two workspaces before close all");
+
+    // Invoke close_all_sessions (the logic behind "Close All" confirmation).
+    window.close_all_sessions();
+    pump_events(50);
+
+    // Window should still be visible.
+    assert!(window.is_visible(), "window should remain open after Close All");
+
+    // Exactly one fresh workspace should exist.
+    let state = window.imp().state.borrow();
+    assert_eq!(state.workspaces.len(), 1, "should have exactly one workspace after Close All");
+    assert!(
+        state.workspaces[0].name.starts_with("Direct"),
+        "the fresh workspace should be a Direct terminal, got: {}",
+        state.workspaces[0].name
+    );
+
+    drop(state);
+    window.close();
+    crate::test_helpers::remove_env("XDG_STATE_HOME");
+    crate::test_helpers::remove_env("XDG_CACHE_HOME");
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -7687,9 +7687,8 @@ fn close_all_keeps_window_open_with_fresh_workspace() {
     crate::test_helpers::set_env("XDG_CACHE_HOME", tmp.path());
     crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
 
-    let app = adw::Application::builder()
-        .application_id("com.illya.rttx.close-all-fresh-test")
-        .build();
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.close-all-fresh-test").build();
     app.register(gtk4::gio::Cancellable::NONE).unwrap();
 
     let window = Window::new(&app);

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.5.2',
+  version: '0.5.3',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

'Close All' from the workspace context menu previously closed the application window entirely. This happened because it iterated `close_session` for each workspace, and when the last workspace was removed, `close_session` called `self.close()` to close the window.

Now `close_all_sessions()` tears down all workspaces (terminals, runtimes, sidebar rows, stack children) without triggering the window-close path, then creates a fresh direct terminal workspace — matching the first-launch experience.

Fixes #939

## How to manually verify

1. Open rttx with 2+ workspaces
2. Right-click a workspace tab → 'Close All'
3. Confirm in the dialog
4. **Expected:** Window stays open with a single 'Direct N' workspace
5. **Before fix:** Window closed entirely

## Tests added

- `close_all_keeps_window_open_with_fresh_workspace` — GTK widget test that verifies the window remains visible after `close_all_sessions()` and contains exactly one fresh 'Direct' workspace.

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76 --lib` — 769 passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — all GTK tests pass including the new one ✅
  - Pre-existing flaky failure: `burst_output_produces_coalesced_deltas` (server timing test, unrelated)

## Version bump

0.5.2 → 0.5.3 (user-visible behavior change)