### PR TITLE
docs: add instructions for resetting rttx to factory state

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,55 @@ meson setup --wipe build --prefix="$HOME/.local"
 meson compile -C build
 ```
 
+### Resetting to factory state
+
+To completely wipe all rttx data and simulate a first launch, stop the daemon and remove all
+configuration, state, and cache directories.
+
+**Production instance:**
+
+```bash
+# Stop the daemon (terminates all running sessions)
+rttx-server stop 2>/dev/null; pkill -f "rttx-server" 2>/dev/null
+
+# Remove configuration (preferences, hosts, bookmarks, color schemes)
+rm -rf "${XDG_CONFIG_HOME:-$HOME/.config}/rttx/"
+
+# Remove client state (workspace layouts, UI state, backups)
+rm -rf "${XDG_STATE_HOME:-$HOME/.local/state}/rttx/client/"
+
+# Remove daemon state (runtimes, scrollback, screen snapshots)
+rm -rf "${XDG_STATE_HOME:-$HOME/.local/state}/rttx/daemon/"
+
+# Remove cache and logs
+rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/rttx/"
+rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/rttx-server/"
+
+# Remove runtime files (socket, PID file)
+rm -rf "${XDG_RUNTIME_DIR}/rttx-server/"
+```
+
+**Development instance** (`RTTX_DEV_MODE=1`):
+
+```bash
+pkill -f "rttx-server" 2>/dev/null
+rm -rf "${XDG_CONFIG_HOME:-$HOME/.config}/rttx-devel/"
+rm -rf "${XDG_STATE_HOME:-$HOME/.local/state}/rttx-devel/"
+rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/rttx-devel/"
+rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/rttx-server-devel/"
+rm -rf "${XDG_RUNTIME_DIR}/rttx-server-devel/"
+```
+
+After removing these directories, the next launch of `rttx` will behave as a fresh install with
+default preferences and no saved workspaces.
+
+To reset only specific parts:
+- **Preferences only:** remove `${XDG_CONFIG_HOME:-$HOME/.config}/rttx/preferences.json`
+- **Workspace layouts only:** remove `${XDG_STATE_HOME:-$HOME/.local/state}/rttx/client/workspaces.json`
+- **Bookmarks only:** remove `${XDG_CONFIG_HOME:-$HOME/.config}/rttx/library.json`
+- **Saved commands only:** remove `${XDG_CONFIG_HOME:-$HOME/.config}/rttx/library.json` (commands and bookmarks share this file)
+- **Color schemes only:** remove `${XDG_CONFIG_HOME:-$HOME/.config}/rttx/schemes/`
+
 ## Flatpak Packaging
 
 The repository keeps a conservative default manifest at


### PR DESCRIPTION
## What changed and why

Adds a "Resetting to factory state" subsection under Development in the README. This documents how to completely wipe all rttx configuration, state, cache, and runtime files to simulate a first launch.

Covers:
- Stopping the daemon
- Removing GUI configuration (preferences, hosts, bookmarks, color schemes)
- Removing client state (workspace layouts, UI state, backups)
- Removing daemon state (runtimes, scrollback, screen snapshots)
- Removing cache, logs, and runtime files (socket, PID file)
- Both production and dev mode paths
- Granular reset options for individual components

## How to manually verify

Read the README section and confirm the paths match the XDG layout documented in the Architecture section and CONTRIBUTING.md.

## Tests

Documentation-only change — no code tests needed. Verified:
- `cargo build --workspace` passes
- `cargo test --workspace` passes
- `bash .github/scripts/run-clippy.sh` passes
- `bash .github/scripts/run-quality-tests.sh` passes

Fixes #941