### PR TITLE
perf(daemon): switch to mimalloc global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-expr"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +289,12 @@ dependencies = [
  "memoffset",
  "rustc_version",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -799,6 +815,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1294,6 +1328,7 @@ dependencies = [
  "bytes",
  "clap",
  "daemonix",
+ "mimalloc",
  "nix",
  "pretty_assertions",
  "proptest",
@@ -1428,6 +1463,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/services/rttx-server/Cargo.toml
+++ b/services/rttx-server/Cargo.toml
@@ -32,6 +32,9 @@ dbg_macro = "warn"
 [dependencies]
 rttx-proto.workspace = true
 
+# Allocator
+mimalloc = "0.1"
+
 # Protocol serialization
 prost.workspace = true
 bytes.workspace = true

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -1,5 +1,8 @@
 //! CLI entry point for rttx-server.
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use clap::{Parser, Subcommand};
 use rttx_proto::proto;
 use rttx_server::ipc;

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -942,4 +942,14 @@ mod tests {
     fn read_pid_missing_file_returns_none() {
         assert_eq!(read_pid(std::path::Path::new("/nonexistent/pid")), None);
     }
+
+    #[test]
+    fn global_allocator_is_mimalloc() {
+        // Confirm the binary's global allocator is mimalloc. The type assertion
+        // is a compile-time guarantee; the allocation exercises it at runtime.
+        fn assert_mimalloc(_: &mimalloc::MiMalloc) {}
+        assert_mimalloc(&GLOBAL);
+        let v: Vec<u8> = vec![0u8; 4096];
+        assert_eq!(v.len(), 4096);
+    }
 }

--- a/services/rttx-server/tests/allocator.rs
+++ b/services/rttx-server/tests/allocator.rs
@@ -1,0 +1,31 @@
+//! Verifies that the mimalloc global allocator handles concurrent small
+//! allocations without panic or corruption — the workload pattern that
+//! motivated the switch from glibc malloc.
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[test]
+fn mimalloc_handles_concurrent_small_allocations() {
+    // Simulate the daemon's PTY buffer churn: many threads doing rapid
+    // 4KB alloc/dealloc cycles concurrently.
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            std::thread::spawn(|| {
+                let mut vecs: Vec<Vec<u8>> = Vec::new();
+                for i in 0..1000 {
+                    vecs.push(vec![0u8; 4096]);
+                    if i % 100 == 0 {
+                        vecs.clear();
+                    }
+                }
+                vecs.len()
+            })
+        })
+        .collect();
+
+    for h in handles {
+        let count = h.join().unwrap();
+        assert!(count > 0);
+    }
+}


### PR DESCRIPTION
## What changed and why

Replaces the default glibc allocator in `rttx-server` with [mimalloc](https://github.com/microsoft/mimalloc) to reduce memory fragmentation, lower allocation latency, and improve multi-threaded throughput.

The daemon's workload (high-frequency 4KB PTY buffer allocations across many concurrent tokio tasks) stresses glibc malloc's global lock and fragmentation behavior. mimalloc is designed for exactly this pattern.

## Changes

- Added `mimalloc = "0.1"` dependency to `services/rttx-server/Cargo.toml`
- Set `#[global_allocator]` to `mimalloc::MiMalloc` in `services/rttx-server/src/main.rs`
- Added integration test verifying concurrent allocation correctness

## Manual verification

- Built and ran `rttx-server` successfully
- All existing tests pass unchanged (drop-in replacement, no behavioral change)

## Tests added

- `tests/allocator.rs::mimalloc_handles_concurrent_small_allocations` — exercises mimalloc under concurrent multi-threaded small-allocation churn matching the daemon's PTY workload pattern

## Tests run

- `cargo build --workspace` (server + proto) ✅
- `cargo test -p rttx-server` (all 517+ lib tests + integration tests) ✅
- `cargo test -p rttx-proto` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅

Fixes #945