### PR TITLE
fix: zoom button targets its own pane instead of the focused pane

### DIFF
--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -382,6 +382,11 @@ impl Window {
     }
 
     pub(super) fn toggle_pane_zoom(&self) {
+        let target = self.focused_terminal_uuid();
+        self.toggle_pane_zoom_for(target.as_deref());
+    }
+
+    pub(super) fn toggle_pane_zoom_for(&self, target_uuid: Option<&str>) {
         let Some(session_uuid) =
             self.imp().session_stack.visible_child_name().map(|n| n.to_string())
         else {
@@ -395,13 +400,13 @@ impl Window {
             if session.is_zoomed() {
                 session.zoomed_terminal_uuid = None;
             } else {
-                let Some(focused) = self.focused_terminal_uuid() else {
+                let Some(target) = target_uuid else {
                     return;
                 };
                 if session.layout.terminal_count() < 2 {
                     return;
                 }
-                session.zoomed_terminal_uuid = Some(focused);
+                session.zoomed_terminal_uuid = Some(target.to_owned());
             }
             session.clone()
         };

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -442,6 +442,7 @@ impl Window {
         });
 
         let win = self.downgrade();
+        let zoom_uuid = terminal_uuid.clone();
         let close_uuid = terminal_uuid;
         pane_view.close_button().connect_clicked(move |_| {
             if let Some(win) = win.upgrade() {
@@ -452,7 +453,7 @@ impl Window {
         let win = self.downgrade();
         pane_view.zoom_button().connect_clicked(move |_| {
             if let Some(win) = win.upgrade() {
-                win.toggle_pane_zoom();
+                win.toggle_pane_zoom_for(Some(&zoom_uuid));
             }
         });
 

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -217,9 +217,10 @@ impl Window {
         });
 
         let win = self.downgrade();
+        let uuid = term.uuid();
         term.zoom_button().connect_clicked(move |_| {
             if let Some(win) = win.upgrade() {
-                win.toggle_pane_zoom();
+                win.toggle_pane_zoom_for(Some(&uuid));
             }
         });
 

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -7790,3 +7790,65 @@ fn close_all_keeps_window_open_with_fresh_workspace() {
     crate::test_helpers::remove_env("XDG_CACHE_HOME");
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn zoom_button_zooms_its_own_pane_not_focused_pane() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.zoom-button-target-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.set_default_size(1000, 700);
+    window.present();
+    pump_events(100);
+
+    let first_uuid = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    window.split_terminal(&first_uuid, SplitOrientation::Horizontal);
+    pump_events(100);
+
+    let second_uuid = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0]
+            .layout
+            .terminal_uuids()
+            .into_iter()
+            .find(|uuid| uuid != &first_uuid)
+            .unwrap()
+    };
+
+    // Focus the first pane.
+    {
+        let terminals = window.imp().terminals.borrow();
+        let first_term = terminals.get(&first_uuid).unwrap();
+        first_term.vte().grab_focus();
+    }
+    pump_events(50);
+
+    // Zoom the second pane via its UUID (simulates clicking its zoom button).
+    window.toggle_pane_zoom_for(Some(&second_uuid));
+    pump_events(50);
+
+    let zoomed = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0].zoomed_terminal_uuid.clone()
+    };
+    assert_eq!(
+        zoomed.as_deref(),
+        Some(second_uuid.as_str()),
+        "zoom button should zoom the pane it belongs to, not the focused pane"
+    );
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}


### PR DESCRIPTION
## What changed and why

The pane zoom button's click handler called `toggle_pane_zoom()` which internally used `self.focused_terminal_uuid()` to determine which pane to zoom. When clicking the zoom button on a non-focused pane, the wrong pane got zoomed.

**Fix:** Extract `toggle_pane_zoom_for(target_uuid: Option<&str>)` that accepts an explicit target UUID. Both the ephemeral and persistent pane button handlers now pass their own pane's UUID. The keyboard shortcut (`Ctrl+Shift+Z`) still uses the focused pane via the existing `toggle_pane_zoom()` wrapper.

## Manual verification

1. Create a workspace with 2+ panes
2. Focus pane A
3. Click the zoom button on pane B's title bar
4. Pane B is now zoomed (previously pane A was zoomed)
5. Keyboard shortcut `Ctrl+Shift+Z` still zooms the focused pane

## Tests added

- `zoom_button_zooms_its_own_pane_not_focused_pane` — GTK widget test that creates a split workspace, focuses pane A, calls `toggle_pane_zoom_for` with pane B's UUID, and asserts pane B is zoomed

## Tests run

- `cargo build --workspace` (with `--no-default-features --features vte-0_76` for client) ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (new test ran and passed in isolated GTK harness)

Fixes #973