### PR TITLE
fix: normalize non-Latin keyvals to Latin for shortcut matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -84,6 +84,21 @@ pub fn encode_terminal_key_input_with_modes_for_test(
     encode_terminal_key_input(key, state, modes)
 }
 
+/// Translate a hardware keycode to its Latin-layout keyval using group 0.
+///
+/// When the active keyboard layout is non-Latin (e.g. Russian), pressing
+/// the physical `C` key produces a Cyrillic keyval. This function returns
+/// the Latin keyval that the same physical key would produce on the first
+/// (Latin) layout group, enabling shortcut matching regardless of the
+/// active layout.
+///
+/// Returns `None` if no display is available or translation fails.
+pub(crate) fn latin_keyval_from_keycode(keycode: u32) -> Option<gtk4::gdk::Key> {
+    let display = gtk4::gdk::Display::default()?;
+    let (key, _, _, _) = display.translate_key(keycode, gtk4::gdk::ModifierType::empty(), 0)?;
+    Some(key)
+}
+
 /// Terminal interaction modes that affect key encoding.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TerminalModes {
@@ -152,26 +167,36 @@ fn should_pass_through_window_accelerator(
     (normalized == (ctrl | shift)
         && matches!(
             key,
-            gtk4::gdk::Key::c
+            gtk4::gdk::Key::a
+                | gtk4::gdk::Key::A
+                | gtk4::gdk::Key::b
+                | gtk4::gdk::Key::B
+                | gtk4::gdk::Key::c
                 | gtk4::gdk::Key::C
+                | gtk4::gdk::Key::d
+                | gtk4::gdk::Key::D
+                | gtk4::gdk::Key::e
+                | gtk4::gdk::Key::E
+                | gtk4::gdk::Key::f
+                | gtk4::gdk::Key::F
+                | gtk4::gdk::Key::i
+                | gtk4::gdk::Key::I
+                | gtk4::gdk::Key::n
+                | gtk4::gdk::Key::N
+                | gtk4::gdk::Key::o
+                | gtk4::gdk::Key::O
+                | gtk4::gdk::Key::r
+                | gtk4::gdk::Key::R
+                | gtk4::gdk::Key::t
+                | gtk4::gdk::Key::T
                 | gtk4::gdk::Key::v
                 | gtk4::gdk::Key::V
                 | gtk4::gdk::Key::w
                 | gtk4::gdk::Key::W
-                | gtk4::gdk::Key::e
-                | gtk4::gdk::Key::E
-                | gtk4::gdk::Key::o
-                | gtk4::gdk::Key::O
-                | gtk4::gdk::Key::f
-                | gtk4::gdk::Key::F
-                | gtk4::gdk::Key::n
-                | gtk4::gdk::Key::N
-                | gtk4::gdk::Key::b
-                | gtk4::gdk::Key::B
-                | gtk4::gdk::Key::i
-                | gtk4::gdk::Key::I
-                | gtk4::gdk::Key::t
-                | gtk4::gdk::Key::T
+                | gtk4::gdk::Key::x
+                | gtk4::gdk::Key::X
+                | gtk4::gdk::Key::z
+                | gtk4::gdk::Key::Z
                 | gtk4::gdk::Key::Tab
                 | gtk4::gdk::Key::ISO_Left_Tab
         ))
@@ -374,6 +399,16 @@ fn smart_clipboard_action(
     None
 }
 
+/// Determine the shortcut-matching key: use the Latin-layout keyval when
+/// the event key is non-Latin (e.g. Cyrillic) so shortcuts work regardless
+/// of the active keyboard layout.
+fn shortcut_key(key: gtk4::gdk::Key, latin_key: Option<gtk4::gdk::Key>) -> gtk4::gdk::Key {
+    if key.to_unicode().is_some_and(|ch| ch.is_ascii_alphabetic()) {
+        return key;
+    }
+    latin_key.unwrap_or(key)
+}
+
 fn terminal_key_action(
     backend: TerminalInputBackend,
     key: gtk4::gdk::Key,
@@ -381,11 +416,13 @@ fn terminal_key_action(
     has_selection: bool,
     smart_clipboard_enabled: bool,
     modes: TerminalModes,
+    latin_key: Option<gtk4::gdk::Key>,
 ) -> TerminalKeyAction {
     let normalized = normalized_shortcut_modifiers(modifiers);
+    let skey = shortcut_key(key, latin_key);
 
     if let Some(action) =
-        smart_clipboard_action(key, normalized, has_selection, smart_clipboard_enabled)
+        smart_clipboard_action(skey, normalized, has_selection, smart_clipboard_enabled)
     {
         return action;
     }
@@ -397,7 +434,7 @@ fn terminal_key_action(
         && normalized
             == (gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK)
     {
-        match key {
+        match skey {
             gtk4::gdk::Key::c | gtk4::gdk::Key::C if has_selection => {
                 return TerminalKeyAction::CopySelection;
             }
@@ -408,7 +445,7 @@ fn terminal_key_action(
         }
     }
 
-    if should_pass_through_window_accelerator(key, normalized) {
+    if should_pass_through_window_accelerator(skey, normalized) {
         return TerminalKeyAction::PassThrough;
     }
 
@@ -443,6 +480,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -454,6 +492,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -471,6 +510,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -482,6 +522,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -497,6 +538,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -508,6 +550,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -523,6 +566,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x03])
         );
@@ -534,6 +578,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::ForwardToPty(b"\x1bx".to_vec())
         );
@@ -557,6 +602,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x04])
         );
