### PR TITLE
fix: daemon-death recovery UX with restart action and frozen pane indicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/application.rs
+++ b/clients/rttx/src/application.rs
@@ -16,6 +16,9 @@ pub const APP_CSS: &str = "\
         border-color: alpha(@accent_bg_color, 0.85);
         background: alpha(@view_bg_color, 0.92);
     }
+    .terminal-pane-frozen vte-terminal {
+        opacity: 0.4;
+    }
     .terminal-header {
         padding: 6px 8px;
         border-top-left-radius: 10px;

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -3740,9 +3740,6 @@ mod tests {
                 saw_daemon_unavailable = true;
             }
         }
-        assert!(
-            saw_daemon_unavailable,
-            "remote circuit breaker should emit DaemonUnavailable"
-        );
+        assert!(saw_daemon_unavailable, "remote circuit breaker should emit DaemonUnavailable");
     }
 }

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -1696,7 +1696,7 @@ impl EndpointActor {
 
         // Circuit breaker: after too many consecutive failures, stop
         // auto-retrying and declare the endpoint unreachable. The user
-        // can manually retry via "Retry Connection" in the UI.
+        // can manually retry via "Retry Connection" or "Restart Daemon".
         let circuit_breaker_limit = self.reconnect_delay_secs.saturating_add(2);
         if self.reconnect_attempt > circuit_breaker_limit {
             tracing::error!(
@@ -1704,11 +1704,12 @@ impl EndpointActor {
                 self.endpoint.key(),
                 self.reconnect_attempt
             );
+            let problem = match self.endpoint {
+                RuntimeEndpoint::Local => ConnectionProblem::DaemonDied,
+                RuntimeEndpoint::Remote { .. } => ConnectionProblem::DaemonUnavailable,
+            };
             for workspace_id in self.tracked_workspaces.keys() {
-                self.emit_status(
-                    workspace_id,
-                    ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable),
-                );
+                self.emit_status(workspace_id, ConnectionStatus::Blocked(problem.clone()));
             }
             return;
         }
@@ -3671,5 +3672,77 @@ mod tests {
             "circuit breaker must fire within 15 attempts to avoid prolonged gray state"
         );
         assert!(limit >= 5, "circuit breaker must allow at least 5 attempts for transient issues");
+    }
+
+    /// Circuit breaker for a local endpoint emits `DaemonDied` instead of
+    /// `DaemonUnavailable` so the GUI can offer "Restart Daemon".
+    #[tokio::test]
+    async fn circuit_breaker_local_emits_daemon_died() {
+        let (event_tx, mut event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
+        let (self_tx, _self_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+
+        let mut actor = EndpointActor::new(
+            RuntimeEndpoint::Local,
+            event_tx,
+            self_tx,
+            cmd_rx,
+            false,
+            10,
+            Arc::new(AtomicBool::new(false)),
+        );
+        actor.tracked_workspaces.insert("ws-1".into(), Uuid::new_v4().to_string());
+        actor.reconnect_attempt = 12;
+
+        actor.schedule_reconnect(10);
+
+        let mut saw_daemon_died = false;
+        while let Ok(event) = event_rx.try_recv() {
+            if let EndpointEvent::WorkspaceConnectionChanged {
+                status: ConnectionStatus::Blocked(ConnectionProblem::DaemonDied),
+                ..
+            } = event
+            {
+                saw_daemon_died = true;
+            }
+        }
+        assert!(saw_daemon_died, "local circuit breaker should emit DaemonDied");
+    }
+
+    /// Circuit breaker for a remote endpoint emits `DaemonUnavailable`.
+    #[tokio::test]
+    async fn circuit_breaker_remote_emits_daemon_unavailable() {
+        let (event_tx, mut event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
+        let (self_tx, _self_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+
+        let mut actor = EndpointActor::new(
+            RuntimeEndpoint::Remote { host: "unreachable.invalid".into() },
+            event_tx,
+            self_tx,
+            cmd_rx,
+            false,
+            10,
+            Arc::new(AtomicBool::new(false)),
+        );
+        actor.tracked_workspaces.insert("ws-1".into(), Uuid::new_v4().to_string());
+        actor.reconnect_attempt = 12;
+
+        actor.schedule_reconnect(10);
+
+        let mut saw_daemon_unavailable = false;
+        while let Ok(event) = event_rx.try_recv() {
+            if let EndpointEvent::WorkspaceConnectionChanged {
+                status: ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable),
+                ..
+            } = event
+            {
+                saw_daemon_unavailable = true;
+            }
+        }
+        assert!(
+            saw_daemon_unavailable,
+            "remote circuit breaker should emit DaemonUnavailable"
+        );
     }
 }

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -203,6 +203,7 @@ impl ConnectionStatus {
             Self::Reconnecting { attempt, retry_in_secs } => {
                 format!("Reconnecting in {retry_in_secs}s (attempt {attempt})")
             }
+            Self::Blocked(ConnectionProblem::DaemonDied) => "Daemon stopped".into(),
             Self::Blocked(problem) => format!("Action Required: {}", problem.label()),
             Self::Disconnected => "Disconnected".into(),
             Self::Recovered => "Recovered".into(),
@@ -224,6 +225,7 @@ impl ConnectionStatus {
             Self::Connecting => "Connecting".into(),
             Self::Connected | Self::Recovered => "Connected".into(),
             Self::Reconnecting { retry_in_secs, .. } => format!("Retry {retry_in_secs}s"),
+            Self::Blocked(ConnectionProblem::DaemonDied) => "Daemon Stopped".into(),
             Self::Blocked(_) => "Action Required".into(),
             Self::Disconnected => "Disconnected".into(),
             Self::SessionMissing => "Session Missing".into(),
@@ -235,6 +237,8 @@ impl ConnectionStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConnectionProblem {
     DaemonUnavailable,
+    /// The daemon process died and repeated reconnect attempts failed.
+    DaemonDied,
     VersionMismatch,
     OwnershipConflict,
     PermissionDenied,
@@ -255,6 +259,7 @@ impl ConnectionProblem {
     pub fn label(&self) -> String {
         match self {
             Self::DaemonUnavailable => "Daemon unavailable".into(),
+            Self::DaemonDied => "Daemon stopped".into(),
             Self::VersionMismatch => "Version mismatch".into(),
             Self::OwnershipConflict => "Runtime already owned".into(),
             Self::PermissionDenied => "Permission denied".into(),
@@ -396,6 +401,7 @@ pub struct WorkspaceMenuItems {
     pub show_edit_connection: bool,
     pub show_reconnect: bool,
     pub show_reconnect_host: bool,
+    pub show_restart_daemon: bool,
     pub show_detach: bool,
 }
 
@@ -407,6 +413,7 @@ pub struct WorkspaceMenuContext {
     pub is_persistent: bool,
     pub is_attached: bool,
     pub is_disconnected: bool,
+    pub is_daemon_died: bool,
     pub has_other_disconnected_from_same_host: bool,
 }
 
@@ -419,6 +426,7 @@ pub const fn workspace_menu_items(ctx: &WorkspaceMenuContext) -> WorkspaceMenuIt
         show_reconnect_host: ctx.is_managed
             && ctx.is_disconnected
             && ctx.has_other_disconnected_from_same_host,
+        show_restart_daemon: ctx.is_managed && ctx.is_daemon_died && !ctx.is_remote,
         show_detach: ctx.is_persistent && ctx.is_attached,
     }
 }
@@ -477,6 +485,9 @@ pub const fn connection_icon(
         ConnectionStatus::Disconnected => ("warning", "Disconnected from runtime"),
         ConnectionStatus::Reconnecting { .. } => ("warning", "Reconnecting to runtime…"),
         ConnectionStatus::SessionMissing => ("warning", "Session no longer exists on daemon"),
+        ConnectionStatus::Blocked(ConnectionProblem::DaemonDied) => {
+            ("error", "Daemon stopped — restart to recover")
+        }
         ConnectionStatus::Blocked(_) => ("error", "Connection blocked — retry manually"),
         _ => ("dim-label", "Connecting…"),
     };
@@ -1236,6 +1247,7 @@ mod tests {
             is_persistent: true,
             is_attached: true,
             is_disconnected: false,
+            is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
         assert!(!items.show_edit_connection);
@@ -1252,6 +1264,7 @@ mod tests {
             is_persistent: true,
             is_attached: true,
             is_disconnected: true,
+            is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
         assert!(items.show_edit_connection);
@@ -1268,6 +1281,7 @@ mod tests {
             is_persistent: false,
             is_attached: true,
             is_disconnected: false,
+            is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
         assert!(!items.show_edit_connection);
@@ -1284,6 +1298,7 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: true,
+            is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
         assert!(items.show_reconnect);
@@ -1299,6 +1314,7 @@ mod tests {
             is_persistent: false,
             is_attached: false,
             is_disconnected: false,
+            is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
         assert!(!items.show_edit_connection);
@@ -1315,6 +1331,7 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: true,
+            is_daemon_died: false,
             has_other_disconnected_from_same_host: true,
         });
         assert!(items.show_reconnect);
@@ -1329,6 +1346,7 @@ mod tests {
             is_persistent: true,
             is_attached: true,
             is_disconnected: false,
+            is_daemon_died: false,
             has_other_disconnected_from_same_host: true,
         });
         assert!(!items.show_reconnect_host);
@@ -1387,6 +1405,7 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: false,
+            is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
         assert!(!items.show_reconnect);
@@ -1425,5 +1444,75 @@ mod tests {
             gtk4::Align::Start,
             "context menu halign must be Start to position adjacent to the pointer"
         );
+    }
+
+    // ── DaemonDied state (#954) ─────────────────────────────────
+
+    #[test]
+    fn daemon_died_is_not_transient() {
+        assert!(!ConnectionProblem::DaemonDied.is_transient());
+    }
+
+    #[test]
+    fn daemon_died_label_says_daemon_stopped() {
+        assert_eq!(ConnectionProblem::DaemonDied.label(), "Daemon stopped");
+    }
+
+    #[test]
+    fn daemon_died_short_label_says_daemon_stopped() {
+        let status = ConnectionStatus::Blocked(ConnectionProblem::DaemonDied);
+        assert_eq!(status.short_label(), "Daemon Stopped");
+    }
+
+    #[test]
+    fn daemon_died_full_label_says_daemon_stopped() {
+        let status = ConnectionStatus::Blocked(ConnectionProblem::DaemonDied);
+        assert_eq!(status.label(), "Daemon stopped");
+    }
+
+    #[test]
+    fn daemon_died_icon_uses_error_class_with_restart_tooltip() {
+        let icon = connection_icon(
+            &RuntimeEndpoint::Local,
+            &ConnectionStatus::Blocked(ConnectionProblem::DaemonDied),
+            true,
+        );
+        assert_eq!(icon.css_class, "error");
+        assert!(icon.tooltip.contains("restart"), "tooltip should mention restart: {}", icon.tooltip);
+    }
+
+    #[test]
+    fn menu_items_daemon_died_shows_restart_daemon() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: false,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: false,
+            is_disconnected: true,
+            is_daemon_died: true,
+            has_other_disconnected_from_same_host: false,
+        });
+        assert!(items.show_restart_daemon);
+        assert!(items.show_reconnect);
+    }
+
+    #[test]
+    fn menu_items_daemon_died_remote_hides_restart_daemon() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: true,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: false,
+            is_disconnected: true,
+            is_daemon_died: true,
+            has_other_disconnected_from_same_host: false,
+        });
+        assert!(!items.show_restart_daemon);
+    }
+
+    #[test]
+    fn daemon_died_disables_input() {
+        let status = ConnectionStatus::Blocked(ConnectionProblem::DaemonDied);
+        assert!(!status.accepts_input());
     }
 }

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -1478,7 +1478,11 @@ mod tests {
             true,
         );
         assert_eq!(icon.css_class, "error");
