### PR TITLE
docs: add man page for rttx-server

### DIFF
--- a/clients/rttx/Cargo.toml
+++ b/clients/rttx/Cargo.toml
@@ -68,6 +68,7 @@ assets = [
     ["data/io.github.IllyaYalovyy.rttx.desktop", "usr/share/applications/", "644"],
     ["data/io.github.IllyaYalovyy.rttx.metainfo.xml", "usr/share/metainfo/", "644"],
     ["data/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg", "usr/share/icons/hicolor/scalable/apps/", "644"],
+    ["../../services/rttx-server/man/rttx-server.1", "usr/share/man/man1/", "644"],
 ]
 
 [package.metadata.generate-rpm]
@@ -77,6 +78,7 @@ assets = [
     { source = "data/io.github.IllyaYalovyy.rttx.desktop", dest = "/usr/share/applications/io.github.IllyaYalovyy.rttx.desktop", mode = "644" },
     { source = "data/io.github.IllyaYalovyy.rttx.metainfo.xml", dest = "/usr/share/metainfo/io.github.IllyaYalovyy.rttx.metainfo.xml", mode = "644" },
     { source = "data/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg", dest = "/usr/share/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg", mode = "644" },
+    { source = "../../services/rttx-server/man/rttx-server.1", dest = "/usr/share/man/man1/rttx-server.1", mode = "644" },
 ]
 
 [package.metadata.generate-rpm.requires]

--- a/meson.build
+++ b/meson.build
@@ -78,3 +78,10 @@ install_data(
   client_data_dir / 'icons' / 'hicolor' / 'scalable' / 'apps' / app_id + '.Devel.svg',
   install_dir: iconsdir / 'hicolor' / 'scalable' / 'apps',
 )
+
+# Man pages
+mandir = datadir / 'man'
+install_data(
+  meson.project_source_root() / 'services' / 'rttx-server' / 'man' / 'rttx-server.1',
+  install_dir: mandir / 'man1',
+)

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -43,6 +43,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/io.github
 %{_datadir}/applications/io.github.IllyaYalovyy.rttx.desktop
 %{_datadir}/metainfo/io.github.IllyaYalovyy.rttx.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/io.github.IllyaYalovyy.rttx.svg
+%{_mandir}/man1/rttx-server.1*
 
 %changelog
 * Fri Mar 20 2026 Yaroslav Yalovyi <yalovoy@gmail.com> - 0.1.0-1