@@ -576,6 +622,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -654,6 +701,7 @@ mod tests {
                 false,
                 false, // smart clipboard OFF
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -672,6 +720,7 @@ mod tests {
                 true,  // has selection
                 false, // smart clipboard OFF
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::CopySelection
         );
@@ -715,6 +764,7 @@ mod tests {
             false,
             false,
             DEFAULT_MODES,
+            None,
         );
         assert!(
             matches!(action, TerminalKeyAction::ForwardToPty(_)),
@@ -878,6 +928,7 @@ mod tests {
             false,
             false,
             DEFAULT_MODES,
+            None,
         );
         assert_eq!(action, TerminalKeyAction::ForwardToPty(vec![0x1b, 0x01]));
     }
@@ -984,6 +1035,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             );
             assert!(
                 matches!(action, TerminalKeyAction::ForwardToPty(_)),
@@ -1025,6 +1077,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough,
         );
@@ -1064,6 +1117,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             );
             assert!(
                 matches!(action, TerminalKeyAction::ForwardToPty(_)),
@@ -1128,8 +1182,138 @@ mod tests {
             false,
             false,
             modes,
+            None,
         );
         assert_eq!(action, TerminalKeyAction::ForwardToPty(b"\x1bOA".to_vec()));
+    }
+
+    /// Cyrillic keyvals must trigger smart clipboard copy when the Latin
+    /// equivalent is `c` and Ctrl is held. Regression for #983.
+    #[test]
+    fn cyrillic_ctrl_c_copies_with_latin_key_hint() {
+        // Russian layout: physical C produces Cyrillic_es (с)
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
+                gtk4::gdk::Key::Cyrillic_es,
+                gtk4::gdk::ModifierType::CONTROL_MASK,
+                true,
+                true,
+                DEFAULT_MODES,
+                Some(gtk4::gdk::Key::c),
+            ),
+            TerminalKeyAction::CopySelection
+        );
+    }
+
+    /// Cyrillic keyvals must trigger smart clipboard paste when the Latin
+    /// equivalent is `v` and Ctrl is held. Regression for #983.
+    #[test]
+    fn cyrillic_ctrl_v_pastes_with_latin_key_hint() {
+        // Russian layout: physical V produces Cyrillic_em (м)
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
+                gtk4::gdk::Key::Cyrillic_em,
+                gtk4::gdk::ModifierType::CONTROL_MASK,
+                false,
+                true,
+                DEFAULT_MODES,
+                Some(gtk4::gdk::Key::v),
+            ),
+            TerminalKeyAction::PasteClipboard
+        );
+    }
+
+    /// Ctrl+Shift+Cyrillic must pass through as a window accelerator when
+    /// the Latin equivalent matches a registered shortcut. Regression for #983.
+    #[test]
+    fn cyrillic_ctrl_shift_t_passes_through_with_latin_key_hint() {
+        // Russian layout: physical T produces Cyrillic_ie (е)
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::Cyrillic_ie,
+                gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
+                false,
+                false,
+                DEFAULT_MODES,
+                Some(gtk4::gdk::Key::t),
+            ),
+            TerminalKeyAction::PassThrough
+        );
+    }
+
+    /// Without a `latin_key` hint, Cyrillic keyvals should still forward to
+    /// PTY in managed mode (no shortcut match). Regression for #983.
+    #[test]
+    fn cyrillic_without_latin_hint_forwards_to_pty() {
+        let action = terminal_key_action(
+            TerminalInputBackend::Managed,
+            gtk4::gdk::Key::Cyrillic_es,
+            gtk4::gdk::ModifierType::CONTROL_MASK,
+            false,
+            true,
+            DEFAULT_MODES,
+            None,
+        );
+        // Without latin hint, Ctrl+с doesn't match 'c' for smart clipboard,
+        // and encode_control_character won't match Cyrillic, so it passes through.
+        assert_eq!(action, TerminalKeyAction::PassThrough);
+    }
+
+    /// Latin keys must still work normally when `latin_key` matches the event key.
+    /// Regression for #983.
+    #[test]
+    fn latin_key_with_matching_hint_unchanged() {
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Direct,
+                gtk4::gdk::Key::c,
+                gtk4::gdk::ModifierType::CONTROL_MASK,
+                true,
+                true,
+                DEFAULT_MODES,
+                Some(gtk4::gdk::Key::c),
+            ),
+            TerminalKeyAction::CopySelection
+        );
+    }
+
+    /// Managed Ctrl+Shift+C with Cyrillic keyval must copy when `latin_key`
+    /// resolves to `c`. Regression for #983.
+    #[test]
+    fn managed_cyrillic_ctrl_shift_c_copies_with_latin_hint() {
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::Cyrillic_ES,
+                gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
+                true,
+                false,
+                DEFAULT_MODES,
+                Some(gtk4::gdk::Key::C),
+            ),
+            TerminalKeyAction::CopySelection
+        );
+    }
+
+    /// Managed Ctrl+Shift+V with Cyrillic keyval must paste when `latin_key`
+    /// resolves to `v`. Regression for #983.
+    #[test]
+    fn managed_cyrillic_ctrl_shift_v_pastes_with_latin_hint() {
+        assert_eq!(
+            terminal_key_action(
+                TerminalInputBackend::Managed,
+                gtk4::gdk::Key::Cyrillic_EM,
+                gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
+                false,
+                false,
+                DEFAULT_MODES,
+                Some(gtk4::gdk::Key::V),
+            ),
+            TerminalKeyAction::PasteClipboard
+        );
     }
 }
 