-        assert!(icon.tooltip.contains("restart"), "tooltip should mention restart: {}", icon.tooltip);
+        assert!(
+            icon.tooltip.contains("restart"),
+            "tooltip should mention restart: {}",
+            icon.tooltip
+        );
     }
 
     #[test]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -643,12 +643,17 @@ impl PersistentPaneView {
         presentation: &ConnectionPresentation,
     ) {
         self.imp().exited.set(false);
-        self.imp()
-            .connected
-            .set(matches!(status, ConnectionStatus::Connected | ConnectionStatus::Recovered));
+        let connected =
+            matches!(status, ConnectionStatus::Connected | ConnectionStatus::Recovered);
+        self.imp().connected.set(connected);
         self.imp().status_label.set_label(&presentation.header_label);
         self.imp().status_label.set_tooltip_text(Some(&status.label()));
         self.imp().accepts_input.set(presentation.input_enabled);
+        if connected {
+            self.remove_css_class("terminal-pane-frozen");
+        } else {
+            self.add_css_class("terminal-pane-frozen");
+        }
     }
 
     /// Mark the remote process as exited and make the pane visibly non-interactive.

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -643,8 +643,7 @@ impl PersistentPaneView {
         presentation: &ConnectionPresentation,
     ) {
         self.imp().exited.set(false);
-        let connected =
-            matches!(status, ConnectionStatus::Connected | ConnectionStatus::Recovered);
+        let connected = matches!(status, ConnectionStatus::Connected | ConnectionStatus::Recovered);
         self.imp().connected.set(connected);
         self.imp().status_label.set_label(&presentation.header_label);
         self.imp().status_label.set_tooltip_text(Some(&status.label()));

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -432,13 +432,17 @@ impl Window {
                 return;
             };
             let statuses = self.imp().workspace_connection_status.borrow();
-            let disconnected = statuses.get(session_uuid).is_some_and(|s| {
+            let current_status = statuses.get(session_uuid);
+            let disconnected = current_status.is_some_and(|s| {
                 matches!(
                     s,
                     ConnectionStatus::Disconnected
                         | ConnectionStatus::Reconnecting { .. }
                         | ConnectionStatus::Blocked(_)
                 )
+            });
+            let is_daemon_died = current_status.is_some_and(|s| {
+                matches!(s, ConnectionStatus::Blocked(ConnectionProblem::DaemonDied))
             });
             let endpoint_key = session.runtime.endpoint.key();
             let has_other_disconnected = state.workspaces.iter().any(|s| {
@@ -462,6 +466,7 @@ impl Window {
                     && matches!(session.runtime.policy, WorkspacePolicy::Persistent),
                 is_attached: session.runtime.runtime_id.is_some(),
                 is_disconnected: disconnected,
+                is_daemon_died,
                 has_other_disconnected_from_same_host: has_other_disconnected,
             })
         };
@@ -470,6 +475,9 @@ impl Window {
         menu.append(Some("Rename…"), Some("win.ctx-rename"));
         if items.show_edit_connection {
             menu.append(Some("Edit Connection…"), Some("win.ctx-edit-connection"));
+        }
+        if items.show_restart_daemon {
+            menu.append(Some("Restart Daemon"), Some("win.ctx-restart-daemon"));
         }
         if items.show_reconnect {
             menu.append(Some("Reconnect"), Some("win.ctx-reconnect"));
@@ -506,6 +514,16 @@ impl Window {
                 w.show_edit_workspace_connection_dialog(&u);
             });
             self.add_action(&edit_action);
+        }
+
+        if items.show_restart_daemon {
+            let w = self.clone();
+            let u = session_uuid.to_string();
+            let restart_action = gtk4::gio::SimpleAction::new("ctx-restart-daemon", None);
+            restart_action.connect_activate(move |_, _| {
+                w.restart_daemon_and_reconnect(&u);
+            });
+            self.add_action(&restart_action);
         }
 
         if items.show_reconnect {

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -14,9 +14,9 @@ use crate::host;
 use crate::places;
 use crate::preferences::{self, Preferences};
 use crate::runtime::{
-    ConnectionPresentation, ConnectionStatus, RuntimeEndpoint, WorkspaceActionPresentation,
-    WorkspacePolicy, connection_icon, pane_description, present_connection_status,
-    present_workspace_actions, workspace_connection_summary,
+    ConnectionPresentation, ConnectionProblem, ConnectionStatus, RuntimeEndpoint,
+    WorkspaceActionPresentation, WorkspacePolicy, connection_icon, pane_description,
+    present_connection_status, present_workspace_actions, workspace_connection_summary,
 };
 use crate::sidebar::WorkspaceRow;
 use crate::terminal::handle::TerminalHandle;

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -471,6 +471,12 @@ impl Window {
         self.connect_managed_workspace(&session_state);
     }
 
+    /// Restart the local daemon and reconnect all workspaces on the local endpoint.
+    pub(super) fn restart_daemon_and_reconnect(&self, workspace_id: &str) {
+        self.set_workspace_connection_status(workspace_id, &ConnectionStatus::Starting);
+        self.retry_all_workspaces_for_endpoint(workspace_id);
+    }
+
     /// Reconnect all managed workspaces sharing the same endpoint as the given workspace.
     pub(super) fn retry_all_workspaces_for_endpoint(&self, workspace_id: &str) {
         let targets: Vec<WorkspaceState> = {

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -1156,3 +1156,32 @@ fn workspace_menu_reconnect_host_requires_sibling_disconnected() {
     });
     assert!(!connected.show_reconnect_host);
 }
+
+/// Daemon-died state surfaces "Restart Daemon" for local endpoints only (#954).
+#[test]
+fn workspace_menu_daemon_died_shows_restart_for_local_only() {
+    use rttx::runtime::{WorkspaceMenuContext, workspace_menu_items};
+
+    let local = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: false,
+        is_managed: true,
+        is_persistent: true,
+        is_attached: false,
+        is_disconnected: true,
+        is_daemon_died: true,
+        has_other_disconnected_from_same_host: false,
+    });
+    assert!(local.show_restart_daemon);
+    assert!(local.show_reconnect);
+
+    let remote = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: true,
+        is_managed: true,
+        is_persistent: true,
+        is_attached: false,
+        is_disconnected: true,
+        is_daemon_died: true,
+        has_other_disconnected_from_same_host: false,
+    });
+    assert!(!remote.show_restart_daemon);
+}

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -1026,6 +1026,7 @@ fn workspace_menu_items_contract() {
         is_persistent: true,
         is_attached: true,
         is_disconnected: true,
+        is_daemon_died: false,
         has_other_disconnected_from_same_host: false,
     });
     assert!(all.show_edit_connection);