--- a/services/rttx-server/man/rttx-server.1
+++ b/services/rttx-server/man/rttx-server.1
@@ -1,0 +1,185 @@
+.TH RTTX-SERVER 1 "2026-05-26" "rttx 0.6.5" "rttx Manual"
+.SH NAME
+rttx-server \- daemon runtime service for the rttx terminal emulator
+.SH SYNOPSIS
+.B rttx-server
+.RI [ command ]
+.RI [ options ]
+.SH DESCRIPTION
+.B rttx-server
+is the daemon component of the rttx tiling terminal emulator. It owns all PTYs
+and runtime state, decoupling terminal lifetime from the GUI. Workspaces attach
+and detach freely while runtimes continue according to their policy and endpoint
+availability.
+.PP
+One daemon per host serves multiple runtimes and clients. The GUI auto-starts
+the daemon when needed; manual invocation is only required for troubleshooting
+or remote access via SSH.
+.PP
+If no command is given,
+.B start
+is assumed.
+.SH COMMANDS
+.TP
+.B start \fR[\fB\-\-foreground\fR]
+Start the daemon. By default it daemonizes into the background. Use
+.B \-\-foreground
+to run in the foreground with log output on stderr (useful for debugging).
+.TP
+.B stop
+Stop the running daemon gracefully. All active runtimes are terminated.
+.TP
+.B status
+Show whether the daemon is running and list active runtimes with their IDs,
+connected client count, and pane count.
+.TP
+.B clean
+Remove all runtimes that have no connected clients. Persistent runtimes with
+disconnected clients are terminated.
+.TP
+.B kill \fIruntime_id\fR
+Terminate a specific runtime by its UUID. The runtime and all its panes are
+destroyed immediately.
+.TP
+.B attach\-stdio
+Serve one client over stdin/stdout. This is the entry point used by the GUI
+when connecting to a remote daemon over SSH:
+.RS
+.PP
+.nf
+ssh <host> rttx-server attach-stdio
+.fi
+.RE
+.IP
+The same protobuf wire protocol is spoken over the SSH subprocess's
+stdin/stdout. No port forwarding is needed.
+.TP
+.B logs
+Print the path to the daemon log directory. Logs use daily rotation with 3-day
+retention.
+.TP
+.B diagnostics
+Show runtime memory diagnostics including per-runtime and per-pane memory usage
+for scrollback buffers and screen state.
+.TP
+.B config
+Show resolved paths and configuration including socket path, state directory,
+cache directory, and log directory.
+.TP
+.B profile \fR[\fB\-\-dump\fR] [\fB\-\-last\-crash\fR] [\fB\-\-json\fR] [\fB\-\-watch\fR]
+Show profiling report from flight recorder data.
+.RS
+.TP
+.B \-\-dump
+Dump all ring buffer events chronologically.
+.TP
+.B \-\-last\-crash
+Read flight.prev.bin from the previous daemon instance (useful for
+post-mortem analysis).
+.TP
+.B \-\-json
+Output the report as JSON.
+.TP
+.B \-\-watch
+Continuously refresh the report every 2 seconds.
+.RE
+.SH ENVIRONMENT
+.TP
+.B RTTX_DEV_MODE
+When set to
+.BR 1 ,
+the daemon uses separate paths for socket, state, cache, and logs so a
+development instance can run alongside a production instance. See the
+.I Development
+section below.
+.TP
+.B RUST_LOG
+Override the log level filter. Default is
+.BR info .
+Example:
+.BR "RUST_LOG=debug rttx-server start --foreground" .
+.SH FILES
+.TP
+.I $XDG_RUNTIME_DIR/rttx-server/v1/
+Unix domain socket for client connections.
+.TP
+.I $XDG_STATE_HOME/rttx/daemon/
+Daemon state directory containing runtime metadata, scrollback logs, and screen
+snapshots. Default:
+.IR ~/.local/state/rttx/daemon/ .
+.TP
+.I $XDG_STATE_HOME/rttx/daemon/runtimes/<id>/runtime.json
+Per-runtime metadata (pane CWD, title, dimensions). Written on dirty-flag.
+.TP
+.I $XDG_STATE_HOME/rttx/daemon/runtimes/<id>/scrollback/<pane>.log
+Append-only raw terminal byte log per pane, rotated periodically.
+.TP
+.I $XDG_STATE_HOME/rttx/daemon/runtimes/<id>/screen/<pane>.snap
+Deterministic screen snapshot for reconnect.
+.TP
+.I $XDG_CACHE_HOME/rttx-server/
+Log files with daily rotation (3-day retention).
+.SH DEVELOPMENT
+With
+.BR RTTX_DEV_MODE=1 ,
+all paths are suffixed with
+.B -devel
+to isolate the development instance:
+.PP
+.RS
+.nf
+Socket:  $XDG_RUNTIME_DIR/rttx-server-devel/v1/
+State:   $XDG_STATE_HOME/rttx-devel/daemon/
+Logs:    $XDG_CACHE_HOME/rttx-server-devel/
+.fi
+.RE
+.SH WIRE PROTOCOL
+Communication uses protobuf messages over 4-byte little-endian length-prefixed
+frames. The same protocol is used for both Unix socket and SSH stdio transports.
+Protocol version is checked during handshake; incompatible versions disconnect
+cleanly.
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+Error (daemon not running, runtime not found, etc.).
+.SH EXAMPLES
+Start the daemon in the foreground with debug logging:
+.PP
+.RS
+.nf
+RUST_LOG=debug rttx-server start --foreground
+.fi
+.RE
+.PP
+Check daemon status:
+.PP
+.RS
+.nf
+rttx-server status
+.fi
+.RE
+.PP
+Connect to a remote daemon over SSH (typically done by the GUI):
+.PP
+.RS
+.nf
+ssh myhost rttx-server attach-stdio
+.fi
+.RE
+.PP
+Clean up orphaned runtimes:
+.PP
+.RS
+.nf
+rttx-server clean
+.fi
+.RE
+.SH SEE ALSO
+.BR rttx (1)
+.SH AUTHORS
+Illya Yalovyy <yalovoy@gmail.com>
+.SH LICENSE
+GPL-3.0-or-later

--- a/services/rttx-server/tests/man_page.rs
+++ b/services/rttx-server/tests/man_page.rs
@@ -1,0 +1,72 @@
+//! Validates that the man page documents all CLI subcommands.
+//! Prevents drift between the CLI and its documentation.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn man_page_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("man/rttx-server.1")
+}
+
+#[test]
+fn man_page_exists_and_is_valid_roff() {
+    let path = man_page_path();
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read man page at {}: {e}", path.display()));
+
+    assert!(
+        content.starts_with(".TH RTTX-SERVER"),
+        "Man page must start with .TH header"
+    );
+    assert!(
+        content.contains(".SH NAME"),
+        "Man page must have NAME section"
+    );
+    assert!(
+        content.contains(".SH SYNOPSIS"),
+        "Man page must have SYNOPSIS section"
+    );
+    assert!(
+        content.contains(".SH COMMANDS"),
+        "Man page must have COMMANDS section"
+    );
+}
+
+#[test]
+fn man_page_documents_all_subcommands() {
+    let content = fs::read_to_string(man_page_path()).unwrap();
+
+    let expected_commands = [
+        "start",
+        "stop",
+        "status",
+        "clean",
+        "kill",
+        "attach-stdio",
+        "logs",
+        "diagnostics",
+        "config",
+        "profile",
+    ];
+
+    for cmd in expected_commands {
+        assert!(
+            content.contains(cmd),
+            "Man page must document the '{cmd}' subcommand"
+        );
+    }
+}
+
+#[test]
+fn man_page_documents_environment_variables() {
+    let content = fs::read_to_string(man_page_path()).unwrap();
+
+    assert!(
+        content.contains("RTTX_DEV_MODE"),
+        "Man page must document RTTX_DEV_MODE"
+    );
+    assert!(
+        content.contains("RUST_LOG"),
+        "Man page must document RUST_LOG"
+    );
+}

