### PR TITLE
chore: validate packaging metadata for Flathub submission

### DIFF
--- a/.github/scripts/validate-packaging-metadata.sh
+++ b/.github/scripts/validate-packaging-metadata.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Validate AppStream metainfo.xml and .desktop file for Flathub submission.
+set -euo pipefail
+
+app_id="io.github.IllyaYalovyy.rttx"
+data_dir="clients/rttx/data"
+
+metainfo="${data_dir}/${app_id}.metainfo.xml"
+desktop="${data_dir}/${app_id}.desktop"
+
+errors=0
+
+if command -v appstreamcli &>/dev/null; then
+    echo "=== Validating ${metainfo} ==="
+    if ! appstreamcli validate "${metainfo}"; then
+        errors=$((errors + 1))
+    fi
+else
+    echo "WARNING: appstreamcli not found, skipping metainfo validation"
+fi
+
+if command -v desktop-file-validate &>/dev/null; then
+    echo "=== Validating ${desktop} ==="
+    if ! desktop-file-validate "${desktop}"; then
+        errors=$((errors + 1))
+    fi
+else
+    echo "WARNING: desktop-file-validate not found, skipping desktop file validation"
+fi
+
+if [[ ${errors} -gt 0 ]]; then
+    echo >&2 "Packaging metadata validation failed with ${errors} error(s)"
+    exit 1
+fi
+
+echo "Packaging metadata validation passed"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -220,6 +220,12 @@ jobs:
       - name: Validate Flatpak manifest JSON
         run: python3 -m json.tool packaging/rttx/io.github.IllyaYalovyy.rttx.json > /dev/null
 
+      - name: Install validation tools
+        run: sudo apt-get update && sudo apt-get install -y appstream desktop-file-utils
+
+      - name: Validate packaging metadata
+        run: bash .github/scripts/validate-packaging-metadata.sh
+
   audit:
     name: Dependency audit
     runs-on: ubuntu-latest

--- a/clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml
+++ b/clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml
@@ -5,6 +5,9 @@
   <project_license>GPL-3.0-or-later</project_license>
   <name>rttx</name>
   <summary>A tiling terminal emulator for GNOME</summary>
+  <developer id="io.github.illyayalovyy">
+    <name>Illya Yalovyy</name>
+  </developer>
   <description>
     <p>
       rttx is a tiling terminal emulator built with GTK4 and Libadwaita,
@@ -17,7 +20,21 @@
   <launchable type="desktop-id">io.github.IllyaYalovyy.rttx.desktop</launchable>
   <url type="homepage">https://github.com/IllyaYalovyy/rttx</url>
   <url type="bugtracker">https://github.com/IllyaYalovyy/rttx/issues</url>
+  <url type="vcs-browser">https://github.com/IllyaYalovyy/rttx</url>
   <content_rating type="oars-1.1"/>
+  <screenshots>
+    <screenshot type="default">
+      <caption>rttx with split panes and workspace sidebar</caption>
+      <image>https://raw.githubusercontent.com/IllyaYalovyy/rttx/mainline/clients/rttx/data/screenshots/rttx-main.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.6.5" date="2026-05-26">
+      <description>
+        <p>This release adds disconnect visualization for persistent panes, remote daemon lifecycle management, and force retry for stuck connections.</p>
+      </description>
+    </release>
+  </releases>
   <provides>
     <binary>rttx</binary>
   </provides>


### PR DESCRIPTION
## What changed and why

Fixes #952 — the metainfo.xml was missing several elements required for a clean Flathub submission:

- **Developer info** — resolves `developer-info-missing` from `appstreamcli validate`
- **Screenshots** — required for Flathub listing, points to the existing screenshot on mainline
- **Release notes** — resolves `releases-info-missing` pedantic warning
- **VCS browser URL** — standard metadata for source-available apps

Also adds a CI validation step that runs `appstreamcli validate` and `desktop-file-validate` on every PR to prevent regressions.

## How to manually verify

```bash
appstreamcli validate clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml
desktop-file-validate clients/rttx/data/io.github.IllyaYalovyy.rttx.desktop
bash .github/scripts/validate-packaging-metadata.sh
```

All should pass. The only remaining pedantic note is `cid-contains-uppercase-letter` which is inherent to the established app ID.

## Tests

- No Rust code changed; no new Rust tests needed.
- CI validation script added and verified locally.

## Tests run

- `cargo build --workspace` (with VTE 0.76 for client) ✅
- `cargo test --workspace` (with VTE 0.76 for client) ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅
- `bash .github/scripts/validate-packaging-metadata.sh` ✅