### PR TITLE
chore: migrate CLI commands to v3 protocol

### DIFF
--- a/services/rttx-server/src/ipc.rs
+++ b/services/rttx-server/src/ipc.rs
@@ -171,6 +171,60 @@ where
         Ok(())
     }
 
+    /// Send a v3 client hello message (used by CLI commands).
+    pub async fn send_v3_client_hello(&mut self, msg: &v3::ClientHello) -> Result<(), IpcError> {
+        let mut buf = BytesMut::new();
+        encode_frame(msg, &mut buf)?;
+        self.stream.write_all(&buf).await?;
+        self.stream.flush().await?;
+        Ok(())
+    }
+
+    /// Read a v3 server hello response.
+    pub async fn recv_v3_server_hello(&mut self) -> Result<v3::ServerHello, IpcError> {
+        loop {
+            match decode_frame::<v3::ServerHello>(&mut self.read_buf) {
+                Ok(msg) => return Ok(msg),
+                Err(rttx_proto::FrameError::Incomplete) => {}
+                Err(e) => return Err(IpcError::Frame(e)),
+            }
+            let n = self.stream.read_buf(&mut self.read_buf).await?;
+            if n == 0 {
+                return Err(IpcError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed during v3 handshake",
+                )));
+            }
+        }
+    }
+
+    /// Send a v3 client envelope.
+    pub async fn send_v3_envelope(&mut self, msg: &v3::ClientEnvelope) -> Result<(), IpcError> {
+        let mut buf = BytesMut::new();
+        encode_frame(msg, &mut buf)?;
+        self.stream.write_all(&buf).await?;
+        self.stream.flush().await?;
+        Ok(())
+    }
+
+    /// Read a v3 server envelope.
+    pub async fn recv_v3_envelope(&mut self) -> Result<v3::ServerEnvelope, IpcError> {
+        loop {
+            match decode_frame::<v3::ServerEnvelope>(&mut self.read_buf) {
+                Ok(msg) => return Ok(msg),
+                Err(rttx_proto::FrameError::Incomplete) => {}
+                Err(e) => return Err(IpcError::Frame(e)),
+            }
+            let n = self.stream.read_buf(&mut self.read_buf).await?;
+            if n == 0 {
+                return Err(IpcError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed",
+                )));
+            }
+        }
+    }
+
     /// Split into independent reader and writer halves.
     pub fn into_split(self) -> (ClientConnectionReader, ClientConnectionWriter)
     where

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -4,7 +4,7 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use clap::{Parser, Subcommand};
-use rttx_proto::proto;
+use rttx_proto::v3;
 use rttx_server::ipc;
 use rttx_server::os::OsInterface;
 use rttx_server::os::unix::UnixOs;