--- a/services/rttx-server/tests/man_page.rs
+++ b/services/rttx-server/tests/man_page.rs
@@ -14,22 +14,10 @@ fn man_page_exists_and_is_valid_roff() {
     let content = fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("Failed to read man page at {}: {e}", path.display()));
 
-    assert!(
-        content.starts_with(".TH RTTX-SERVER"),
-        "Man page must start with .TH header"
-    );
-    assert!(
-        content.contains(".SH NAME"),
-        "Man page must have NAME section"
-    );
-    assert!(
-        content.contains(".SH SYNOPSIS"),
-        "Man page must have SYNOPSIS section"
-    );
-    assert!(
-        content.contains(".SH COMMANDS"),
-        "Man page must have COMMANDS section"
-    );
+    assert!(content.starts_with(".TH RTTX-SERVER"), "Man page must start with .TH header");
+    assert!(content.contains(".SH NAME"), "Man page must have NAME section");
+    assert!(content.contains(".SH SYNOPSIS"), "Man page must have SYNOPSIS section");
+    assert!(content.contains(".SH COMMANDS"), "Man page must have COMMANDS section");
 }
 
 #[test]
@@ -50,10 +38,7 @@ fn man_page_documents_all_subcommands() {
     ];
 
     for cmd in expected_commands {
-        assert!(
-            content.contains(cmd),
-            "Man page must document the '{cmd}' subcommand"
-        );
+        assert!(content.contains(cmd), "Man page must document the '{cmd}' subcommand");
     }
 }
 
@@ -61,12 +46,6 @@ fn man_page_documents_all_subcommands() {
 fn man_page_documents_environment_variables() {
     let content = fs::read_to_string(man_page_path()).unwrap();
 
-    assert!(
-        content.contains("RTTX_DEV_MODE"),
-        "Man page must document RTTX_DEV_MODE"
-    );
-    assert!(
-        content.contains("RUST_LOG"),
-        "Man page must document RUST_LOG"
-    );
+    assert!(content.contains("RTTX_DEV_MODE"), "Man page must document RTTX_DEV_MODE");
+    assert!(content.contains("RUST_LOG"), "Man page must document RUST_LOG");
 }


### PR DESCRIPTION
## What changed and why

Adds a man page for `rttx-server` so that `man rttx-server` works after installing via DEB/RPM/meson. Users expect man pages for system daemons.

The man page documents:
- All 10 subcommands: start, stop, status, clean, kill, attach-stdio, logs, diagnostics, config, profile
- All options for each subcommand (e.g. `--foreground`, `--dump`, `--json`, `--watch`, `--last-crash`)
- Environment variables (`RTTX_DEV_MODE`, `RUST_LOG`)
- File paths (socket, state, cache, logs)
- Development mode path isolation
- Wire protocol overview
- Usage examples

## Packaging integration

- **Meson**: installs to `{prefix}/share/man/man1/rttx-server.1`
- **cargo-deb**: included in DEB assets
- **cargo-generate-rpm**: included in RPM assets
- **rttx.spec**: listed in `%files` section

## How to manually verify

```bash
man -l services/rttx-server/man/rttx-server.1
```

Or after meson install:
```bash
meson setup build --prefix=/tmp/test -Dvte_version=0.76
meson compile -C build
meson install -C build
man -M /tmp/test/share/man rttx-server
```

## Tests added

- `services/rttx-server/tests/man_page.rs` — drift-detection tests:
  - `man_page_exists_and_is_valid_roff`: validates roff structure
  - `man_page_documents_all_subcommands`: ensures all 10 subcommands are documented
  - `man_page_documents_environment_variables`: ensures env vars are documented

## Tests run

- `cargo test -p rttx-server --test man_page` — 3 passed
- `cargo test -p rttx-server -p rttx-proto` — all passed
- `bash .github/scripts/run-clippy.sh` — passed
- `bash .github/scripts/run-quality-tests.sh` — all passed (pre-existing flaky PTY timing failures in `managed_input_parity` and `pty_coalesce` are unrelated)

Fixes #951