### PR TITLE
Fix stuck "Connecting..." + force retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -731,10 +731,7 @@ impl EndpointActor {
                         let delay_secs = self.next_reconnect_delay_secs();
                         self.emit_status(
                             &workspace_id,
-                            ConnectionStatus::Reconnecting {
-                                attempt,
-                                retry_in_secs: delay_secs,
-                            },
+                            ConnectionStatus::Reconnecting { attempt, retry_in_secs: delay_secs },
                         );
                         self.schedule_reconnect(delay_secs);
                         self.emit_error(
@@ -1419,15 +1416,17 @@ impl EndpointActor {
                     self.daemon_start_attempted = true;
                     Self::start_local_daemon(&socket_path).await?;
                 }
-                let connection =
-                    tokio::time::timeout(HANDSHAKE_TIMEOUT, DaemonConnection::connect(&socket_path))
-                        .await
-                        .map_err(|_| {
-                            DaemonError::Io(std::io::Error::new(
-                                std::io::ErrorKind::TimedOut,
-                                "Local daemon handshake timed out".to_string(),
-                            ))
-                        })??;
+                let connection = tokio::time::timeout(
+                    HANDSHAKE_TIMEOUT,
+                    DaemonConnection::connect(&socket_path),
+                )
+                .await
+                .map_err(|_| {
+                    DaemonError::Io(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "Local daemon handshake timed out".to_string(),
+                    ))
+                })??;
                 self.connection = Some(connection);
                 self.daemon_start_attempted = false;
             }

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -29,6 +29,13 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 
 const SSH_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Maximum time for daemon handshake after transport connects.
+/// Prevents indefinite "Connecting..." when the daemon accepts but never responds.
+#[cfg(not(test))]
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(test)]
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Capacity for the event channel (`EndpointEvent` → GTK main loop).
 const EVENT_CHANNEL_BOUND: usize = 4096;
 
@@ -696,10 +703,49 @@ impl EndpointActor {
                     return;
                 }
 
