### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-26
+
 ## [0.6.5] - 2026-05-26
 
 ### Added
@@ -248,7 +250,8 @@ Initial release — a tiling terminal emulator for GNOME built with Rust, GTK4, 
 - Workspace state persists locally only — no remote sync
 - Single window only — multi-window support planned for a future release
 
-[Unreleased]: https://github.com/IllyaYalovyy/rttx/compare/v0.6.5...HEAD
+[Unreleased]: https://github.com/IllyaYalovyy/rttx/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/IllyaYalovyy/rttx/compare/v0.6.5...v0.9.0
 [0.6.5]: https://github.com/IllyaYalovyy/rttx/compare/v0.6.1...v0.6.5
 [0.6.1]: https://github.com/IllyaYalovyy/rttx/compare/v0.5.1...v0.6.1
 [0.5.1]: https://github.com/IllyaYalovyy/rttx/compare/v0.4.0...v0.5.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.6.5"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.6.5"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.6.5"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.6.5"
+version = "0.9.0"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml
+++ b/clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml
@@ -29,6 +29,11 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.9.0" date="2026-05-26">
+      <description>
+        <p>Version bump release.</p>
+      </description>
+    </release>
     <release version="0.6.5" date="2026-05-26">
       <description>
         <p>This release adds disconnect visualization for persistent panes, remote daemon lifecycle management, and force retry for stuck connections.</p>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.6.5',
+  version: '0.9.0',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/packaging/rttx/rttx.spec
+++ b/packaging/rttx/rttx.spec
@@ -1,5 +1,5 @@
 Name:           rttx
-Version:        0.6.3
+Version:        0.9.0
 Release:        1%{?dist}
 Summary:        A tiling terminal emulator for GNOME
 

--- a/services/rttx-server/man/rttx-server.1
+++ b/services/rttx-server/man/rttx-server.1
@@ -1,4 +1,4 @@
-.TH RTTX-SERVER 1 "2026-05-26" "rttx 0.6.5" "rttx Manual"
+.TH RTTX-SERVER 1 "2026-05-26" "rttx 0.9.0" "rttx Manual"
 .SH NAME
 rttx-server \- daemon runtime service for the rttx terminal emulator
 .SH SYNOPSIS


### PR DESCRIPTION
## What changed

Bumps the project version from 0.6.5 to 0.9.0 across all metadata and packaging files.

## Files updated

- `Cargo.toml` — workspace version
- `Cargo.lock` — all workspace crate versions
- `meson.build` — project version
- `clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml` — new release entry
- `packaging/rttx/rttx.spec` — RPM spec version
- `services/rttx-server/man/rttx-server.1` — man page header
- `CHANGELOG.md` — new 0.9.0 section and comparison links

## Manual verification

- `cargo build --workspace` (with VTE 0.76 flag for client) — passes
- `cargo test -p rttx-proto -p rttx-server` — all pass
- `cargo test -p rttx --no-default-features --features vte-0_76` — all pass
- `bash .github/scripts/run-clippy.sh` — passes
- `bash .github/scripts/run-quality-tests.sh` — all pass

## Tests added

None — this is a metadata-only version bump with no source code changes.

## Tests run

- All workspace tests pass (800+ client tests, 333 proto tests, 900+ server tests)
- Clippy passes
- Quality test suite passes

Fixes #971