### PR TITLE
fix(server): set PROMPT_COMMAND=history -a for crash-safe shell history

### DIFF
--- a/services/rttx-server/src/pty.rs
+++ b/services/rttx-server/src/pty.rs
@@ -198,6 +198,27 @@ mod tests {
     }
 
     #[test]
+    fn spawned_pty_child_inherits_custom_env_vars() {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        rt.block_on(async {
+            let config = PtyConfig {
+                command: vec!["/bin/sh".into(), "-c".into(), "sleep 60".into()],
+                env: vec![("PROMPT_COMMAND".into(), "history -a".into())],
+                ..PtyConfig::default()
+            };
+            let mut pty = Pty::spawn(Uuid::new_v4(), &config).expect("spawn must succeed");
+            let pid = pty.pid().expect("child must be running");
+            let environ = std::fs::read_to_string(format!("/proc/{pid}/environ"))
+                .expect("read /proc environ");
+            assert!(
+                environ.contains("PROMPT_COMMAND=history -a"),
+                "PTY child must have PROMPT_COMMAND=history -a in its environment"
+            );
+            pty.kill().expect("kill must succeed");
+        });
+    }
+
+    #[test]
     fn none_cwd_resolves_to_home_directory() {
         let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
         rt.block_on(async {

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -477,6 +477,7 @@ impl Server {
                         let _ = std::fs::create_dir_all(parent);
                     }
                     env.push(("HISTFILE".into(), hist.to_string_lossy().into_owned()));
+                    env.push(("PROMPT_COMMAND".into(), "history -a".into()));
                 }
                 env.push(("COLORFGBG".into(), "15;0".into()));
                 let config = PaneSpawnConfig { command: vec![], cwd, env, cols, rows };
@@ -987,6 +988,7 @@ impl Server {
                             let _ = std::fs::create_dir_all(parent);
                         }
                         env.push(("HISTFILE".into(), hist.to_string_lossy().into_owned()));
+                        env.push(("PROMPT_COMMAND".into(), "history -a".into()));
                     }
                     let colorfgbg =
                         if req.dark_background.unwrap_or(true) { "15;0" } else { "0;15" };
@@ -1967,6 +1969,7 @@ impl Server {
                     let _ = std::fs::create_dir_all(parent);
                 }
                 env.push(("HISTFILE".into(), hist.to_string_lossy().into_owned()));
+                env.push(("PROMPT_COMMAND".into(), "history -a".into()));
             }
             let colorfgbg = if req.dark_background.unwrap_or(true) { "15;0" } else { "0;15" };
             env.push(("COLORFGBG".into(), colorfgbg.into()));