@@ -1039,6 +1040,7 @@ fn workspace_menu_items_contract() {
         is_persistent: false,
         is_attached: true,
         is_disconnected: false,
+        is_daemon_died: false,
         has_other_disconnected_from_same_host: false,
     });
     assert!(!minimal.show_edit_connection);
@@ -1125,6 +1127,7 @@ fn workspace_menu_reconnect_host_requires_sibling_disconnected() {
         is_persistent: true,
         is_attached: false,
         is_disconnected: true,
+        is_daemon_died: false,
         has_other_disconnected_from_same_host: true,
     });
     assert!(with_siblings.show_reconnect_host);
@@ -1136,6 +1139,7 @@ fn workspace_menu_reconnect_host_requires_sibling_disconnected() {
         is_persistent: true,
         is_attached: false,
         is_disconnected: true,
+        is_daemon_died: false,
         has_other_disconnected_from_same_host: false,
     });
     assert!(!without_siblings.show_reconnect_host);
@@ -1147,6 +1151,7 @@ fn workspace_menu_reconnect_host_requires_sibling_disconnected() {
         is_persistent: true,
         is_attached: true,
         is_disconnected: false,
+        is_daemon_died: false,
         has_other_disconnected_from_same_host: true,
     });
     assert!(!connected.show_reconnect_host);

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.6.1',
+  version: '0.6.2',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -1,5 +1,5 @@
 Name:           rttx
