### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "proptest",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.3"
+version = "0.6.1"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.5.3',
+  version: '0.6.1',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -1,5 +1,5 @@
 Name:           rttx
-Version:        0.4.26
+Version:        0.6.1
 Release:        1%{?dist}
 Summary:        A tiling terminal emulator for GNOME
 


### PR DESCRIPTION
## What changed and why

Bumps the project version from 0.5.3 to 0.6.1 across all version-defining files:
- `Cargo.toml` (workspace version)
- `Cargo.lock` (auto-updated)
- `meson.build`
- `packaging/rttx/rttx.spec`

## Manual verification

```bash
cargo build --workspace  # (with --no-default-features --features vte-0_76 for client on VTE 0.76)
grep version Cargo.toml | head -1  # shows 0.6.1
grep version meson.build           # shows 0.6.1
grep Version packaging/rttx/rttx.spec  # shows 0.6.1
```

## Tests

No new tests needed — this is a version metadata change only.

## Tests run

- `cargo build -p rttx-proto -p rttx-server` ✅
- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅ (all pass)
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (all pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (0 failures)

Fixes #947