### PR TITLE
chore: cap test concurrency to 5 threads per binary

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+# Cap the number of tests that run concurrently within a single test binary.
+#
+# The rttx-server integration tests each spawn a real daemon subprocess. With
+# the default (one thread per CPU), a single binary can launch dozens of
+# daemons at once and exhaust local machine resources. Capping to 5 keeps the
+# concurrent daemon count bounded while still allowing useful parallelism.
+[env]
+RUST_TEST_THREADS = "5"


### PR DESCRIPTION
## Summary

Caps the libtest thread count to 5 via `.cargo/config.toml` (`[env] RUST_TEST_THREADS = "5"`).

## Why

The `rttx-server` integration tests each spawn a real daemon subprocess. At the default (one test thread per CPU), a single test binary can launch dozens of daemons concurrently and exhaust local machine resources — this crashed a full local `cargo test` run. Capping concurrent tests to 5 bounds the number of simultaneous daemons while keeping useful parallelism.

Applies to both local and CI runs. `--test-threads N` on the command line still overrides it when needed.

## Testing
- Verified `RUST_TEST_THREADS=5` reaches the spawned test binary (throwaway env-assertion test, since removed).
- `cargo build` / targeted tests unaffected.