--- a/clients/rttx/src/terminal/mod.rs
+++ b/clients/rttx/src/terminal/mod.rs
@@ -84,6 +84,29 @@ pub fn encode_terminal_key_input_with_modes_for_test(
     encode_terminal_key_input(key, state, modes)
 }
 
+/// Test-only re-export of `terminal_key_action` with `latin_key` support.
+#[doc(hidden)]
+#[must_use]
+pub fn terminal_key_action_for_test(
+    backend: TerminalInputBackend,
+    key: gtk4::gdk::Key,
+    modifiers: gtk4::gdk::ModifierType,
+    has_selection: bool,
+    smart_clipboard_enabled: bool,
+    modes: TerminalModes,
+    latin_key: Option<gtk4::gdk::Key>,
+) -> TerminalKeyAction {
+    terminal_key_action(
+        backend,
+        key,
+        modifiers,
+        has_selection,
+        smart_clipboard_enabled,
+        modes,
+        latin_key,
+    )
+}
+
 /// Translate a hardware keycode to its Latin-layout keyval using group 0.
 ///
 /// When the active keyboard layout is non-Latin (e.g. Russian), pressing
@@ -124,14 +147,16 @@ pub const fn terminal_cleanup_bytes() -> &'static [u8] {
     b"\x18\x1b[?1l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?1004l\x1b[?2004l\x1b>\x1b[?25h\x1b[m"
 }
 
+#[doc(hidden)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TerminalInputBackend {
+pub enum TerminalInputBackend {
     Direct,
     Managed,
 }
 
