### PR TITLE
fix(tests): enforce test isolation by clearing RTTX_DEV_MODE and killing child processes

### DIFF
--- a/services/rttx-server/tests/clean_runtimes.rs
+++ b/services/rttx-server/tests/clean_runtimes.rs
@@ -109,6 +109,7 @@ fn clean_reports_not_running_without_daemon() {
     let output = std::process::Command::new(bin)
         .arg("clean")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .output()
         .expect("failed to run clean");
 

--- a/services/rttx-server/tests/kill_command.rs
+++ b/services/rttx-server/tests/kill_command.rs
@@ -59,9 +59,14 @@ async fn kill_nonexistent_runtime_returns_error() {
 #[test]
 fn kill_invalid_uuid_exits_with_error() {
     let bin = env!("CARGO_BIN_EXE_rttx-server");
+    let tmp = tempfile::TempDir::new().unwrap();
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
 
     let output = std::process::Command::new(bin)
         .args(["kill", "not-a-uuid"])
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .output()
         .expect("failed to run kill");
 
@@ -84,6 +89,7 @@ fn kill_reports_not_running_without_daemon() {
     let output = std::process::Command::new(bin)
         .args(["kill", "d7d04564-b2bf-4302-9495-e65c4df12ac6"])
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .output()
         .expect("failed to run kill");
 

--- a/services/rttx-server/tests/managed_input_parity.rs
+++ b/services/rttx-server/tests/managed_input_parity.rs
@@ -45,6 +45,7 @@ async fn start_binary_server(tmp: &tempfile::TempDir) -> (PathBuf, Child) {
         .arg("start")
         .arg("--foreground")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .env("XDG_CACHE_HOME", &cache_dir)
         .env("XDG_CONFIG_HOME", &config_dir)
         .env("XDG_STATE_HOME", tmp.path())

--- a/services/rttx-server/tests/shell_editing.rs
+++ b/services/rttx-server/tests/shell_editing.rs
@@ -43,6 +43,7 @@ async fn start_binary_server(tmp: &tempfile::TempDir) -> (PathBuf, Child) {
         .arg("start")
         .arg("--foreground")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .env("XDG_CACHE_HOME", &cache_dir)
         .env("XDG_CONFIG_HOME", &config_dir)
         .env("XDG_STATE_HOME", tmp.path())

--- a/services/rttx-server/tests/sighup_shutdown.rs
+++ b/services/rttx-server/tests/sighup_shutdown.rs
@@ -20,11 +20,13 @@ async fn sighup_triggers_graceful_shutdown() {
         .arg("start")
         .arg("--foreground")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .env("XDG_CACHE_HOME", &cache_dir)
         .env("XDG_STATE_HOME", &state_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
+        .kill_on_drop(true)
         .spawn()
         .expect("spawn daemon");
 

--- a/services/rttx-server/tests/stdio_failures.rs
+++ b/services/rttx-server/tests/stdio_failures.rs
@@ -22,11 +22,13 @@ async fn spawn_daemon(tmp: &TempDir) -> Child {
         .arg("start")
         .arg("--foreground")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .env("XDG_CACHE_HOME", &cache_dir)
         .env("XDG_STATE_HOME", tmp.path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
+        .kill_on_drop(true)
         .spawn()
         .expect("failed to spawn daemon");
 
@@ -49,11 +51,13 @@ fn spawn_stdio(tmp: &TempDir) -> Child {
     Command::new(bin)
         .arg("attach-stdio")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .env("XDG_CACHE_HOME", &cache_dir)
         .env("XDG_STATE_HOME", tmp.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
+        .kill_on_drop(true)
         .spawn()
         .expect("failed to spawn rttx-server attach-stdio")
 }

--- a/services/rttx-server/tests/stdio_transport.rs
+++ b/services/rttx-server/tests/stdio_transport.rs
@@ -21,11 +21,13 @@ async fn start_daemon(
         .arg("start")
         .arg("--foreground")
         .env("XDG_RUNTIME_DIR", runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .env("XDG_CACHE_HOME", cache_dir)
         .env("XDG_STATE_HOME", state_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
+        .kill_on_drop(true)
         .spawn()
         .expect("failed to spawn daemon");
 
@@ -73,11 +75,13 @@ async fn attach_stdio_hello_and_create_runtime() {
     let mut child = Command::new(bin)
         .arg("attach-stdio")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .env("XDG_CACHE_HOME", &cache_dir)
         .env("XDG_STATE_HOME", &state_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
+        .kill_on_drop(true)
         .spawn()
         .expect("failed to spawn attach-stdio");
 
@@ -178,6 +182,7 @@ fn attach_stdio_requires_running_daemon() {
     let output = std::process::Command::new(bin)
         .arg("attach-stdio")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .env("XDG_CACHE_HOME", &cache_dir)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -204,6 +209,7 @@ fn status_command_shows_not_running_when_no_daemon() {
     let output = std::process::Command::new(bin)
         .arg("status")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .output()
         .expect("failed to run status");
 

--- a/services/rttx-server/tests/tui_parity.rs
+++ b/services/rttx-server/tests/tui_parity.rs
@@ -118,6 +118,7 @@ async fn start_exerciser_server(tmp: &tempfile::TempDir) -> (PathBuf, Child) {
         .arg("start")
         .arg("--foreground")
         .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .env("RTTX_DEV_MODE", "")
         .env("XDG_CACHE_HOME", &cache_dir)
         .env("XDG_CONFIG_HOME", &config_dir)
         .env("XDG_STATE_HOME", tmp.path())


### PR DESCRIPTION
This PR fixes a critical test isolation issue where the tests spawned the local daemon inheriting `RTTX_DEV_MODE=1` from the environment. This caused tests to timeout waiting for the production socket to appear, resulting in panic. Because the daemons were spawned without `.kill_on_drop(true)`, the failing tests resulted in dozens of leaked orphaned daemons, exhausting system resources (PTYs/file descriptors) and crashing the production console.

Fixed by:
1. Enforcing `.env("RTTX_DEV_MODE", "")` in test binary spawns.
2. Appending `.kill_on_drop(true)` to all `tokio::process::Command::new` calls in tests.
3. Ensuring isolated `XDG_RUNTIME_DIR` across all tests.