-                let Ok((runtime_id, snapshot)) = self
-                    .resolve_and_attach_runtime(&workspace_id, &name, policy, runtime_id.as_deref())
-                    .await
-                else {
+                let attach_result = tokio::time::timeout(
+                    HANDSHAKE_TIMEOUT,
+                    self.resolve_and_attach_runtime(
+                        &workspace_id,
+                        &name,
+                        policy,
+                        runtime_id.as_deref(),
+                    ),
+                )
+                .await;
+
+                let Ok((runtime_id, snapshot)) = (match attach_result {
+                    Ok(inner) => inner,
+                    Err(_elapsed) => {
+                        tracing::warn!(
+                            "Handshake timeout for workspace {workspace_id} on {}",
+                            self.endpoint.key()
+                        );
+                        self.connection = None;
+                        self.reader = None;
+                        self.writer = None;
+                        self.ssh_handle = None;
+                        let problem = ConnectionProblem::DaemonUnavailable;
+                        self.emit_status(&workspace_id, ConnectionStatus::Disconnected);
+                        let attempt = self.next_reconnect_attempt();
+                        let delay_secs = self.next_reconnect_delay_secs();
+                        self.emit_status(
+                            &workspace_id,
+                            ConnectionStatus::Reconnecting {
+                                attempt,
+                                retry_in_secs: delay_secs,
+                            },
+                        );
+                        self.schedule_reconnect(delay_secs);
+                        self.emit_error(
+                            &workspace_id,
+                            ManagerOperation::OpenWorkspace,
+                            problem,
+                            "Daemon handshake timed out".into(),
+                        );
+                        return;
+                    }
+                }) else {
                     return;
                 };
 
@@ -1373,7 +1419,16 @@ impl EndpointActor {
                     self.daemon_start_attempted = true;
                     Self::start_local_daemon(&socket_path).await?;
                 }
-                self.connection = Some(DaemonConnection::connect(&socket_path).await?);
+                let connection =
+                    tokio::time::timeout(HANDSHAKE_TIMEOUT, DaemonConnection::connect(&socket_path))
+                        .await
+                        .map_err(|_| {
+                            DaemonError::Io(std::io::Error::new(
+                                std::io::ErrorKind::TimedOut,
+                                "Local daemon handshake timed out".to_string(),
+                            ))
+                        })??;
+                self.connection = Some(connection);
                 self.daemon_start_attempted = false;
             }
             RuntimeEndpoint::Remote { host } => {
@@ -2519,6 +2574,19 @@ mod tests {
         assert!(
             SSH_CONNECT_TIMEOUT <= Duration::from_mins(1),
             "SSH timeout should not exceed 60s to avoid blocking the actor too long"
+        );
+    }
+
+    /// Handshake timeout must be bounded to prevent indefinite "Connecting..." state (#955).
+    #[test]
+    fn handshake_timeout_is_bounded() {
+        assert!(
+            HANDSHAKE_TIMEOUT >= Duration::from_secs(5),
+            "Handshake timeout should be at least 5s for slow daemons"
+        );
+        assert!(
+            HANDSHAKE_TIMEOUT <= Duration::from_mins(1),
+            "Handshake timeout must not exceed 60s to prevent stuck Connecting state"
         );
     }
 

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -413,6 +413,7 @@ pub struct WorkspaceMenuContext {
     pub is_persistent: bool,
     pub is_attached: bool,
     pub is_disconnected: bool,
+    pub is_connecting: bool,
     pub is_daemon_died: bool,
     pub has_other_disconnected_from_same_host: bool,
 }
@@ -422,7 +423,7 @@ pub struct WorkspaceMenuContext {
 pub const fn workspace_menu_items(ctx: &WorkspaceMenuContext) -> WorkspaceMenuItems {
     WorkspaceMenuItems {
         show_edit_connection: ctx.is_remote,
-        show_reconnect: ctx.is_managed && ctx.is_disconnected,
+        show_reconnect: ctx.is_managed && (ctx.is_disconnected || ctx.is_connecting),
         show_reconnect_host: ctx.is_managed
             && ctx.is_disconnected
             && ctx.has_other_disconnected_from_same_host,
@@ -1247,6 +1248,7 @@ mod tests {
             is_persistent: true,
             is_attached: true,
             is_disconnected: false,
+            is_connecting: false,
             is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
@@ -1264,6 +1266,7 @@ mod tests {
             is_persistent: true,
             is_attached: true,
             is_disconnected: true,
+            is_connecting: false,
             is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
@@ -1281,6 +1284,7 @@ mod tests {
             is_persistent: false,
             is_attached: true,
             is_disconnected: false,
+            is_connecting: false,
             is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
@@ -1298,6 +1302,7 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: true,
+            is_connecting: false,
             is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
@@ -1314,6 +1319,7 @@ mod tests {
             is_persistent: false,
             is_attached: false,
             is_disconnected: false,
+            is_connecting: false,
             is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
@@ -1331,6 +1337,7 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: true,
+            is_connecting: false,
             is_daemon_died: false,
             has_other_disconnected_from_same_host: true,
         });
@@ -1346,6 +1353,7 @@ mod tests {
             is_persistent: true,
             is_attached: true,
             is_disconnected: false,
+            is_connecting: false,
             is_daemon_died: false,
             has_other_disconnected_from_same_host: true,
         });
@@ -1405,6 +1413,7 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: false,
+            is_connecting: false,
             is_daemon_died: false,
             has_other_disconnected_from_same_host: false,
         });
@@ -1493,6 +1502,7 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: true,
+            is_connecting: false,
             is_daemon_died: true,
             has_other_disconnected_from_same_host: false,
         });
@@ -1508,6 +1518,7 @@ mod tests {
             is_persistent: true,
             is_attached: false,
             is_disconnected: true,
+            is_connecting: false,
             is_daemon_died: true,
             has_other_disconnected_from_same_host: false,
         });