--- a/services/rttx-server/tests/history_crash_survival.rs
+++ b/services/rttx-server/tests/history_crash_survival.rs
@@ -140,23 +140,11 @@ async fn history_survives_hard_restart() {
         // The shell inherits PROMPT_COMMAND="history -a" but user rc files
         // may overwrite it. Ensure history -a is active for this test by
         // explicitly setting PROMPT_COMMAND in the shell.
-        send_input(
-            &mut client,
-            &runtime_id,
-            &pane_id,
-            b"PROMPT_COMMAND='history -a'\n",
-        )
-        .await;
+        send_input(&mut client, &runtime_id, &pane_id, b"PROMPT_COMMAND='history -a'\n").await;
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         // Run a unique command so it gets written to history.
-        send_input(
-            &mut client,
-            &runtime_id,
-            &pane_id,
-            b"echo UNIQUE_MARKER_12345\n",
-        )
-        .await;
+        send_input(&mut client, &runtime_id, &pane_id, b"echo UNIQUE_MARKER_12345\n").await;
 
         // Wait for output to confirm command executed.
         let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
@@ -184,8 +172,7 @@ async fn history_survives_hard_restart() {
     let state_dir = tmp.path().join("state/rttx/daemon");
     let pane_uuid = rttx_proto::bytes_to_uuid(&pane_id).unwrap();
     let runtime_uuid = rttx_proto::bytes_to_uuid(&runtime_id).unwrap();
-    let hist_path =
-        rttx_server::state::layout::history_file(&state_dir, runtime_uuid, pane_uuid);
+    let hist_path = rttx_server::state::layout::history_file(&state_dir, runtime_uuid, pane_uuid);
 
     let hist_content = std::fs::read_to_string(&hist_path).unwrap_or_default();
     assert!(

--- a/services/rttx-server/tests/history_crash_survival.rs
+++ b/services/rttx-server/tests/history_crash_survival.rs
@@ -1,0 +1,196 @@
+//! Integration tests for shell history crash survival.
+//!
+//! Verifies that spawned panes have `PROMPT_COMMAND` set to flush history
+//! after every command, so history survives hard crashes.
+
+mod common;
+
+use common::*;
+use rttx_proto::proto;
+use std::time::Duration;
+
+/// Persistent panes must have `history -a` in the `PROMPT_COMMAND` env var
+/// passed to the shell process at spawn time.
+#[tokio::test]
+async fn persistent_pane_spawns_with_history_flush_env() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let runtime_id =
+        create_runtime(&mut client, "history-flush", proto::RuntimePolicy::Persistent).await;
+    let pane_id = create_pane(&mut client, &runtime_id).await;
+    attach_rw(&mut client, &runtime_id).await;
+
+    // Use /proc to read the initial environment passed to the shell process.
+    // This is more reliable than echoing $PROMPT_COMMAND because rc files may
+    // modify it after shell startup.
+    send_input(
+        &mut client,
+        &runtime_id,
+        &pane_id,
+        b"cat /proc/$$/environ | tr '\\0' '\\n' | grep --color=never PROMPT_COMMAND\n",
+    )
+    .await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut output = Vec::new();
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(d)) = msg.msg
+        {
+            output.extend_from_slice(&d.data);
+            let text = String::from_utf8_lossy(&output);
+            if text.contains("PROMPT_COMMAND=") && text.contains("history") {
+                break;
+            }
+        }
+    }
+
+    let text = String::from_utf8_lossy(&output);
+    assert!(
+        text.contains("PROMPT_COMMAND=") && text.contains("history -a"),
+        "spawn env must contain PROMPT_COMMAND with 'history -a', got: {text}"
+    );
+}
+
+/// Ephemeral (no-persist) panes must NOT get history -a since their
+/// HISTFILE is /dev/null — flushing to /dev/null is pointless overhead.
+#[tokio::test]
+async fn ephemeral_pane_skips_history_flush_env() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let runtime_id =
+        create_runtime(&mut client, "ephemeral-hist", proto::RuntimePolicy::Persistent).await;
+
+    // Create pane with no_persist=true.
+    client
+        .send(&proto::ClientMessage {
+            msg: Some(proto::client_message::Msg::CreatePane(proto::CreatePane {
+                runtime_id: runtime_id.clone(),
+                cwd: None,
+                dark_background: None,
+                cols: 80,
+                rows: 24,
+                no_persist: Some(true),
+            })),
+        })
+        .await;
+    let pane_id = loop {
+        match client.recv_or_timeout().await.msg {
+            Some(proto::server_message::Msg::PaneCreated(pc)) => break pc.pane_id,
+            Some(proto::server_message::Msg::Delta(_)) => {}
+            other => panic!("expected PaneCreated, got {other:?}"),
+        }
+    };
+    attach_rw(&mut client, &runtime_id).await;
+
+    // Read PROMPT_COMMAND from /proc environ.
+    send_input(
+        &mut client,
+        &runtime_id,
+        &pane_id,
+        b"cat /proc/$$/environ | tr '\\0' '\\n' | grep --color=never PROMPT_COMMAND || echo NO_PROMPT_CMD\n",
+    )
+    .await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut output = Vec::new();
+    while tokio::time::Instant::now() < deadline {
+        if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+            && let Some(proto::server_message::Msg::Delta(d)) = msg.msg
+        {
+            output.extend_from_slice(&d.data);
+            let text = String::from_utf8_lossy(&output);
+            if text.contains("NO_PROMPT_CMD") || text.contains("PROMPT_COMMAND") {
+                break;
+            }
+        }
+    }
+
+    let text = String::from_utf8_lossy(&output);
+    assert!(
+        !text.contains("history -a"),
+        "ephemeral pane env must NOT contain 'history -a', got: {text}"
+    );
+}
+
+/// After a hard crash (server kill + restart), shell history from a
+/// persistent pane must survive because `history -a` flushed it to disk.
+#[tokio::test]
+async fn history_survives_hard_restart() {
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    let runtime_id;
+    let pane_id;
+    {
+        let (sock, handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&sock).await;
+        client.handshake().await;
+
+        runtime_id =
+            create_runtime(&mut client, "crash-hist", proto::RuntimePolicy::Persistent).await;
+        pane_id = create_pane(&mut client, &runtime_id).await;
+        attach_rw(&mut client, &runtime_id).await;
+
+        // The shell inherits PROMPT_COMMAND="history -a" but user rc files
+        // may overwrite it. Ensure history -a is active for this test by
+        // explicitly setting PROMPT_COMMAND in the shell.
+        send_input(
+            &mut client,
+            &runtime_id,
+            &pane_id,
+            b"PROMPT_COMMAND='history -a'\n",
+        )
+        .await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Run a unique command so it gets written to history.
+        send_input(
+            &mut client,
+            &runtime_id,
+            &pane_id,
+            b"echo UNIQUE_MARKER_12345\n",
+        )
+        .await;
+
+        // Wait for output to confirm command executed.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline {
+            if let Some(msg) = client.try_recv(Duration::from_millis(200)).await
+                && let Some(proto::server_message::Msg::Delta(d)) = msg.msg
+            {
+                let text = String::from_utf8_lossy(&d.data);
+                if text.contains("UNIQUE_MARKER_12345") {
+                    break;
+                }
+            }
+        }
+
+        // Trigger the next prompt so PROMPT_COMMAND runs history -a.
+        send_input(&mut client, &runtime_id, &pane_id, b"true\n").await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Simulate hard crash: abort the handle.
+        handle.abort();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Verify the HISTFILE on disk contains the command.
+    let state_dir = tmp.path().join("state/rttx/daemon");
+    let pane_uuid = rttx_proto::bytes_to_uuid(&pane_id).unwrap();
+    let runtime_uuid = rttx_proto::bytes_to_uuid(&runtime_id).unwrap();
+    let hist_path =
+        rttx_server::state::layout::history_file(&state_dir, runtime_uuid, pane_uuid);
+
+    let hist_content = std::fs::read_to_string(&hist_path).unwrap_or_default();
+    assert!(
+        hist_content.contains("UNIQUE_MARKER_12345"),
+        "history file must contain the command after crash, path={}, content={hist_content}",
+        hist_path.display()
+    );
+}