-Version:        0.6.1
+Version:        0.6.2
 Release:        1%{?dist}
 Summary:        A tiling terminal emulator for GNOME
 


### PR DESCRIPTION
## What changed and why

When the daemon dies unexpectedly (SIGKILL, crash), the GUI previously showed workspaces as "Disconnected" with a generic reconnect loop. There was no clear indication that the daemon died vs a transient network issue, no one-click restart, and stale pane content looked live.

This PR adds:

1. **DaemonDied detection** — circuit breaker on local endpoint emits `ConnectionProblem::DaemonDied` instead of `DaemonUnavailable`
2. **Clear status messaging** — "Daemon stopped" label with error icon and tooltip mentioning restart
3. **Restart Daemon action** — context menu item (local endpoints only) that resets status and triggers reconnect (which auto-starts the daemon)
4. **Frozen pane indicator** — disconnected panes get `terminal-pane-frozen` CSS class that dims VTE content to 40% opacity

## How to manually verify

1. Start rttx with a daemon-backed workspace
2. Kill the daemon: `pkill -9 rttx-server`
3. Wait for circuit breaker to trip (~12 reconnect attempts)
4. Observe: pane content dims, status shows "Daemon Stopped", icon is error-red
5. Right-click workspace → "Restart Daemon" appears
6. Click it → daemon restarts, workspace reconnects

## Tests added

Unit tests (9 new):
- `daemon_died_is_not_transient`
- `daemon_died_label_says_daemon_stopped`
- `daemon_died_short_label_says_daemon_stopped`
- `daemon_died_full_label_says_daemon_stopped`
- `daemon_died_icon_uses_error_class_with_restart_tooltip`
- `menu_items_daemon_died_shows_restart_daemon`
- `menu_items_daemon_died_remote_hides_restart_daemon`
- `daemon_died_disables_input`
- `circuit_breaker_local_emits_daemon_died` (async integration)

Plus `circuit_breaker_remote_emits_daemon_unavailable` to verify remote endpoints still get the generic status.

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo build -p rttx-server -p rttx-proto` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (all pass)
- `cargo test -p rttx-proto -p rttx-server` ✅ (all pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (0 failures, all daemon_died tests pass)

Fixes #954