### PR TITLE
feat: remote daemon CWD tracking via /proc polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.1',
+  version: '0.9.2',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -478,6 +478,50 @@ mod tests {
     }
 
     #[test]
+    fn read_proc_cwd_returns_none_without_pid() {
+        let pane = Pane::new(Uuid::new_v4(), 80, 24);
+        assert!(pane.read_proc_cwd().is_none());
+    }
+
+    #[test]
+    fn read_proc_cwd_reads_current_process_cwd() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.child_pid = Some(std::process::id());
+        let cwd = pane.read_proc_cwd();
+        assert!(cwd.is_some(), "/proc/self/cwd should be readable");
+    }
+
+    #[test]
+    fn proc_cwd_poll_updates_pane_cwd_when_different() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.child_pid = Some(std::process::id());
+        assert!(pane.cwd.is_none());
+
+        // Simulate the poll: read_proc_cwd detects a new value.
+        let proc_cwd = pane.read_proc_cwd();
+        assert!(proc_cwd.is_some());
+        if let Some(ref new_cwd) = proc_cwd
+            && pane.cwd.as_deref() != Some(new_cwd.as_str())
+        {
+            pane.cwd = Some(new_cwd.clone());
+        }
+        assert!(pane.cwd.is_some());
+    }
+
+    #[test]
+    fn proc_cwd_poll_no_update_when_same() {
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        pane.child_pid = Some(std::process::id());
+        let current = pane.read_proc_cwd().unwrap();
+        pane.cwd = Some(current.clone());
+
+        // When proc CWD matches stored CWD, no update needed.
+        let proc_cwd = pane.read_proc_cwd();
+        assert_eq!(proc_cwd.as_deref(), Some(current.as_str()));
+        assert_eq!(pane.cwd.as_deref(), proc_cwd.as_deref());
+    }
+
+    #[test]
     fn effective_cwd_returns_none_without_pid_or_osc7() {
         let pane = Pane::new(Uuid::new_v4(), 80, 24);
         assert!(pane.effective_cwd().is_none());

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -2658,8 +2658,10 @@ pub async fn serialization_loop(
                 let mut s = crate::instrument::lock_server(&server, &metrics).await;
                 for (runtime_id, pane_id, cwd, revision, client_ids) in &cwd_changes {
                     let msg = ClientMsg::V2(protocol::cwd_changed(
-                        *runtime_id, *pane_id,
-                        cwd.clone(), *revision,
+                        *runtime_id,
+                        *pane_id,
+                        cwd.clone(),
+                        *revision,
                     ));
                     s.broadcast_to_clients(client_ids.iter().copied(), None, &msg);
                 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -2266,6 +2266,9 @@ const COALESCE_WINDOW: Duration = Duration::from_millis(1);
 /// Warn when the server mutex is held longer than this in the PTY read loop.
 pub const MUTEX_HOLD_WARN_THRESHOLD: Duration = Duration::from_millis(10);
 
+/// How often (in serialization ticks) to poll /proc/<pid>/cwd for CWD changes.
+const CWD_POLL_INTERVAL_TICKS: u64 = 5;
+
 /// How long a PTY read loop yields after detecting mutex contention.
 ///
 /// When the Phase 1 lock hold exceeds [`MUTEX_HOLD_WARN_THRESHOLD`], the
@@ -2614,6 +2617,53 @@ pub async fn serialization_loop(
         if diagnostics_counter.is_multiple_of(30) {
             let s = crate::instrument::lock_server(&server, &metrics).await;
             s.log_diagnostics();
+        }
+
+        // CWD polling via /proc/<pid>/cwd every 5 ticks (~5s).
+        // Detects CWD changes when OSC 7 is not emitted by the shell.
+        if diagnostics_counter.is_multiple_of(CWD_POLL_INTERVAL_TICKS) {
+            let mut cwd_changes: Vec<(Uuid, Uuid, String, u64, Vec<Uuid>)> = Vec::new();
+            for (runtime_id, rt_lock) in &runtime_entries {
+                let mut rt = crate::instrument::lock_runtime(rt_lock, &metrics).await;
+                let client_ids: Vec<Uuid> = rt.attached_clients.keys().copied().collect();
+                if client_ids.is_empty() {
+                    continue;
+                }
+                let pane_ids: Vec<Uuid> = rt.panes.keys().copied().collect();
+                for pane_id in pane_ids {
+                    let Some(pane) = rt.panes.get(&pane_id) else { continue };
+                    if pane.is_exited() || pane.child_pid.is_none() {
+                        continue;
+                    }
+                    let proc_cwd = pane.read_proc_cwd();
+                    if let Some(ref new_cwd) = proc_cwd
+                        && pane.cwd.as_deref() != Some(new_cwd.as_str())
+                    {
+                        let cwd_val = new_cwd.clone();
+                        let Some(pane) = rt.panes.get_mut(&pane_id) else { continue };
+                        pane.cwd = Some(cwd_val.clone());
+                        if let Some(rev) = rt.set_pane_cwd(pane_id, &cwd_val) {
+                            cwd_changes.push((
+                                *runtime_id,
+                                pane_id,
+                                cwd_val,
+                                rev,
+                                client_ids.clone(),
+                            ));
+                        }
+                    }
+                }
+            }
+            if !cwd_changes.is_empty() {
+                let mut s = crate::instrument::lock_server(&server, &metrics).await;
+                for (runtime_id, pane_id, cwd, revision, client_ids) in &cwd_changes {
+                    let msg = ClientMsg::V2(protocol::cwd_changed(
+                        *runtime_id, *pane_id,
+                        cwd.clone(), *revision,
+                    ));
+                    s.broadcast_to_clients(client_ids.iter().copied(), None, &msg);
+                }
+            }
         }
 
         // Collect v2 runtime files only for dirty persistent runtimes.

--- a/services/rttx-server/tests/cwd_proc_polling.rs
+++ b/services/rttx-server/tests/cwd_proc_polling.rs
@@ -83,8 +83,5 @@ async fn proc_cwd_poll_detects_cd_without_osc7() {
         }
     }
 
-    assert!(
-        found,
-        "expected CwdChanged with path {target} from /proc poll within 12 seconds"
-    );
+    assert!(found, "expected CwdChanged with path {target} from /proc poll within 12 seconds");
 }

--- a/services/rttx-server/tests/cwd_proc_polling.rs
+++ b/services/rttx-server/tests/cwd_proc_polling.rs
@@ -1,0 +1,90 @@
+//! Integration test: CWD polling via /proc/<pid>/cwd detects changes
+//! even when OSC 7 is not emitted by the shell.
+
+mod common;
+
+use common::{TestClient, send_input, start_test_server};
+use rttx_proto::proto;
+use std::time::Duration;
+
+/// Helper: create runtime, pane, attach, return IDs.
+async fn setup_attached_pane(client: &mut TestClient) -> (Vec<u8>, Vec<u8>) {
+    client.handshake().await;
+
+    let create = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreateRuntime(proto::CreateRuntime {
+            name: "proc-poll-test".into(),
+            policy: proto::RuntimePolicy::Persistent as i32,
+        })),
+    };
+    client.send(&create).await;
+    let runtime_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::RuntimeCreated(sc)) => sc.runtime_id,
+        other => panic!("expected RuntimeCreated, got {other:?}"),
+    };
+
+    let create_pane = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+            runtime_id: runtime_id.clone(),
+            cwd: None,
+            dark_background: None,
+            cols: 0,
+            rows: 0,
+            no_persist: None,
+        })),
+    };
+    client.send(&create_pane).await;
+    let pane_id = match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::PaneCreated(pc)) => pc.pane_id,
+        other => panic!("expected PaneCreated, got {other:?}"),
+    };
+
+    let attach = proto::ClientMessage {
+        msg: Some(proto::client_message::Msg::AttachRuntime(proto::AttachRuntime {
+            runtime_id: runtime_id.clone(),
+            attach_mode: proto::RuntimeAttachMode::ReadWrite as i32,
+        })),
+    };
+    client.send(&attach).await;
+    match client.recv_or_timeout().await.msg {
+        Some(proto::server_message::Msg::Snapshot(_)) => {}
+        other => panic!("expected Snapshot, got {other:?}"),
+    }
+
+    (runtime_id, pane_id)
+}
+
+/// When OSC 7 is never emitted, the serialization loop's /proc poll
+/// should detect the CWD change and broadcast `CwdChanged`.
+#[tokio::test]
+async fn proc_cwd_poll_detects_cd_without_osc7() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&sock).await;
+    let (runtime_id, pane_id) = setup_attached_pane(&mut client).await;
+
+    // Use `cd` followed by `cat` to hold open the pane without running
+    // PROMPT_COMMAND (which would emit OSC 7 if configured). The shell
+    // itself changes CWD, so /proc/<pid>/cwd reflects it.
+    let target = "/tmp";
+    let cmd = format!("cd {target} && exec cat\n");
+    send_input(&mut client, &runtime_id, &pane_id, cmd.as_bytes()).await;
+
+    // Wait for the 5-second CWD poll interval to fire.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(12);
+    let mut found = false;
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(500)).await
+            && let Some(proto::server_message::Msg::CwdChanged(c)) = &msg.msg
+            && c.cwd == target
+        {
+            found = true;
+            break;
+        }
+    }
+
+    assert!(
+        found,
+        "expected CwdChanged with path {target} from /proc poll within 12 seconds"
+    );
+}


