### PR TITLE
feat: Remote daemon lifecycle management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -90,6 +90,15 @@ pub enum DaemonError {
     /// Connection was closed by the server.
     #[error("connection closed")]
     Disconnected,
+
+    /// The daemon binary was not found on the remote host.
+    #[error("rttx-server not installed on {host} (tried: {binary})")]
+    DaemonNotInstalled {
+        /// Remote host where the binary was not found.
+        host: String,
+        /// Binary path that was attempted.
+        binary: String,
+    },
 }
 
 /// Successful detach outcome from the daemon.
@@ -172,16 +181,22 @@ impl DaemonConnection {
     }
 
     /// Connect to `rttx-server` on a remote host via SSH.
-    pub async fn connect_ssh(host: &str) -> Result<(Self, SshHandle), DaemonError> {
+    ///
+    /// When `binary_path` is `None`, uses `rttx-server` (resolved via PATH on the remote).
+    pub async fn connect_ssh(
+        host: &str,
+        binary_path: Option<&str>,
+    ) -> Result<(Self, SshHandle), DaemonError> {
+        let binary = binary_path.unwrap_or("rttx-server");
         let mut child = tokio::process::Command::new("ssh")
             .args(["-o", "BatchMode=yes"])
             .args(["-o", "ConnectTimeout=10"])
             .arg(host)
-            .arg("rttx-server")
+            .arg(binary)
             .arg("attach-stdio")
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
             .spawn()?;
 
         let child_stdin =
@@ -199,8 +214,57 @@ impl DaemonConnection {
             effective_caps: Vec::new(),
             id_gen: RequestIdGenerator::new(),
         };
-        conn.handshake().await?;
-        Ok((conn, SshHandle { child }))
+        match conn.handshake().await {
+            Ok(()) => Ok((conn, SshHandle { child })),
+            Err(DaemonError::Disconnected | DaemonError::Frame(_)) => {
+                // Connection closed before handshake — check stderr for clues.
+                let stderr = child.stderr.take();
+                let stderr_text = if let Some(mut stderr) = stderr {
+                    let mut buf = Vec::new();
+                    let _ = tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut buf).await;
+                    String::from_utf8_lossy(&buf).to_string()
+                } else {
+                    String::new()
+                };
+                if stderr_text.contains("not found")
+                    || stderr_text.contains("No such file")
+                    || stderr_text.contains("command not found")
+                {
+                    Err(DaemonError::DaemonNotInstalled {
+                        host: host.to_string(),
+                        binary: binary.to_string(),
+                    })
+                } else {
+                    Err(DaemonError::Disconnected)
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Start the remote daemon via SSH (runs `rttx-server start` in background).
+    pub async fn start_remote_daemon(
+        host: &str,
+        binary_path: Option<&str>,
+    ) -> Result<(), DaemonError> {
+        let binary = binary_path.unwrap_or("rttx-server");
+        let status = tokio::process::Command::new("ssh")
+            .args(["-o", "BatchMode=yes"])
+            .args(["-o", "ConnectTimeout=10"])
+            .arg(host)
+            .arg(binary)
+            .arg("start")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .status()
+            .await?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(DaemonError::Io(std::io::Error::other(format!(
+                "remote daemon start exited with {status}"
+            ))))
+        }
     }
 
     /// Split into independent reader and writer halves.
@@ -998,7 +1062,7 @@ mod tests {
     #[tokio::test]
     async fn connect_ssh_to_bogus_host_fails_fast() {
         let start = std::time::Instant::now();
-        let result = DaemonConnection::connect_ssh("rttx-nonexistent-host-test").await;
+        let result = DaemonConnection::connect_ssh("rttx-nonexistent-host-test", None).await;
         assert!(result.is_err(), "SSH to bogus host should fail");
         // BatchMode=yes makes SSH fail immediately instead of hanging for auth.
         assert!(start.elapsed().as_secs() < 15, "SSH should fail fast, not hang");
@@ -1062,5 +1126,24 @@ mod tests {
             )),
         };
         assert_eq!(extract_pane_id(&env), Some(pane_id));
+    }
+
+    #[tokio::test]
+    async fn connect_ssh_with_custom_binary_path() {
+        let result =
+            DaemonConnection::connect_ssh("rttx-nonexistent-host-test", Some("/opt/bin/rttx-server"))
+                .await;
+        assert!(result.is_err(), "SSH to bogus host should fail regardless of binary path");
+    }
+
+    #[test]
+    fn daemon_not_installed_error_displays_host_and_binary() {
+        let err = DaemonError::DaemonNotInstalled {
+            host: "example.com".into(),
+            binary: "~/.local/bin/rttx-server".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("example.com"), "error should mention the host");
+        assert!(msg.contains("~/.local/bin/rttx-server"), "error should mention the binary path");
     }
 }

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -1130,9 +1130,11 @@ mod tests {
 
     #[tokio::test]
     async fn connect_ssh_with_custom_binary_path() {
-        let result =
-            DaemonConnection::connect_ssh("rttx-nonexistent-host-test", Some("/opt/bin/rttx-server"))
-                .await;
+        let result = DaemonConnection::connect_ssh(
+            "rttx-nonexistent-host-test",
+            Some("/opt/bin/rttx-server"),
+        )
+        .await;
         assert!(result.is_err(), "SSH to bogus host should fail regardless of binary path");
     }
 

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -1430,18 +1430,51 @@ impl EndpointActor {
                 self.connection = Some(connection);
                 self.daemon_start_attempted = false;
             }
-            RuntimeEndpoint::Remote { host } => {
-                let (connection, ssh_handle) =
-                    tokio::time::timeout(SSH_CONNECT_TIMEOUT, DaemonConnection::connect_ssh(host))
+            RuntimeEndpoint::Remote { host, daemon_binary_path } => {
+                let binary_path = daemon_binary_path.as_deref();
+                let connect_result = tokio::time::timeout(
+                    SSH_CONNECT_TIMEOUT,
+                    DaemonConnection::connect_ssh(host, binary_path),
+                )
+                .await
+                .map_err(|_| {
+                    DaemonError::Io(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!("SSH connection to {host} timed out"),
+                    ))
+                })?;
+
+                match connect_result {
+                    Ok((connection, ssh_handle)) => {
+                        self.connection = Some(connection);
+                        self.ssh_handle = Some(ssh_handle);
+                        self.daemon_start_attempted = false;
+                    }
+                    Err(DaemonError::Disconnected)
+                        if !self.daemon_start_attempted && self.auto_start_daemon =>
+                    {
+                        // Daemon not running — try to start it remotely.
+                        tracing::info!("Auto-starting remote daemon on {host}");
+                        self.daemon_start_attempted = true;
+                        DaemonConnection::start_remote_daemon(host, binary_path).await?;
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        // Retry connection after start.
+                        let (connection, ssh_handle) = tokio::time::timeout(
+                            SSH_CONNECT_TIMEOUT,
+                            DaemonConnection::connect_ssh(host, binary_path),
+                        )
                         .await
                         .map_err(|_| {
                             DaemonError::Io(std::io::Error::new(
                                 std::io::ErrorKind::TimedOut,
-                                format!("SSH connection to {host} timed out"),
+                                format!("SSH connection to {host} timed out after daemon start"),
                             ))
                         })??;
-                self.connection = Some(connection);
-                self.ssh_handle = Some(ssh_handle);
+                        self.connection = Some(connection);
+                        self.ssh_handle = Some(ssh_handle);
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         }
         Ok(())
@@ -1758,10 +1791,7 @@ impl EndpointActor {
                 self.endpoint.key(),
                 self.reconnect_attempt
             );
-            let problem = match self.endpoint {
-                RuntimeEndpoint::Local => ConnectionProblem::DaemonDied,
-                RuntimeEndpoint::Remote { .. } => ConnectionProblem::DaemonUnavailable,
-            };
+            let problem = ConnectionProblem::DaemonDied;
             for workspace_id in self.tracked_workspaces.keys() {
                 self.emit_status(workspace_id, ConnectionStatus::Blocked(problem.clone()));
             }
@@ -3096,7 +3126,7 @@ mod tests {
         let (self_tx, _self_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
         let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
         let mut actor = EndpointActor::new(
-            RuntimeEndpoint::Remote { host: "nonexistent.invalid".into() },
+            RuntimeEndpoint::remote("nonexistent.invalid"),
             event_tx,
             self_tx,
             cmd_rx,
@@ -3595,7 +3625,7 @@ mod tests {
         let (self_tx, _self_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
         let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
         let mut actor = EndpointActor::new(
-            RuntimeEndpoint::Remote { host: "nonexistent.invalid".into() },
+            RuntimeEndpoint::remote("nonexistent.invalid"),
             event_tx,
             self_tx,
             cmd_rx,
@@ -3627,7 +3657,7 @@ mod tests {
         let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
 
         let mut actor = EndpointActor::new(
-            RuntimeEndpoint::Remote { host: "unreachable.invalid".into() },
+            RuntimeEndpoint::remote("unreachable.invalid"),
             event_tx,
             self_tx,
             cmd_rx,
@@ -3672,7 +3702,7 @@ mod tests {
         let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
 
         let mut actor = EndpointActor::new(
-            RuntimeEndpoint::Remote { host: "unreachable.invalid".into() },
+            RuntimeEndpoint::remote("unreachable.invalid"),
             event_tx,
             self_tx,
             cmd_rx,
@@ -3776,15 +3806,15 @@ mod tests {
         assert!(saw_daemon_died, "local circuit breaker should emit DaemonDied");
     }
 
-    /// Circuit breaker for a remote endpoint emits `DaemonUnavailable`.
+    /// Circuit breaker for a remote endpoint emits `DaemonDied`.
     #[tokio::test]
-    async fn circuit_breaker_remote_emits_daemon_unavailable() {
+    async fn circuit_breaker_remote_emits_daemon_died() {
         let (event_tx, mut event_rx) = mpsc::channel(EVENT_CHANNEL_BOUND);
         let (self_tx, _self_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
         let (_, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
 
         let mut actor = EndpointActor::new(
-            RuntimeEndpoint::Remote { host: "unreachable.invalid".into() },
+            RuntimeEndpoint::remote("unreachable.invalid"),
             event_tx,
             self_tx,
             cmd_rx,
@@ -3797,16 +3827,16 @@ mod tests {
 
         actor.schedule_reconnect(10);
 
-        let mut saw_daemon_unavailable = false;
+        let mut saw_daemon_died = false;
         while let Ok(event) = event_rx.try_recv() {
             if let EndpointEvent::WorkspaceConnectionChanged {
-                status: ConnectionStatus::Blocked(ConnectionProblem::DaemonUnavailable),
+                status: ConnectionStatus::Blocked(ConnectionProblem::DaemonDied),
                 ..
             } = event
             {
-                saw_daemon_unavailable = true;
+                saw_daemon_died = true;
             }
         }
-        assert!(saw_daemon_unavailable, "remote circuit breaker should emit DaemonUnavailable");
+        assert!(saw_daemon_died, "remote circuit breaker should emit DaemonDied");
     }
 }

--- a/clients/rttx/src/host.rs
+++ b/clients/rttx/src/host.rs
@@ -23,6 +23,8 @@ pub struct Host {
     pub kind: HostKind,
     #[serde(default)]
     pub ssh_target: Option<String>,
+    #[serde(default)]
+    pub daemon_binary_path: Option<String>,
 }
 
 impl Host {
@@ -34,6 +36,7 @@ impl Host {
             name: "Local".into(),
             kind: HostKind::Local,
             ssh_target: None,
+            daemon_binary_path: None,
         }
     }
 
@@ -45,7 +48,13 @@ impl Host {
     pub fn remote(ssh_target: &str) -> Self {
         let key = normalize_ssh_key(ssh_target);
         let name = display_name_from_ssh(ssh_target);
-        Self { key, name, kind: HostKind::Remote, ssh_target: Some(ssh_target.into()) }
+        Self {
+            key,
+            name,
+            kind: HostKind::Remote,
+            ssh_target: Some(ssh_target.into()),
+            daemon_binary_path: None,
+        }
     }
 
     #[must_use]
@@ -162,6 +171,7 @@ pub fn resolve(key: &str, saved: &[Host]) -> Host {
         name: key.split('.').next().unwrap_or(key).to_string(),
         kind: HostKind::Remote,
         ssh_target: Some(key.into()),
+        daemon_binary_path: None,
     }
 }
 
@@ -292,7 +302,23 @@ mod tests {
         let json = r#"{"key":"local","name":"Local","kind":"local"}"#;
         let host: Host = serde_json::from_str(json).unwrap();
         assert_eq!(host.ssh_target, None);
+        assert_eq!(host.daemon_binary_path, None);
         assert!(host.is_local());
+    }
+
+    #[test]
+    fn deserialize_without_daemon_binary_path_defaults_to_none() {
+        let json = r#"{"key":"example.com","name":"example","kind":"remote","ssh_target":"deploy@example.com"}"#;
+        let host: Host = serde_json::from_str(json).unwrap();
+        assert_eq!(host.daemon_binary_path, None);
+        assert!(host.is_remote());
+    }
+
+    #[test]
+    fn deserialize_with_daemon_binary_path() {
+        let json = r#"{"key":"example.com","name":"example","kind":"remote","ssh_target":"deploy@example.com","daemon_binary_path":"~/.local/bin/rttx-server"}"#;
+        let host: Host = serde_json::from_str(json).unwrap();
+        assert_eq!(host.daemon_binary_path.as_deref(), Some("~/.local/bin/rttx-server"));
     }
 
     #[test]

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -323,11 +323,9 @@ pub fn classify_connection_problem(error: &DaemonError) -> ConnectionProblem {
             ConnectionProblem::UserActionRequired(message.clone())
         }
         DaemonError::Io(_) | DaemonError::Disconnected => ConnectionProblem::DaemonUnavailable,
-        DaemonError::DaemonNotInstalled { host, binary } => {
-            ConnectionProblem::DaemonNotInstalled(format!(
-                "rttx-server not installed on {host} (tried: {binary})"
-            ))
-        }
+        DaemonError::DaemonNotInstalled { host, binary } => ConnectionProblem::DaemonNotInstalled(
+            format!("rttx-server not installed on {host} (tried: {binary})"),
+        ),
         DaemonError::Frame(frame_error) => ConnectionProblem::Protocol(frame_error.to_string()),
         DaemonError::UnexpectedMessage => {
             ConnectionProblem::Protocol("Unexpected daemon message".into())
@@ -998,11 +996,8 @@ mod tests {
     fn connected_color_consistent_across_all_workspace_types() {
         let local_managed =
             connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, true);
-        let remote_managed = connection_icon(
-            &RuntimeEndpoint::remote("h"),
-            &ConnectionStatus::Connected,
-            true,
-        );
+        let remote_managed =
+            connection_icon(&RuntimeEndpoint::remote("h"), &ConnectionStatus::Connected, true);
         let direct = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, false);
         assert_eq!(local_managed.css_class, "accent");
         assert_eq!(remote_managed.css_class, "accent");
@@ -1299,8 +1294,7 @@ mod tests {
 
     #[test]
     fn remote_endpoint_serde_roundtrip_with_daemon_binary_path() {
-        let endpoint =
-            RuntimeEndpoint::remote_with_binary("host", Some("/opt/rttx-server".into()));
+        let endpoint = RuntimeEndpoint::remote_with_binary("host", Some("/opt/rttx-server".into()));
         let json = serde_json::to_string(&endpoint).unwrap();
         let deserialized: RuntimeEndpoint = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.daemon_binary_path(), Some("/opt/rttx-server"));

--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -51,16 +51,32 @@ pub enum RuntimeEndpoint {
     #[default]
     Local,
     /// A remote daemon reached through SSH.
-    Remote { host: String },
+    Remote {
+        host: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        daemon_binary_path: Option<String>,
+    },
 }
 
 impl RuntimeEndpoint {
+    /// Create a remote endpoint with default binary path (`rttx-server` in PATH).
+    #[must_use]
+    pub fn remote(host: impl Into<String>) -> Self {
+        Self::Remote { host: host.into(), daemon_binary_path: None }
+    }
+
+    /// Create a remote endpoint with a custom daemon binary path.
+    #[must_use]
+    pub fn remote_with_binary(host: impl Into<String>, binary_path: Option<String>) -> Self {
+        Self::Remote { host: host.into(), daemon_binary_path: binary_path }
+    }
+
     /// Stable key string for maps and diagnostics.
     #[must_use]
     pub fn key(&self) -> String {
         match self {
             Self::Local => "local".into(),
-            Self::Remote { host } => format!("remote:{host}"),
+            Self::Remote { host, .. } => format!("remote:{host}"),
         }
     }
 
@@ -69,7 +85,16 @@ impl RuntimeEndpoint {
     pub fn host_key(&self) -> String {
         match self {
             Self::Local => crate::host::LOCAL_KEY.into(),
-            Self::Remote { host } => crate::host::normalize_ssh_key(host),
+            Self::Remote { host, .. } => crate::host::normalize_ssh_key(host),
+        }
+    }
+
+    /// The daemon binary path for a remote endpoint, or `None` for local.
+    #[must_use]
+    pub fn daemon_binary_path(&self) -> Option<&str> {
+        match self {
+            Self::Local => None,
+            Self::Remote { daemon_binary_path, .. } => daemon_binary_path.as_deref(),
         }
     }
 }
@@ -111,7 +136,7 @@ impl WorkspaceRuntime {
         policy: WorkspacePolicy,
         layout_terminal_uuids: &[String],
     ) -> Self {
-        Self::managed(RuntimeEndpoint::Remote { host: host.into() }, policy, layout_terminal_uuids)
+        Self::managed(RuntimeEndpoint::remote(host), policy, layout_terminal_uuids)
     }
 
     fn managed(
@@ -239,6 +264,8 @@ pub enum ConnectionProblem {
     DaemonUnavailable,
     /// The daemon process died and repeated reconnect attempts failed.
     DaemonDied,
+    /// The daemon binary is not installed on the remote host.
+    DaemonNotInstalled(String),
     VersionMismatch,
     OwnershipConflict,
     PermissionDenied,
@@ -264,7 +291,9 @@ impl ConnectionProblem {
             Self::OwnershipConflict => "Runtime already owned".into(),
             Self::PermissionDenied => "Permission denied".into(),
             Self::SessionMissing => "Session no longer exists".into(),
-            Self::Protocol(detail) | Self::UserActionRequired(detail) => detail.clone(),
+            Self::DaemonNotInstalled(detail)
+            | Self::Protocol(detail)
+            | Self::UserActionRequired(detail) => detail.clone(),
         }
     }
 }
@@ -294,6 +323,11 @@ pub fn classify_connection_problem(error: &DaemonError) -> ConnectionProblem {
             ConnectionProblem::UserActionRequired(message.clone())
         }
         DaemonError::Io(_) | DaemonError::Disconnected => ConnectionProblem::DaemonUnavailable,
+        DaemonError::DaemonNotInstalled { host, binary } => {
+            ConnectionProblem::DaemonNotInstalled(format!(
+                "rttx-server not installed on {host} (tried: {binary})"
+            ))
+        }
         DaemonError::Frame(frame_error) => ConnectionProblem::Protocol(frame_error.to_string()),
         DaemonError::UnexpectedMessage => {
             ConnectionProblem::Protocol("Unexpected daemon message".into())
@@ -427,7 +461,7 @@ pub const fn workspace_menu_items(ctx: &WorkspaceMenuContext) -> WorkspaceMenuIt
         show_reconnect_host: ctx.is_managed
             && ctx.is_disconnected
             && ctx.has_other_disconnected_from_same_host,
-        show_restart_daemon: ctx.is_managed && ctx.is_daemon_died && !ctx.is_remote,
+        show_restart_daemon: ctx.is_managed && ctx.is_daemon_died,
         show_detach: ctx.is_persistent && ctx.is_attached,
     }
 }
@@ -507,7 +541,7 @@ pub fn workspace_connection_summary(
     let pane_part = active_pane_info.filter(|s| !s.is_empty()).unwrap_or("");
     match endpoint {
         RuntimeEndpoint::Local => pane_part.to_string(),
-        RuntimeEndpoint::Remote { host } => {
+        RuntimeEndpoint::Remote { host, .. } => {
             if pane_part.is_empty() {
                 host.clone()
             } else {
@@ -752,7 +786,7 @@ mod tests {
         assert_eq!(workspace_connection_summary(&RuntimeEndpoint::Local, Some("")), "");
         assert_eq!(
             workspace_connection_summary(
-                &RuntimeEndpoint::Remote { host: "builder.example".into() },
+                &RuntimeEndpoint::remote("builder.example"),
                 Some("~/src"),
             ),
             "builder.example · ~/src"
@@ -761,7 +795,7 @@ mod tests {
 
     #[test]
     fn workspace_connection_summary_for_remote_endpoint() {
-        let endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
+        let endpoint = RuntimeEndpoint::remote("builder.example");
 
         assert_eq!(workspace_connection_summary(&endpoint, Some("bash")), "builder.example · bash");
         assert_eq!(workspace_connection_summary(&endpoint, None), "builder.example");
@@ -876,7 +910,7 @@ mod tests {
     #[test]
     fn connection_icon_reconnecting_uses_warning_not_dim_label() {
         let local = RuntimeEndpoint::Local;
-        let remote = RuntimeEndpoint::Remote { host: "h".into() };
+        let remote = RuntimeEndpoint::remote("h");
         let reconnecting = ConnectionStatus::Reconnecting { attempt: 3, retry_in_secs: 5 };
 
         let local_icon = connection_icon(&local, &reconnecting, true);
@@ -910,7 +944,7 @@ mod tests {
 
     #[test]
     fn connection_icon_shape_constant_for_remote() {
-        let ep = RuntimeEndpoint::Remote { host: "h".into() };
+        let ep = RuntimeEndpoint::remote("h");
         for status in [
             ConnectionStatus::Connected,
             ConnectionStatus::Disconnected,
@@ -930,7 +964,7 @@ mod tests {
 
     #[test]
     fn connection_icon_color_for_remote() {
-        let ep = RuntimeEndpoint::Remote { host: "h".into() };
+        let ep = RuntimeEndpoint::remote("h");
         assert_eq!(connection_icon(&ep, &ConnectionStatus::Connected, true).css_class, "accent");
         assert_eq!(connection_icon(&ep, &ConnectionStatus::Recovered, true).css_class, "accent");
         assert_eq!(
@@ -965,7 +999,7 @@ mod tests {
         let local_managed =
             connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, true);
         let remote_managed = connection_icon(
-            &RuntimeEndpoint::Remote { host: "h".into() },
+            &RuntimeEndpoint::remote("h"),
             &ConnectionStatus::Connected,
             true,
         );
@@ -977,7 +1011,7 @@ mod tests {
 
     #[test]
     fn connection_icon_tooltips_describe_state() {
-        let remote = RuntimeEndpoint::Remote { host: "h".into() };
+        let remote = RuntimeEndpoint::remote("h");
         let local = RuntimeEndpoint::Local;
 
         let connected = connection_icon(&remote, &ConnectionStatus::Connected, true);
@@ -999,7 +1033,7 @@ mod tests {
     #[test]
     fn connection_icon_shape_never_changes_with_status_regression() {
         let local = RuntimeEndpoint::Local;
-        let remote = RuntimeEndpoint::Remote { host: "h".into() };
+        let remote = RuntimeEndpoint::remote("h");
         let statuses = [
             ConnectionStatus::Connected,
             ConnectionStatus::Disconnected,
@@ -1079,7 +1113,7 @@ mod tests {
             &uuids,
         );
         assert!(runtime.is_managed());
-        assert_eq!(runtime.endpoint, RuntimeEndpoint::Remote { host: "server.example.com".into() });
+        assert_eq!(runtime.endpoint, RuntimeEndpoint::remote("server.example.com"));
         assert_eq!(runtime.policy, WorkspacePolicy::Persistent);
         assert!(runtime.pending_layout_panes.contains("t1"));
     }
@@ -1093,7 +1127,7 @@ mod tests {
 
         assert!(runtime.pane_bindings.contains_key("t2"));
         assert!(runtime.pending_layout_panes.contains("t2"));
-        assert_eq!(runtime.endpoint, RuntimeEndpoint::Remote { host: "host".into() });
+        assert_eq!(runtime.endpoint, RuntimeEndpoint::remote("host"));
     }
 
     #[test]
@@ -1203,7 +1237,7 @@ mod tests {
     #[test]
     fn endpoint_key_distinguishes_local_and_remote() {
         let local = RuntimeEndpoint::Local;
-        let remote = RuntimeEndpoint::Remote { host: "host".into() };
+        let remote = RuntimeEndpoint::remote("host");
         assert_ne!(local.key(), remote.key());
         assert_eq!(local.key(), "local");
         assert!(remote.key().contains("host"));
@@ -1216,21 +1250,60 @@ mod tests {
 
     #[test]
     fn host_key_remote_normalizes_ssh_target() {
-        let endpoint = RuntimeEndpoint::Remote { host: "deploy@example.com".into() };
+        let endpoint = RuntimeEndpoint::remote("deploy@example.com");
         assert_eq!(endpoint.host_key(), "example.com");
     }
 
     #[test]
     fn host_key_remote_bare_hostname() {
-        let endpoint = RuntimeEndpoint::Remote { host: "dev-box".into() };
+        let endpoint = RuntimeEndpoint::remote("dev-box");
         assert_eq!(endpoint.host_key(), "dev-box");
     }
 
     #[test]
     fn remote_endpoint_host_key_matches_saved_host_key() {
-        let endpoint = RuntimeEndpoint::Remote { host: "deploy@builder.example.com".into() };
+        let endpoint = RuntimeEndpoint::remote("deploy@builder.example.com");
         let host = crate::host::Host::remote("deploy@builder.example.com");
         assert_eq!(endpoint.host_key(), host.key);
+    }
+
+    #[test]
+    fn remote_with_binary_stores_path() {
+        let endpoint =
+            RuntimeEndpoint::remote_with_binary("host", Some("~/.local/bin/rttx-server".into()));
+        assert_eq!(endpoint.daemon_binary_path(), Some("~/.local/bin/rttx-server"));
+    }
+
+    #[test]
+    fn remote_without_binary_returns_none() {
+        let endpoint = RuntimeEndpoint::remote("host");
+        assert_eq!(endpoint.daemon_binary_path(), None);
+    }
+
+    #[test]
+    fn local_endpoint_daemon_binary_path_is_none() {
+        assert_eq!(RuntimeEndpoint::Local.daemon_binary_path(), None);
+    }
+
+    #[test]
+    fn remote_endpoint_serde_backward_compat_without_daemon_binary_path() {
+        let json = r#"{"kind":"remote","host":"example.com"}"#;
+        let endpoint: RuntimeEndpoint = serde_json::from_str(json).unwrap();
+        assert_eq!(endpoint.daemon_binary_path(), None);
+        if let RuntimeEndpoint::Remote { host, .. } = &endpoint {
+            assert_eq!(host, "example.com");
+        } else {
+            panic!("expected Remote endpoint");
+        }
+    }
+
+    #[test]
+    fn remote_endpoint_serde_roundtrip_with_daemon_binary_path() {
+        let endpoint =
+            RuntimeEndpoint::remote_with_binary("host", Some("/opt/rttx-server".into()));
+        let json = serde_json::to_string(&endpoint).unwrap();
+        let deserialized: RuntimeEndpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.daemon_binary_path(), Some("/opt/rttx-server"));
     }
 
     #[test]
@@ -1463,6 +1536,30 @@ mod tests {
     }
 
     #[test]
+    fn daemon_not_installed_is_not_transient() {
+        let problem = ConnectionProblem::DaemonNotInstalled("not found".into());
+        assert!(!problem.is_transient());
+    }
+
+    #[test]
+    fn classify_daemon_not_installed_error() {
+        let error = DaemonError::DaemonNotInstalled {
+            host: "example.com".into(),
+            binary: "rttx-server".into(),
+        };
+        let problem = classify_connection_problem(&error);
+        assert!(matches!(problem, ConnectionProblem::DaemonNotInstalled(_)));
+    }
+
+    #[test]
+    fn daemon_not_installed_label_includes_detail() {
+        let problem = ConnectionProblem::DaemonNotInstalled(
+            "rttx-server not installed on example.com (tried: rttx-server)".into(),
+        );
+        assert!(problem.label().contains("example.com"));
+    }
+
+    #[test]
     fn daemon_died_label_says_daemon_stopped() {
         assert_eq!(ConnectionProblem::DaemonDied.label(), "Daemon stopped");
     }
@@ -1511,7 +1608,7 @@ mod tests {
     }
 
     #[test]
-    fn menu_items_daemon_died_remote_hides_restart_daemon() {
+    fn menu_items_daemon_died_remote_shows_restart_daemon() {
         let items = workspace_menu_items(&WorkspaceMenuContext {
             is_remote: true,
             is_managed: true,
@@ -1522,7 +1619,7 @@ mod tests {
             is_daemon_died: true,
             has_other_disconnected_from_same_host: false,
         });
-        assert!(!items.show_restart_daemon);
+        assert!(items.show_restart_daemon);
     }
 
     #[test]

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -830,7 +830,7 @@ mod tests {
         assert!(restored.runtime.is_managed());
         assert_eq!(
             restored.runtime.endpoint,
-            RuntimeEndpoint::Remote { host: "example.com".into() }
+            RuntimeEndpoint::remote("example.com")
         );
     }
 
@@ -945,6 +945,7 @@ mod tests {
                     name: "Server".into(),
                     kind: models::hosts::HostKind::Remote,
                     ssh_target: Some("user@srv".into()),
+                    daemon_binary_path: None,
                     labels: vec![],
                 }],
             }),

--- a/clients/rttx/src/store/mod.rs
+++ b/clients/rttx/src/store/mod.rs
@@ -828,10 +828,7 @@ mod tests {
 
         let restored = record.to_workspace_state();
         assert!(restored.runtime.is_managed());
-        assert_eq!(
-            restored.runtime.endpoint,
-            RuntimeEndpoint::remote("example.com")
-        );
+        assert_eq!(restored.runtime.endpoint, RuntimeEndpoint::remote("example.com"));
     }
 
     #[test]

--- a/clients/rttx/src/store/models/export.rs
+++ b/clients/rttx/src/store/models/export.rs
@@ -202,6 +202,7 @@ mod tests {
                     name: "Example".into(),
                     kind: HostKind::default(),
                     ssh_target: Some("user@example.com".into()),
+                    daemon_binary_path: None,
                     labels: vec![],
                 }],
             }),

--- a/clients/rttx/src/store/models/hosts.rs
+++ b/clients/rttx/src/store/models/hosts.rs
@@ -25,6 +25,8 @@ pub struct HostRecord {
     #[serde(default)]
     pub ssh_target: Option<String>,
     #[serde(default)]
+    pub daemon_binary_path: Option<String>,
+    #[serde(default)]
     pub labels: Vec<String>,
 }
 
@@ -47,6 +49,7 @@ impl From<HostRecord> for crate::host::Host {
                 HostKind::Remote => crate::host::HostKind::Remote,
             },
             ssh_target: rec.ssh_target,
+            daemon_binary_path: rec.daemon_binary_path,
         }
     }
 }
@@ -61,6 +64,7 @@ impl From<&crate::host::Host> for HostRecord {
                 crate::host::HostKind::Remote => HostKind::Remote,
             },
             ssh_target: host.ssh_target.clone(),
+            daemon_binary_path: host.daemon_binary_path.clone(),
             labels: Vec::new(),
         }
     }

--- a/clients/rttx/src/store/models/workspaces.rs
+++ b/clients/rttx/src/store/models/workspaces.rs
@@ -366,7 +366,7 @@ impl From<&LayoutNode> for crate::workspace::layout::LayoutNode {
 fn endpoint_key_from_runtime(runtime: &WorkspaceRuntime) -> String {
     match &runtime.endpoint {
         RuntimeEndpoint::Local => "local".into(),
-        RuntimeEndpoint::Remote { host } => crate::host::normalize_ssh_key(host),
+        RuntimeEndpoint::Remote { host, .. } => crate::host::normalize_ssh_key(host),
     }
 }
 
@@ -411,7 +411,7 @@ impl WorkspaceRecord {
         let endpoint = if self.endpoint_key == "local" {
             RuntimeEndpoint::Local
         } else {
-            RuntimeEndpoint::Remote { host: self.endpoint_key.clone() }
+            RuntimeEndpoint::remote(&self.endpoint_key)
         };
 
         let layout: crate::workspace::layout::LayoutNode = (&self.layout).into();

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -690,7 +690,9 @@ impl Window {
         let visible = self.imp().session_stack.visible_child_name()?;
         let session = state.workspaces.iter().find(|s| s.uuid == visible.as_str())?;
         match &session.runtime.endpoint {
-            RuntimeEndpoint::Remote { host, .. } if session.runtime.is_managed() => Some(host.clone()),
+            RuntimeEndpoint::Remote { host, .. } if session.runtime.is_managed() => {
+                Some(host.clone())
+            }
             _ => None,
         }
     }

--- a/clients/rttx/src/window/dialogs.rs
+++ b/clients/rttx/src/window/dialogs.rs
@@ -690,7 +690,7 @@ impl Window {
         let visible = self.imp().session_stack.visible_child_name()?;
         let session = state.workspaces.iter().find(|s| s.uuid == visible.as_str())?;
         match &session.runtime.endpoint {
-            RuntimeEndpoint::Remote { host } if session.runtime.is_managed() => Some(host.clone()),
+            RuntimeEndpoint::Remote { host, .. } if session.runtime.is_managed() => Some(host.clone()),
             _ => None,
         }
     }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -181,7 +181,10 @@ impl Window {
         let endpoint = if host.is_local() {
             RuntimeEndpoint::Local
         } else {
-            RuntimeEndpoint::remote_with_binary(host.ssh_target.clone().unwrap_or_default(), host.daemon_binary_path.clone())
+            RuntimeEndpoint::remote_with_binary(
+                host.ssh_target.clone().unwrap_or_default(),
+                host.daemon_binary_path.clone(),
+            )
         };
         self.imp().pending_connect_existing.replace(Some(host.clone()));
         if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
@@ -194,7 +197,10 @@ impl Window {
         let endpoint = if host.is_local() {
             RuntimeEndpoint::Local
         } else {
-            RuntimeEndpoint::remote_with_binary(host.ssh_target.clone().unwrap_or_default(), host.daemon_binary_path.clone())
+            RuntimeEndpoint::remote_with_binary(
+                host.ssh_target.clone().unwrap_or_default(),
+                host.daemon_binary_path.clone(),
+            )
         };
         let state = self.imp().state.borrow();
         state
@@ -694,7 +700,10 @@ impl Window {
                 let expected_endpoint = if host.is_local() {
                     RuntimeEndpoint::Local
                 } else {
-                    RuntimeEndpoint::remote_with_binary(host.ssh_target.clone().unwrap_or_default(), host.daemon_binary_path.clone())
+                    RuntimeEndpoint::remote_with_binary(
+                        host.ssh_target.clone().unwrap_or_default(),
+                        host.daemon_binary_path.clone(),
+                    )
                 };
                 if endpoint == expected_endpoint {
                     crate::connect_existing_dialog::show(self, &host, &runtimes);

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -181,7 +181,7 @@ impl Window {
         let endpoint = if host.is_local() {
             RuntimeEndpoint::Local
         } else {
-            RuntimeEndpoint::Remote { host: host.ssh_target.clone().unwrap_or_default() }
+            RuntimeEndpoint::remote_with_binary(host.ssh_target.clone().unwrap_or_default(), host.daemon_binary_path.clone())
         };
         self.imp().pending_connect_existing.replace(Some(host.clone()));
         if let Some(manager) = self.imp().connection_manager.borrow().as_ref() {
@@ -194,7 +194,7 @@ impl Window {
         let endpoint = if host.is_local() {
             RuntimeEndpoint::Local
         } else {
-            RuntimeEndpoint::Remote { host: host.ssh_target.clone().unwrap_or_default() }
+            RuntimeEndpoint::remote_with_binary(host.ssh_target.clone().unwrap_or_default(), host.daemon_binary_path.clone())
         };
         let state = self.imp().state.borrow();
         state
@@ -235,7 +235,7 @@ impl Window {
     pub(crate) fn add_remote_managed_session_at(&self, host: &str, initial_cwd: Option<String>) {
         let imp = self.imp();
         let count = imp.state.borrow().workspaces.len() + 1;
-        let endpoint = RuntimeEndpoint::Remote { host: host.to_string() };
+        let endpoint = RuntimeEndpoint::remote(host);
         let name = crate::workspace::state::workspace_display_name(
             &endpoint,
             initial_cwd.as_deref(),
@@ -694,7 +694,7 @@ impl Window {
                 let expected_endpoint = if host.is_local() {
                     RuntimeEndpoint::Local
                 } else {
-                    RuntimeEndpoint::Remote { host: host.ssh_target.clone().unwrap_or_default() }
+                    RuntimeEndpoint::remote_with_binary(host.ssh_target.clone().unwrap_or_default(), host.daemon_binary_path.clone())
                 };
                 if endpoint == expected_endpoint {
                     crate::connect_existing_dialog::show(self, &host, &runtimes);
@@ -1137,7 +1137,7 @@ impl Window {
             else {
                 return;
             };
-            let RuntimeEndpoint::Remote { host } = &session.runtime.endpoint else {
+            let RuntimeEndpoint::Remote { host, .. } = &session.runtime.endpoint else {
                 return;
             };
             host.clone()
@@ -1181,14 +1181,14 @@ impl Window {
                 status_label.set_text("SSH target / args is required");
                 return;
             }
-            win.update_workspace_endpoint(&workspace_id, host);
+            win.update_workspace_endpoint(&workspace_id, &host);
             dialog_for_save.close();
         });
 
         dialog.present(Some(self));
     }
 
-    pub(super) fn update_workspace_endpoint(&self, workspace_id: &str, host: String) {
+    pub(super) fn update_workspace_endpoint(&self, workspace_id: &str, host: &str) {
         let (session_state, previous_endpoint) = {
             let mut state = self.imp().state.borrow_mut();
             let Some(session) =
@@ -1197,7 +1197,7 @@ impl Window {
                 return;
             };
             let previous_endpoint = session.runtime.endpoint.clone();
-            session.runtime.endpoint = RuntimeEndpoint::Remote { host };
+            session.runtime.endpoint = RuntimeEndpoint::remote(host);
             (session.clone(), previous_endpoint)
         };
 
@@ -1381,7 +1381,7 @@ mod tests {
     fn coalesce_separates_endpoints() {
         let pane = Uuid::new_v4();
         let local = RuntimeEndpoint::Local;
-        let remote = RuntimeEndpoint::Remote { host: "host1".into() };
+        let remote = RuntimeEndpoint::remote("host1");
         let events = vec![
             delta_event(local.clone(), pane, b"local", 1),
             delta_event(remote.clone(), pane, b"remote", 1),

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -2366,7 +2366,7 @@ fn blocked_remote_workspace_shows_edit_retry_and_disables_input() {
         "workspace-remote",
         "Remote Workspace",
         LayoutNode::new_terminal_with_uuid("managed-pane"),
-        RuntimeEndpoint::Remote { host: "builder.example".into() },
+        RuntimeEndpoint::remote("builder.example"),
         WorkspacePolicy::Persistent,
         None,
     );
@@ -2866,7 +2866,7 @@ fn workspace_detached_event_preserves_runtime_id_for_manual_reattach() {
         "workspace-detached",
         "Detached Workspace",
         LayoutNode::new_terminal_with_uuid("managed-pane"),
-        RuntimeEndpoint::Remote { host: "builder.example".into() },
+        RuntimeEndpoint::remote("builder.example"),
         WorkspacePolicy::Persistent,
         Some(&runtime_id),
     );
@@ -2916,7 +2916,7 @@ fn save_state_persists_detached_workspace_runtime_binding() {
         "workspace-detached-save",
         "Detached Workspace",
         LayoutNode::new_terminal_with_uuid("managed-pane"),
-        RuntimeEndpoint::Remote { host: "builder.example".into() },
+        RuntimeEndpoint::remote("builder.example"),
         WorkspacePolicy::Persistent,
         Some(&runtime_id),
     );
@@ -2939,7 +2939,7 @@ fn save_state_persists_detached_workspace_runtime_binding() {
     assert!(saved_session.runtime.is_managed());
     assert_eq!(
         saved_session.runtime.endpoint,
-        RuntimeEndpoint::Remote { host: "builder.example".into() }
+        RuntimeEndpoint::remote("builder.example")
     );
     assert_eq!(saved_session.runtime.policy, WorkspacePolicy::Persistent);
     assert_eq!(saved_session.runtime.runtime_id.as_deref(), Some(runtime_id.as_str()));
@@ -2973,7 +2973,7 @@ fn runtime_terminated_event_clears_runtime_id_but_keeps_workspace() {
         "workspace-terminated",
         "Terminated Workspace",
         LayoutNode::new_terminal_with_uuid("managed-pane"),
-        RuntimeEndpoint::Remote { host: "builder.example".into() },
+        RuntimeEndpoint::remote("builder.example"),
         WorkspacePolicy::Persistent,
         Some(&runtime_id),
     );
@@ -3024,7 +3024,7 @@ fn save_state_persists_terminated_workspace_without_runtime_id() {
         "workspace-terminated-save",
         "Terminated Workspace",
         LayoutNode::new_terminal_with_uuid("managed-pane"),
-        RuntimeEndpoint::Remote { host: "builder.example".into() },
+        RuntimeEndpoint::remote("builder.example"),
         WorkspacePolicy::Persistent,
         Some(&runtime_id),
     );
@@ -3048,7 +3048,7 @@ fn save_state_persists_terminated_workspace_without_runtime_id() {
     assert!(saved_session.runtime.is_managed());
     assert_eq!(
         saved_session.runtime.endpoint,
-        RuntimeEndpoint::Remote { host: "builder.example".into() }
+        RuntimeEndpoint::remote("builder.example")
     );
     assert_eq!(saved_session.runtime.policy, WorkspacePolicy::Persistent);
     assert_eq!(saved_session.runtime.runtime_id, None);
@@ -5944,7 +5944,7 @@ fn open_runtime_ids_for_endpoint_returns_bound_runtime_ids() {
         "ws-remote",
         "Remote",
         LayoutNode::new_terminal_with_uuid("pane-remote"),
-        RuntimeEndpoint::Remote { host: "deploy@prod".into() },
+        RuntimeEndpoint::remote("deploy@prod"),
         WorkspacePolicy::Persistent,
         Some("runtime-bbb"),
     );
@@ -7581,7 +7581,7 @@ fn reconnect_host_action_shown_when_multiple_disconnected_from_same_host() {
         "ws-remote-1",
         "Remote 1",
         LayoutNode::new_terminal_with_uuid("pane-r1"),
-        RuntimeEndpoint::Remote { host: "server.example.com".into() },
+        RuntimeEndpoint::remote("server.example.com"),
         WorkspacePolicy::Persistent,
         Some("rt-1"),
     );
@@ -7589,7 +7589,7 @@ fn reconnect_host_action_shown_when_multiple_disconnected_from_same_host() {
         "ws-remote-2",
         "Remote 2",
         LayoutNode::new_terminal_with_uuid("pane-r2"),
-        RuntimeEndpoint::Remote { host: "server.example.com".into() },
+        RuntimeEndpoint::remote("server.example.com"),
         WorkspacePolicy::Persistent,
         Some("rt-2"),
     );
@@ -7636,7 +7636,7 @@ fn reconnect_host_action_hidden_when_only_one_disconnected() {
         "ws-solo-1",
         "Solo Remote",
         LayoutNode::new_terminal_with_uuid("pane-solo"),
-        RuntimeEndpoint::Remote { host: "solo.example.com".into() },
+        RuntimeEndpoint::remote("solo.example.com"),
         WorkspacePolicy::Persistent,
         Some("rt-solo"),
     );
@@ -7679,7 +7679,7 @@ fn reconnect_host_reconnects_all_disconnected_workspaces_from_same_endpoint() {
         "ws-host-a1",
         "Host A - 1",
         LayoutNode::new_terminal_with_uuid("pane-a1"),
-        RuntimeEndpoint::Remote { host: "host-a.example.com".into() },
+        RuntimeEndpoint::remote("host-a.example.com"),
         WorkspacePolicy::Persistent,
         Some("rt-a1"),
     );
@@ -7687,7 +7687,7 @@ fn reconnect_host_reconnects_all_disconnected_workspaces_from_same_endpoint() {
         "ws-host-a2",
         "Host A - 2",
         LayoutNode::new_terminal_with_uuid("pane-a2"),
-        RuntimeEndpoint::Remote { host: "host-a.example.com".into() },
+        RuntimeEndpoint::remote("host-a.example.com"),
         WorkspacePolicy::Persistent,
         Some("rt-a2"),
     );
@@ -7695,7 +7695,7 @@ fn reconnect_host_reconnects_all_disconnected_workspaces_from_same_endpoint() {
         "ws-host-b1",
         "Host B - 1",
         LayoutNode::new_terminal_with_uuid("pane-b1"),
-        RuntimeEndpoint::Remote { host: "host-b.example.com".into() },
+        RuntimeEndpoint::remote("host-b.example.com"),
         WorkspacePolicy::Persistent,
         Some("rt-b1"),
     );

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -2937,10 +2937,7 @@ fn save_state_persists_detached_workspace_runtime_binding() {
         .expect("detached workspace should persist in saved state");
 
     assert!(saved_session.runtime.is_managed());
-    assert_eq!(
-        saved_session.runtime.endpoint,
-        RuntimeEndpoint::remote("builder.example")
-    );
+    assert_eq!(saved_session.runtime.endpoint, RuntimeEndpoint::remote("builder.example"));
     assert_eq!(saved_session.runtime.policy, WorkspacePolicy::Persistent);
     assert_eq!(saved_session.runtime.runtime_id.as_deref(), Some(runtime_id.as_str()));
     assert_eq!(
@@ -3046,10 +3043,7 @@ fn save_state_persists_terminated_workspace_without_runtime_id() {
         .expect("terminated workspace should persist in saved state");
 
     assert!(saved_session.runtime.is_managed());
-    assert_eq!(
-        saved_session.runtime.endpoint,
-        RuntimeEndpoint::remote("builder.example")
-    );
+    assert_eq!(saved_session.runtime.endpoint, RuntimeEndpoint::remote("builder.example"));
     assert_eq!(saved_session.runtime.policy, WorkspacePolicy::Persistent);
     assert_eq!(saved_session.runtime.runtime_id, None);
     assert_eq!(

--- a/clients/rttx/src/workspace/state.rs
+++ b/clients/rttx/src/workspace/state.rs
@@ -651,10 +651,7 @@ mod module_boundary_tests {
             Some("/home/user".into()),
         );
         assert!(session.runtime.is_managed());
-        assert_eq!(
-            session.runtime.endpoint,
-            RuntimeEndpoint::remote("server.example.com")
-        );
+        assert_eq!(session.runtime.endpoint, RuntimeEndpoint::remote("server.example.com"));
         assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
         assert_eq!(
             session.layout.terminal_cwd(&session.layout.terminal_uuids()[0]).as_deref(),

--- a/clients/rttx/src/workspace/state.rs
+++ b/clients/rttx/src/workspace/state.rs
@@ -215,7 +215,7 @@ impl WorkspaceState {
 /// Returns `None` when no meaningful name can be derived.
 #[must_use]
 pub fn auto_name_for_workspace(endpoint: &RuntimeEndpoint, cwd: Option<&str>) -> Option<String> {
-    if let RuntimeEndpoint::Remote { host } = endpoint {
+    if let RuntimeEndpoint::Remote { host, .. } = endpoint {
         let short = host.split('@').next_back().unwrap_or(host);
         let short = short.split('.').next().unwrap_or(short);
         if !short.is_empty() {
@@ -653,7 +653,7 @@ mod module_boundary_tests {
         assert!(session.runtime.is_managed());
         assert_eq!(
             session.runtime.endpoint,
-            RuntimeEndpoint::Remote { host: "server.example.com".into() }
+            RuntimeEndpoint::remote("server.example.com")
         );
         assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
         assert_eq!(
@@ -732,19 +732,19 @@ mod module_boundary_tests {
 
     #[test]
     fn auto_name_from_remote_uses_short_hostname() {
-        let ep = RuntimeEndpoint::Remote { host: "etf@nucbox.local".into() };
+        let ep = RuntimeEndpoint::remote("etf@nucbox.local");
         assert_eq!(auto_name_for_workspace(&ep, None), Some("nucbox".into()));
     }
 
     #[test]
     fn auto_name_remote_without_user_prefix() {
-        let ep = RuntimeEndpoint::Remote { host: "builder.example.com".into() };
+        let ep = RuntimeEndpoint::remote("builder.example.com");
         assert_eq!(auto_name_for_workspace(&ep, None), Some("builder".into()));
     }
 
     #[test]
     fn auto_name_remote_ignores_cwd() {
-        let ep = RuntimeEndpoint::Remote { host: "etf@nucbox".into() };
+        let ep = RuntimeEndpoint::remote("etf@nucbox");
         assert_eq!(auto_name_for_workspace(&ep, Some("/home/etf/work")), Some("nucbox".into()));
     }
 
@@ -779,7 +779,7 @@ mod module_boundary_tests {
 
     #[test]
     fn workspace_display_name_uses_hostname_for_remote() {
-        let ep = RuntimeEndpoint::Remote { host: "user@builder.example.com".into() };
+        let ep = RuntimeEndpoint::remote("user@builder.example.com");
         assert_eq!(workspace_display_name(&ep, None, 1), "builder");
     }
 

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -742,7 +742,7 @@ mod tests {
 
     #[test]
     fn runtime_lookup_helpers_resolve_workspace_and_pane_targets() {
-        let endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
+        let endpoint = RuntimeEndpoint::remote("builder.example");
         let mut session = managed_session_with_runtime(
             "workspace-1",
             "Workspace",
@@ -1088,9 +1088,7 @@ mod tests {
         let state = window_state(vec![workspace("session-1", "Session 1", term("pane-1"))]);
 
         assert!(state.needs_inventory_bootstrap(&RuntimeEndpoint::Local));
-        assert!(state.needs_inventory_bootstrap(&RuntimeEndpoint::Remote {
-            host: "builder.example".into(),
-        }));
+        assert!(state.needs_inventory_bootstrap(&RuntimeEndpoint::remote("builder.example")));
     }
 
     #[test]
@@ -1108,20 +1106,16 @@ mod tests {
                 "workspace-2",
                 "Remote Workspace",
                 term("remote-pane"),
-                RuntimeEndpoint::Remote { host: "builder.example".into() },
+                RuntimeEndpoint::remote("builder.example"),
                 WorkspacePolicy::Persistent,
                 Some("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
             ),
         ]);
 
         assert!(!state.needs_inventory_bootstrap(&RuntimeEndpoint::Local));
-        assert!(!state.needs_inventory_bootstrap(&RuntimeEndpoint::Remote {
-            host: "builder.example".into(),
-        }));
+        assert!(!state.needs_inventory_bootstrap(&RuntimeEndpoint::remote("builder.example")));
         assert!(
-            state.needs_inventory_bootstrap(&RuntimeEndpoint::Remote {
-                host: "other.example".into(),
-            })
+            state.needs_inventory_bootstrap(&RuntimeEndpoint::remote("other.example"))
         );
     }
 
@@ -1309,7 +1303,7 @@ mod tests {
             "workspace-1",
             "Workspace",
             term("pane-1"),
-            RuntimeEndpoint::Remote { host: "builder.example".into() },
+            RuntimeEndpoint::remote("builder.example"),
             WorkspacePolicy::Persistent,
             Some(&runtime_id),
         )]);
@@ -1335,7 +1329,7 @@ mod tests {
             "workspace-1",
             "Workspace",
             term("pane-1"),
-            RuntimeEndpoint::Remote { host: "builder.example".into() },
+            RuntimeEndpoint::remote("builder.example"),
             WorkspacePolicy::Persistent,
             Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
         )]);
@@ -1406,7 +1400,7 @@ mod tests {
     fn dismissed_remote_runtime_is_not_resurrected_by_inventory() {
         let runtime_id = uuid::Uuid::new_v4().to_string();
         let pane_id = uuid::Uuid::new_v4().to_string();
-        let endpoint = RuntimeEndpoint::Remote { host: "build-host".into() };
+        let endpoint = RuntimeEndpoint::remote("build-host");
         let mut state = WindowState::default_for_test();
 
         state.dismiss_runtime(&endpoint, &runtime_id);
@@ -1581,7 +1575,7 @@ mod tests {
             "workspace-1",
             "Workspace",
             hsplit(term("left"), term("right")),
-            RuntimeEndpoint::Remote { host: "cdt2".into() },
+            RuntimeEndpoint::remote("cdt2"),
             WorkspacePolicy::Persistent,
             Some(runtime_id),
         );
@@ -1644,7 +1638,7 @@ mod tests {
             "workspace-1",
             "Workspace",
             hsplit(term("left"), term("right")),
-            RuntimeEndpoint::Remote { host: "cdt2".into() },
+            RuntimeEndpoint::remote("cdt2"),
             WorkspacePolicy::Persistent,
             Some(runtime_id),
         );
@@ -2142,7 +2136,7 @@ mod tests {
 
     #[test]
     fn reverse_index_matches_linear_scan_for_bound_pane() {
-        let endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
+        let endpoint = RuntimeEndpoint::remote("builder.example");
         let runtime_pane_id = "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26";
         let mut session = managed_session_with_runtime(
             "workspace-1",
@@ -2315,7 +2309,7 @@ mod tests {
     fn reverse_index_multi_workspace_multi_endpoint() {
         let local_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
         let remote_pane = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
-        let remote_endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
+        let remote_endpoint = RuntimeEndpoint::remote("builder.example");
 
         let mut local_session = managed_session_with_runtime(
             "ws-local",

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1114,9 +1114,7 @@ mod tests {
 
         assert!(!state.needs_inventory_bootstrap(&RuntimeEndpoint::Local));
         assert!(!state.needs_inventory_bootstrap(&RuntimeEndpoint::remote("builder.example")));
-        assert!(
-            state.needs_inventory_bootstrap(&RuntimeEndpoint::remote("other.example"))
-        );
+        assert!(state.needs_inventory_bootstrap(&RuntimeEndpoint::remote("other.example")));
     }
 
     #[test]

--- a/clients/rttx/tests/document_models.rs
+++ b/clients/rttx/tests/document_models.rs
@@ -191,6 +191,7 @@ fn hosts_atomic_round_trip() {
             name: "Test".into(),
             kind: HostKind::Remote,
             ssh_target: Some("user@test.host".into()),
+            daemon_binary_path: None,
             labels: vec!["test".into()],
         }],
     };

--- a/clients/rttx/tests/export_action.rs
+++ b/clients/rttx/tests/export_action.rs
@@ -92,6 +92,7 @@ fn export_full_bundle_round_trips_through_file() {
                 name: "Dev Server".into(),
                 kind: HostKind::default(),
                 ssh_target: Some("user@dev.example.com".into()),
+                daemon_binary_path: None,
                 labels: vec![],
             }],
         }),

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -1060,11 +1060,7 @@ fn connected_icon_color_consistent_across_endpoints() {
     use rttx::runtime::{ConnectionStatus, RuntimeEndpoint, connection_icon};
 
     let local = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, true);
-    let remote = connection_icon(
-        &RuntimeEndpoint::remote("h"),
-        &ConnectionStatus::Connected,
-        true,
-    );
+    let remote = connection_icon(&RuntimeEndpoint::remote("h"), &ConnectionStatus::Connected, true);
     let direct = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, false);
 
     assert_eq!(local.css_class, remote.css_class, "local and remote connected must match");

--- a/clients/rttx/tests/gtk_boundary_contracts.rs
+++ b/clients/rttx/tests/gtk_boundary_contracts.rs
@@ -719,7 +719,7 @@ fn workspace_connection_summary_shows_endpoint_and_pane_info() {
     use rttx::runtime::{RuntimeEndpoint, workspace_connection_summary};
 
     let local = RuntimeEndpoint::Local;
-    let remote = RuntimeEndpoint::Remote { host: "dev@host".into() };
+    let remote = RuntimeEndpoint::remote("dev@host");
 
     assert_eq!(workspace_connection_summary(&local, Some("vim")), "vim");
     assert_eq!(workspace_connection_summary(&local, None), "");
@@ -745,7 +745,7 @@ fn connection_icon_always_returns_icon() {
     // Shape stays constant regardless of state.
     assert_eq!(local_disconnected.icon_name, "computer-symbolic");
 
-    let remote = RuntimeEndpoint::Remote { host: "h".into() };
+    let remote = RuntimeEndpoint::remote("h");
     let connected = connection_icon(&remote, &ConnectionStatus::Connected, true);
     assert_eq!(connected.css_class, "accent");
     assert_eq!(connected.icon_name, "network-server-symbolic");
@@ -772,7 +772,7 @@ fn connection_icon_direct_uses_terminal_symbolic() {
 fn connection_icon_always_has_tooltip() {
     use rttx::runtime::{ConnectionProblem, ConnectionStatus, RuntimeEndpoint, connection_icon};
 
-    let remote = RuntimeEndpoint::Remote { host: "h".into() };
+    let remote = RuntimeEndpoint::remote("h");
     let local = RuntimeEndpoint::Local;
 
     for (endpoint, status) in [
@@ -816,7 +816,7 @@ fn workspace_connection_summary_contains_no_status_text() {
     use rttx::runtime::{RuntimeEndpoint, workspace_connection_summary};
 
     let local = RuntimeEndpoint::Local;
-    let remote = RuntimeEndpoint::Remote { host: "h".into() };
+    let remote = RuntimeEndpoint::remote("h");
 
     for (ep, info) in
         [(&local, Some("bash")), (&local, None), (&remote, Some("vim")), (&remote, None)]
@@ -874,7 +874,7 @@ fn pane_description_subtitle_structure_regression() {
         "/tmp/rttx"
     );
     // Remote subtitle includes host.
-    let remote = RuntimeEndpoint::Remote { host: "dev-box".into() };
+    let remote = RuntimeEndpoint::remote("dev-box");
     assert_eq!(workspace_connection_summary(&remote, Some("/tmp/rttx")), "dev-box · /tmp/rttx");
     assert_eq!(workspace_connection_summary(&remote, None), "dev-box");
 }
@@ -1061,7 +1061,7 @@ fn connected_icon_color_consistent_across_endpoints() {
 
     let local = connection_icon(&RuntimeEndpoint::Local, &ConnectionStatus::Connected, true);
     let remote = connection_icon(
-        &RuntimeEndpoint::Remote { host: "h".into() },
+        &RuntimeEndpoint::remote("h"),
         &ConnectionStatus::Connected,
         true,
     );
@@ -1190,7 +1190,7 @@ fn workspace_menu_daemon_died_shows_restart_for_local_only() {
         is_daemon_died: true,
         has_other_disconnected_from_same_host: false,
     });
-    assert!(!remote.show_restart_daemon);
+    assert!(remote.show_restart_daemon);
 }
 
 /// Regression test for #955: Force Reconnect must be available when a workspace

--- a/clients/rttx/tests/host_sidebar_tests.rs
+++ b/clients/rttx/tests/host_sidebar_tests.rs
@@ -28,13 +28,13 @@ fn host_key_local_endpoint_returns_local_key() {
 
 #[test]
 fn host_key_remote_endpoint_normalizes_ssh_target() {
-    let endpoint = RuntimeEndpoint::Remote { host: "deploy@example.com".into() };
+    let endpoint = RuntimeEndpoint::remote("deploy@example.com");
     assert_eq!(endpoint.host_key(), "example.com");
 }
 
 #[test]
 fn host_key_remote_endpoint_bare_hostname() {
-    let endpoint = RuntimeEndpoint::Remote { host: "dev-box".into() };
+    let endpoint = RuntimeEndpoint::remote("dev-box");
     assert_eq!(endpoint.host_key(), "dev-box");
 }
 
@@ -77,7 +77,7 @@ fn places_visible_for_host_includes_builtins_and_tagged() {
 
 #[test]
 fn endpoint_host_key_matches_place_and_command_tags() {
-    let endpoint = RuntimeEndpoint::Remote { host: "deploy@example.com".into() };
+    let endpoint = RuntimeEndpoint::remote("deploy@example.com");
     let host_key = endpoint.host_key();
 
     let mut place = Place::new("app", "/srv/app");

--- a/clients/rttx/tests/pane_reverse_index.rs
+++ b/clients/rttx/tests/pane_reverse_index.rs
@@ -182,7 +182,7 @@ fn multi_endpoint_isolation_through_full_lifecycle() {
     let remote_runtime = "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26";
     let local_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
     let remote_pane = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
-    let remote_endpoint = RuntimeEndpoint::Remote { host: "builder.example".into() };
+    let remote_endpoint = RuntimeEndpoint::remote("builder.example");
 
     let mut state = window_state(vec![
         managed_session(

--- a/clients/rttx/tests/reconnecting_visibility.rs
+++ b/clients/rttx/tests/reconnecting_visibility.rs
@@ -34,7 +34,7 @@ fn reconnecting_visually_distinct_from_connecting() {
 /// diagnostic information about the retry state.
 #[test]
 fn reconnecting_tooltip_differs_from_connecting() {
-    let ep = RuntimeEndpoint::Remote { host: "host".into() };
+    let ep = RuntimeEndpoint::remote("host");
     let connecting = connection_icon(&ep, &ConnectionStatus::Connecting, true);
     let reconnecting = connection_icon(
         &ep,

--- a/clients/rttx/tests/ssh_connection.rs
+++ b/clients/rttx/tests/ssh_connection.rs
@@ -8,7 +8,7 @@ use rttx::daemon::{DaemonConnection, DaemonError};
 #[tokio::test]
 async fn ssh_connection_to_unreachable_host_fails_within_timeout() {
     let start = std::time::Instant::now();
-    let result = DaemonConnection::connect_ssh("rttx-nonexistent-host-test").await;
+    let result = DaemonConnection::connect_ssh("rttx-nonexistent-host-test", None).await;
 
     assert!(result.is_err(), "SSH to unreachable host should fail");
     assert!(

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -521,10 +521,7 @@ fn new_managed_remote_produces_remote_persistent_session() {
     );
 
     assert!(session.runtime.is_managed());
-    assert_eq!(
-        session.runtime.endpoint,
-        RuntimeEndpoint::remote("dev-box.internal")
-    );
+    assert_eq!(session.runtime.endpoint, RuntimeEndpoint::remote("dev-box.internal"));
     assert!(!session.layout.terminal_uuids().is_empty());
     assert!(!session.runtime.pending_layout_panes.is_empty());
 }
@@ -546,10 +543,7 @@ fn remote_managed_session_persists_and_restores() {
     let restored: WorkspaceState = serde_json::from_str(&json).unwrap();
 
     assert!(restored.runtime.is_managed());
-    assert_eq!(
-        restored.runtime.endpoint,
-        RuntimeEndpoint::remote("dev@build-host")
-    );
+    assert_eq!(restored.runtime.endpoint, RuntimeEndpoint::remote("dev@build-host"));
     assert_eq!(
         restored.layout.terminal_cwd(&restored.layout.terminal_uuids()[0]).as_deref(),
         Some("/home/dev/project")
@@ -571,10 +565,7 @@ fn remote_host_creates_managed_remote_session() {
     );
 
     assert!(session.runtime.is_managed());
-    assert_eq!(
-        session.runtime.endpoint,
-        RuntimeEndpoint::remote("deploy@example.com")
-    );
+    assert_eq!(session.runtime.endpoint, RuntimeEndpoint::remote("deploy@example.com"));
 }
 
 /// Updating a remote workspace endpoint must change the host and sync mode.
@@ -592,10 +583,7 @@ fn update_remote_endpoint_changes_host() {
 
     session.runtime.endpoint = RuntimeEndpoint::remote("new-host.example.com");
 
-    assert_eq!(
-        session.runtime.endpoint,
-        RuntimeEndpoint::remote("new-host.example.com")
-    );
+    assert_eq!(session.runtime.endpoint, RuntimeEndpoint::remote("new-host.example.com"));
     assert!(session.runtime.is_managed());
 }
 

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -523,7 +523,7 @@ fn new_managed_remote_produces_remote_persistent_session() {
     assert!(session.runtime.is_managed());
     assert_eq!(
         session.runtime.endpoint,
-        RuntimeEndpoint::Remote { host: "dev-box.internal".into() }
+        RuntimeEndpoint::remote("dev-box.internal")
     );
     assert!(!session.layout.terminal_uuids().is_empty());
     assert!(!session.runtime.pending_layout_panes.is_empty());
@@ -548,7 +548,7 @@ fn remote_managed_session_persists_and_restores() {
     assert!(restored.runtime.is_managed());
     assert_eq!(
         restored.runtime.endpoint,
-        RuntimeEndpoint::Remote { host: "dev@build-host".into() }
+        RuntimeEndpoint::remote("dev@build-host")
     );
     assert_eq!(
         restored.layout.terminal_cwd(&restored.layout.terminal_uuids()[0]).as_deref(),
@@ -573,7 +573,7 @@ fn remote_host_creates_managed_remote_session() {
     assert!(session.runtime.is_managed());
     assert_eq!(
         session.runtime.endpoint,
-        RuntimeEndpoint::Remote { host: "deploy@example.com".into() }
+        RuntimeEndpoint::remote("deploy@example.com")
     );
 }
 
@@ -590,11 +590,11 @@ fn update_remote_endpoint_changes_host() {
         None,
     );
 
-    session.runtime.endpoint = RuntimeEndpoint::Remote { host: "new-host.example.com".into() };
+    session.runtime.endpoint = RuntimeEndpoint::remote("new-host.example.com");
 
     assert_eq!(
         session.runtime.endpoint,
-        RuntimeEndpoint::Remote { host: "new-host.example.com".into() }
+        RuntimeEndpoint::remote("new-host.example.com")
     );
     assert!(session.runtime.is_managed());
 }
@@ -629,7 +629,7 @@ fn split_remote_session_preserves_endpoint_and_adds_pending_pane() {
     // Endpoint must still be remote.
     assert_eq!(
         session.runtime.endpoint,
-        RuntimeEndpoint::Remote { host: "build-host.internal".into() },
+        RuntimeEndpoint::remote("build-host.internal"),
         "split must not change the workspace endpoint"
     );
 
@@ -670,7 +670,7 @@ fn double_split_remote_session_keeps_all_panes_pending() {
     session.set_recovery(&t3, PaneRecovery::empty_shell());
     session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
 
-    assert_eq!(session.runtime.endpoint, RuntimeEndpoint::Remote { host: "gpu-box".into() });
+    assert_eq!(session.runtime.endpoint, RuntimeEndpoint::remote("gpu-box"));
     assert_eq!(session.layout.terminal_count(), 3);
     assert!(session.runtime.pending_layout_panes.contains(&t2));
     assert!(session.runtime.pending_layout_panes.contains(&t3));
@@ -685,7 +685,7 @@ fn close_remote_workspace_prevents_resurrection_on_reconnect() {
     use rttx::workspace::state::WindowState;
 
     let runtime_id = uuid::Uuid::new_v4().to_string();
-    let endpoint = RuntimeEndpoint::Remote { host: "prod-server".into() };
+    let endpoint = RuntimeEndpoint::remote("prod-server");
 
     let mut state = WindowState::default();
 
@@ -721,7 +721,7 @@ fn remote_managed_session_is_ready_for_inventory_binding() {
     use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
     use rttx::workspace::state::WindowState;
 
-    let endpoint = RuntimeEndpoint::Remote { host: "gpu-box".into() };
+    let endpoint = RuntimeEndpoint::remote("gpu-box");
 
     let mut state = WindowState::default();
     state.workspaces.clear();

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -1443,3 +1443,53 @@ fn serialized_managed_workspace_omits_legacy_mode_field() {
     assert!(ws.get("mode").is_none(), "mode must not appear in serialized state");
     assert!(ws.get("runtime").is_some(), "runtime must be present in serialized state");
 }
+
+/// Remote endpoint with custom daemon binary path must persist through
+/// serialization and restore correctly. Regression test for #956.
+#[test]
+fn remote_endpoint_with_custom_binary_path_persists() {
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+    use rttx::workspace::WorkspaceState;
+
+    let mut session = WorkspaceState::new_managed_remote(
+        "Remote Custom".into(),
+        "build-host",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+    // Override endpoint with custom binary path.
+    session.runtime.endpoint =
+        RuntimeEndpoint::remote_with_binary("build-host", Some("~/.local/bin/rttx-server".into()));
+
+    let json = serde_json::to_string(&session).unwrap();
+    let restored: WorkspaceState = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(restored.runtime.endpoint.daemon_binary_path(), Some("~/.local/bin/rttx-server"),);
+    assert_eq!(restored.runtime.endpoint, session.runtime.endpoint);
+}
+
+/// Remote endpoint without custom binary path must deserialize from JSON
+/// that lacks the `daemon_binary_path` field. Regression test for #956.
+#[test]
+fn remote_endpoint_without_binary_path_backward_compat() {
+    use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
+    use rttx::workspace::WorkspaceState;
+
+    // Serialize a workspace with default remote endpoint (no binary path).
+    let session = WorkspaceState::new_managed_remote(
+        "Legacy Remote".into(),
+        "old-host",
+        WorkspacePolicy::Persistent,
+        None,
+    );
+    let mut json_value: serde_json::Value = serde_json::to_value(&session).unwrap();
+
+    // Strip daemon_binary_path from the endpoint to simulate legacy data.
+    if let Some(endpoint) = json_value.get_mut("runtime").and_then(|r| r.get_mut("endpoint")) {
+        endpoint.as_object_mut().unwrap().remove("daemon_binary_path");
+    }
+
+    let restored: WorkspaceState = serde_json::from_value(json_value).unwrap();
+    assert_eq!(restored.runtime.endpoint, RuntimeEndpoint::remote("old-host"));
+    assert_eq!(restored.runtime.endpoint.daemon_binary_path(), None);
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.6.3',
+  version: '0.6.4',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What changed and why

Implements #956 — remote daemon lifecycle management including auto-start, restart from GUI, configurable binary path per host, and clear error reporting.

### Changes

1. **Configurable remote binary path per host** — Added `daemon_binary_path` field to `Host`, `HostRecord`, and `RuntimeEndpoint::Remote`. Defaults to `rttx-server` in PATH when not set.

2. **Remote daemon auto-start** — When connecting to a remote host where the daemon is not running, the GUI now auto-starts it via `ssh <host> rttx-server start` (same behavior as local daemon auto-start).

3. **"Restart Daemon" action for remote endpoints** — Previously only available for local endpoints. Now the restart button appears for remote workspaces when the daemon dies.

4. **Clear error for missing binary** — New `DaemonNotInstalled` error variant detects "command not found" in SSH stderr and reports `rttx-server not installed on <host> (tried: <binary>)` instead of a generic connection error.

5. **Remote circuit breaker emits DaemonDied** — Previously emitted `DaemonUnavailable` for remote, which didn't show the restart button. Now emits `DaemonDied` for both local and remote.

### How to verify

1. Configure a remote host with a custom binary path in hosts.json
2. Connect to a remote host where rttx-server is not running — should auto-start
3. Kill the remote daemon — should show "Restart Daemon" in workspace menu
4. Connect to a host without rttx-server installed — should show clear error message

### Tests added

- `daemon_not_installed_error_displays_host_and_binary` — error message format
- `connect_ssh_with_custom_binary_path` — custom binary path passed to SSH
- `classify_daemon_not_installed_error` — error classification
- `daemon_not_installed_is_not_transient` — not auto-retried
- `daemon_not_installed_label_includes_detail` — user-visible label
- `remote_with_binary_stores_path` — endpoint stores binary path
- `remote_without_binary_returns_none` — default behavior
- `local_endpoint_daemon_binary_path_is_none` — local has no binary path
- `remote_endpoint_serde_backward_compat_without_daemon_binary_path` — backward compat
- `remote_endpoint_serde_roundtrip_with_daemon_binary_path` — roundtrip
- `menu_items_daemon_died_remote_shows_restart_daemon` — restart button for remote
- `circuit_breaker_remote_emits_daemon_died` — updated from DaemonUnavailable
- `deserialize_without_daemon_binary_path_defaults_to_none` — Host backward compat
- `deserialize_with_daemon_binary_path` — Host with custom path

### Tests run

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (all pass)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (795 lib + GTK tests pass)

### Backward compatibility

All new fields use `#[serde(default)]` — existing persisted state loads without error.

Fixes #956