@@ -266,7 +266,40 @@ fn config() {
     println!("State: {}", state.display());
     println!("Scrollback: {}", scrollback.display());
     println!("Logs: {}", log_dir.display());
-    println!("Protocol version: {}", rttx_proto::PROTOCOL_VERSION);
+    println!("Protocol version: {}", rttx_proto::v3_handshake::V3_PROTOCOL_VERSION);
+}
+
+/// Connect to the daemon socket and perform a v3 handshake.
+async fn v3_connect(
+    socket_path: &std::path::Path,
+) -> anyhow::Result<ipc::ClientConnection<tokio::net::UnixStream>> {
+    let stream = tokio::net::UnixStream::connect(socket_path).await?;
+    let mut conn = ipc::ClientConnection::from_stream(stream);
+
+    let hello = rttx_proto::v3_handshake::build_client_hello(
+        uuid::Uuid::new_v4(),
+        "rttx-server-cli",
+        env!("CARGO_PKG_VERSION"),
+        &[
+            v3::Capability::CoreRuntimeLifecycle,
+            v3::Capability::CorePaneLifecycle,
+            v3::Capability::CoreTerminalIo,
+            v3::Capability::CoreTerminalModes,
+            v3::Capability::CorePasteIntent,
+            v3::Capability::CoreFocusEvents,
+            v3::Capability::OptDiagnostics,
+        ],
+    );
+    conn.send_v3_client_hello(&hello).await?;
+    let _server_hello = conn.recv_v3_server_hello().await?;
+    Ok(conn)
+}
+
+/// Receive the next v3 server envelope from the connection.
+async fn recv_v3_response(
+    conn: &mut ipc::ClientConnection<tokio::net::UnixStream>,
+) -> anyhow::Result<v3::ServerEnvelope> {
+    Ok(conn.recv_v3_envelope().await?)
 }
 
 fn profile(opts: &ProfileOpts) -> anyhow::Result<()> {
@@ -345,10 +378,6 @@ fn read_pid(pid_path: &std::path::Path) -> Option<u32> {
 }
 
 fn diagnostics() -> anyhow::Result<()> {
-    use bytes::BytesMut;
-    use rttx_proto::{decode_frame, encode_frame};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
     let os = UnixOs;
     let socket_path = os.runtime_dir().join("rttx-server.sock");
 
@@ -359,51 +388,18 @@ fn diagnostics() -> anyhow::Result<()> {
             return Ok(());
         }
 
-        let mut stream = tokio::net::UnixStream::connect(&socket_path).await?;
-        let mut buf = BytesMut::new();
-        let mut read_buf = BytesMut::with_capacity(8192);
-
-        // Hello.
-        let hello = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Hello(proto::Hello {
-                protocol_version: rttx_proto::PROTOCOL_VERSION,
-                client_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
-            })),
-        };
-        encode_frame(&hello, &mut buf)?;
-        stream.write_all(&buf).await?;
-        stream.flush().await?;
-
-        // Read HelloAck.
-        loop {
-            stream.read_buf(&mut read_buf).await?;
-            if decode_frame::<proto::ServerMessage>(&mut read_buf).is_ok() {
-                break;
-            }
-        }
+        let mut conn = v3_connect(&socket_path).await?;
+        let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
 
         // GetDiagnostics.
-        buf.clear();
-        encode_frame(
-            &proto::ClientMessage {
-                msg: Some(proto::client_message::Msg::GetDiagnostics(proto::GetDiagnostics {})),
-            },
-            &mut buf,
-        )?;
-        stream.write_all(&buf).await?;
-        stream.flush().await?;
+        let env = rttx_proto::v3_envelope::build_client_envelope(
+            &id_gen,
+            v3::client_envelope::Command::GetDiagnostics(v3::GetDiagnostics {}),
+        );
+        conn.send_v3_envelope(&env).await?;
 
-        // Read DiagnosticsReport.
-        let resp: proto::ServerMessage = loop {
-            stream.read_buf(&mut read_buf).await?;
-            match decode_frame::<proto::ServerMessage>(&mut read_buf) {
-                Ok(msg) => break msg,
-                Err(rttx_proto::FrameError::Incomplete) => {}
-                Err(e) => anyhow::bail!("decode error: {e}"),
-            }
-        };
-
-        if let Some(proto::server_message::Msg::DiagnosticsReport(report)) = resp.msg {
+        let resp = recv_v3_response(&mut conn).await?;
+        if let Some(v3::server_envelope::Payload::DiagnosticsReport(report)) = resp.payload {
             println!("Runtimes: {}", report.runtime_count);
             println!(
                 "Panes: {} ({} active, {} exited)",
@@ -490,23 +486,19 @@ fn stop() -> anyhow::Result<()> {
             std::process::exit(1);
         }
 
-        let stream = tokio::net::UnixStream::connect(&socket_path).await?;
-        let mut conn = ipc::ClientConnection::from_stream(stream);
+        let mut conn = v3_connect(&socket_path).await?;
 
-        let shutdown = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Shutdown(proto::Shutdown {})),
-        };
-        conn.send_client_message(&shutdown).await?;
+        let shutdown = rttx_proto::v3_envelope::build_client_envelope(
+            &rttx_proto::v3_envelope::RequestIdGenerator::new(),
+            v3::client_envelope::Command::Shutdown(v3::Shutdown {}),
+        );
+        conn.send_v3_envelope(&shutdown).await?;
         println!("Shutdown signal sent");
         Ok(())
     })
 }
 
 fn status() -> anyhow::Result<()> {
-    use bytes::BytesMut;
-    use rttx_proto::{decode_frame, encode_frame};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
     let os = UnixOs;
     let socket_path = os.runtime_dir().join("rttx-server.sock");
 
@@ -520,54 +512,27 @@ fn status() -> anyhow::Result<()> {
             return Ok(());
         }
 
-        let mut stream = tokio::net::UnixStream::connect(&socket_path).await?;
-        let mut buf = BytesMut::new();
-        let mut read_buf = BytesMut::with_capacity(8192);
-
-        // Hello.
-        let hello = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Hello(proto::Hello {
-                protocol_version: rttx_proto::PROTOCOL_VERSION,
-                client_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
-            })),
-        };
-        encode_frame(&hello, &mut buf)?;
-        stream.write_all(&buf).await?;
-        stream.flush().await?;
-
-        // Read HelloAck.
-        loop {
-            stream.read_buf(&mut read_buf).await?;
-            if decode_frame::<proto::ServerMessage>(&mut read_buf).is_ok() {
-                break;
-            }
-        }
+        let mut conn = v3_connect(&socket_path).await?;
+        let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
 
         // ListRuntimes.