### PR DESCRIPTION
## What changed and why

Adds periodic `/proc/<pid>/cwd` polling as a fallback CWD detection mechanism for panes where OSC 7 is not emitted.

**Root cause:** Remote shells (or shells without `/etc/profile.d/vte-2.91.sh` sourced) never emit OSC 7, leaving the daemon unaware of CWD changes after pane creation.

**Fix:** The serialization loop (which already runs every 1 second) now polls `/proc/<pid>/cwd` every 5 ticks (5 seconds) for each live pane. When the polled value differs from the stored CWD, it updates the pane state and broadcasts `CwdChanged` to all attached clients.

This ensures:
- GUI shows the correct working directory for all panes
- New splits inherit the actual CWD (not creation-time folder)
- Session recovery restores to the correct directory
- Works without requiring any shell configuration on the remote host

## How to manually verify

1. Start rttx-server in foreground
2. Connect a client, create a workspace
3. `cd /tmp` in the pane without any OSC 7 integration
4. Within ~5 seconds, observe the CWD update in the GUI sidebar/title

## Tests added

**Unit tests (pane.rs):**
- `read_proc_cwd_returns_none_without_pid`
- `read_proc_cwd_reads_current_process_cwd`
- `proc_cwd_poll_updates_pane_cwd_when_different`
- `proc_cwd_poll_no_update_when_same`

**Integration test:**
- `proc_cwd_poll_detects_cd_without_osc7` — creates a pane, runs `cd /tmp && exec cat` (no OSC 7 emission), and verifies `CwdChanged` arrives within 12 seconds

## Tests run

- `cargo build --workspace` ✓
- `cargo test -p rttx-server --lib` — 521 passed ✓
- `cargo test -p rttx-server --tests` — all passed ✓
- `bash .github/scripts/run-clippy.sh` ✓
- `bash .github/scripts/run-quality-tests.sh` ✓

## Limitations

- `/proc/<pid>/cwd` only works on Linux (the daemon's target platform)
- For remote daemons accessed via SSH, the daemon runs on the remote host where `/proc` is available
- The 5-second poll interval means CWD updates may lag up to 5 seconds vs. instant with OSC 7

Fixes #986