@@ -1518,5 +1529,52 @@ mod tests {
     fn daemon_died_disables_input() {
         let status = ConnectionStatus::Blocked(ConnectionProblem::DaemonDied);
         assert!(!status.accepts_input());
+    }
+
+    // ── Force reconnect during Connecting (#955) ────────────────
+
+    #[test]
+    fn menu_items_connecting_shows_force_reconnect() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: true,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: false,
+            is_disconnected: false,
+            is_connecting: true,
+            is_daemon_died: false,
+            has_other_disconnected_from_same_host: false,
+        });
+        assert!(items.show_reconnect, "Force Reconnect should be available during Connecting");
+    }
+
+    #[test]
+    fn menu_items_connecting_local_shows_force_reconnect() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: false,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: false,
+            is_disconnected: false,
+            is_connecting: true,
+            is_daemon_died: false,
+            has_other_disconnected_from_same_host: false,
+        });
+        assert!(items.show_reconnect, "Force Reconnect should be available for local connecting");
+    }
+
+    #[test]
+    fn menu_items_connected_hides_reconnect() {
+        let items = workspace_menu_items(&WorkspaceMenuContext {
+            is_remote: true,
+            is_managed: true,
+            is_persistent: true,
+            is_attached: true,
+            is_disconnected: false,
+            is_connecting: false,
+            is_daemon_died: false,
+            has_other_disconnected_from_same_host: false,
+        });
+        assert!(!items.show_reconnect, "Reconnect should be hidden when connected");
     }
 }

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -444,6 +444,9 @@ impl Window {
             let is_daemon_died = current_status.is_some_and(|s| {
                 matches!(s, ConnectionStatus::Blocked(ConnectionProblem::DaemonDied))
             });
+            let is_connecting = current_status.is_some_and(|s| {
+                matches!(s, ConnectionStatus::Connecting | ConnectionStatus::Starting)
+            });
             let endpoint_key = session.runtime.endpoint.key();
             let has_other_disconnected = state.workspaces.iter().any(|s| {
                 s.uuid != session_uuid
@@ -466,6 +469,7 @@ impl Window {
                     && matches!(session.runtime.policy, WorkspacePolicy::Persistent),
                 is_attached: session.runtime.runtime_id.is_some(),
                 is_disconnected: disconnected,
+                is_connecting,
                 is_daemon_died,
                 has_other_disconnected_from_same_host: has_other_disconnected,
             })

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -498,6 +498,8 @@ impl Window {
                                 ConnectionStatus::Disconnected
                                     | ConnectionStatus::Reconnecting { .. }
                                     | ConnectionStatus::Blocked(_)
+                                    | ConnectionStatus::Connecting
+                                    | ConnectionStatus::Starting
                             )
                         })
                 })

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -1026,6 +1026,7 @@ fn workspace_menu_items_contract() {
         is_persistent: true,
         is_attached: true,
         is_disconnected: true,
+        is_connecting: false,
         is_daemon_died: false,
         has_other_disconnected_from_same_host: false,
     });
@@ -1040,6 +1041,7 @@ fn workspace_menu_items_contract() {
         is_persistent: false,
         is_attached: true,
         is_disconnected: false,
+        is_connecting: false,
         is_daemon_died: false,
         has_other_disconnected_from_same_host: false,
     });
@@ -1127,6 +1129,7 @@ fn workspace_menu_reconnect_host_requires_sibling_disconnected() {
         is_persistent: true,
         is_attached: false,
         is_disconnected: true,
+        is_connecting: false,
         is_daemon_died: false,
         has_other_disconnected_from_same_host: true,
     });
@@ -1139,6 +1142,7 @@ fn workspace_menu_reconnect_host_requires_sibling_disconnected() {
         is_persistent: true,
         is_attached: false,
         is_disconnected: true,
+        is_connecting: false,
         is_daemon_died: false,
         has_other_disconnected_from_same_host: false,
     });
@@ -1151,6 +1155,7 @@ fn workspace_menu_reconnect_host_requires_sibling_disconnected() {
         is_persistent: true,
         is_attached: true,
         is_disconnected: false,
+        is_connecting: false,
         is_daemon_died: false,
         has_other_disconnected_from_same_host: true,
     });
@@ -1168,6 +1173,7 @@ fn workspace_menu_daemon_died_shows_restart_for_local_only() {
         is_persistent: true,
         is_attached: false,
         is_disconnected: true,
+        is_connecting: false,
         is_daemon_died: true,
         has_other_disconnected_from_same_host: false,
     });
