### PR TITLE
feat: show pane count indicator when a pane is zoomed

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1391,6 +1391,17 @@ mod search_tests {
         assert!(visible(true, true), "zoomed + multi → visible");
     }
 
+    /// Pane count label visibility rule: visible only when zoomed AND multi-pane.
+    #[test]
+    fn pane_count_label_visibility_rule() {
+        let visible = |zoomed: bool, pane_total: usize| zoomed && pane_total > 1;
+        assert!(!visible(false, 1), "single pane, not zoomed → hidden");
+        assert!(!visible(false, 3), "multi pane, not zoomed → hidden");
+        assert!(!visible(true, 1), "zoomed single pane → hidden");
+        assert!(visible(true, 2), "zoomed multi pane → visible");
+        assert!(visible(true, 5), "zoomed many panes → visible");
+    }
+
     /// Copy Link should show the filesystem path for file URIs, not the URI.
     #[test]
     fn display_text_for_file_uri_shows_path() {

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -431,7 +431,13 @@ impl PersistentPaneView {
         &self.imp().pane_count_label
     }
 
-    pub fn set_zoom_state(&self, zoomed: bool, multi_pane: bool, pane_index: usize, pane_total: usize) {
+    pub fn set_zoom_state(
+        &self,
+        zoomed: bool,
+        multi_pane: bool,
+        pane_index: usize,
+        pane_total: usize,
+    ) {
         let btn = &self.imp().zoom_button;
         btn.set_visible(zoomed || multi_pane);
         if zoomed {

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -52,6 +52,7 @@ mod imp {
         pub split_h_button: gtk4::Button,
         pub split_v_button: gtk4::Button,
         pub zoom_button: gtk4::Button,
+        pub pane_count_label: gtk4::Label,
         pub status_label: gtk4::Label,
         pub search_bar: gtk4::SearchBar,
         pub search_entry: gtk4::SearchEntry,
@@ -91,6 +92,7 @@ mod imp {
                 split_h_button: gtk4::Button::default(),
                 split_v_button: gtk4::Button::default(),
                 zoom_button: gtk4::Button::default(),
+                pane_count_label: gtk4::Label::default(),
                 status_label: gtk4::Label::default(),
                 search_bar: gtk4::SearchBar::default(),
                 search_entry: gtk4::SearchEntry::default(),
@@ -160,10 +162,14 @@ mod imp {
             self.zoom_button.set_tooltip_text(Some("Zoom pane"));
             self.zoom_button.set_visible(false);
 
+            self.pane_count_label.add_css_class("dim-label");
+            self.pane_count_label.set_visible(false);
+
             self.header.append(&self.title_label);
             self.header.append(&self.status_label);
             self.header.append(&self.split_h_button);
             self.header.append(&self.split_v_button);
+            self.header.append(&self.pane_count_label);
             self.header.append(&self.zoom_button);
             self.header.append(&self.close_button);
 
@@ -420,7 +426,12 @@ impl PersistentPaneView {
         &self.imp().zoom_button
     }
 
-    pub fn set_zoom_state(&self, zoomed: bool, multi_pane: bool) {
+    #[must_use]
+    pub fn pane_count_label(&self) -> &gtk4::Label {
+        &self.imp().pane_count_label
+    }
+
+    pub fn set_zoom_state(&self, zoomed: bool, multi_pane: bool, pane_index: usize, pane_total: usize) {
         let btn = &self.imp().zoom_button;
         btn.set_visible(zoomed || multi_pane);
         if zoomed {
@@ -429,6 +440,13 @@ impl PersistentPaneView {
         } else {
             btn.set_icon_name("view-fullscreen-symbolic");
             btn.set_tooltip_text(Some("Zoom pane"));
+        }
+        let count_label = &self.imp().pane_count_label;
+        if zoomed && pane_total > 1 {
+            count_label.set_label(&format!("{}/{pane_total}", pane_index + 1));
+            count_label.set_visible(true);
+        } else {
+            count_label.set_visible(false);
         }
     }
 

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -38,6 +38,7 @@ mod imp {
         pub split_h_button: gtk4::Button,
         pub split_v_button: gtk4::Button,
         pub zoom_button: gtk4::Button,
+        pub pane_count_label: gtk4::Label,
         pub search_bar: gtk4::SearchBar,
         pub search_entry: gtk4::SearchEntry,
         pub child_exited_handler: RefCell<Option<glib::SignalHandlerId>>,
@@ -98,9 +99,13 @@ mod imp {
             self.zoom_button.set_tooltip_text(Some("Zoom pane"));
             self.zoom_button.set_visible(false);
 
+            self.pane_count_label.add_css_class("dim-label");
+            self.pane_count_label.set_visible(false);
+
             self.header.append(&self.title_label);
             self.header.append(&self.split_h_button);
             self.header.append(&self.split_v_button);
+            self.header.append(&self.pane_count_label);
             self.header.append(&self.zoom_button);
             self.header.append(&self.close_button);
 
@@ -365,7 +370,12 @@ impl TerminalWidget {
         &self.imp().zoom_button
     }
 
-    pub fn set_zoom_state(&self, zoomed: bool, multi_pane: bool) {
+    #[must_use]
+    pub fn pane_count_label(&self) -> &gtk4::Label {
+        &self.imp().pane_count_label
+    }
+
+    pub fn set_zoom_state(&self, zoomed: bool, multi_pane: bool, pane_index: usize, pane_total: usize) {
         let btn = &self.imp().zoom_button;
         btn.set_visible(zoomed || multi_pane);
         if zoomed {
@@ -374,6 +384,13 @@ impl TerminalWidget {
         } else {
             btn.set_icon_name("view-fullscreen-symbolic");
             btn.set_tooltip_text(Some("Zoom pane"));
+        }
+        let count_label = &self.imp().pane_count_label;
+        if zoomed && pane_total > 1 {
+            count_label.set_label(&format!("{}/{pane_total}", pane_index + 1));
+            count_label.set_visible(true);
+        } else {
+            count_label.set_visible(false);
         }
     }
 

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -375,7 +375,13 @@ impl TerminalWidget {
         &self.imp().pane_count_label
     }
 
-    pub fn set_zoom_state(&self, zoomed: bool, multi_pane: bool, pane_index: usize, pane_total: usize) {
+    pub fn set_zoom_state(
+        &self,
+        zoomed: bool,
+        multi_pane: bool,
+        pane_index: usize,
+        pane_total: usize,
+    ) {
         let btn = &self.imp().zoom_button;
         btn.set_visible(zoomed || multi_pane);
         if zoomed {

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -14,6 +14,7 @@ impl Window {
 
         let zoomed = session_state.is_zoomed();
         let multi_pane = session_state.layout.terminal_count() > 1;
+        let (pane_index, pane_total) = pane_position(&session_state.layout, uuid);
 
         let existing = {
             let terminals = self.imp().terminals.borrow();
@@ -23,7 +24,7 @@ impl Window {
             if existing.parent().is_some() {
                 existing.unparent();
             }
-            existing.set_zoom_state(zoomed, multi_pane);
+            existing.set_zoom_state(zoomed, multi_pane, pane_index, pane_total);
             return existing.upcast();
         }
 
@@ -31,7 +32,7 @@ impl Window {
         if let Some(title) = custom_title {
             term.set_custom_title(Some(title));
         }
-        term.set_zoom_state(zoomed, multi_pane);
+        term.set_zoom_state(zoomed, multi_pane, pane_index, pane_total);
         self.connect_terminal_signals(&term);
         self.imp().terminals.borrow_mut().insert(uuid.to_string(), term.clone());
         self.initialize_terminal_recovery(&term, session_state, uuid);
@@ -47,6 +48,7 @@ impl Window {
     ) -> gtk4::Widget {
         let zoomed = session_state.is_zoomed();
         let multi_pane = session_state.layout.terminal_count() > 1;
+        let (pane_index, pane_total) = pane_position(&session_state.layout, uuid);
 
         let existing = {
             let panes = self.imp().persistent_terminals.borrow();
@@ -56,7 +58,7 @@ impl Window {
             if existing.parent().is_some() {
                 existing.unparent();
             }
-            existing.set_zoom_state(zoomed, multi_pane);
+            existing.set_zoom_state(zoomed, multi_pane, pane_index, pane_total);
             return existing.upcast();
         }
 
@@ -65,7 +67,7 @@ impl Window {
         if let Some(title) = custom_title {
             pane_view.set_custom_title(Some(title));
         }
-        pane_view.set_zoom_state(zoomed, multi_pane);
+        pane_view.set_zoom_state(zoomed, multi_pane, pane_index, pane_total);
         self.apply_preferences_to_persistent_pane(&pane_view);
         self.connect_managed_pane(session_state, &pane_view);
         self.imp().persistent_terminals.borrow_mut().insert(uuid.to_string(), pane_view.clone());
@@ -877,4 +879,10 @@ impl Window {
         term.show_recovery_message(&target.failure_message(status));
         true
     }
+}
+
+fn pane_position(layout: &LayoutNode, uuid: &str) -> (usize, usize) {
+    let uuids = layout.terminal_uuids();
+    let index = uuids.iter().position(|u| u == uuid).unwrap_or(0);
+    (index, uuids.len())
 }

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -1708,9 +1708,10 @@ fn terminal_widget_zoom_button_hidden_by_default() {
 fn terminal_widget_zoom_button_visible_for_multi_pane() {
     require_display!();
     let term = rttx::terminal::widget::TerminalWidget::new("t1", None);
-    term.set_zoom_state(false, true);
+    term.set_zoom_state(false, true, 0, 3);
     assert!(term.zoom_button().is_visible());
     assert_eq!(term.zoom_button().icon_name().unwrap(), "view-fullscreen-symbolic");
+    assert!(!term.pane_count_label().is_visible());
 }
 
 #[test]
@@ -1718,9 +1719,11 @@ fn terminal_widget_zoom_button_visible_for_multi_pane() {
 fn terminal_widget_zoom_button_shows_restore_when_zoomed() {
     require_display!();
     let term = rttx::terminal::widget::TerminalWidget::new("t1", None);
-    term.set_zoom_state(true, true);
+    term.set_zoom_state(true, true, 1, 3);
     assert!(term.zoom_button().is_visible());
     assert_eq!(term.zoom_button().icon_name().unwrap(), "view-restore-symbolic");
+    assert!(term.pane_count_label().is_visible());
+    assert_eq!(term.pane_count_label().label(), "2/3");
 }
 
 #[test]
@@ -1728,8 +1731,9 @@ fn terminal_widget_zoom_button_shows_restore_when_zoomed() {
 fn terminal_widget_zoom_button_hidden_for_single_pane_unzoomed() {
     require_display!();
     let term = rttx::terminal::widget::TerminalWidget::new("t1", None);
-    term.set_zoom_state(false, false);
+    term.set_zoom_state(false, false, 0, 1);
     assert!(!term.zoom_button().is_visible());
+    assert!(!term.pane_count_label().is_visible());
 }
 
 #[test]
@@ -1737,9 +1741,10 @@ fn terminal_widget_zoom_button_hidden_for_single_pane_unzoomed() {
 fn persistent_pane_zoom_button_visible_for_multi_pane() {
     require_display!();
     let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("p1", "s1");
-    pane.set_zoom_state(false, true);
+    pane.set_zoom_state(false, true, 0, 2);
     assert!(pane.zoom_button().is_visible());
     assert_eq!(pane.zoom_button().icon_name().unwrap(), "view-fullscreen-symbolic");
+    assert!(!pane.pane_count_label().is_visible());
 }
 
 #[test]
@@ -1747,9 +1752,23 @@ fn persistent_pane_zoom_button_visible_for_multi_pane() {
 fn persistent_pane_zoom_button_shows_restore_when_zoomed() {
     require_display!();
     let pane = rttx::terminal::persistent_widget::PersistentPaneView::new("p1", "s1");
-    pane.set_zoom_state(true, false);
+    pane.set_zoom_state(true, false, 0, 2);
     assert!(pane.zoom_button().is_visible());
     assert_eq!(pane.zoom_button().icon_name().unwrap(), "view-restore-symbolic");
+    assert!(pane.pane_count_label().is_visible());
+    assert_eq!(pane.pane_count_label().label(), "1/2");
+}
+
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn pane_count_label_hides_when_unzoomed() {
+    require_display!();
+    let term = rttx::terminal::widget::TerminalWidget::new("t1", None);
+    term.set_zoom_state(true, true, 2, 4);
+    assert!(term.pane_count_label().is_visible());
+    assert_eq!(term.pane_count_label().label(), "3/4");
+    term.set_zoom_state(false, true, 2, 4);
+    assert!(!term.pane_count_label().is_visible());
 }
 
 #[test]


### PR DESCRIPTION
## What changed and why

When a pane is maximized (zoomed via Ctrl+Shift+Z), there was no visual indicator showing how many panes exist in the workspace. Users lost context about the workspace layout.

This PR adds a "N/M" label (e.g. "2/3") next to the zoom button in the pane header when the workspace is in zoomed state. The label shows which pane is currently visible (1-based index) and the total number of panes.

## How to manually verify

1. Create a workspace with 3+ panes (split horizontally/vertically)
2. Press Ctrl+Shift+Z to zoom a pane
3. Observe the "N/M" label appears next to the restore button in the header
4. Press Ctrl+Shift+Z again to unzoom — label disappears
5. Verify the label shows correct position (e.g. zooming the 2nd of 3 panes shows "2/3")

## Tests added

- Unit test: `pane_count_label_visibility_rule` — validates the visibility logic (visible only when zoomed AND multi-pane)
- GTK widget tests (updated existing + new):
  - `terminal_widget_zoom_button_visible_for_multi_pane` — now also asserts count label hidden when not zoomed
  - `terminal_widget_zoom_button_shows_restore_when_zoomed` — now also asserts count label shows "2/3"
  - `terminal_widget_zoom_button_hidden_for_single_pane_unzoomed` — now also asserts count label hidden
  - `persistent_pane_zoom_button_visible_for_multi_pane` — now also asserts count label hidden
  - `persistent_pane_zoom_button_shows_restore_when_zoomed` — now also asserts count label shows "1/2"
  - `pane_count_label_hides_when_unzoomed` (NEW) — verifies label hides when transitioning from zoomed to unzoomed

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (801 passed)
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass via Broadway)

Fixes #975