-        buf.clear();
-        let list = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::ListRuntimes(proto::ListRuntimes {})),
-        };
-        encode_frame(&list, &mut buf)?;
-        stream.write_all(&buf).await?;
-        stream.flush().await?;
+        let env = rttx_proto::v3_envelope::build_client_envelope(
+            &id_gen,
+            v3::client_envelope::Command::ListRuntimes(v3::ListRuntimes {}),
+        );
+        conn.send_v3_envelope(&env).await?;
 
-        // Read RuntimeList.
-        let resp: proto::ServerMessage = loop {
-            stream.read_buf(&mut read_buf).await?;
-            match decode_frame::<proto::ServerMessage>(&mut read_buf) {
-                Ok(msg) => break msg,
-                Err(rttx_proto::FrameError::Incomplete) => {}
-                Err(e) => anyhow::bail!("decode error: {e}"),
-            }
-        };
-
-        if let Some(proto::server_message::Msg::RuntimeList(sl)) = resp.msg {
+        let resp = recv_v3_response(&mut conn).await?;
+        if let Some(v3::server_envelope::Payload::RuntimeList(sl)) = resp.payload {
             println!("Status: running");
             println!("Runtimes: {}", sl.runtimes.len());
 
-            let total_panes: usize = sl.runtimes.iter().map(|s| s.panes.len()).sum();
-            let total_clients: u32 = sl.runtimes.iter().map(|s| s.attached_client_count).sum();
+            let total_panes: u32 = sl.runtimes.iter().map(|s| s.pane_count).sum();
+            let total_clients: u32 = sl
+                .runtimes
+                .iter()
+                .map(|s| u32::from(s.has_write_owner) + s.read_only_client_count)
+                .sum();
             println!("Panes: {total_panes}");
             println!("Connected clients: {total_clients}");
 
@@ -580,18 +545,20 @@ fn status() -> anyhow::Result<()> {
                 for rt_info in &sl.runtimes {
                     let id = rttx_proto::bytes_to_uuid(&rt_info.id)
                         .map_or_else(|_| "?".into(), |u| u.to_string());
-                    let policy = match proto::RuntimePolicy::try_from(rt_info.policy) {
-                        Ok(proto::RuntimePolicy::Persistent) => "persistent",
-                        Ok(proto::RuntimePolicy::Ephemeral) => "ephemeral",
+                    let policy = match v3::RuntimePolicy::try_from(rt_info.policy) {
+                        Ok(v3::RuntimePolicy::Persistent) => "persistent",
+                        Ok(v3::RuntimePolicy::Ephemeral) => "ephemeral",
                         _ => "unknown",
                     };
+                    let clients =
+                        u32::from(rt_info.has_write_owner) + rt_info.read_only_client_count;
                     println!(
                         "{:<38} {:<20} {:<12} {:<6} {:<8}",
                         id,
                         truncate(&rt_info.name, 20),
                         policy,
-                        rt_info.panes.len(),
-                        rt_info.attached_client_count,
+                        rt_info.pane_count,
+                        clients,
                     );
                 }
             }
@@ -602,10 +569,6 @@ fn status() -> anyhow::Result<()> {
 }
 
 fn clean() -> anyhow::Result<()> {
-    use bytes::BytesMut;
-    use rttx_proto::{decode_frame, encode_frame};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
     let os = UnixOs;
     let socket_path = os.runtime_dir().join("rttx-server.sock");
 
@@ -616,54 +579,26 @@ fn clean() -> anyhow::Result<()> {
             return Ok(());
         }
 
-        let mut stream = tokio::net::UnixStream::connect(&socket_path).await?;
-        let mut buf = BytesMut::new();
-        let mut read_buf = BytesMut::with_capacity(8192);
-
-        // Hello.
-        let hello = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Hello(proto::Hello {
-                protocol_version: rttx_proto::PROTOCOL_VERSION,
-                client_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
-            })),
-        };
-        encode_frame(&hello, &mut buf)?;
-        stream.write_all(&buf).await?;
-        stream.flush().await?;
-
-        loop {
-            stream.read_buf(&mut read_buf).await?;
-            if decode_frame::<proto::ServerMessage>(&mut read_buf).is_ok() {
-                break;
-            }
-        }
+        let mut conn = v3_connect(&socket_path).await?;
+        let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
 
         // ListRuntimes.
-        buf.clear();
-        encode_frame(
-            &proto::ClientMessage {
-                msg: Some(proto::client_message::Msg::ListRuntimes(proto::ListRuntimes {})),
-            },
-            &mut buf,
-        )?;
-        stream.write_all(&buf).await?;
-        stream.flush().await?;
+        let env = rttx_proto::v3_envelope::build_client_envelope(
+            &id_gen,
+            v3::client_envelope::Command::ListRuntimes(v3::ListRuntimes {}),
+        );
+        conn.send_v3_envelope(&env).await?;
 
-        let resp: proto::ServerMessage = loop {
-            stream.read_buf(&mut read_buf).await?;
-            match decode_frame::<proto::ServerMessage>(&mut read_buf) {
-                Ok(msg) => break msg,
-                Err(rttx_proto::FrameError::Incomplete) => {}
-                Err(e) => anyhow::bail!("decode error: {e}"),
-            }
-        };
-
-        let runtimes = match resp.msg {
-            Some(proto::server_message::Msg::RuntimeList(sl)) => sl.runtimes,
+        let resp = recv_v3_response(&mut conn).await?;
+        let runtimes = match resp.payload {
+            Some(v3::server_envelope::Payload::RuntimeList(sl)) => sl.runtimes,
             _ => anyhow::bail!("unexpected response"),
         };
 
-        let unused: Vec<_> = runtimes.iter().filter(|s| s.attached_client_count == 0).collect();
+        let unused: Vec<_> = runtimes
+            .iter()
+            .filter(|s| !s.has_write_owner && s.read_only_client_count == 0)
+            .collect();
 
         if unused.is_empty() {
             println!("No unused runtimes");
@@ -672,33 +607,26 @@ fn clean() -> anyhow::Result<()> {
 
         let mut cleaned = 0u32;
         for rt_info in &unused {
-            buf.clear();
-            encode_frame(
-                &proto::ClientMessage {
-                    msg: Some(proto::client_message::Msg::TerminateRuntime(
-                        proto::TerminateRuntime { runtime_id: rt_info.id.clone() },
-                    )),
-                },
-                &mut buf,
-            )?;
-            stream.write_all(&buf).await?;
-            stream.flush().await?;
+            let env = rttx_proto::v3_envelope::build_client_envelope(
+                &id_gen,
+                v3::client_envelope::Command::TerminateRuntime(v3::TerminateRuntime {
+                    runtime_id: rt_info.id.clone(),
+                }),
+            );
+            conn.send_v3_envelope(&env).await?;
 
             // Wait for RuntimeTerminated.
             loop {
-                stream.read_buf(&mut read_buf).await?;
-                match decode_frame::<proto::ServerMessage>(&mut read_buf) {
-                    Ok(msg) => {
-                        if matches!(msg.msg, Some(proto::server_message::Msg::RuntimeTerminated(_)))
-                        {
-                            let name = truncate(&rt_info.name, 40);
-                            println!("Removed: {name}");
-                            cleaned += 1;
-                            break;
-                        }
+                let resp = recv_v3_response(&mut conn).await?;
+                match resp.payload {
+                    Some(v3::server_envelope::Payload::RuntimeTerminated(_)) => {
+                        let name = truncate(&rt_info.name, 40);
+                        println!("Removed: {name}");
+                        cleaned += 1;
+                        break;
                     }
-                    Err(rttx_proto::FrameError::Incomplete) => {}
-                    Err(e) => anyhow::bail!("decode error: {e}"),
+                    Some(v3::server_envelope::Payload::OutputDelta(_)) => {}
+                    other => anyhow::bail!("unexpected response: {other:?}"),
                 }
             }
         }
@@ -709,10 +637,6 @@ fn clean() -> anyhow::Result<()> {
 }
 
 fn kill(runtime_id_str: &str) -> anyhow::Result<()> {
-    use bytes::BytesMut;
-    use rttx_proto::{decode_frame, encode_frame};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
     let runtime_id: uuid::Uuid = runtime_id_str
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid runtime ID: not a valid UUID"))?;
@@ -727,56 +651,25 @@ fn kill(runtime_id_str: &str) -> anyhow::Result<()> {
             std::process::exit(1);
         }
 
-        let mut stream = tokio::net::UnixStream::connect(&socket_path).await?;
-        let mut buf = BytesMut::new();
-        let mut read_buf = BytesMut::with_capacity(8192);
-
-        // Hello handshake.
-        let hello = proto::ClientMessage {
-            msg: Some(proto::client_message::Msg::Hello(proto::Hello {
-                protocol_version: rttx_proto::PROTOCOL_VERSION,
-                client_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
-            })),
-        };
-        encode_frame(&hello, &mut buf)?;
-        stream.write_all(&buf).await?;
-        stream.flush().await?;
-
-        loop {
-            stream.read_buf(&mut read_buf).await?;
-            if decode_frame::<proto::ServerMessage>(&mut read_buf).is_ok() {
-                break;
-            }
-        }
+        let mut conn = v3_connect(&socket_path).await?;
+        let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
 
         // TerminateRuntime.
-        buf.clear();
-        encode_frame(
-            &proto::ClientMessage {
-                msg: Some(proto::client_message::Msg::TerminateRuntime(proto::TerminateRuntime {
-                    runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
-                })),
-            },
-            &mut buf,
-        )?;
-        stream.write_all(&buf).await?;
-        stream.flush().await?;
+        let env = rttx_proto::v3_envelope::build_client_envelope(
+            &id_gen,
+            v3::client_envelope::Command::TerminateRuntime(v3::TerminateRuntime {
+                runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
+            }),
+        );
+        conn.send_v3_envelope(&env).await?;
 
         // Wait for RuntimeTerminated or Error.
-        let resp: proto::ServerMessage = loop {
-            stream.read_buf(&mut read_buf).await?;
-            match decode_frame::<proto::ServerMessage>(&mut read_buf) {
-                Ok(msg) => break msg,
-                Err(rttx_proto::FrameError::Incomplete) => {}
-                Err(e) => anyhow::bail!("decode error: {e}"),
-            }
-        };
-
-        match resp.msg {
-            Some(proto::server_message::Msg::RuntimeTerminated(_)) => {
+        let resp = recv_v3_response(&mut conn).await?;
+        match resp.payload {
+            Some(v3::server_envelope::Payload::RuntimeTerminated(_)) => {
                 println!("Runtime terminated.");
             }
-            Some(proto::server_message::Msg::Error(e)) => {
+            Some(v3::server_envelope::Payload::Error(e)) => {
                 eprintln!("Error: {}", e.message);
                 std::process::exit(1);
             }
@@ -951,5 +844,29 @@ mod tests {
         assert_mimalloc(&GLOBAL);
         let v: Vec<u8> = vec![0u8; 4096];
         assert_eq!(v.len(), 4096);
+    }
+
+    #[test]
+    fn cli_v3_handshake_includes_diagnostics_capability() {
+        use rttx_proto::v3_handshake;
+
+        let hello = v3_handshake::build_client_hello(
+            uuid::Uuid::new_v4(),
+            "rttx-server-cli",
+            env!("CARGO_PKG_VERSION"),
+            &[
+                v3::Capability::CoreRuntimeLifecycle,
+                v3::Capability::CorePaneLifecycle,
+                v3::Capability::CoreTerminalIo,
+                v3::Capability::CoreTerminalModes,
+                v3::Capability::CorePasteIntent,
+                v3::Capability::CoreFocusEvents,
+                v3::Capability::OptDiagnostics,
+            ],
+        );
+        assert!(hello.capabilities.contains(&(v3::Capability::OptDiagnostics as i32)));
+        assert_eq!(hello.min_protocol_version, v3_handshake::V3_PROTOCOL_VERSION);
+        assert_eq!(hello.max_protocol_version, v3_handshake::V3_PROTOCOL_VERSION);
+        assert_eq!(hello.client_name, "rttx-server-cli");
     }
 }

--- a/services/rttx-server/tests/cli_v3_protocol.rs
+++ b/services/rttx-server/tests/cli_v3_protocol.rs
@@ -1,0 +1,244 @@
+//! Integration tests verifying CLI commands use v3 protocol exclusively.
+//!
+//! These tests exercise the same v3 handshake + envelope pattern that the
+//! CLI commands (`stop`, `status`, `diagnostics`, `clean`, `kill`) use.
+
+mod common;
+
+use bytes::BytesMut;
+use common::start_test_server;
+use rttx_proto::{decode_frame, encode_frame, v3};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+/// Perform a v3 handshake on a raw stream (same pattern as CLI `v3_connect`).
+async fn cli_v3_handshake(stream: &mut UnixStream) {
+    let hello = rttx_proto::v3_handshake::build_client_hello(
+        uuid::Uuid::new_v4(),
+        "rttx-server-cli",
+        "0.0.0-test",
+        &[
+            v3::Capability::CoreRuntimeLifecycle,
+            v3::Capability::CorePaneLifecycle,
+            v3::Capability::CoreTerminalIo,
+            v3::Capability::CoreTerminalModes,
+            v3::Capability::CorePasteIntent,
+            v3::Capability::CoreFocusEvents,
+            v3::Capability::OptDiagnostics,
+        ],
+    );
+    let mut buf = BytesMut::new();
+    encode_frame(&hello, &mut buf).unwrap();
+    stream.write_all(&buf).await.unwrap();
+    stream.flush().await.unwrap();
+
+    // Read ServerHello.
+    let mut read_buf = BytesMut::with_capacity(4096);
+    loop {
+        stream.read_buf(&mut read_buf).await.unwrap();
+        match decode_frame::<v3::ServerHello>(&mut read_buf) {
+            Ok(_) => break,
+            Err(rttx_proto::FrameError::Incomplete) => {}
+            Err(e) => panic!("failed to decode ServerHello: {e}"),
+        }
+    }
+}
+
+/// Send a v3 envelope and receive the response.
+async fn send_and_recv(stream: &mut UnixStream, env: &v3::ClientEnvelope) -> v3::ServerEnvelope {
+    let mut buf = BytesMut::new();
+    encode_frame(env, &mut buf).unwrap();
+    stream.write_all(&buf).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let mut read_buf = BytesMut::with_capacity(8192);
+    loop {
+        stream.read_buf(&mut read_buf).await.unwrap();
+        match decode_frame::<v3::ServerEnvelope>(&mut read_buf) {
+            Ok(resp) => return resp,
+            Err(rttx_proto::FrameError::Incomplete) => {}
+            Err(e) => panic!("decode error: {e}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn cli_status_via_v3_list_runtimes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut stream = UnixStream::connect(&sock).await.unwrap();
+    cli_v3_handshake(&mut stream).await;
+
+    let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
+    let env = rttx_proto::v3_envelope::build_client_envelope(
+        &id_gen,
+        v3::client_envelope::Command::ListRuntimes(v3::ListRuntimes {}),
+    );
+
+    let resp = send_and_recv(&mut stream, &env).await;
+    assert!(
+        matches!(resp.payload, Some(v3::server_envelope::Payload::RuntimeList(_))),
+        "expected RuntimeList, got {:?}",
+        resp.payload
+    );
+}
+
+#[tokio::test]
+async fn cli_diagnostics_via_v3() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut stream = UnixStream::connect(&sock).await.unwrap();
+    cli_v3_handshake(&mut stream).await;
+
+    let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
+    let env = rttx_proto::v3_envelope::build_client_envelope(
+        &id_gen,
+        v3::client_envelope::Command::GetDiagnostics(v3::GetDiagnostics {}),
+    );
+
+    let resp = send_and_recv(&mut stream, &env).await;
+    match resp.payload {
+        Some(v3::server_envelope::Payload::DiagnosticsReport(report)) => {
+            assert_eq!(report.runtime_count, 0);
+            assert_eq!(report.total_pane_count, 0);
+            assert_eq!(report.client_count, 1); // this test client
+        }
+        other => panic!("expected DiagnosticsReport, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cli_kill_via_v3_terminate_runtime() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    // Create a runtime via v3 first.
+    let mut v3_client = common::TestV3Client::connect(&sock).await;
+    let runtime_id = v3_client.create_runtime("kill-target").await;
+
+    // Now simulate the CLI kill command via a fresh v3 connection.
+    let mut stream = UnixStream::connect(&sock).await.unwrap();
+    cli_v3_handshake(&mut stream).await;
+
+    let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
+    let env = rttx_proto::v3_envelope::build_client_envelope(
+        &id_gen,
+        v3::client_envelope::Command::TerminateRuntime(v3::TerminateRuntime {
+            runtime_id: runtime_id.clone(),
+        }),
+    );
+
+    let resp = send_and_recv(&mut stream, &env).await;
+    assert!(
+        matches!(resp.payload, Some(v3::server_envelope::Payload::RuntimeTerminated(_))),
+        "expected RuntimeTerminated, got {:?}",
+        resp.payload
+    );
+}
+
+#[tokio::test]
+async fn cli_kill_nonexistent_returns_error() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut stream = UnixStream::connect(&sock).await.unwrap();
+    cli_v3_handshake(&mut stream).await;
+
+    let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
+    let env = rttx_proto::v3_envelope::build_client_envelope(
+        &id_gen,
+        v3::client_envelope::Command::TerminateRuntime(v3::TerminateRuntime {
+            runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::new_v4()),
+        }),
+    );
+
+    let resp = send_and_recv(&mut stream, &env).await;
+    match resp.payload {
+        Some(v3::server_envelope::Payload::Error(e)) => {
+            assert_eq!(e.kind, v3::ErrorKind::RuntimeNotFound as i32);
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cli_clean_via_v3_list_and_terminate() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    // Create a runtime (no clients attached after creation without attach).
+    let mut v3_client = common::TestV3Client::connect(&sock).await;
+    let runtime_id = v3_client.create_runtime("clean-target").await;
+    drop(v3_client);
+
+    // Small delay for disconnect to propagate.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Simulate CLI clean: list runtimes, find unused, terminate.
+    let mut stream = UnixStream::connect(&sock).await.unwrap();
+    cli_v3_handshake(&mut stream).await;
+
+    let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
+
+    // List runtimes.
+    let list_env = rttx_proto::v3_envelope::build_client_envelope(
+        &id_gen,
+        v3::client_envelope::Command::ListRuntimes(v3::ListRuntimes {}),
+    );
+    let resp = send_and_recv(&mut stream, &list_env).await;
+    let runtimes = match resp.payload {
+        Some(v3::server_envelope::Payload::RuntimeList(sl)) => sl.runtimes,
+        other => panic!("expected RuntimeList, got {other:?}"),
+    };
+
+    // Find unused (no write owner, no readers).
+    let unused: Vec<_> =
+        runtimes.iter().filter(|r| !r.has_write_owner && r.read_only_client_count == 0).collect();
+    assert_eq!(unused.len(), 1);
+    assert_eq!(unused[0].id, runtime_id);
+
+    // Terminate unused.
+    let term_env = rttx_proto::v3_envelope::build_client_envelope(
+        &id_gen,
+        v3::client_envelope::Command::TerminateRuntime(v3::TerminateRuntime {
+            runtime_id: runtime_id.clone(),
+        }),
+    );
+    let resp = send_and_recv(&mut stream, &term_env).await;
+    assert!(matches!(resp.payload, Some(v3::server_envelope::Payload::RuntimeTerminated(_))));
+
+    // Verify it's gone.
+    let resp = send_and_recv(&mut stream, &list_env).await;
+    match resp.payload {
+        Some(v3::server_envelope::Payload::RuntimeList(sl)) => {
+            assert!(sl.runtimes.is_empty());
+        }
+        other => panic!("expected empty RuntimeList, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cli_stop_via_v3_shutdown() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, handle) = start_test_server(tmp.path()).await;
+
+    let mut stream = UnixStream::connect(&sock).await.unwrap();
+    cli_v3_handshake(&mut stream).await;
+
+    let id_gen = rttx_proto::v3_envelope::RequestIdGenerator::new();
+    let env = rttx_proto::v3_envelope::build_client_envelope(
+        &id_gen,
+        v3::client_envelope::Command::Shutdown(v3::Shutdown {}),
+    );
+
+    let mut buf = BytesMut::new();
+    encode_frame(&env, &mut buf).unwrap();
+    stream.write_all(&buf).await.unwrap();
+    stream.flush().await.unwrap();
+
+    // Server should shut down.
+    let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    assert!(result.is_ok(), "server should shut down after Shutdown command");
+}


### PR DESCRIPTION
## What changed and why

Migrates all CLI commands (`stop`, `status`, `diagnostics`, `clean`, `kill`) from v2 `ClientMessage`/`ServerMessage` protocol to v3 `ClientHello`/`ClientEnvelope`/`ServerEnvelope`.

This is the first step toward removing all v2 protocol code from the daemon (tracked in #980). The CLI was the last non-test consumer of v2 protocol in the `main.rs` binary.

### Changes:
- **`main.rs`**: All CLI commands now use `v3_connect()` helper for v3 handshake, then send/receive v3 envelopes
- **`ipc.rs`**: Added `send_v3_client_hello`, `recv_v3_server_hello`, `send_v3_envelope`, `recv_v3_envelope` methods to `ClientConnection`
- **`config` command**: Now displays v3 protocol version (3) instead of v2 (2)
- **New test file**: `tests/cli_v3_protocol.rs` with 6 integration tests covering the v3 CLI protocol path

### Remaining work (follow-up):
The full v2 removal from server dispatch (`server.rs`, `protocol.rs`) requires migrating 69 integration test files from v2 `TestClient` to v3 `TestV3Client`. This is tracked in #980 as subsequent work.

## How to manually verify

```bash
# Build and start daemon
cargo build -p rttx-server
./target/debug/rttx-server start --foreground &

# Test each CLI command
./target/debug/rttx-server status
./target/debug/rttx-server diagnostics
./target/debug/rttx-server config
./target/debug/rttx-server clean
./target/debug/rttx-server stop
```

## Tests added

- `cli_status_via_v3_list_runtimes` — verifies ListRuntimes via v3
- `cli_diagnostics_via_v3` — verifies GetDiagnostics via v3
- `cli_kill_via_v3_terminate_runtime` — verifies TerminateRuntime via v3
- `cli_kill_nonexistent_returns_error` — verifies error handling via v3
- `cli_clean_via_v3_list_and_terminate` — verifies full clean workflow via v3
- `cli_stop_via_v3_shutdown` — verifies Shutdown via v3

## Tests run

- `cargo test -p rttx-server --lib` — 517 passed
- `cargo test -p rttx-server --tests` — all passed (0 failures)
- `cargo clippy -p rttx-server -p rttx-proto --tests -- -D warnings` — clean
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed

Refs #980