@@ -1180,6 +1186,7 @@ fn workspace_menu_daemon_died_shows_restart_for_local_only() {
         is_persistent: true,
         is_attached: false,
         is_disconnected: true,
+        is_connecting: false,
         is_daemon_died: true,
         has_other_disconnected_from_same_host: false,
     });

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -1192,3 +1192,49 @@ fn workspace_menu_daemon_died_shows_restart_for_local_only() {
     });
     assert!(!remote.show_restart_daemon);
 }
+
+/// Regression test for #955: Force Reconnect must be available when a workspace
+/// is stuck in Connecting or Starting state, not only when Disconnected.
+#[test]
+fn workspace_menu_force_reconnect_available_during_connecting() {
+    use rttx::runtime::{WorkspaceMenuContext, workspace_menu_items};
+
+    // Connecting state should show reconnect
+    let connecting = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: true,
+        is_managed: true,
+        is_persistent: true,
+        is_attached: false,
+        is_disconnected: false,
+        is_connecting: true,
+        is_daemon_died: false,
+        has_other_disconnected_from_same_host: false,
+    });
+    assert!(connecting.show_reconnect, "Force Reconnect must be available during Connecting state");
+
+    // Disconnected state should still show reconnect (existing behavior)
+    let disconnected = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: true,
+        is_managed: true,
+        is_persistent: true,
+        is_attached: false,
+        is_disconnected: true,
+        is_connecting: false,
+        is_daemon_died: false,
+        has_other_disconnected_from_same_host: false,
+    });
+    assert!(disconnected.show_reconnect, "Force Reconnect must remain available when Disconnected");
+
+    // Connected state should NOT show reconnect
+    let connected = workspace_menu_items(&WorkspaceMenuContext {
+        is_remote: true,
+        is_managed: true,
+        is_persistent: true,
+        is_attached: true,
+        is_disconnected: false,
+        is_connecting: false,
+        is_daemon_died: false,
+        has_other_disconnected_from_same_host: false,
+    });
+    assert!(!connected.show_reconnect, "Force Reconnect must be hidden when already connected");
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.6.2',
+  version: '0.6.3',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -1,5 +1,5 @@
 Name:           rttx
-Version:        0.6.2
+Version:        0.6.3
 Release:        1%{?dist}
 Summary:        A tiling terminal emulator for GNOME
 


### PR DESCRIPTION
## What changed and why

Fixes #955 — Remote connections could get stuck in "Connecting..." state indefinitely when the daemon accepts a TCP/SSH connection but never completes the protocol handshake. Users had no way to cancel or retry.

### Changes

1. **Handshake timeout** (30s): Wraps both local socket connect and remote runtime attach in `tokio::time::timeout(HANDSHAKE_TIMEOUT, ...)`. On timeout, the connection is torn down and automatic reconnect is scheduled with exponential backoff.

2. **Force Reconnect for Connecting/Starting states**: The workspace context menu now shows "Force Reconnect" when a workspace is in Connecting or Starting state (previously only shown for Disconnected). The reconnect target filter also includes these states so the action actually cancels the stuck attempt.

3. **Version bump** to 0.6.3 (touches >3 source files and affects UX).

## Manual verification

1. Start rttx with a remote host configured
2. Simulate a hanging daemon (e.g., `socat` accepting connections but not responding)
3. Observe that after 30s the workspace transitions from "Connecting..." to "Reconnecting" with backoff
4. Right-click a workspace in Connecting state → "Force Reconnect" is available
5. Normal connections still work without delay

## Tests added

- `handshake_timeout_is_bounded` — validates timeout constant bounds
- `menu_items_connecting_shows_force_reconnect` — remote workspace in Connecting state shows reconnect
- `menu_items_connecting_local_shows_force_reconnect` — local workspace in Connecting state shows reconnect
- `menu_items_connected_hides_reconnect` — connected workspace hides reconnect (regression guard)
- Updated all existing `WorkspaceMenuContext` test sites with new `is_connecting` field

## Tests run

- `cargo build --workspace` (with VTE 0.76 flag for client) ✅
- `cargo test --workspace` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass including new ones)

## Limitations

- Integration test for the actual timeout behavior (waiting 30s for a real timeout) is not included as it would be too slow for CI. The timeout logic is covered by the constant bounds test and the code path is straightforward `tokio::time::timeout` wrapping.