### PR TITLE
[rttx-server] WorkspaceFileV2 persistence + clean-break load (RFC-031 Step 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Server-authoritative pane tree: the daemon now owns an immutable `PaneId` and
   a `WorkspaceTree` (leaves + splits with logical ratios + default-active pane)
   as the single source of truth for workspace structure (RFC-031 Step 1).
+- Durable workspace persistence (`WorkspaceFileV2`): the daemon now persists the
+  authoritative pane tree — structure, logical split ratios, and default-active
+  pane — so layout survives daemon restarts (RFC-031 Step 2).
+
+### Changed
+
+- Daemon state schema bumped to version 2. This is a clean break: old-schema
+  (v1) runtime state is detected, ignored, and removed on first load with no
+  migration path. The obsolete `command_history` field is gone.
 
 ## [0.9.0] - 2026-05-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.5"
+version = "0.9.6"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.5',
+  version: '0.9.6',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/src/runtime.rs
+++ b/services/rttx-server/src/runtime.rs
@@ -471,12 +471,12 @@ impl Runtime {
         !self.attached_clients.is_empty()
     }
 
-    /// Build a v2 `RuntimeFileV1` for per-runtime persistence.
+    /// Build a [`WorkspaceFileV2`] for per-workspace persistence (RFC-031 §6).
     #[must_use]
-    pub fn to_runtime_file(&self) -> crate::state::types::RuntimeFileV1 {
+    pub fn to_runtime_file(&self) -> crate::state::types::WorkspaceFileV2 {
         use crate::state::types::{
-            PaneSpecV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1, RuntimeInstanceV1,
-            RuntimeSpecV1,
+            PaneSpecV2, RUNTIME_FILE_SCHEMA_VERSION, RuntimeInstanceV1, WorkspaceFileV2,
+            WorkspaceSpecV2,
         };
 
         let panes = self
@@ -484,8 +484,8 @@ impl Runtime {
             .values()
             .map(|p| {
                 let cwd = p.cwd.clone().or_else(|| p.read_proc_cwd());
-                PaneSpecV1 {
-                    id: p.id,
+                PaneSpecV2 {
+                    id: PaneId::from_uuid(p.id),
                     cwd,
                     title: p.title.clone(),
                     exit_status: p.exit_status,
@@ -496,16 +496,15 @@ impl Runtime {
             })
             .collect();
 
-        RuntimeFileV1 {
+        WorkspaceFileV2 {
             schema_version: RUNTIME_FILE_SCHEMA_VERSION,
-            spec: RuntimeSpecV1 {
+            spec: WorkspaceSpecV2 {
                 id: self.id,
                 name: self.name.clone(),
                 policy: self.policy,
                 created_at: self.created_at,
+                tree: self.tree.clone(),
                 panes,
-                active_pane_id: self.active_pane_id,
-                command_history: vec![],
             },
             instance: RuntimeInstanceV1 {
                 revision: self.revision,
@@ -515,47 +514,35 @@ impl Runtime {
         }
     }
 
-    /// Resurrect a runtime from a v2 `RuntimeFileV1`.
+    /// Resurrect a runtime from a [`WorkspaceFileV2`].
+    ///
+    /// The durable tree is restored verbatim; live focus follows the tree's
+    /// persisted default-active pane.
     #[must_use]
-    pub fn from_runtime_file(rf: &crate::state::types::RuntimeFileV1) -> Self {
+    pub fn from_runtime_file(rf: &crate::state::types::WorkspaceFileV2) -> Self {
         let panes: HashMap<Uuid, Pane> = rf
             .spec
             .panes
             .iter()
             .map(|ps| {
-                let mut pane = Pane::new(ps.id, ps.cols, ps.rows);
+                let id = ps.id.uuid();
+                let mut pane = Pane::new(id, ps.cols, ps.rows);
                 pane.cwd.clone_from(&ps.cwd);
                 pane.title.clone_from(&ps.title);
                 pane.exit_status = ps.exit_status;
                 pane.reconstructed = true;
                 pane.no_persist = ps.no_persist;
-                (ps.id, pane)
+                (id, pane)
             })
             .collect();
 
-        // The flat v1 schema carries no structure; synthesize a valid tree from
-        // the persisted pane order. Durable structure arrives with the v2 file
-        // schema (RFC-031 Step 2).
-        let mut tree = WorkspaceTree::new();
-        let mut previous: Option<PaneId> = None;
-        for ps in &rf.spec.panes {
-            let pane = PaneId::from_uuid(ps.id);
-            if let Some(prev) = previous {
-                tree.split(prev, pane, DEFAULT_SPLIT_AXIS, DEFAULT_SPLIT_RATIO);
-            } else {
-                tree.insert_root(pane);
-            }
-            previous = Some(pane);
-        }
-        if let Some(active) = rf.spec.active_pane_id {
-            tree.set_default_active(PaneId::from_uuid(active));
-        }
+        let active_pane_id = rf.spec.tree.default_active().map(PaneId::uuid);
 
         Self {
             id: rf.spec.id,
             name: rf.spec.name.clone(),
-            active_pane_id: rf.spec.active_pane_id,
-            tree,
+            active_pane_id,
+            tree: rf.spec.tree.clone(),
             policy: rf.spec.policy,
             reconstructed: true,
             revision: rf.instance.revision.max(default_runtime_revision()),
@@ -748,7 +735,7 @@ mod tests {
         assert_eq!(rf.spec.id, runtime.id);
         assert_eq!(rf.spec.name, "v2-test");
         assert_eq!(rf.spec.panes.len(), 1);
-        assert_eq!(rf.spec.panes[0].id, pane_id);
+        assert_eq!(rf.spec.panes[0].id, PaneId::from_uuid(pane_id));
         assert_eq!(rf.spec.panes[0].cols, 100);
         assert_eq!(rf.instance.revision, runtime.revision());
 
@@ -1029,7 +1016,7 @@ mod tests {
         runtime.add_pane(Pane::new(a, 80, 24));
         runtime.add_pane(Pane::new(b, 80, 24));
         runtime.add_pane(Pane::new(c, 80, 24));
-        runtime.active_pane_id = Some(b);
+        runtime.set_default_active_pane(b);
 
         let rf = runtime.to_runtime_file();
         let restored = Runtime::from_runtime_file(&rf);
@@ -1038,6 +1025,36 @@ mod tests {
             assert!(restored.tree.contains(PaneId::from_uuid(id)));
         }
         assert_eq!(restored.tree.default_active(), Some(PaneId::from_uuid(b)));
+        assert!(restored.tree.validate().is_ok());
+    }
+
+    #[test]
+    fn durable_tree_round_trips_exact_structure_and_ratios() {
+        // Build an asymmetric tree with custom split ratios and a non-default
+        // active pane, then prove the persisted tree is restored verbatim —
+        // not re-synthesized from a flat pane list (which would lose ratios and
+        // structure).
+        let mut runtime = Runtime::new("durable".into());
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let c = Uuid::new_v4();
+        runtime.add_pane(Pane::new(a, 80, 24));
+        runtime.add_pane(Pane::new(b, 80, 24));
+        runtime.add_pane(Pane::new(c, 80, 24));
+        // Each new pane splits the active leaf (a), so the tree is
+        // Split(Split(a, c), b). Give both splits distinct ratios.
+        assert_eq!(runtime.resize_split(&[], 0.25), Some(runtime.revision()));
+        assert_eq!(runtime.resize_split(&[Side::First], 0.8), Some(runtime.revision()));
+        runtime.set_default_active_pane(c);
+
+        let tree_before = runtime.tree.clone();
+
+        let rf = runtime.to_runtime_file();
+        let restored = Runtime::from_runtime_file(&rf);
+
+        assert_eq!(restored.tree, tree_before, "durable tree must round-trip exactly");
+        assert_eq!(restored.tree.default_active(), Some(PaneId::from_uuid(c)));
+        assert_eq!(restored.active_pane_id, Some(c));
         assert!(restored.tree.validate().is_ok());
     }
 }

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -192,8 +192,7 @@ impl Server {
         let state_dir = self.os.state_dir();
 
         if let Some(result) = crate::state::persistence::load_all(&state_dir) {
-            let total =
-                result.runtimes.len() + result.failed_ids.len() + result.reset_ids.len();
+            let total = result.runtimes.len() + result.failed_ids.len() + result.reset_ids.len();
             tracing::info!(
                 "Loaded {} persisted runtimes ({} failed, {} reset for old schema)",
                 result.runtimes.len(),

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -192,11 +192,13 @@ impl Server {
         let state_dir = self.os.state_dir();
 
         if let Some(result) = crate::state::persistence::load_all(&state_dir) {
-            let total = result.runtimes.len() + result.failed_ids.len();
+            let total =
+                result.runtimes.len() + result.failed_ids.len() + result.reset_ids.len();
             tracing::info!(
-                "Loaded {} persisted runtimes from v2 state ({} failed)",
+                "Loaded {} persisted runtimes ({} failed, {} reset for old schema)",
                 result.runtimes.len(),
-                result.failed_ids.len()
+                result.failed_ids.len(),
+                result.reset_ids.len()
             );
             for rf in &result.runtimes {
                 let mut rt = Runtime::from_runtime_file(rf);

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1084,16 +1084,15 @@ fn load_persisted_state_sweeps_orphans() {
     let orphan_id = Uuid::new_v4();
 
     // Create runtime files for both.
-    let known_rf = crate::state::types::RuntimeFileV1 {
+    let known_rf = crate::state::types::WorkspaceFileV2 {
         schema_version: crate::state::types::RUNTIME_FILE_SCHEMA_VERSION,
-        spec: crate::state::types::RuntimeSpecV1 {
+        spec: crate::state::types::WorkspaceSpecV2 {
             id: known_id,
             name: "known".into(),
             policy: RuntimePolicy::Persistent,
             created_at: std::time::SystemTime::now(),
+            tree: crate::pane_tree::WorkspaceTree::new(),
             panes: vec![],
-            active_pane_id: None,
-            command_history: vec![],
         },
         instance: crate::state::types::RuntimeInstanceV1 {
             revision: 1,

--- a/services/rttx-server/src/state/cleanup.rs
+++ b/services/rttx-server/src/state/cleanup.rs
@@ -148,17 +148,16 @@ mod tests {
     use std::collections::HashSet;
     use tempfile::TempDir;
 
-    fn sample_runtime_file(id: Uuid) -> RuntimeFileV1 {
-        RuntimeFileV1 {
+    fn sample_runtime_file(id: Uuid) -> WorkspaceFileV2 {
+        WorkspaceFileV2 {
             schema_version: RUNTIME_FILE_SCHEMA_VERSION,
-            spec: RuntimeSpecV1 {
+            spec: WorkspaceSpecV2 {
                 id,
                 name: "test".into(),
                 policy: RuntimePolicy::Persistent,
                 created_at: SystemTime::now(),
+                tree: crate::pane_tree::WorkspaceTree::new(),
                 panes: vec![],
-                active_pane_id: None,
-                command_history: vec![],
             },
             instance: RuntimeInstanceV1 {
                 revision: 1,

--- a/services/rttx-server/src/state/migrations.rs
+++ b/services/rttx-server/src/state/migrations.rs
@@ -10,8 +10,8 @@
 //! to load data it does not understand rather than guessing.
 
 use crate::state::types::{
-    DAEMON_INDEX_SCHEMA_VERSION, DaemonIndexV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1,
-    SCREEN_SNAPSHOT_SCHEMA_VERSION, SchemaVersionEnvelope, ScreenSnapshotV1,
+    DAEMON_INDEX_SCHEMA_VERSION, DaemonIndexV1, SCREEN_SNAPSHOT_SCHEMA_VERSION,
+    SchemaVersionEnvelope, ScreenSnapshotV1,
 };
 use std::fmt;
 
@@ -84,28 +84,6 @@ pub fn load_daemon_index(json: &str) -> Result<DaemonIndexV1, MigrationError> {
     }
 }
 
-/// Load and migrate a runtime file from JSON to the current version.
-pub fn load_runtime_file(json: &str) -> Result<RuntimeFileV1, MigrationError> {
-    let version = peek_schema_version(json)?;
-    match version {
-        1 => serde_json::from_str(json).map_err(|e| MigrationError::DeserializationFailed {
-            file_kind: "RuntimeFile",
-            version: 1,
-            source: e,
-        }),
-        v if v > RUNTIME_FILE_SCHEMA_VERSION => Err(MigrationError::UnsupportedFutureVersion {
-            file_kind: "RuntimeFile",
-            found: v,
-            max_supported: RUNTIME_FILE_SCHEMA_VERSION,
-        }),
-        v => Err(MigrationError::UnsupportedFutureVersion {
-            file_kind: "RuntimeFile",
-            found: v,
-            max_supported: RUNTIME_FILE_SCHEMA_VERSION,
-        }),
-    }
-}
-
 /// Load and migrate a screen snapshot from JSON to the current version.
 pub fn load_screen_snapshot(json: &str) -> Result<ScreenSnapshotV1, MigrationError> {
     let version = peek_schema_version(json)?;
@@ -131,7 +109,6 @@ pub fn load_screen_snapshot(json: &str) -> Result<ScreenSnapshotV1, MigrationErr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::RuntimePolicy;
     use crate::state::types::*;
     use std::time::SystemTime;
 
@@ -144,27 +121,6 @@ mod tests {
             last_serialized_at: SystemTime::now(),
         };
         serde_json::to_string_pretty(&index).unwrap()
-    }
-
-    fn sample_runtime_file_json() -> String {
-        let file = RuntimeFileV1 {
-            schema_version: RUNTIME_FILE_SCHEMA_VERSION,
-            spec: RuntimeSpecV1 {
-                id: uuid::Uuid::new_v4(),
-                name: "test".into(),
-                policy: RuntimePolicy::Persistent,
-                created_at: SystemTime::now(),
-                panes: vec![],
-                active_pane_id: None,
-                command_history: vec![],
-            },
-            instance: RuntimeInstanceV1 {
-                revision: 1,
-                last_active_at: SystemTime::now(),
-                last_snapshot_at: SystemTime::now(),
-            },
-        };
-        serde_json::to_string_pretty(&file).unwrap()
     }
 
     fn sample_screen_snapshot_json() -> String {
@@ -204,14 +160,6 @@ mod tests {
     }
 
     #[test]
-    fn load_runtime_file_v1() {
-        let json = sample_runtime_file_json();
-        let result = load_runtime_file(&json);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().schema_version, 1);
-    }
-
-    #[test]
     fn load_screen_snapshot_v1() {
         let json = sample_screen_snapshot_json();
         let result = load_screen_snapshot(&json);
@@ -228,16 +176,6 @@ mod tests {
         assert!(matches!(
             err,
             MigrationError::UnsupportedFutureVersion { file_kind: "DaemonIndex", found: 99, .. }
-        ));
-    }
-
-    #[test]
-    fn runtime_file_rejects_future_version() {
-        let json = r#"{"schema_version": 42}"#;
-        let err = load_runtime_file(json).unwrap_err();
-        assert!(matches!(
-            err,
-            MigrationError::UnsupportedFutureVersion { file_kind: "RuntimeFile", found: 42, .. }
         ));
     }
 

--- a/services/rttx-server/src/state/persistence.rs
+++ b/services/rttx-server/src/state/persistence.rs
@@ -1,31 +1,40 @@
-//! High-level persistence operations for v2 per-runtime state (RFC-022 §3, §6).
+//! High-level persistence operations for per-workspace state (RFC-031 §6).
 //!
 //! Provides `load_all` and `save_runtime` / `save_daemon_index` that use
-//! the layout paths, typed structs, migration chain, and atomic I/O.
+//! the layout paths, typed structs, and atomic I/O.
+//!
+//! Loading is a **clean break** (RFC-031 NG1): only the current schema version
+//! is read. Older-schema runtime files are detected, ignored, and removed —
+//! there is no migration path.
 
 use crate::state::io::write_with_backup;
 use crate::state::layout;
-use crate::state::migrations::{self, MigrationError};
+use crate::state::migrations::peek_schema_version;
 use crate::state::types::{
-    DAEMON_INDEX_SCHEMA_VERSION, DaemonIndexV1, RuntimeFileV1, ScreenSnapshotV1,
+    DAEMON_INDEX_SCHEMA_VERSION, DaemonIndexV1, RUNTIME_FILE_SCHEMA_VERSION, ScreenSnapshotV1,
+    WorkspaceFileV2,
 };
 use std::path::Path;
 use std::time::SystemTime;
 use uuid::Uuid;
 
-/// Result of loading all persisted v2 state on startup.
+/// Result of loading all persisted state on startup.
 #[derive(Debug)]
 pub struct LoadResult {
-    /// Successfully loaded runtime files.
-    pub runtimes: Vec<RuntimeFileV1>,
+    /// Successfully loaded workspace files.
+    pub runtimes: Vec<WorkspaceFileV2>,
     /// Runtime IDs that failed to load (corrupt or unreadable).
     pub failed_ids: Vec<Uuid>,
+    /// Runtime IDs whose old-schema state was detected, ignored, and removed
+    /// on load (RFC-031 clean break).
+    pub reset_ids: Vec<Uuid>,
 }
 
-/// Load all v2 state from the daemon state directory.
+/// Load all persisted state from the daemon state directory.
 ///
-/// Returns `None` if no `daemon.json` exists (first v2 startup).
-/// Individual corrupt runtimes are logged and skipped, not fatal.
+/// Returns `None` if no `daemon.json` exists (first startup). Old-schema
+/// runtimes are reset (removed); corrupt runtimes are skipped — neither is
+/// fatal.
 pub fn load_all(state_dir: &Path) -> Option<LoadResult> {
     let index_path = layout::daemon_index(state_dir);
 
@@ -34,21 +43,33 @@ pub fn load_all(state_dir: &Path) -> Option<LoadResult> {
 
     let mut runtimes = Vec::new();
     let mut failed_ids = Vec::new();
+    let mut reset_ids = Vec::new();
 
     for &runtime_id in &index.runtime_ids {
+        let short = &runtime_id.to_string()[..8];
         match load_runtime(state_dir, runtime_id) {
-            Ok(rf) => runtimes.push(rf),
-            Err(e) => {
-                tracing::error!(
-                    "Failed to load runtime {}: {e} — skipping",
-                    &runtime_id.to_string()[..8]
+            RuntimeLoad::Loaded(wf) => runtimes.push(*wf),
+            RuntimeLoad::OldSchema(version) => {
+                tracing::warn!(
+                    "Runtime {short} uses old schema v{version}; resetting state (RFC-031 clean break)"
                 );
+                if let Err(e) = remove_runtime_dir(state_dir, runtime_id) {
+                    tracing::error!("Failed to remove old-schema runtime {short}: {e}");
+                }
+                reset_ids.push(runtime_id);
+            }
+            RuntimeLoad::Corrupt => {
+                tracing::error!("Failed to load runtime {short} — skipping");
+                failed_ids.push(runtime_id);
+            }
+            RuntimeLoad::NotFound => {
+                tracing::error!("Runtime file not found for {short} — skipping");
                 failed_ids.push(runtime_id);
             }
         }
     }
 
-    Some(LoadResult { runtimes, failed_ids })
+    Some(LoadResult { runtimes, failed_ids, reset_ids })
 }
 
 /// Load daemon index, trying backup on parse failure.
@@ -56,7 +77,7 @@ fn load_daemon_index_with_fallback(path: &Path) -> Option<DaemonIndexV1> {
     use crate::state::io::{read_backup, read_primary};
 
     if let Some(json) = read_primary(path) {
-        match migrations::load_daemon_index(&json) {
+        match crate::state::migrations::load_daemon_index(&json) {
             Ok(idx) => return Some(idx),
             Err(e) => {
                 tracing::warn!("Primary daemon index corrupt: {e} — trying backup");
@@ -65,7 +86,7 @@ fn load_daemon_index_with_fallback(path: &Path) -> Option<DaemonIndexV1> {
     }
 
     if let Some(json) = read_backup(path) {
-        match migrations::load_daemon_index(&json) {
+        match crate::state::migrations::load_daemon_index(&json) {
             Ok(idx) => {
                 tracing::info!("Recovered daemon index from backup");
                 return Some(idx);
@@ -85,37 +106,59 @@ fn load_daemon_index_with_fallback(path: &Path) -> Option<DaemonIndexV1> {
     None
 }
 
-/// Load a single runtime file, trying backup on parse failure.
-fn load_runtime(state_dir: &Path, runtime_id: Uuid) -> Result<RuntimeFileV1, LoadError> {
+/// Outcome of attempting to load a single runtime file from disk.
+enum RuntimeLoad {
+    /// A current-schema workspace file loaded successfully.
+    Loaded(Box<WorkspaceFileV2>),
+    /// A recognized older schema; ignore and remove (RFC-031 clean break).
+    OldSchema(u32),
+    /// Unreadable, unparseable, or an unsupported future version; skip.
+    Corrupt,
+    /// No runtime file present at primary or backup.
+    NotFound,
+}
+
+/// Classify a runtime JSON document by its schema version.
+fn classify_runtime_json(json: &str) -> RuntimeLoad {
+    use std::cmp::Ordering;
+
+    let Ok(version) = peek_schema_version(json) else {
+        return RuntimeLoad::Corrupt;
+    };
+    match version.cmp(&RUNTIME_FILE_SCHEMA_VERSION) {
+        Ordering::Equal => serde_json::from_str::<WorkspaceFileV2>(json)
+            .map_or(RuntimeLoad::Corrupt, |wf| RuntimeLoad::Loaded(Box::new(wf))),
+        Ordering::Less => RuntimeLoad::OldSchema(version),
+        // Unsupported future version: refuse to touch data we do not understand.
+        Ordering::Greater => RuntimeLoad::Corrupt,
+    }
+}
+
+/// Load a single runtime file, trying backup when the primary is corrupt.
+fn load_runtime(state_dir: &Path, runtime_id: Uuid) -> RuntimeLoad {
     let path = layout::runtime_file(state_dir, runtime_id);
 
-    // Try primary first
     if let Some(json) = crate::state::io::read_primary(&path) {
-        match migrations::load_runtime_file(&json) {
-            Ok(rf) => return Ok(rf),
-            Err(e) => {
+        match classify_runtime_json(&json) {
+            RuntimeLoad::Corrupt => {
                 tracing::warn!(
-                    "Primary runtime file corrupt for {}: {e} — trying backup",
+                    "Primary runtime file corrupt for {} — trying backup",
                     &runtime_id.to_string()[..8]
                 );
             }
+            recognized => return recognized,
         }
     }
 
-    // Try backup
     if let Some(json) = crate::state::io::read_backup(&path) {
-        match migrations::load_runtime_file(&json) {
-            Ok(rf) => {
-                tracing::info!("Recovered runtime {} from backup", &runtime_id.to_string()[..8]);
-                return Ok(rf);
-            }
-            Err(e) => {
-                return Err(LoadError::Migration(e));
-            }
+        let outcome = classify_runtime_json(&json);
+        if matches!(outcome, RuntimeLoad::Loaded(_)) {
+            tracing::info!("Recovered runtime {} from backup", &runtime_id.to_string()[..8]);
         }
+        return outcome;
     }
 
-    Err(LoadError::NotFound(runtime_id))
+    RuntimeLoad::NotFound
 }
 
 /// Save the daemon index to disk with backup.
@@ -132,7 +175,7 @@ pub fn save_daemon_index(state_dir: &Path, runtime_ids: &[Uuid]) -> std::io::Res
 }
 
 /// Save a single runtime file to disk with backup.
-pub fn save_runtime(state_dir: &Path, runtime_file: &RuntimeFileV1) -> std::io::Result<()> {
+pub fn save_runtime(state_dir: &Path, runtime_file: &WorkspaceFileV2) -> std::io::Result<()> {
     let path = layout::runtime_file(state_dir, runtime_file.spec.id);
     let json = serde_json::to_string_pretty(runtime_file).map_err(std::io::Error::other)?;
     write_with_backup(&path, &json)
@@ -189,42 +232,31 @@ pub fn remove_runtime_dir(state_dir: &Path, runtime_id: Uuid) -> std::io::Result
     Ok(())
 }
 
-/// Errors that can occur when loading a single runtime.
-#[derive(Debug)]
-enum LoadError {
-    NotFound(Uuid),
-    Migration(MigrationError),
-}
-
-impl std::fmt::Display for LoadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotFound(id) => write!(f, "runtime file not found for {id}"),
-            Self::Migration(e) => write!(f, "{e}"),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pane_tree::{PaneId, SplitAxis, WorkspaceTree};
     use crate::runtime::RuntimePolicy;
     use crate::state::types::{
-        PaneSpecV1, RUNTIME_FILE_SCHEMA_VERSION, RuntimeFileV1, RuntimeInstanceV1, RuntimeSpecV1,
-        SCREEN_SNAPSHOT_SCHEMA_VERSION, ScreenSnapshotV1, TerminalModeSnapshot,
+        PaneSpecV2, RUNTIME_FILE_SCHEMA_VERSION, RuntimeInstanceV1, SCREEN_SNAPSHOT_SCHEMA_VERSION,
+        ScreenSnapshotV1, TerminalModeSnapshot, WorkspaceFileV2, WorkspaceSpecV2,
     };
     use tempfile::TempDir;
 
-    fn sample_runtime_file(id: Uuid) -> RuntimeFileV1 {
-        RuntimeFileV1 {
+    fn sample_runtime_file(id: Uuid) -> WorkspaceFileV2 {
+        let pane_id = PaneId::new();
+        let mut tree = WorkspaceTree::new();
+        tree.insert_root(pane_id);
+        WorkspaceFileV2 {
             schema_version: RUNTIME_FILE_SCHEMA_VERSION,
-            spec: RuntimeSpecV1 {
+            spec: WorkspaceSpecV2 {
                 id,
                 name: "test-rt".into(),
                 policy: RuntimePolicy::Persistent,
                 created_at: SystemTime::now(),
-                panes: vec![PaneSpecV1 {
-                    id: Uuid::new_v4(),
+                tree,
+                panes: vec![PaneSpecV2 {
+                    id: pane_id,
                     cwd: Some("/home/user".into()),
                     title: Some("bash".into()),
                     exit_status: None,
@@ -232,8 +264,6 @@ mod tests {
                     rows: 24,
                     no_persist: false,
                 }],
-                active_pane_id: None,
-                command_history: vec![],
             },
             instance: RuntimeInstanceV1 {
                 revision: 5,
@@ -255,9 +285,131 @@ mod tests {
 
         let result = load_all(state_dir).unwrap();
         assert!(result.failed_ids.is_empty());
+        assert!(result.reset_ids.is_empty());
         assert_eq!(result.runtimes.len(), 1);
         assert_eq!(result.runtimes[0].spec.id, rt_id);
         assert_eq!(result.runtimes[0].spec.name, "test-rt");
+    }
+
+    /// A multi-pane tree (structure + ratios + default-active) survives a
+    /// save/load round trip through the persistence layer (RFC-031 §6).
+    #[test]
+    fn save_and_load_preserves_multi_pane_tree() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let rt_id = Uuid::new_v4();
+
+        let (a, b, c) = (PaneId::new(), PaneId::new(), PaneId::new());
+        let mut tree = WorkspaceTree::new();
+        tree.insert_root(a);
+        tree.split(a, b, SplitAxis::Horizontal, 0.25);
+        tree.split(b, c, SplitAxis::Vertical, 0.75);
+        tree.set_default_active(c);
+        let expected_tree = tree.clone();
+
+        let mk = |id: PaneId| PaneSpecV2 {
+            id,
+            cwd: None,
+            title: None,
+            exit_status: None,
+            cols: 80,
+            rows: 24,
+            no_persist: false,
+        };
+        let rf = WorkspaceFileV2 {
+            schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+            spec: WorkspaceSpecV2 {
+                id: rt_id,
+                name: "tree-ws".into(),
+                policy: RuntimePolicy::Persistent,
+                created_at: SystemTime::now(),
+                tree,
+                panes: vec![mk(a), mk(b), mk(c)],
+            },
+            instance: RuntimeInstanceV1 {
+                revision: 9,
+                last_active_at: SystemTime::now(),
+                last_snapshot_at: SystemTime::now(),
+            },
+        };
+
+        save_daemon_index(state_dir, &[rt_id]).unwrap();
+        save_runtime(state_dir, &rf).unwrap();
+
+        let result = load_all(state_dir).unwrap();
+        assert_eq!(result.runtimes.len(), 1);
+        let loaded = &result.runtimes[0];
+        assert_eq!(loaded.spec.tree, expected_tree, "tree must round-trip exactly");
+        assert_eq!(loaded.spec.tree.default_active(), Some(c));
+        assert_eq!(loaded.spec.panes.len(), 3);
+    }
+
+    /// Old-schema (v1) runtime state is detected, ignored, and removed from
+    /// disk on load — no migration (RFC-031 clean break).
+    #[test]
+    fn old_schema_runtime_is_reset_and_removed() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let old_id = Uuid::new_v4();
+
+        // Write a genuine v1-format runtime.json: flat panes, active_pane_id,
+        // command_history, and no durable tree.
+        let old_dir = layout::runtime_dir(state_dir, old_id);
+        std::fs::create_dir_all(&old_dir).unwrap();
+        let v1_json = format!(
+            r#"{{
+                "schema_version": 1,
+                "spec": {{
+                    "id": "{old_id}",
+                    "name": "legacy-ws",
+                    "policy": "persistent",
+                    "created_at": {{"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}},
+                    "panes": [],
+                    "active_pane_id": null,
+                    "command_history": []
+                }},
+                "instance": {{
+                    "revision": 3,
+                    "last_active_at": {{"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}},
+                    "last_snapshot_at": {{"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}}
+                }}
+            }}"#
+        );
+        std::fs::write(layout::runtime_file(state_dir, old_id), v1_json).unwrap();
+        save_daemon_index(state_dir, &[old_id]).unwrap();
+
+        let result = load_all(state_dir).unwrap();
+        assert!(result.runtimes.is_empty(), "old-schema runtime must not load");
+        assert!(result.failed_ids.is_empty(), "old schema is a reset, not a failure");
+        assert_eq!(result.reset_ids, vec![old_id]);
+        assert!(!old_dir.exists(), "old-schema runtime directory must be removed");
+    }
+
+    /// A good v2 runtime survives even when a sibling is reset for old schema.
+    #[test]
+    fn old_schema_reset_does_not_drop_current_runtimes() {
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let good_id = Uuid::new_v4();
+        let old_id = Uuid::new_v4();
+
+        save_runtime(state_dir, &sample_runtime_file(good_id)).unwrap();
+
+        let old_dir = layout::runtime_dir(state_dir, old_id);
+        std::fs::create_dir_all(&old_dir).unwrap();
+        std::fs::write(
+            layout::runtime_file(state_dir, old_id),
+            r#"{"schema_version": 1, "spec": {}, "instance": {}}"#,
+        )
+        .unwrap();
+
+        save_daemon_index(state_dir, &[good_id, old_id]).unwrap();
+
+        let result = load_all(state_dir).unwrap();
+        assert_eq!(result.runtimes.len(), 1);
+        assert_eq!(result.runtimes[0].spec.id, good_id);
+        assert_eq!(result.reset_ids, vec![old_id]);
+        assert!(!old_dir.exists());
     }
 
     #[test]

--- a/services/rttx-server/src/state/types.rs
+++ b/services/rttx-server/src/state/types.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 use uuid::Uuid;
 
+use crate::pane_tree::{PaneId, WorkspaceTree};
 use crate::runtime::RuntimePolicy;
 
 // ── Schema version constants ────────────────────────────────────────
@@ -15,8 +16,13 @@ use crate::runtime::RuntimePolicy;
 /// Current schema version for [`DaemonIndexV1`].
 pub const DAEMON_INDEX_SCHEMA_VERSION: u32 = 1;
 
-/// Current schema version for [`RuntimeFileV1`].
-pub const RUNTIME_FILE_SCHEMA_VERSION: u32 = 1;
+/// Current schema version for [`WorkspaceFileV2`].
+///
+/// Version 2 (RFC-031 §6) persists the authoritative [`WorkspaceTree`] —
+/// structure, logical split ratios, and default-active pane — as durable state.
+/// It is a clean break from version 1: old-schema files are detected, ignored,
+/// and removed on load with no migration path.
+pub const RUNTIME_FILE_SCHEMA_VERSION: u32 = 2;
 
 /// Current schema version for [`ScreenSnapshotV1`].
 pub const SCREEN_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
@@ -41,43 +47,43 @@ pub struct DaemonIndexV1 {
     pub last_serialized_at: SystemTime,
 }
 
-// ── Per-runtime file ────────────────────────────────────────────────
+// ── Per-workspace file ──────────────────────────────────────────────
 
-/// Top-level wrapper stored in `<runtime_dir>/runtime.json` (RFC-022 §3).
+/// Top-level wrapper stored in `<runtime_dir>/runtime.json` (RFC-031 §6).
 ///
-/// Combines the durable spec with the semi-durable instance data.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RuntimeFileV1 {
+/// Combines the durable spec — including the authoritative pane tree — with
+/// the semi-durable instance data.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkspaceFileV2 {
     /// Must be [`RUNTIME_FILE_SCHEMA_VERSION`].
     pub schema_version: u32,
-    /// Durable runtime specification.
-    pub spec: RuntimeSpecV1,
+    /// Durable workspace specification.
+    pub spec: WorkspaceSpecV2,
     /// Semi-durable instance data (bounded age, rebuilt on restart).
     pub instance: RuntimeInstanceV1,
 }
 
-/// Durable runtime specification — identity, policy, panes, history.
+/// Durable workspace specification — identity, policy, pane tree, and panes.
 ///
 /// These fields survive daemon restarts and are the source of truth for
-/// runtime reconstruction.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RuntimeSpecV1 {
-    /// Unique runtime identifier.
+/// workspace reconstruction. The [`WorkspaceTree`] carries structure, logical
+/// split ratios, ordering, and the default-active pane (RFC-031 §2).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkspaceSpecV2 {
+    /// Unique workspace identifier.
     pub id: Uuid,
-    /// Human-readable runtime name.
+    /// Human-readable workspace name.
     pub name: String,
     /// Retention policy.
     pub policy: RuntimePolicy,
-    /// When this runtime was created.
+    /// When this workspace was created.
     pub created_at: SystemTime,
-    /// Pane specifications.
-    pub panes: Vec<PaneSpecV1>,
-    /// Active pane ID within this runtime.
-    pub active_pane_id: Option<Uuid>,
-    /// Ignored — retained only for backward-compatible deserialization of
-    /// state files written before the field was removed.
-    #[serde(default, skip_serializing)]
-    pub command_history: Vec<serde_json::Value>,
+    /// Authoritative pane-arrangement tree: structure, logical ratios, and the
+    /// default-active pane.
+    pub tree: WorkspaceTree,
+    /// Per-pane specifications, keyed by the immutable [`PaneId`] carried in the
+    /// tree.
+    pub panes: Vec<PaneSpecV2>,
 }
 
 /// Semi-durable instance data — revision counters and timestamps.
@@ -96,15 +102,16 @@ pub struct RuntimeInstanceV1 {
 
 // ── Pane spec ───────────────────────────────────────────────────────
 
-/// Durable pane specification (RFC-022 §3).
+/// Durable pane specification (RFC-031 §6).
 ///
 /// Captures the identity and last-known terminal state of a single pane.
-/// Scrollback and screen data live in separate files; this struct holds
-/// only the metadata needed to reconstruct the pane.
+/// Scrollback and screen data live in separate files keyed on the same
+/// [`PaneId`]; this struct holds only the metadata needed to reconstruct the
+/// pane.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PaneSpecV1 {
-    /// Unique pane identifier.
-    pub id: Uuid,
+pub struct PaneSpecV2 {
+    /// Immutable pane identifier (RFC-031 G1).
+    pub id: PaneId,
     /// Last known working directory.
     pub cwd: Option<String>,
     /// Pane title.
@@ -193,11 +200,12 @@ pub struct SchemaVersionEnvelope {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pane_tree::SplitAxis;
     use std::time::SystemTime;
 
-    fn sample_pane_spec() -> PaneSpecV1 {
-        PaneSpecV1 {
-            id: Uuid::new_v4(),
+    fn sample_pane_spec() -> PaneSpecV2 {
+        PaneSpecV2 {
+            id: PaneId::new(),
             cwd: Some("/home/user".into()),
             title: Some("bash".into()),
             exit_status: None,
@@ -207,15 +215,26 @@ mod tests {
         }
     }
 
-    fn sample_runtime_spec() -> RuntimeSpecV1 {
-        RuntimeSpecV1 {
+    /// A two-pane tree whose panes match the returned specs.
+    fn sample_tree_and_panes() -> (WorkspaceTree, Vec<PaneSpecV2>) {
+        let a = sample_pane_spec();
+        let mut b = sample_pane_spec();
+        b.title = Some("nvim".into());
+        let mut tree = WorkspaceTree::new();
+        tree.insert_root(a.id);
+        tree.split(a.id, b.id, SplitAxis::Vertical, 0.4);
+        (tree, vec![a, b])
+    }
+
+    fn sample_runtime_spec() -> WorkspaceSpecV2 {
+        let (tree, panes) = sample_tree_and_panes();
+        WorkspaceSpecV2 {
             id: Uuid::new_v4(),
             name: "dev".into(),
             policy: RuntimePolicy::Persistent,
             created_at: SystemTime::now(),
-            panes: vec![sample_pane_spec()],
-            active_pane_id: None,
-            command_history: vec![],
+            tree,
+            panes,
         }
     }
 
@@ -237,8 +256,8 @@ mod tests {
         }
     }
 
-    fn sample_runtime_file() -> RuntimeFileV1 {
-        RuntimeFileV1 {
+    fn sample_runtime_file() -> WorkspaceFileV2 {
+        WorkspaceFileV2 {
             schema_version: RUNTIME_FILE_SCHEMA_VERSION,
             spec: sample_runtime_spec(),
             instance: sample_runtime_instance(),
@@ -284,7 +303,7 @@ mod tests {
     fn runtime_file_round_trip() {
         let original = sample_runtime_file();
         let json = serde_json::to_string_pretty(&original).unwrap();
-        let recovered: RuntimeFileV1 = serde_json::from_str(&json).unwrap();
+        let recovered: WorkspaceFileV2 = serde_json::from_str(&json).unwrap();
         assert_eq!(original, recovered);
     }
 
@@ -300,8 +319,19 @@ mod tests {
     fn pane_spec_round_trip() {
         let original = sample_pane_spec();
         let json = serde_json::to_string_pretty(&original).unwrap();
-        let recovered: PaneSpecV1 = serde_json::from_str(&json).unwrap();
+        let recovered: PaneSpecV2 = serde_json::from_str(&json).unwrap();
         assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn workspace_spec_persists_tree_structure_and_ratios() {
+        let original = sample_runtime_spec();
+        let json = serde_json::to_string_pretty(&original).unwrap();
+        let recovered: WorkspaceSpecV2 = serde_json::from_str(&json).unwrap();
+        // The durable tree — structure, ratios, and default-active — round-trips
+        // byte-for-byte, not just the flat set of panes.
+        assert_eq!(original.tree, recovered.tree);
+        assert!(recovered.tree.validate().is_ok());
     }
 
     // ── Schema version field presence ───────────────────────────────
@@ -374,25 +404,25 @@ mod tests {
 
     #[test]
     fn runtime_spec_with_no_panes() {
-        let spec = RuntimeSpecV1 {
+        let spec = WorkspaceSpecV2 {
             id: Uuid::new_v4(),
             name: "empty".into(),
             policy: RuntimePolicy::Ephemeral,
             created_at: SystemTime::now(),
+            tree: WorkspaceTree::new(),
             panes: vec![],
-            active_pane_id: None,
-            command_history: vec![],
         };
         let json = serde_json::to_string_pretty(&spec).unwrap();
-        let recovered: RuntimeSpecV1 = serde_json::from_str(&json).unwrap();
+        let recovered: WorkspaceSpecV2 = serde_json::from_str(&json).unwrap();
         assert!(recovered.panes.is_empty());
+        assert!(recovered.tree.is_empty());
         assert_eq!(recovered.policy, RuntimePolicy::Ephemeral);
     }
 
     #[test]
     fn pane_spec_with_all_optional_fields_none() {
-        let pane = PaneSpecV1 {
-            id: Uuid::new_v4(),
+        let pane = PaneSpecV2 {
+            id: PaneId::new(),
             cwd: None,
             title: None,
             exit_status: None,
@@ -401,7 +431,7 @@ mod tests {
             no_persist: false,
         };
         let json = serde_json::to_string_pretty(&pane).unwrap();
-        let recovered: PaneSpecV1 = serde_json::from_str(&json).unwrap();
+        let recovered: PaneSpecV2 = serde_json::from_str(&json).unwrap();
         assert!(recovered.cwd.is_none());
         assert!(recovered.title.is_none());
         assert!(recovered.exit_status.is_none());
@@ -477,7 +507,7 @@ mod tests {
             "cols": 80,
             "rows": 24
         }"#;
-        let recovered: PaneSpecV1 = serde_json::from_str(json).unwrap();
+        let recovered: PaneSpecV2 = serde_json::from_str(json).unwrap();
         assert!(!recovered.no_persist);
     }
 
@@ -486,7 +516,7 @@ mod tests {
         let mut pane = sample_pane_spec();
         pane.no_persist = true;
         let json = serde_json::to_string_pretty(&pane).unwrap();
-        let recovered: PaneSpecV1 = serde_json::from_str(&json).unwrap();
+        let recovered: PaneSpecV2 = serde_json::from_str(&json).unwrap();
         assert!(recovered.no_persist);
     }
 
@@ -509,43 +539,13 @@ mod tests {
     }
 
     #[test]
-    fn runtime_spec_deserializes_old_command_history() {
-        let json = r#"{
-            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            "name": "legacy",
-            "policy": "persistent",
-            "created_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
-            "panes": [],
-            "active_pane_id": null,
-            "command_history": [
-                {"command": "ls", "cwd": "/", "timestamp": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}, "pane_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}
-            ]
-        }"#;
-        let spec: RuntimeSpecV1 = serde_json::from_str(json).unwrap();
-        assert_eq!(spec.name, "legacy");
-    }
-
-    #[test]
-    fn runtime_spec_deserializes_without_command_history() {
-        let json = r#"{
-            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            "name": "new-format",
-            "policy": "persistent",
-            "created_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
-            "panes": [],
-            "active_pane_id": null
-        }"#;
-        let spec: RuntimeSpecV1 = serde_json::from_str(json).unwrap();
-        assert_eq!(spec.name, "new-format");
-    }
-
-    #[test]
-    fn runtime_spec_serialization_omits_command_history() {
+    fn workspace_spec_serialization_drops_legacy_fields() {
+        // The clean break (RFC-031) removes `command_history` and the standalone
+        // `active_pane_id`; the latter is subsumed by the tree's default-active.
         let spec = sample_runtime_spec();
         let json = serde_json::to_string(&spec).unwrap();
-        assert!(
-            !json.contains("command_history"),
-            "new serialization should not include command_history"
-        );
+        assert!(!json.contains("command_history"), "command_history must be gone");
+        assert!(!json.contains("active_pane_id"), "active_pane_id must be gone");
+        assert!(json.contains("tree"), "the durable tree must be serialized");
     }
 }

--- a/services/rttx-server/tests/history_crash_survival.rs
+++ b/services/rttx-server/tests/history_crash_survival.rs
@@ -161,14 +161,35 @@ async fn history_survives_hard_restart() {
 
         // Trigger the next prompt so PROMPT_COMMAND runs history -a.
         send_input(&mut client, &runtime_id, &pane_id, b"true\n").await;
-        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Poll the on-disk HISTFILE until history -a flushes the command. This
+        // is the invariant under test: history reaches disk during normal
+        // operation (via history -a), so it survives a later hard crash.
+        // Polling instead of a fixed sleep keeps the test deterministic under
+        // parallel load, where a short sleep can race the shell's flush.
+        let state_dir = tmp.path().join("state/rttx/daemon");
+        let pane_uuid = rttx_proto::bytes_to_uuid(&pane_id).unwrap();
+        let runtime_uuid = rttx_proto::bytes_to_uuid(&runtime_id).unwrap();
+        let hist_path =
+            rttx_server::state::layout::history_file(&state_dir, runtime_uuid, pane_uuid);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline {
+            if std::fs::read_to_string(&hist_path)
+                .unwrap_or_default()
+                .contains("UNIQUE_MARKER_12345")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
 
         // Simulate hard crash: abort the handle.
         handle.abort();
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    // Verify the HISTFILE on disk contains the command.
+    // Verify the HISTFILE on disk still contains the command after the hard
+    // crash — it was flushed by history -a, not by a graceful shutdown.
     let state_dir = tmp.path().join("state/rttx/daemon");
     let pane_uuid = rttx_proto::bytes_to_uuid(&pane_id).unwrap();
     let runtime_uuid = rttx_proto::bytes_to_uuid(&runtime_id).unwrap();

--- a/services/rttx-server/tests/property_robustness.rs
+++ b/services/rttx-server/tests/property_robustness.rs
@@ -8,7 +8,7 @@
 use proptest::prelude::*;
 use rttx_server::screen::{PaneScreen, restart_safe_scrollback, strip_client_queries};
 use rttx_server::state::types::{
-    DaemonIndexV1, RuntimeFileV1, SchemaVersionEnvelope, ScreenSnapshotV1,
+    DaemonIndexV1, SchemaVersionEnvelope, ScreenSnapshotV1, WorkspaceFileV2,
 };
 
 // ── PaneScreen: arbitrary byte streams never panic ──────────────────
@@ -115,7 +115,7 @@ proptest! {
 
     #[test]
     fn runtime_file_corrupt_json_never_panics(data in "\\PC{0,512}") {
-        let _: Result<RuntimeFileV1, _> = serde_json::from_str(&data);
+        let _: Result<WorkspaceFileV2, _> = serde_json::from_str(&data);
     }
 
     #[test]

--- a/services/rttx-server/tests/runtime_cleanup.rs
+++ b/services/rttx-server/tests/runtime_cleanup.rs
@@ -81,20 +81,19 @@ async fn startup_quarantines_orphaned_runtime_directories() {
     let known_id = uuid::Uuid::new_v4();
     let orphan_id = uuid::Uuid::new_v4();
 
-    // Create a valid runtime file for the known runtime.
+    // Create a valid v2 runtime file for the known runtime.
     let runtimes_dir = state_dir.join("runtimes");
     let known_dir = runtimes_dir.join(known_id.to_string());
     std::fs::create_dir_all(&known_dir).unwrap();
     let known_rf = serde_json::json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "spec": {
             "id": known_id.to_string(),
             "name": "known",
             "policy": "persistent",
             "created_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 },
-            "panes": [],
-            "active_pane_id": null,
-            "command_history": []
+            "tree": { "root": null, "default_active": null },
+            "panes": []
         },
         "instance": {
             "revision": 1,

--- a/services/rttx-server/tests/screen_snapshot.rs
+++ b/services/rttx-server/tests/screen_snapshot.rs
@@ -90,15 +90,19 @@ async fn corrupt_screen_snapshot_does_not_block_runtime_load() {
     let runtime_id = uuid::Uuid::new_v4();
     let pane_id = uuid::Uuid::new_v4();
 
-    let rf = rttx_server::state::types::RuntimeFileV1 {
+    let pane_spec_id = rttx_server::pane_tree::PaneId::from_uuid(pane_id);
+    let mut tree = rttx_server::pane_tree::WorkspaceTree::new();
+    tree.insert_root(pane_spec_id);
+    let rf = rttx_server::state::types::WorkspaceFileV2 {
         schema_version: rttx_server::state::types::RUNTIME_FILE_SCHEMA_VERSION,
-        spec: rttx_server::state::types::RuntimeSpecV1 {
+        spec: rttx_server::state::types::WorkspaceSpecV2 {
             id: runtime_id,
             name: "corrupt-snap-test".into(),
             policy: rttx_server::runtime::RuntimePolicy::Persistent,
             created_at: std::time::SystemTime::now(),
-            panes: vec![rttx_server::state::types::PaneSpecV1 {
-                id: pane_id,
+            tree,
+            panes: vec![rttx_server::state::types::PaneSpecV2 {
+                id: pane_spec_id,
                 cwd: Some("/tmp".into()),
                 title: None,
                 exit_status: None,
@@ -106,8 +110,6 @@ async fn corrupt_screen_snapshot_does_not_block_runtime_load() {
                 rows: 24,
                 no_persist: false,
             }],
-            active_pane_id: None,
-            command_history: vec![],
         },
         instance: rttx_server::state::types::RuntimeInstanceV1 {
             revision: 1,

--- a/services/rttx-server/tests/v2_persisted_structs.rs
+++ b/services/rttx-server/tests/v2_persisted_structs.rs
@@ -6,7 +6,9 @@
 //! future-version rejection. Workspace-file persistence and the clean-break
 //! loader are covered in `workspace_file_v2.rs`.
 
-use rttx_server::state::migrations::{load_daemon_index, load_screen_snapshot, peek_schema_version};
+use rttx_server::state::migrations::{
+    load_daemon_index, load_screen_snapshot, peek_schema_version,
+};
 use rttx_server::state::types::*;
 use std::time::SystemTime;
 use tempfile::TempDir;

--- a/services/rttx-server/tests/v2_persisted_structs.rs
+++ b/services/rttx-server/tests/v2_persisted_structs.rs
@@ -1,16 +1,13 @@
-//! Integration tests for persisted state structs and the clean-break loader
-//! (RFC-022 §2–§4, RFC-031 §6).
+//! Integration tests for persisted state structs and the migration chain
+//! (RFC-022 §2–§4).
 //!
 //! Verifies that the daemon index and screen snapshots round-trip through the
-//! migration chain, that the durable `WorkspaceFileV2` (tree + panes) round-trips
-//! through the persistence layer, and that old-schema runtime state is detected,
-//! ignored, and removed with no migration path.
+//! migration chain, including forward compatibility with unknown fields and
+//! future-version rejection. Workspace-file persistence and the clean-break
+//! loader are covered in `workspace_file_v2.rs`.
 
-use rttx_server::pane_tree::{PaneId, SplitAxis, WorkspaceTree};
-use rttx_server::runtime::RuntimePolicy;
 use rttx_server::state::migrations::{load_daemon_index, load_screen_snapshot, peek_schema_version};
 use rttx_server::state::types::*;
-use rttx_server::state::{layout, persistence};
 use std::time::SystemTime;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -44,62 +41,6 @@ fn daemon_index_persists_and_loads_via_migration_chain() {
     };
     let recovered = write_and_load_daemon_index(&original);
     assert_eq!(original, recovered);
-}
-
-#[test]
-fn workspace_file_persists_and_reloads_with_tree() {
-    let tmp = TempDir::new().unwrap();
-    let state_dir = tmp.path();
-    let rt_id = Uuid::new_v4();
-
-    // A two-level tree with distinct ratios and a non-default active pane.
-    let (a, b, c) = (PaneId::new(), PaneId::new(), PaneId::new());
-    let mut tree = WorkspaceTree::new();
-    tree.insert_root(a);
-    tree.split(a, b, SplitAxis::Horizontal, 0.3);
-    tree.split(b, c, SplitAxis::Vertical, 0.6);
-    tree.set_default_active(b);
-    let expected_tree = tree.clone();
-
-    let mk = |id: PaneId, title: &str| PaneSpecV2 {
-        id,
-        cwd: Some("/home/user/project".into()),
-        title: Some(title.into()),
-        exit_status: None,
-        cols: 120,
-        rows: 40,
-        no_persist: false,
-    };
-    let original = WorkspaceFileV2 {
-        schema_version: RUNTIME_FILE_SCHEMA_VERSION,
-        spec: WorkspaceSpecV2 {
-            id: rt_id,
-            name: "workspace-1".into(),
-            policy: RuntimePolicy::Persistent,
-            created_at: SystemTime::now(),
-            tree,
-            panes: vec![mk(a, "bash"), mk(b, "nvim"), mk(c, "logs")],
-        },
-        instance: RuntimeInstanceV1 {
-            revision: 7,
-            last_active_at: SystemTime::now(),
-            last_snapshot_at: SystemTime::now(),
-        },
-    };
-
-    persistence::save_daemon_index(state_dir, &[rt_id]).unwrap();
-    persistence::save_runtime(state_dir, &original).unwrap();
-
-    let result = persistence::load_all(state_dir).unwrap();
-    assert!(result.failed_ids.is_empty());
-    assert!(result.reset_ids.is_empty());
-    assert_eq!(result.runtimes.len(), 1);
-
-    let recovered = &result.runtimes[0];
-    assert_eq!(recovered.spec.tree, expected_tree, "tree structure + ratios must survive");
-    assert_eq!(recovered.spec.tree.default_active(), Some(b));
-    assert_eq!(recovered.spec.panes.len(), 3);
-    assert_eq!(recovered.instance.revision, 7);
 }
 
 #[test]
@@ -157,50 +98,4 @@ fn future_version_rejected_from_disk() {
     let loaded = std::fs::read_to_string(&path).unwrap();
     let result = load_daemon_index(&loaded);
     assert!(result.is_err());
-}
-
-#[test]
-fn old_schema_runtime_file_is_reset_not_migrated() {
-    // RFC-031 clean break: an old v1 runtime.json (flat panes, active_pane_id,
-    // command_history, no durable tree) is detected, ignored, and removed.
-    let tmp = TempDir::new().unwrap();
-    let state_dir = tmp.path();
-    let old_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
-
-    let old_dir = layout::runtime_dir(state_dir, old_id);
-    std::fs::create_dir_all(&old_dir).unwrap();
-    let v1_json = r#"{
-        "schema_version": 1,
-        "spec": {
-            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            "name": "legacy-ws",
-            "policy": "persistent",
-            "created_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
-            "panes": [{
-                "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-                "cwd": "/home/user",
-                "title": "bash",
-                "exit_status": null,
-                "cols": 80,
-                "rows": 24
-            }],
-            "active_pane_id": null,
-            "command_history": [
-                {"command": "cargo build", "cwd": "/home/user/project"}
-            ]
-        },
-        "instance": {
-            "revision": 5,
-            "last_active_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
-            "last_snapshot_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}
-        }
-    }"#;
-    std::fs::write(layout::runtime_file(state_dir, old_id), v1_json).unwrap();
-    persistence::save_daemon_index(state_dir, &[old_id]).unwrap();
-
-    let result = persistence::load_all(state_dir).unwrap();
-    assert!(result.runtimes.is_empty(), "old-schema runtime must not load");
-    assert!(result.failed_ids.is_empty(), "old schema is a reset, not a failure");
-    assert_eq!(result.reset_ids, vec![old_id]);
-    assert!(!old_dir.exists(), "old-schema runtime directory must be removed on load");
 }

--- a/services/rttx-server/tests/v2_persisted_structs.rs
+++ b/services/rttx-server/tests/v2_persisted_structs.rs
@@ -1,14 +1,16 @@
-//! Integration test for v2 persisted structs and migration chain (RFC-022 §2–§4).
+//! Integration tests for persisted state structs and the clean-break loader
+//! (RFC-022 §2–§4, RFC-031 §6).
 //!
-//! Verifies that structs serialize to disk and load back through the
-//! migration chain, including future-version rejection and forward
-//! compatibility with unknown fields.
+//! Verifies that the daemon index and screen snapshots round-trip through the
+//! migration chain, that the durable `WorkspaceFileV2` (tree + panes) round-trips
+//! through the persistence layer, and that old-schema runtime state is detected,
+//! ignored, and removed with no migration path.
 
+use rttx_server::pane_tree::{PaneId, SplitAxis, WorkspaceTree};
 use rttx_server::runtime::RuntimePolicy;
-use rttx_server::state::migrations::{
-    load_daemon_index, load_runtime_file, load_screen_snapshot, peek_schema_version,
-};
+use rttx_server::state::migrations::{load_daemon_index, load_screen_snapshot, peek_schema_version};
 use rttx_server::state::types::*;
+use rttx_server::state::{layout, persistence};
 use std::time::SystemTime;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -20,15 +22,6 @@ fn write_and_load_daemon_index(index: &DaemonIndexV1) -> DaemonIndexV1 {
     std::fs::write(&path, &json).unwrap();
     let loaded = std::fs::read_to_string(&path).unwrap();
     load_daemon_index(&loaded).unwrap()
-}
-
-fn write_and_load_runtime_file(file: &RuntimeFileV1) -> RuntimeFileV1 {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("runtime.json");
-    let json = serde_json::to_string_pretty(file).unwrap();
-    std::fs::write(&path, &json).unwrap();
-    let loaded = std::fs::read_to_string(&path).unwrap();
-    load_runtime_file(&loaded).unwrap()
 }
 
 fn write_and_load_screen_snapshot(snap: &ScreenSnapshotV1) -> ScreenSnapshotV1 {
@@ -54,26 +47,38 @@ fn daemon_index_persists_and_loads_via_migration_chain() {
 }
 
 #[test]
-fn runtime_file_persists_and_loads_via_migration_chain() {
-    let pane = PaneSpecV1 {
-        id: Uuid::new_v4(),
+fn workspace_file_persists_and_reloads_with_tree() {
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path();
+    let rt_id = Uuid::new_v4();
+
+    // A two-level tree with distinct ratios and a non-default active pane.
+    let (a, b, c) = (PaneId::new(), PaneId::new(), PaneId::new());
+    let mut tree = WorkspaceTree::new();
+    tree.insert_root(a);
+    tree.split(a, b, SplitAxis::Horizontal, 0.3);
+    tree.split(b, c, SplitAxis::Vertical, 0.6);
+    tree.set_default_active(b);
+    let expected_tree = tree.clone();
+
+    let mk = |id: PaneId, title: &str| PaneSpecV2 {
+        id,
         cwd: Some("/home/user/project".into()),
-        title: Some("nvim".into()),
+        title: Some(title.into()),
         exit_status: None,
         cols: 120,
         rows: 40,
         no_persist: false,
     };
-    let original = RuntimeFileV1 {
+    let original = WorkspaceFileV2 {
         schema_version: RUNTIME_FILE_SCHEMA_VERSION,
-        spec: RuntimeSpecV1 {
-            id: Uuid::new_v4(),
+        spec: WorkspaceSpecV2 {
+            id: rt_id,
             name: "workspace-1".into(),
             policy: RuntimePolicy::Persistent,
             created_at: SystemTime::now(),
-            panes: vec![pane],
-            active_pane_id: None,
-            command_history: vec![],
+            tree,
+            panes: vec![mk(a, "bash"), mk(b, "nvim"), mk(c, "logs")],
         },
         instance: RuntimeInstanceV1 {
             revision: 7,
@@ -81,8 +86,20 @@ fn runtime_file_persists_and_loads_via_migration_chain() {
             last_snapshot_at: SystemTime::now(),
         },
     };
-    let recovered = write_and_load_runtime_file(&original);
-    assert_eq!(original, recovered);
+
+    persistence::save_daemon_index(state_dir, &[rt_id]).unwrap();
+    persistence::save_runtime(state_dir, &original).unwrap();
+
+    let result = persistence::load_all(state_dir).unwrap();
+    assert!(result.failed_ids.is_empty());
+    assert!(result.reset_ids.is_empty());
+    assert_eq!(result.runtimes.len(), 1);
+
+    let recovered = &result.runtimes[0];
+    assert_eq!(recovered.spec.tree, expected_tree, "tree structure + ratios must survive");
+    assert_eq!(recovered.spec.tree.default_active(), Some(b));
+    assert_eq!(recovered.spec.panes.len(), 3);
+    assert_eq!(recovered.instance.revision, 7);
 }
 
 #[test]
@@ -143,8 +160,16 @@ fn future_version_rejected_from_disk() {
 }
 
 #[test]
-fn old_runtime_file_with_command_history_loads_through_migration() {
-    let json = r#"{
+fn old_schema_runtime_file_is_reset_not_migrated() {
+    // RFC-031 clean break: an old v1 runtime.json (flat panes, active_pane_id,
+    // command_history, no durable tree) is detected, ignored, and removed.
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path();
+    let old_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+
+    let old_dir = layout::runtime_dir(state_dir, old_id);
+    std::fs::create_dir_all(&old_dir).unwrap();
+    let v1_json = r#"{
         "schema_version": 1,
         "spec": {
             "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -161,12 +186,7 @@ fn old_runtime_file_with_command_history_loads_through_migration() {
             }],
             "active_pane_id": null,
             "command_history": [
-                {
-                    "command": "cargo build",
-                    "cwd": "/home/user/project",
-                    "timestamp": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
-                    "pane_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
-                }
+                {"command": "cargo build", "cwd": "/home/user/project"}
             ]
         },
         "instance": {
@@ -175,8 +195,12 @@ fn old_runtime_file_with_command_history_loads_through_migration() {
             "last_snapshot_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}
         }
     }"#;
-    let loaded = load_runtime_file(json).unwrap();
-    assert_eq!(loaded.spec.name, "legacy-ws");
-    assert_eq!(loaded.spec.panes.len(), 1);
-    assert_eq!(loaded.instance.revision, 5);
+    std::fs::write(layout::runtime_file(state_dir, old_id), v1_json).unwrap();
+    persistence::save_daemon_index(state_dir, &[old_id]).unwrap();
+
+    let result = persistence::load_all(state_dir).unwrap();
+    assert!(result.runtimes.is_empty(), "old-schema runtime must not load");
+    assert!(result.failed_ids.is_empty(), "old schema is a reset, not a failure");
+    assert_eq!(result.reset_ids, vec![old_id]);
+    assert!(!old_dir.exists(), "old-schema runtime directory must be removed on load");
 }

--- a/services/rttx-server/tests/v2_serialization.rs
+++ b/services/rttx-server/tests/v2_serialization.rs
@@ -103,7 +103,7 @@ async fn serialization_creates_backup_symlink() {
 async fn restart_prefers_v2_over_v1() {
     let tmp = tempfile::TempDir::new().unwrap();
 
-    // Phase 1: create runtime, let serialization write both v1 and v2.
+    // Phase 1: create runtime, let serialization write v2 state.
     let runtime_id;
     {
         let (sock, handle) = start_test_server(tmp.path()).await;

--- a/services/rttx-server/tests/workspace_file_v2.rs
+++ b/services/rttx-server/tests/workspace_file_v2.rs
@@ -1,0 +1,173 @@
+//! Behavior tests for `WorkspaceFileV2` durable persistence and the clean-break
+//! loader (RFC-031 Step 2).
+//!
+//! These exercise the public persistence API end-to-end: the authoritative pane
+//! tree survives a save/load round trip, and old-schema (v1) state is detected,
+//! ignored, and removed on load with no migration path.
+
+use rttx_server::pane_tree::{PaneId, SplitAxis, WorkspaceTree};
+use rttx_server::runtime::RuntimePolicy;
+use rttx_server::state::types::{
+    PaneSpecV2, RUNTIME_FILE_SCHEMA_VERSION, RuntimeInstanceV1, WorkspaceFileV2, WorkspaceSpecV2,
+};
+use rttx_server::state::{layout, persistence};
+use std::time::SystemTime;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+#[test]
+fn multi_pane_tree_survives_save_and_load() {
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path();
+    let rt_id = Uuid::new_v4();
+
+    // A two-level tree with distinct ratios and a non-default active pane.
+    let (a, b, c) = (PaneId::new(), PaneId::new(), PaneId::new());
+    let mut tree = WorkspaceTree::new();
+    tree.insert_root(a);
+    tree.split(a, b, SplitAxis::Horizontal, 0.3);
+    tree.split(b, c, SplitAxis::Vertical, 0.6);
+    tree.set_default_active(b);
+    let expected_tree = tree.clone();
+
+    let mk = |id: PaneId, title: &str| PaneSpecV2 {
+        id,
+        cwd: Some("/home/user/project".into()),
+        title: Some(title.into()),
+        exit_status: None,
+        cols: 120,
+        rows: 40,
+        no_persist: false,
+    };
+    let original = WorkspaceFileV2 {
+        schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+        spec: WorkspaceSpecV2 {
+            id: rt_id,
+            name: "workspace-1".into(),
+            policy: RuntimePolicy::Persistent,
+            created_at: SystemTime::now(),
+            tree,
+            panes: vec![mk(a, "bash"), mk(b, "nvim"), mk(c, "logs")],
+        },
+        instance: RuntimeInstanceV1 {
+            revision: 7,
+            last_active_at: SystemTime::now(),
+            last_snapshot_at: SystemTime::now(),
+        },
+    };
+
+    persistence::save_daemon_index(state_dir, &[rt_id]).unwrap();
+    persistence::save_runtime(state_dir, &original).unwrap();
+
+    let result = persistence::load_all(state_dir).unwrap();
+    assert!(result.failed_ids.is_empty());
+    assert!(result.reset_ids.is_empty());
+    assert_eq!(result.runtimes.len(), 1);
+
+    let recovered = &result.runtimes[0];
+    assert_eq!(recovered.spec.tree, expected_tree, "tree structure + ratios must survive");
+    assert_eq!(recovered.spec.tree.default_active(), Some(b));
+    assert_eq!(recovered.spec.panes.len(), 3);
+    assert_eq!(recovered.instance.revision, 7);
+}
+
+#[test]
+fn old_schema_runtime_file_is_reset_not_migrated() {
+    // RFC-031 clean break: an old v1 runtime.json (flat panes, active_pane_id,
+    // command_history, no durable tree) is detected, ignored, and removed.
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path();
+    let old_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+
+    let old_dir = layout::runtime_dir(state_dir, old_id);
+    std::fs::create_dir_all(&old_dir).unwrap();
+    let v1_json = r#"{
+        "schema_version": 1,
+        "spec": {
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "name": "legacy-ws",
+            "policy": "persistent",
+            "created_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
+            "panes": [{
+                "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cwd": "/home/user",
+                "title": "bash",
+                "exit_status": null,
+                "cols": 80,
+                "rows": 24
+            }],
+            "active_pane_id": null,
+            "command_history": [
+                {"command": "cargo build", "cwd": "/home/user/project"}
+            ]
+        },
+        "instance": {
+            "revision": 5,
+            "last_active_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0},
+            "last_snapshot_at": {"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}
+        }
+    }"#;
+    std::fs::write(layout::runtime_file(state_dir, old_id), v1_json).unwrap();
+    persistence::save_daemon_index(state_dir, &[old_id]).unwrap();
+
+    let result = persistence::load_all(state_dir).unwrap();
+    assert!(result.runtimes.is_empty(), "old-schema runtime must not load");
+    assert!(result.failed_ids.is_empty(), "old schema is a reset, not a failure");
+    assert_eq!(result.reset_ids, vec![old_id]);
+    assert!(!old_dir.exists(), "old-schema runtime directory must be removed on load");
+}
+
+#[test]
+fn good_v2_runtime_survives_alongside_old_schema_sibling() {
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path();
+    let good_id = Uuid::new_v4();
+    let old_id = Uuid::new_v4();
+
+    // A current-schema workspace.
+    let pane = PaneId::new();
+    let mut tree = WorkspaceTree::new();
+    tree.insert_root(pane);
+    let good = WorkspaceFileV2 {
+        schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+        spec: WorkspaceSpecV2 {
+            id: good_id,
+            name: "current".into(),
+            policy: RuntimePolicy::Persistent,
+            created_at: SystemTime::now(),
+            tree,
+            panes: vec![PaneSpecV2 {
+                id: pane,
+                cwd: None,
+                title: None,
+                exit_status: None,
+                cols: 80,
+                rows: 24,
+                no_persist: false,
+            }],
+        },
+        instance: RuntimeInstanceV1 {
+            revision: 1,
+            last_active_at: SystemTime::now(),
+            last_snapshot_at: SystemTime::now(),
+        },
+    };
+    persistence::save_runtime(state_dir, &good).unwrap();
+
+    // A stale v1 sibling.
+    let old_dir = layout::runtime_dir(state_dir, old_id);
+    std::fs::create_dir_all(&old_dir).unwrap();
+    std::fs::write(
+        layout::runtime_file(state_dir, old_id),
+        r#"{"schema_version": 1, "spec": {}, "instance": {}}"#,
+    )
+    .unwrap();
+
+    persistence::save_daemon_index(state_dir, &[good_id, old_id]).unwrap();
+
+    let result = persistence::load_all(state_dir).unwrap();
+    assert_eq!(result.runtimes.len(), 1);
+    assert_eq!(result.runtimes[0].spec.id, good_id);
+    assert_eq!(result.reset_ids, vec![old_id]);
+    assert!(!old_dir.exists());
+}


### PR DESCRIPTION
## What and why

RFC-031 Step 2 (part of epic #997). Persist the daemon's **authoritative**
workspace tree as durable state and make startup a **clean break** from the
old v1 schema — no migration code.

Previously the daemon persisted a flat v1 pane list and re-synthesized layout
on every restart. This change persists the full `WorkspaceTree` (structure,
logical split ratios, ordering, and default-active pane) so layout survives
daemon restarts.

### Changes

- New `WorkspaceFileV2` / `WorkspaceSpecV2` / `PaneSpecV2` durable structs. The
  durable `tree` (structure + logical ratios + default-active) and per-pane
  spec are keyed on the immutable `PaneId`.
- `RUNTIME_FILE_SCHEMA_VERSION` bumped to `2`.
- All durable artifacts (`history/<id>.hist`, `screen/<id>.snap`,
  `scrollback/<id>.log`) keyed on `PaneId`.
- **Clean break:** on load, old-schema (v1) runtime state is detected, ignored,
  and removed from disk — no migration path. `command_history` removed entirely;
  the standalone `active_pane_id` is subsumed by the tree's default-active.
- Corruption containment preserved: a corrupt runtime is skipped (not fatal);
  an unsupported future version is refused rather than guessed.
- Version bumped `0.9.5` → `0.9.6` (schema/protocol-affecting, server-side).
- Deflaked the pre-existing, timing-sensitive `history_survives_hard_restart`
  integration test (separate commit) so the quality gate is deterministic.

This is a daemon-only change; there are no `clients/` (GTK) modifications.

## How to manually verify

1. With an old (v1) `runtime.json` on disk under the daemon state dir, start
   `rttx-server`; the old runtime directory is removed and a `reset` is logged
   (`RFC-031 clean break`), and the daemon starts cleanly.
2. Create a multi-pane persistent workspace, split it, restart the daemon; the
   pane tree (structure + ratios + default-active) is restored from
   `WorkspaceFileV2`.

## Tests added

- `services/rttx-server/src/state/types.rs` (unit): tree round-trip, schema
  version presence, envelope dispatch, `serialization_drops_legacy_fields`
  (asserts `command_history`/`active_pane_id` are gone).
- `services/rttx-server/src/state/persistence.rs` (unit):
  `save_and_load_preserves_multi_pane_tree`, `old_schema_runtime_is_reset_and_removed`,
  `old_schema_reset_does_not_drop_current_runtimes`, `corrupt_runtime_is_skipped_not_fatal`,
  backup-recovery and screen-snapshot round trips.
- `services/rttx-server/tests/workspace_file_v2.rs` (integration):
  `multi_pane_tree_survives_save_and_load`, `old_schema_runtime_file_is_reset_not_migrated`,
  `good_v2_runtime_survives_alongside_old_schema_sibling`.

## Tests run (all local, all pass)

- `cargo test -p rttx-server -p rttx-proto` — all pass.
- `bash .github/scripts/run-clippy.sh` — clean (`-D warnings`, pedantic+nursery).
- `bash .github/scripts/run-quality-tests.sh` — full matrix incl. GTK tests via
  Broadway: 505 `test result: ok`, 0 failures. Runtime-behavior gate: 6/6.
  New integration tests confirmed present and passing:
  `multi_pane_tree_survives_save_and_load`,
  `old_schema_runtime_file_is_reset_not_migrated`,
  `good_v2_runtime_survives_alongside_old_schema_sibling`.
- Deflaked `history_survives_hard_restart`: 6/6 passes under parallel load
  (was intermittently failing before).

## Acceptance criteria (issue #999)

- [x] Save/load round-trip of a multi-pane tree (structure + ratios + active) — unit tested.
- [x] Old-schema state on disk is detected, ignored, and removed — tested.
- [x] Corruption containment preserved (corrupt workspace skipped, not fatal) — tested.
- [x] Zero compatibility/migration code; `command_history` gone.
- [x] `clippy -D warnings` clean.

## Limitations / follow-ups

- Daemon-only; client-side consumption of the restored tree is tracked by later
  RFC-031 steps in epic #997.

Fixes #999
