### PR TITLE
fix: isolate VTE crashes to individual panes

### DIFF
--- a/clients/rttx/src/terminal/handle.rs
+++ b/clients/rttx/src/terminal/handle.rs
@@ -125,10 +125,17 @@ impl TerminalHandle {
     /// Feed the terminal cleanup byte sequence into VTE to restore sane
     /// state after a remote TUI dies without cleaning up. Resets tracked
     /// mode state for managed panes so key encoding stays correct.
+    /// Also clears the crashed state if the pane was previously isolated.
     pub fn repair_terminal(&self) {
-        self.vte().feed(crate::terminal::terminal_cleanup_bytes());
         if let Self::Managed(pane) = self {
+            pane.clear_crashed();
             pane.reset_tracked_modes();
         }
+        // Use safe_feed for the cleanup sequence since the VTE may be in a
+        // broken state from a prior crash.
+        let _ = crate::terminal::persistent_widget::safe_feed(
+            self.vte(),
+            crate::terminal::terminal_cleanup_bytes(),
+        );
     }
 }

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1346,6 +1346,36 @@ mod pane_passive_tests {
         );
         window.close();
     }
+
+    /// `safe_feed` catches panics from VTE and returns false, preventing
+    /// a single bad pane from crashing the entire GUI. Regression for #958.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn safe_feed_isolates_vte_panic_from_process() {
+        if !crate::test_helpers::ensure_gtk() {
+            eprintln!("SKIPPED: no display available");
+            return;
+        }
+
+        let pane = super::persistent_widget::PersistentPaneView::new("sf-iso", "rt-1");
+        // Normal feed succeeds.
+        assert!(super::persistent_widget::safe_feed(pane.vte(), b"normal output"));
+        assert!(!pane.is_crashed());
+
+        // After marking crashed, feed_output is a no-op.
+        pane.mark_crashed();
+        pane.feed_output(b"should be ignored");
+        assert!(pane.is_crashed());
+
+        // Repair clears the crashed state.
+        let handle = super::handle::TerminalHandle::Managed(pane.clone());
+        handle.repair_terminal();
+        assert!(!pane.is_crashed());
+
+        // Feed works again after repair.
+        pane.feed_output(b"recovered output");
+        assert!(!pane.is_crashed());
+    }
 }
 
 #[cfg(test)]

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -34,6 +34,7 @@ mod imp {
         pub connected: Cell<bool>,
         pub accepts_input: Cell<bool>,
         pub exited: Cell<bool>,
+        pub crashed: Cell<bool>,
         pub bracketed_paste_mode: Cell<bool>,
         pub application_cursor_keys: Cell<bool>,
         pub application_keypad: Cell<bool>,
@@ -45,6 +46,7 @@ mod imp {
         pub vte: vte4::Terminal,
         pub terminal_scroller: gtk4::ScrolledWindow,
         pub overlay: gtk4::Overlay,
+        pub crash_banner: gtk4::Label,
         pub disconnect_banner: gtk4::Label,
         pub header: gtk4::Box,
         pub title_label: gtk4::Label,
@@ -74,6 +76,7 @@ mod imp {
                 connected: Cell::default(),
                 accepts_input: Cell::default(),
                 exited: Cell::default(),
+                crashed: Cell::default(),
                 bracketed_paste_mode: Cell::default(),
                 application_cursor_keys: Cell::default(),
                 application_keypad: Cell::default(),
@@ -85,6 +88,7 @@ mod imp {
                 vte: vte4::Terminal::new(),
                 terminal_scroller: gtk4::ScrolledWindow::new(),
                 overlay: gtk4::Overlay::new(),
+                crash_banner: gtk4::Label::default(),
                 disconnect_banner: gtk4::Label::default(),
                 header: gtk4::Box::default(),
                 title_label: gtk4::Label::default(),
@@ -319,10 +323,17 @@ mod imp {
             self.disconnect_banner.add_css_class("disconnect-banner");
             self.disconnect_banner.set_visible(false);
 
+            // Crash banner — shown when VTE panics on bad input.
+            self.crash_banner.set_halign(gtk4::Align::Center);
+            self.crash_banner.set_valign(gtk4::Align::Center);
+            self.crash_banner.add_css_class("disconnect-banner");
+            self.crash_banner.set_visible(false);
+
             self.overlay.set_hexpand(true);
             self.overlay.set_vexpand(true);
             self.overlay.set_child(Some(&self.terminal_scroller));
             self.overlay.add_overlay(&self.disconnect_banner);
+            self.overlay.add_overlay(&self.crash_banner);
 
             obj.append(&self.header);
             obj.append(&self.search_bar);
@@ -557,14 +568,22 @@ impl PersistentPaneView {
     ///
     /// Called when a `Delta` message arrives from the daemon.
     pub fn feed_output(&self, data: &[u8]) {
+        if self.imp().crashed.get() {
+            return;
+        }
         update_bracketed_paste_mode(&self.imp().bracketed_paste_mode, data);
         // Feed in chunks to avoid overwhelming VTE with a single massive
         // blob that could trigger bugs in the C library.
         if data.len() <= VTE_FEED_CHUNK {
-            self.imp().vte.feed(data);
+            if !safe_feed(&self.imp().vte, data) {
+                self.mark_crashed();
+            }
         } else {
             for chunk in data.chunks(VTE_FEED_CHUNK) {
-                self.imp().vte.feed(chunk);
+                if !safe_feed(&self.imp().vte, chunk) {
+                    self.mark_crashed();
+                    return;
+                }
             }
         }
     }
@@ -577,14 +596,18 @@ impl PersistentPaneView {
     /// updates its layout asynchronously after `feed()` — the adjustment's
     /// `upper` value is not yet correct at the point `feed()` returns.
     pub fn feed_snapshot(&self, scrollback: &[u8]) {
-        if scrollback.is_empty() {
+        if scrollback.is_empty() || self.imp().crashed.get() {
             return;
         }
-        if scrollback.contains(&0x07) {
+        let ok = if scrollback.contains(&0x07) {
             let filtered: Vec<u8> = scrollback.iter().copied().filter(|&b| b != 0x07).collect();
-            self.imp().vte.feed(&filtered);
+            safe_feed(&self.imp().vte, &filtered)
         } else {
-            self.imp().vte.feed(scrollback);
+            safe_feed(&self.imp().vte, scrollback)
+        };
+        if !ok {
+            self.mark_crashed();
+            return;
         }
         let vte_weak = self.imp().vte.downgrade();
         glib::idle_add_local_once(move || {
@@ -728,6 +751,44 @@ impl PersistentPaneView {
             };
             self.imp().vte.feed(message.as_bytes());
         }
+    }
+
+    /// Mark this pane as crashed due to a VTE panic. Disables further feed
+    /// operations and shows an error overlay. Other panes remain functional.
+    pub fn mark_crashed(&self) {
+        if self.imp().crashed.replace(true) {
+            return;
+        }
+        self.imp().accepts_input.set(false);
+        self.imp().status_label.set_label("Crashed");
+        self.imp()
+            .status_label
+            .set_tooltip_text(Some("VTE crashed — use Repair Terminal to recover"));
+        self.add_css_class("terminal-pane-frozen");
+        self.imp()
+            .crash_banner
+            .set_label("Terminal crashed — press Ctrl+Shift+X to repair");
+        self.imp().crash_banner.set_visible(true);
+        tracing::error!(pane_uuid = %self.uuid(), "VTE crash detected, pane isolated");
+    }
+
+    /// Clear the crashed state after a successful repair.
+    pub fn clear_crashed(&self) {
+        if !self.imp().crashed.replace(false) {
+            return;
+        }
+        self.imp().crash_banner.set_visible(false);
+        self.remove_css_class("terminal-pane-frozen");
+        self.imp().status_label.set_label("⏻");
+        self.imp()
+            .status_label
+            .set_tooltip_text(Some("Persistent workspace — daemon-backed runtime"));
+    }
+
+    /// Whether this pane is in a crashed state.
+    #[must_use]
+    pub fn is_crashed(&self) -> bool {
+        self.imp().crashed.get()
     }
 
     /// Mark this pane as active (focused).
@@ -1067,6 +1128,16 @@ impl PersistentPaneView {
         self.imp().disconnect_message_fed.get()
     }
 
+    #[cfg(test)]
+    pub(crate) fn crash_banner_visible_for_test(&self) -> bool {
+        self.imp().crash_banner.is_visible()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn crash_banner_text_for_test(&self) -> String {
+        self.imp().crash_banner.label().to_string()
+    }
+
     #[doc(hidden)]
     #[must_use]
     pub fn emit_input_key_for_test(
@@ -1131,6 +1202,21 @@ fn format_disconnect_banner(status: &ConnectionStatus) -> String {
 /// Maximum bytes to feed to VTE in a single call. Prevents overwhelming
 /// the C library with a massive blob that could trigger parser bugs.
 const VTE_FEED_CHUNK: usize = 16 * 1024;
+
+/// Feed data to VTE, catching any panic from the C library.
+///
+/// Returns `true` if the feed succeeded, `false` if VTE panicked.
+/// On panic the VTE widget is left in an indeterminate state — the caller
+/// should mark the pane as crashed and stop feeding further data.
+pub(crate) fn safe_feed(vte: &vte4::Terminal, data: &[u8]) -> bool {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let vte = AssertUnwindSafe(vte);
+    catch_unwind(|| {
+        vte.feed(data);
+    })
+    .is_ok()
+}
 
 /// Convert clipboard text to terminal input bytes.
 ///
@@ -2809,5 +2895,99 @@ mod tests {
     fn format_disconnect_banner_for_session_missing() {
         let banner = format_disconnect_banner(&ConnectionStatus::SessionMissing);
         assert!(banner.contains("no longer exists"));
+    }
+
+    /// `safe_feed` returns true for normal data.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn safe_feed_returns_true_for_normal_data() {
+        require_display!();
+        let pane = PersistentPaneView::new("sf-ok", "rt-1");
+        assert!(safe_feed(pane.vte(), b"hello world"));
+    }
+
+    /// `mark_crashed` sets the crashed flag and shows the crash banner.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn mark_crashed_shows_banner_and_freezes_pane() {
+        require_display!();
+        let pane = PersistentPaneView::new("crash-1", "rt-1");
+        assert!(!pane.is_crashed());
+        assert!(!pane.crash_banner_visible_for_test());
+
+        pane.mark_crashed();
+
+        assert!(pane.is_crashed());
+        assert!(pane.crash_banner_visible_for_test());
+        assert!(pane.crash_banner_text_for_test().contains("crashed"));
+        assert_eq!(pane.status_label_text_for_test(), "Crashed");
+        assert!(!pane.input_enabled_for_test());
+    }
+
+    /// `clear_crashed` resets the crashed state and hides the banner.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn clear_crashed_restores_normal_state() {
+        require_display!();
+        let pane = PersistentPaneView::new("crash-2", "rt-1");
+        pane.mark_crashed();
+        assert!(pane.is_crashed());
+
+        pane.clear_crashed();
+
+        assert!(!pane.is_crashed());
+        assert!(!pane.crash_banner_visible_for_test());
+    }
+
+    /// `feed_output` is a no-op after the pane is marked crashed.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn feed_output_noop_after_crash() {
+        require_display!();
+        let pane = PersistentPaneView::new("crash-3", "rt-1");
+        pane.mark_crashed();
+
+        // Should not panic or feed anything.
+        pane.feed_output(b"data after crash");
+        assert!(pane.is_crashed());
+    }
+
+    /// `feed_snapshot` is a no-op after the pane is marked crashed.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn feed_snapshot_noop_after_crash() {
+        require_display!();
+        let pane = PersistentPaneView::new("crash-4", "rt-1");
+        pane.mark_crashed();
+
+        pane.feed_snapshot(b"snapshot after crash");
+        assert!(pane.is_crashed());
+    }
+
+    /// `mark_crashed` is idempotent — calling it twice does not panic.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn mark_crashed_is_idempotent() {
+        require_display!();
+        let pane = PersistentPaneView::new("crash-5", "rt-1");
+        pane.mark_crashed();
+        pane.mark_crashed();
+        assert!(pane.is_crashed());
+    }
+
+    /// Repair terminal clears the crashed state on managed panes.
+    #[test]
+    #[ignore = "requires isolated GTK harness"]
+    fn repair_terminal_clears_crashed_state() {
+        require_display!();
+        let pane = PersistentPaneView::new("crash-6", "rt-1");
+        pane.mark_crashed();
+        assert!(pane.is_crashed());
+
+        let handle = crate::terminal::handle::TerminalHandle::Managed(pane.clone());
+        handle.repair_terminal();
+
+        assert!(!pane.is_crashed());
+        assert!(!pane.crash_banner_visible_for_test());
     }
 }

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -765,9 +765,7 @@ impl PersistentPaneView {
             .status_label
             .set_tooltip_text(Some("VTE crashed — use Repair Terminal to recover"));
         self.add_css_class("terminal-pane-frozen");
-        self.imp()
-            .crash_banner
-            .set_label("Terminal crashed — press Ctrl+Shift+X to repair");
+        self.imp().crash_banner.set_label("Terminal crashed — press Ctrl+Shift+X to repair");
         self.imp().crash_banner.set_visible(true);
         tracing::error!(pane_uuid = %self.uuid(), "VTE crash detected, pane isolated");
     }

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -833,19 +833,21 @@ impl Window {
         let was_accepting = pane.imp().accepts_input.get();
         pane.imp().accepts_input.set(false);
         pane.feed_snapshot(&restore.scrollback_tail);
-        if let Some(ref modes) = restore.terminal_modes {
-            pane.set_bracketed_paste_mode(modes.bracketed_paste);
-            // alternate_screen is intentionally not restored: the snapshot
-            // already contains the rendered screen content, and switching
-            // VTE into alt-screen mode would discard it.
-            pane.restore_interaction_modes(modes);
-        } else {
-            // No mode state available — feed cleanup bytes to ensure any
-            // mouse tracking or other modes left by the scrollback data
-            // are disabled. Without this, stale DECSET sequences in the
-            // scrollback can leave VTE with mouse tracking on, causing
-            // mouse clicks to print escape sequences instead of working.
-            pane.vte().feed(crate::terminal::terminal_cleanup_bytes());
+        if !pane.is_crashed() {
+            if let Some(ref modes) = restore.terminal_modes {
+                pane.set_bracketed_paste_mode(modes.bracketed_paste);
+                // alternate_screen is intentionally not restored: the snapshot
+                // already contains the rendered screen content, and switching
+                // VTE into alt-screen mode would discard it.
+                pane.restore_interaction_modes(modes);
+            } else {
+                // No mode state available — feed cleanup bytes to ensure any
+                // mouse tracking or other modes left by the scrollback data
+                // are disabled. Without this, stale DECSET sequences in the
+                // scrollback can leave VTE with mouse tracking on, causing
+                // mouse clicks to print escape sequences instead of working.
+                pane.vte().feed(crate::terminal::terminal_cleanup_bytes());
+            }
         }
         pane.imp().accepts_input.set(was_accepting);
         pane.set_current_directory(Some(&restore.cwd));

--- a/clients/rttx/tests/vte_crash_resilience.rs
+++ b/clients/rttx/tests/vte_crash_resilience.rs
@@ -1,0 +1,109 @@
+//! Integration tests for VTE crash resilience (#958).
+//!
+//! Verifies that a VTE panic in one pane does not affect other panes
+//! or the overall GUI state.
+
+use rttx::terminal::handle::TerminalHandle;
+use rttx::terminal::persistent_widget::PersistentPaneView;
+use std::sync::Once;
+
+static GTK_INIT: Once = Once::new();
+static GTK_AVAILABLE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+fn ensure_gtk_init() -> bool {
+    GTK_INIT.call_once(|| {
+        // SAFETY: GTK init runs once before any threads spawn; no concurrent env readers.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("GTK_A11Y", "none");
+        };
+        let ok = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| gtk4::init().is_ok()))
+            .unwrap_or(false);
+        if ok && let Some(display) = gtk4::gdk::Display::default() {
+            std::mem::forget(display);
+        }
+        GTK_AVAILABLE.store(ok, std::sync::atomic::Ordering::Relaxed);
+    });
+    GTK_AVAILABLE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+macro_rules! require_display {
+    () => {
+        if !ensure_gtk_init() {
+            eprintln!("SKIPPED: no display available");
+            return;
+        }
+    };
+}
+
+/// A crashed pane does not affect sibling panes in the same workspace.
+/// Regression test for #958.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn crashed_pane_does_not_affect_sibling() {
+    require_display!();
+
+    let pane_a = PersistentPaneView::new("pane-a", "rt-1");
+    let pane_b = PersistentPaneView::new("pane-b", "rt-1");
+
+    // Both panes start healthy.
+    assert!(!pane_a.is_crashed());
+    assert!(!pane_b.is_crashed());
+
+    // Pane A crashes.
+    pane_a.mark_crashed();
+
+    // Pane A is isolated.
+    assert!(pane_a.is_crashed());
+
+    // Pane B remains fully functional.
+    assert!(!pane_b.is_crashed());
+    pane_b.feed_output(b"still working");
+    assert!(!pane_b.is_crashed());
+}
+
+/// Repair terminal restores a crashed pane to a functional state.
+/// Regression test for #958.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn repair_recovers_crashed_pane() {
+    require_display!();
+
+    let pane = PersistentPaneView::new("repair-int", "rt-1");
+    pane.feed_output(b"initial output");
+    assert!(!pane.is_crashed());
+
+    // Simulate crash.
+    pane.mark_crashed();
+    assert!(pane.is_crashed());
+    pane.feed_output(b"ignored after crash");
+
+    // Repair via the handle (same path as Ctrl+Shift+X).
+    let handle = TerminalHandle::Managed(pane.clone());
+    handle.repair_terminal();
+
+    // Pane is functional again.
+    assert!(!pane.is_crashed());
+    pane.feed_output(b"working after repair");
+    assert!(!pane.is_crashed());
+}
+
+/// The daemon connection is preserved when a pane crashes — the pane
+/// remains addressable and can receive future deltas after repair.
+/// Regression test for #958.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn daemon_connection_survives_pane_crash() {
+    require_display!();
+
+    let pane = PersistentPaneView::new("daemon-surv", "rt-1");
+    pane.set_connected(true);
+
+    pane.mark_crashed();
+
+    // The pane object still exists and retains its identity.
+    assert_eq!(pane.uuid(), "daemon-surv");
+    assert_eq!(pane.runtime_id(), "rt-1");
+    // The pane is crashed but not destroyed — daemon can still reference it.
+    assert!(pane.is_crashed());
+}


### PR DESCRIPTION
## What changed and why

Fixes #958 — GUI resilience against VTE crashes.

When VTE's C library panics while processing malformed escape sequences (e.g., from a misbehaving script or tool), the panic was previously unhandled and killed the entire rttx GUI process, destroying all workspaces and disconnecting from the daemon.

This PR wraps all VTE `feed()` calls on the data path with `std::panic::catch_unwind`, isolating the crash to the single offending pane:

- **`safe_feed()`** — a new helper that catches panics from `vte.feed()`
- **`mark_crashed()`** — stops further feed operations, shows a crash banner overlay, and freezes the pane
- **`clear_crashed()`** — resets the state after repair
- **Repair Terminal (Ctrl+Shift+X)** — extended to clear the crashed state and attempt VTE recovery

### Behavior after this change

| Before | After |
|--------|-------|
| One bad pane kills all workspaces | Only the offending pane is frozen |
| Daemon connection lost | Daemon connection preserved |
| Must restart GUI and wait for recovery | Other panes continue working normally |
| No indication of what happened | Clear crash banner with repair instructions |

## How to manually verify

1. Open rttx with multiple workspaces
2. In one pane, trigger a VTE panic (e.g., feed malformed escape sequences that trigger a GLib assertion)
3. Observe: only that pane shows the crash banner; other panes remain functional
4. Press Ctrl+Shift+X to repair the crashed pane

## Tests added

7 new GTK widget tests in `persistent_widget::tests`:
- `safe_feed_returns_true_for_normal_data`
- `mark_crashed_shows_banner_and_freezes_pane`
- `clear_crashed_restores_normal_state`
- `feed_output_noop_after_crash`
- `feed_snapshot_noop_after_crash`
- `mark_crashed_is_idempotent`
- `repair_terminal_clears_crashed_state`

## Tests run

- `cargo build --workspace` ✅ (with `--no-default-features --features vte-0_76`)
- `cargo test -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-proto -p rttx-server` ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` ✅ (all 7 new tests pass via Broadway)

## Limitations

- `catch_unwind` catches Rust panics (including GLib assertion failures that gtk-rs converts to panics). It does **not** catch true C-level crashes (SIGSEGV/SIGABRT) that corrupt process memory — those require process isolation (tracked as a long-term follow-up).
- After a crash, the VTE widget is in an indeterminate state. Repair Terminal feeds cleanup bytes but cannot guarantee the widget is fully functional. Closing and re-splitting the pane is the safest recovery.