### PR TITLE
fix: allow pane navigation while zoomed by switching the zoomed pane

### DIFF
--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -256,19 +256,41 @@ impl Window {
         }
     }
 
-    fn navigate_focused(&self, direction: Direction) {
+    pub(super) fn navigate_focused(&self, direction: Direction) {
         let Some(current_uuid) = self.focused_terminal_uuid() else { return };
-        let adjacent_uuid = {
+
+        let (adjacent_uuid, is_zoomed, session_uuid) = {
             let state = self.imp().state.borrow();
-            state
+            let session = state
                 .workspaces
                 .iter()
-                .find(|s| s.layout.contains_terminal(&current_uuid))
-                .and_then(|s| s.layout.find_adjacent(&current_uuid, direction))
+                .find(|s| s.layout.contains_terminal(&current_uuid));
+            let adjacent = session.and_then(|s| s.layout.find_adjacent(&current_uuid, direction));
+            let zoomed = session.is_some_and(WorkspaceState::is_zoomed);
+            let sess_uuid = session.map(|s| s.uuid.clone());
+            (adjacent, zoomed, sess_uuid)
         };
-        if let Some(target_uuid) = adjacent_uuid
-            && let Some(terminal) = self.terminal_handle(&target_uuid)
-        {
+
+        let Some(target_uuid) = adjacent_uuid else { return };
+        let Some(session_uuid) = session_uuid else { return };
+
+        if is_zoomed {
+            let session_state = {
+                let mut state = self.imp().state.borrow_mut();
+                let Some(session) =
+                    state.workspaces.iter_mut().find(|s| s.uuid == session_uuid)
+                else {
+                    return;
+                };
+                session.zoomed_terminal_uuid = Some(target_uuid);
+                session.clone()
+            };
+            self.rebuild_session_content(&session_uuid, &session_state);
+            self.focus_session_terminal(&session_uuid);
+            return;
+        }
+
+        if let Some(terminal) = self.terminal_handle(&target_uuid) {
             let win = self.clone();
             glib::idle_add_local_once(move || {
                 if terminal.grab_focus() {

--- a/clients/rttx/src/window/actions.rs
+++ b/clients/rttx/src/window/actions.rs
@@ -261,10 +261,8 @@ impl Window {
 
         let (adjacent_uuid, is_zoomed, session_uuid) = {
             let state = self.imp().state.borrow();
-            let session = state
-                .workspaces
-                .iter()
-                .find(|s| s.layout.contains_terminal(&current_uuid));
+            let session =
+                state.workspaces.iter().find(|s| s.layout.contains_terminal(&current_uuid));
             let adjacent = session.and_then(|s| s.layout.find_adjacent(&current_uuid, direction));
             let zoomed = session.is_some_and(WorkspaceState::is_zoomed);
             let sess_uuid = session.map(|s| s.uuid.clone());
@@ -277,8 +275,7 @@ impl Window {
         if is_zoomed {
             let session_state = {
                 let mut state = self.imp().state.borrow_mut();
-                let Some(session) =
-                    state.workspaces.iter_mut().find(|s| s.uuid == session_uuid)
+                let Some(session) = state.workspaces.iter_mut().find(|s| s.uuid == session_uuid)
                 else {
                     return;
                 };

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -7852,3 +7852,129 @@ fn zoom_button_zooms_its_own_pane_not_focused_pane() {
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
 }
+
+#[test]
+#[ignore = "requires GTK display"]
+fn navigate_while_zoomed_switches_zoomed_pane() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.navigate-while-zoomed-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.set_default_size(1000, 700);
+    window.present();
+    pump_events(100);
+
+    let first_uuid = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    window.split_terminal(&first_uuid, SplitOrientation::Horizontal);
+    pump_events(100);
+
+    let second_uuid = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0]
+            .layout
+            .terminal_uuids()
+            .into_iter()
+            .find(|uuid| uuid != &first_uuid)
+            .unwrap()
+    };
+
+    // Zoom the first pane.
+    window.toggle_pane_zoom_for(Some(&first_uuid));
+    pump_events(50);
+
+    {
+        let state = window.imp().state.borrow();
+        assert_eq!(
+            state.workspaces[0].zoomed_terminal_uuid.as_deref(),
+            Some(first_uuid.as_str()),
+            "first pane should be zoomed"
+        );
+    }
+
+    // Navigate right while zoomed — should switch zoom to the second pane.
+    window.navigate_focused(Direction::Right);
+    pump_events(50);
+
+    {
+        let state = window.imp().state.borrow();
+        assert_eq!(
+            state.workspaces[0].zoomed_terminal_uuid.as_deref(),
+            Some(second_uuid.as_str()),
+            "navigation while zoomed should switch the zoomed pane"
+        );
+    }
+
+    // Navigate left — should switch back to the first pane.
+    window.navigate_focused(Direction::Left);
+    pump_events(50);
+
+    {
+        let state = window.imp().state.borrow();
+        assert_eq!(
+            state.workspaces[0].zoomed_terminal_uuid.as_deref(),
+            Some(first_uuid.as_str()),
+            "navigating back should restore zoom to the first pane"
+        );
+    }
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}
+
+#[test]
+#[ignore = "requires GTK display"]
+fn navigate_while_zoomed_no_op_at_edge() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app = adw::Application::builder()
+        .application_id("com.illya.rttx.navigate-zoomed-edge-tests")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.set_default_size(1000, 700);
+    window.present();
+    pump_events(100);
+
+    let first_uuid = {
+        let state = window.imp().state.borrow();
+        state.workspaces[0].layout.terminal_uuids().into_iter().next().unwrap()
+    };
+    window.split_terminal(&first_uuid, SplitOrientation::Horizontal);
+    pump_events(100);
+
+    // Zoom the first pane.
+    window.toggle_pane_zoom_for(Some(&first_uuid));
+    pump_events(50);
+
+    // Navigate left (no adjacent pane in that direction) — should remain on first pane.
+    window.navigate_focused(Direction::Left);
+    pump_events(50);
+
+    {
+        let state = window.imp().state.borrow();
+        assert_eq!(
+            state.workspaces[0].zoomed_terminal_uuid.as_deref(),
+            Some(first_uuid.as_str()),
+            "navigating at edge while zoomed should not change the zoomed pane"
+        );
+    }
+
+    window.close();
+    crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
+}


### PR DESCRIPTION
## What changed and why

When a pane is zoomed (Ctrl+Shift+Z), the pane navigation shortcuts (Alt+Arrow) did nothing because `navigate_focused` tried to grab focus on the adjacent terminal widget, which is not in the visible widget tree during zoom.

The fix detects the zoomed state and, instead of attempting a focus grab, updates `zoomed_terminal_uuid` to the adjacent pane and rebuilds the session content. This switches the zoomed view to the target pane while keeping zoom active.

Fixes #977

## How to manually verify

1. Create a workspace with 2+ panes (Ctrl+Shift+E to split)
2. Zoom a pane (Ctrl+Shift+Z)
3. Navigate with Alt+Right / Alt+Left
4. The zoomed view should switch to the adjacent pane
5. Navigating at the edge (no adjacent pane) should be a no-op

## Tests added

- `navigate_while_zoomed_switches_zoomed_pane` — verifies navigation right/left switches the zoomed pane
- `navigate_while_zoomed_no_op_at_edge` — verifies navigation at the layout edge is a no-op

## Tests run

- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo build -p rttx-server -p rttx-proto` ✅
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅ (47 passed)
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all GTK tests pass including the 2 new ones)