### PR DESCRIPTION
## What changed and why

Spawned persistent panes now inherit `PROMPT_COMMAND="history -a"` in their environment. This causes bash to flush each executed command to the per-pane HISTFILE immediately after every prompt, ensuring shell history survives:

- Daemon hard crash (SIGKILL)
- Host power loss / reboot
- GUI crash
- Clean restart

At most the command currently being executed at crash time is lost.

Ephemeral panes (`no_persist=true`, HISTFILE=/dev/null) skip the env var since flushing to /dev/null is pointless overhead.

The fix is applied at all three pane spawn points: reconstruction after restart, V2 CreatePane, and V3 CreatePane.

## How it works

The `PROMPT_COMMAND` env var is set to `"history -a"` before the shell starts. Standard shell initialization scripts (like `/etc/profile.d/vte-2.91.sh`) typically append to existing `PROMPT_COMMAND` rather than overwrite it, preserving our history flush alongside their own functionality.

## Manual verification

1. Start rttx with a daemon: `RTTX_DEV_MODE=1 cargo run -p rttx`
2. Open a workspace and run several commands
3. Kill the daemon: `kill -9 $(pgrep rttx-server)`
4. Restart rttx — the new pane should retain history via arrow-up
5. Verify with: `cat /proc/$$/environ | tr '\0' '\n' | grep PROMPT_COMMAND`

## Tests added

- **Unit test**: `pty::tests::spawned_pty_child_inherits_custom_env_vars` — verifies env vars (including PROMPT_COMMAND) are passed through to spawned PTY children
- **Integration test**: `persistent_pane_spawns_with_history_flush_env` — verifies persistent panes receive PROMPT_COMMAND=history -a in their spawn environment
- **Integration test**: `ephemeral_pane_skips_history_flush_env` — verifies ephemeral panes do NOT get history -a
- **Integration test**: `history_survives_hard_restart` — end-to-end test that commands are flushed to disk and survive server abort

## Tests run

- `cargo build -p rttx-server -p rttx-proto` ✅
- `cargo build -p rttx --no-default-features --features vte-0_76` ✅
- `cargo test -p rttx-server --lib` — 522 passed ✅
- `cargo test -p rttx-server --tests` — all passed ✅
- `cargo test -p rttx-proto` — 9 passed ✅
- `bash .github/scripts/run-clippy.sh` ✅
- `bash .github/scripts/run-quality-tests.sh` — 809 passed, 0 failed ✅

## Limitations

If a user's `.bashrc` completely overwrites `PROMPT_COMMAND` (rather than appending to it), the `history -a` seed value will be lost. This affects users with custom prompts that don't follow the standard append pattern. Most shell environments (VTE integration, starship, etc.) preserve existing PROMPT_COMMAND values.

Fixes #987