### PR TITLE
fix: use GDK set_text for clipboard to preserve non-ASCII characters

### DIFF
--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -15,18 +15,24 @@ fn trim_trailing_whitespace(text: &str) -> String {
 
 /// Copy the terminal selection to the system clipboard, trimming trailing
 /// whitespace per line when the preference is enabled.
+///
+/// Always retrieves text via `text_selected` and sets it through
+/// `gdk_clipboard_set_text` to guarantee correct UTF-8 encoding on the
+/// clipboard. VTE's native `copy_clipboard_format` can produce escaped
+/// byte sequences for non-ASCII characters (e.g. Cyrillic) on some VTE
+/// versions. See #982.
 pub(crate) fn copy_to_clipboard(vte: &vte4::Terminal) {
-    let prefs = crate::store::default_store().load_preferences().into_value().unwrap_or_default();
-    if !prefs.trim_trailing_whitespace_on_copy {
-        vte.copy_clipboard_format(vte4::Format::Text);
-        return;
-    }
     let Some(selected) = vte.text_selected(vte4::Format::Text) else {
         return;
     };
-    let trimmed = trim_trailing_whitespace(&selected);
+    let prefs = crate::store::default_store().load_preferences().into_value().unwrap_or_default();
+    let text = if prefs.trim_trailing_whitespace_on_copy {
+        trim_trailing_whitespace(&selected)
+    } else {
+        selected.to_string()
+    };
     if let Some(display) = gtk4::gdk::Display::default() {
-        display.clipboard().set_text(&trimmed);
+        display.clipboard().set_text(&text);
     }
 }
 
@@ -1174,6 +1180,15 @@ mod trim_tests {
     #[test]
     fn preserves_internal_spaces() {
         assert_eq!(trim_trailing_whitespace("hello  world   "), "hello  world");
+    }
+
+    /// Non-ASCII (Cyrillic) text must pass through without byte escaping. #982.
+    #[test]
+    fn cyrillic_text_preserved() {
+        assert_eq!(
+            trim_trailing_whitespace("Маро, Маро,   \nПривет  "),
+            "Маро, Маро,\nПривет"
+        );
     }
 }
 

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -1185,10 +1185,7 @@ mod trim_tests {
     /// Non-ASCII (Cyrillic) text must pass through without byte escaping. #982.
     #[test]
     fn cyrillic_text_preserved() {
-        assert_eq!(
-            trim_trailing_whitespace("Маро, Маро,   \nПривет  "),
-            "Маро, Маро,\nПривет"
-        );
+        assert_eq!(trim_trailing_whitespace("Маро, Маро,   \nПривет  "), "Маро, Маро,\nПривет");
     }
 }
 

--- a/clients/rttx/tests/gtk_widget_tests.rs
+++ b/clients/rttx/tests/gtk_widget_tests.rs
@@ -3062,3 +3062,31 @@ fn window_has_rename_workspace_action() {
     );
     window.close();
 }
+
+/// Copying Cyrillic (non-ASCII) text from a terminal must preserve Unicode
+/// characters on the clipboard, not produce escaped UTF-8 byte sequences. #982.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn copy_cyrillic_text_preserves_unicode_on_clipboard() {
+    require_display!();
+
+    let display = gtk4::gdk::Display::default().expect("display should be available for GTK tests");
+    display.clipboard().set_text("");
+
+    let direct = rttx::terminal::widget::TerminalWidget::new("cyrillic-1", None);
+    let window = present_widget(&direct);
+    direct.vte().feed("Привет мир\r\n".as_bytes());
+    pump_events(50);
+    direct.vte().select_all();
+
+    let handle = rttx::terminal::handle::TerminalHandle::Direct(direct);
+    handle.copy_clipboard();
+    assert!(
+        wait_until(1000, || {
+            clipboard_text().is_some_and(|text| text.contains("Привет мир"))
+        }),
+        "clipboard must contain original Cyrillic text, got: {:?}",
+        clipboard_text()
+    );
+    window.close();
+}


### PR DESCRIPTION
## What changed and why

Fixes #982 — Copying Cyrillic (non-ASCII) terminal text puts escaped UTF-8 bytes on the clipboard instead of actual characters.

**Root cause:** VTE's `copy_clipboard_format(Format::Text)` uses a content provider that can produce escaped byte sequences for non-ASCII characters on some VTE versions (observed on VTE 0.76).

**Fix:** Always retrieve selected text via `vte.text_selected(Format::Text)` (which returns a proper UTF-8 `GString`) and set it on the clipboard via `gdk_clipboard_set_text`, which correctly handles UTF-8 encoding. This bypasses VTE's native clipboard handling entirely.

The trim-trailing-whitespace path already used this approach; now the non-trim path does too.

## Manual verification

1. Open rttx, type Cyrillic text (e.g. `echo Привет мир`)
2. Select the text and copy (Ctrl+Shift+C)
3. Paste into another application — should show proper Cyrillic characters, not escaped bytes

## Tests added

- **Unit test:** `terminal::trim_tests::cyrillic_text_preserved` — verifies trim function preserves Cyrillic text
- **GTK widget test:** `copy_cyrillic_text_preserves_unicode_on_clipboard` — feeds Cyrillic text to VTE, copies via the clipboard path, and asserts the clipboard contains proper Unicode

## Tests run

- `cargo build --workspace` ✓
- `cargo test -p rttx --lib` ✓ (802 passed)
- `cargo test -p rttx-server --lib` ✓ (517 passed)
- `cargo test -p rttx-server --tests` ✓
- `bash .github/scripts/run-clippy.sh` ✓
- `bash .github/scripts/run-quality-tests.sh` ✓ (all GTK tests pass including new test)

GTK test output:
- `copy_cyrillic_text_preserves_unicode_on_clipboard ... ok`
- `terminal_handle_copy_clipboard_uses_direct_terminal_selection ... ok`
- `terminal_handle_copy_clipboard_uses_managed_terminal_selection ... ok`