+#[doc(hidden)]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum TerminalKeyAction {
+pub enum TerminalKeyAction {
     CopySelection,
     PasteClipboard,
     PassThrough,

--- a/clients/rttx/src/terminal/persistent_widget.rs
+++ b/clients/rttx/src/terminal/persistent_widget.rs
@@ -981,10 +981,11 @@ impl PersistentPaneView {
         let key_controller = gtk4::EventControllerKey::new();
         key_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
         key_controller.set_im_context(Some(&im_context));
-        key_controller.connect_key_pressed(move |_, key, _keycode, state| {
+        key_controller.connect_key_pressed(move |_, key, keycode, state| {
             let Some(pane) = pane_weak.upgrade() else {
                 return glib::Propagation::Proceed;
             };
+            let latin_key = crate::terminal::latin_keyval_from_keycode(keycode);
             match terminal_key_action(
                 TerminalInputBackend::Managed,
                 key,
@@ -992,6 +993,7 @@ impl PersistentPaneView {
                 pane.vte().has_selection(),
                 pane.imp().smart_clipboard.get(),
                 pane.terminal_modes(),
+                latin_key,
             ) {
                 TerminalKeyAction::CopySelection => {
                     crate::terminal::copy_to_clipboard(pane.vte());
@@ -1532,6 +1534,7 @@ mod tests {
                 true,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::CopySelection
         );
@@ -1543,6 +1546,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -1555,6 +1559,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1567,6 +1572,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -1584,6 +1590,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -1597,6 +1604,7 @@ mod tests {
                 true,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::CopySelection
         );
@@ -1612,6 +1620,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1625,6 +1634,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1636,6 +1646,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1647,6 +1658,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -1662,6 +1674,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x03])
         );
@@ -1673,6 +1686,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x16])
         );
@@ -1684,9 +1698,11 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::ForwardToPty(vec![0x04])
         );
+        // Ctrl+Shift+X is the "Repair Terminal" window accelerator.
         assert_eq!(
             terminal_key_action(
                 TerminalInputBackend::Managed,
@@ -1695,8 +1711,9 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
-            TerminalKeyAction::ForwardToPty(vec![0x18])
+            TerminalKeyAction::PassThrough
         );
     }
 

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -165,10 +165,11 @@ mod imp {
             let term_weak = obj.downgrade();
             let smart_clipboard_key_controller = gtk4::EventControllerKey::new();
             smart_clipboard_key_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
-            smart_clipboard_key_controller.connect_key_pressed(move |_, key, _keycode, state| {
+            smart_clipboard_key_controller.connect_key_pressed(move |_, key, keycode, state| {
                 let Some(term) = term_weak.upgrade() else {
                     return glib::Propagation::Proceed;
                 };
+                let latin_key = crate::terminal::latin_keyval_from_keycode(keycode);
                 let vte = term.imp().vte.clone();
                 match terminal_key_action(
                     TerminalInputBackend::Direct,
@@ -177,6 +178,7 @@ mod imp {
                     vte.has_selection(),
                     term.imp().smart_clipboard.get(),
                     crate::terminal::TerminalModes::default(),
+                    latin_key,
                 ) {
                     TerminalKeyAction::CopySelection => {
                         crate::terminal::copy_to_clipboard(&vte);
@@ -807,6 +809,7 @@ mod tests {
                 true,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::CopySelection
         );
@@ -818,6 +821,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -833,6 +837,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -844,6 +849,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -855,6 +861,7 @@ mod tests {
                 false,
                 false,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PassThrough
         );
@@ -872,6 +879,7 @@ mod tests {
                 false,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::PasteClipboard
         );
@@ -885,6 +893,7 @@ mod tests {
                 true,
                 true,
                 DEFAULT_MODES,
+                None,
             ),
             TerminalKeyAction::CopySelection
         );

--- a/clients/rttx/tests/keyboard_layout_shortcuts.rs
+++ b/clients/rttx/tests/keyboard_layout_shortcuts.rs
@@ -1,0 +1,132 @@
+//! Integration tests for keyboard shortcut behavior with non-Latin layouts.
+//!
+//! Verifies that the shortcut normalization logic correctly maps Cyrillic
+//! keyvals to their Latin equivalents for both direct and managed terminals.
+//! Regression coverage for #983.
+
+use rttx::terminal::{
+    TerminalInputBackend, TerminalKeyAction, TerminalModes,
+    terminal_key_action_for_test as terminal_key_action,
+};
+
+const DEFAULT_MODES: TerminalModes =
+    TerminalModes { application_cursor_keys: false, application_keypad: false };
+
+/// Smart copy triggers via Latin hint when Cyrillic keyval is active. #983.
+#[test]
+fn non_latin_ctrl_c_triggers_smart_copy_via_latin_hint() {
+    assert_eq!(
+        terminal_key_action(
+            TerminalInputBackend::Direct,
+            gtk4::gdk::Key::Cyrillic_es,
+            gtk4::gdk::ModifierType::CONTROL_MASK,
+            true,
+            true,
+            DEFAULT_MODES,
+            Some(gtk4::gdk::Key::c),
+        ),
+        TerminalKeyAction::CopySelection,
+    );
+}
+
+/// Smart paste triggers via Latin hint when Cyrillic keyval is active. #983.
+#[test]
+fn non_latin_ctrl_v_triggers_smart_paste_via_latin_hint() {
+    assert_eq!(
+        terminal_key_action(
+            TerminalInputBackend::Direct,
+            gtk4::gdk::Key::Cyrillic_em,
+            gtk4::gdk::ModifierType::CONTROL_MASK,
+            false,
+            true,
+            DEFAULT_MODES,
+            Some(gtk4::gdk::Key::v),
+        ),
+        TerminalKeyAction::PasteClipboard,
+    );
+}
+
+/// Window accelerator pass-through works via Latin hint in managed mode. #983.
+#[test]
+fn non_latin_ctrl_shift_t_passes_through_for_window_accelerator() {
+    assert_eq!(
+        terminal_key_action(
+            TerminalInputBackend::Managed,
+            gtk4::gdk::Key::Cyrillic_IE,
+            gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
+            false,
+            false,
+            DEFAULT_MODES,
+            Some(gtk4::gdk::Key::T),
+        ),
+        TerminalKeyAction::PassThrough,
+    );
+}
+
+/// Managed copy triggers via Latin hint with Cyrillic keyval. #983.
+#[test]
+fn non_latin_managed_ctrl_shift_c_copies_with_selection() {
+    assert_eq!(
+        terminal_key_action(
+            TerminalInputBackend::Managed,
+            gtk4::gdk::Key::Cyrillic_ES,
+            gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
+            true,
+            false,
+            DEFAULT_MODES,
+            Some(gtk4::gdk::Key::C),
+        ),
+        TerminalKeyAction::CopySelection,
+    );
+}
+
+/// Managed paste triggers via Latin hint with Cyrillic keyval. #983.
+#[test]
+fn non_latin_managed_ctrl_shift_v_pastes() {
+    assert_eq!(
+        terminal_key_action(
+            TerminalInputBackend::Managed,
+            gtk4::gdk::Key::Cyrillic_EM,
+            gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
+            false,
+            false,
+            DEFAULT_MODES,
+            Some(gtk4::gdk::Key::V),
+        ),
+        TerminalKeyAction::PasteClipboard,
+    );
+}
+
+/// All window accelerator shortcuts pass through with Latin hint. #983.
+#[test]
+fn all_ctrl_shift_window_shortcuts_pass_through_with_latin_hint() {
+    let ctrl_shift =
+        gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK;
+
+    let mappings: &[(gtk4::gdk::Key, gtk4::gdk::Key)] = &[
+        (gtk4::gdk::Key::Cyrillic_IE, gtk4::gdk::Key::T),
+        (gtk4::gdk::Key::Cyrillic_TSE, gtk4::gdk::Key::W),
+        (gtk4::gdk::Key::Cyrillic_U, gtk4::gdk::Key::E),
+        (gtk4::gdk::Key::Cyrillic_SHCHA, gtk4::gdk::Key::O),
+        (gtk4::gdk::Key::Cyrillic_A, gtk4::gdk::Key::F),
+        (gtk4::gdk::Key::Cyrillic_I, gtk4::gdk::Key::B),
+        (gtk4::gdk::Key::Cyrillic_TE, gtk4::gdk::Key::N),
+    ];
+
+    for (cyrillic, latin) in mappings {
+        let action = terminal_key_action(
+            TerminalInputBackend::Managed,
+            *cyrillic,
+            ctrl_shift,
+            false,
+            false,
+            DEFAULT_MODES,
+            Some(*latin),
+        );
+        assert_eq!(
+            action,
+            TerminalKeyAction::PassThrough,
+            "Ctrl+Shift+{cyrillic:?} with latin_key={latin:?} must PassThrough"
+        );
+    }
+}

--- a/clients/rttx/tests/keyboard_layout_shortcuts.rs
+++ b/clients/rttx/tests/keyboard_layout_shortcuts.rs
@@ -100,8 +100,7 @@ fn non_latin_managed_ctrl_shift_v_pastes() {
 /// All window accelerator shortcuts pass through with Latin hint. #983.
 #[test]
 fn all_ctrl_shift_window_shortcuts_pass_through_with_latin_hint() {
-    let ctrl_shift =
-        gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK;
+    let ctrl_shift = gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK;
 
     let mappings: &[(gtk4::gdk::Key, gtk4::gdk::Key)] = &[
         (gtk4::gdk::Key::Cyrillic_IE, gtk4::gdk::Key::T),

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.0',
+  version: '0.9.1',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## Summary

Fixes #983 — keyboard shortcuts fail on non-English keyboard layouts.

## Root Cause

When the active keyboard layout is non-Latin (e.g. Russian), pressing physical keys produces Cyrillic keyvals instead of Latin ones. The terminal key controllers intercept keys in the GTK Capture phase before GTK's accelerator system can process them. The shortcut matching logic in `terminal_key_action` only checked for Latin key values, so shortcuts like Ctrl+C, Ctrl+Shift+T, etc. failed when a non-English layout was active.

## What Changed

1. **Added `latin_keyval_from_keycode()`** — uses `Display::translate_key(keycode, empty_state, group=0)` to resolve the Latin keyval from the hardware keycode regardless of the active layout.

2. **Added `shortcut_key()` helper** — returns the original key if it's already ASCII alphabetic, otherwise falls back to the Latin keyval hint. This ensures shortcut matching uses the physical key intent.

3. **Updated `terminal_key_action()`** — accepts an optional `latin_key` parameter. Smart clipboard, managed terminal copy/paste, and window accelerator pass-through all use the normalized key for matching while PTY encoding still uses the original keyval.

4. **Updated key controllers** in both `widget.rs` (direct terminals) and `persistent_widget.rs` (managed terminals) to compute and pass the Latin keyval from the hardware keycode.

5. **Added missing shortcuts** (a/A, d/D, r/R, x/X, z/Z) to `should_pass_through_window_accelerator` so managed terminals correctly defer Ctrl+Shift+A/D/R/X/Z to the window accelerator system.

6. **Version bump** to 0.9.1 (user-visible behavior change).

## Tests Added

7 new regression tests in `terminal::tests`:
- `cyrillic_ctrl_c_copies_with_latin_key_hint`
- `cyrillic_ctrl_v_pastes_with_latin_key_hint`
- `cyrillic_ctrl_shift_t_passes_through_with_latin_key_hint`
- `cyrillic_without_latin_hint_forwards_to_pty`
- `latin_key_with_matching_hint_unchanged`
- `managed_cyrillic_ctrl_shift_c_copies_with_latin_hint`
- `managed_cyrillic_ctrl_shift_v_pastes_with_latin_hint`

Updated 1 existing test that was asserting incorrect behavior (Ctrl+Shift+X forwarding to PTY instead of passing through as the Repair Terminal accelerator).

## Tests Run

- `cargo test -p rttx --no-default-features --features vte-0_76` — 809 passed, 0 failed
- `cargo test -p rttx-proto -p rttx-server` — all passed
- `bash .github/scripts/run-clippy.sh` — clean
- `bash .github/scripts/run-quality-tests.sh` — all passed

## Manual Verification

The fix uses `Display::translate_key` with group 0 which is the standard GTK4 approach for layout-independent shortcut matching (same technique used by GNOME Terminal and Ptyxis). The unit tests simulate the exact scenario by passing Cyrillic keyvals with Latin key hints.

## Limitations

- The `latin_keyval_from_keycode` function requires a GDK Display, so it returns `None` in headless test environments. Unit tests pass the Latin key directly as a parameter to verify the logic.
- The fix assumes group 0 is the Latin layout, which is the standard convention on Linux systems with multiple keyboard layouts.