### PR TITLE
[rttx-proto + 2 more] Server-authoritative tree protocol (RFC-031 Step 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Durable workspace persistence (`WorkspaceFileV2`): the daemon now persists the
   authoritative pane tree — structure, logical split ratios, and default-active
   pane — so layout survives daemon restarts (RFC-031 Step 2).
+- Server-authoritative tree protocol (RFC-031 Step 3): the attach snapshot now
+  carries the full workspace tree and default-active pane; new tree mutations
+  `SplitPane` (server-minted, immutable pane id), `ResizeSplit`, and viewport
+  messages `SetFocus`/`ReportClientSize` drive a multi-client PTY min-size
+  policy so no client sees truncated output.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.6"
+version = "0.9.7"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -723,6 +723,8 @@ pub fn extract_pane_id(env: &v3::ServerEnvelope) -> Option<Uuid> {
         Payload::Bell(m) => &m.pane_id,
         Payload::PaneResized(m) => &m.pane_id,
         Payload::TerminalModeChanged(m) => &m.pane_id,
+        Payload::PaneSplit(m) => &m.new_pane_id,
+        Payload::FocusChanged(m) => &m.pane_id,
         Payload::Pong(_)
         | Payload::RuntimeList(_)
         | Payload::RuntimeCreated(_)
@@ -737,6 +739,7 @@ pub fn extract_pane_id(env: &v3::ServerEnvelope) -> Option<Uuid> {
         | Payload::ScrollbackChunk(_)
         | Payload::TakeoverCompleted(_)
         | Payload::LeaseLost(_)
+        | Payload::SplitResized(_)
         | Payload::OwnerDisconnected(_) => return None,
     };
     bytes_to_uuid(bytes).ok()

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -2027,6 +2027,8 @@ mod tests {
                     request_id: request.request_id,
                     payload: Some(v3::server_envelope::Payload::RuntimeSnapshot(
                         v3::RuntimeSnapshot {
+                            tree: None,
+                            default_active_pane_id: Vec::new(),
                             runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
                             panes: vec![],
                             runtime_revision: 1,
@@ -2862,6 +2864,8 @@ mod tests {
                     request_id: request.request_id,
                     payload: Some(v3::server_envelope::Payload::RuntimeSnapshot(
                         v3::RuntimeSnapshot {
+                            tree: None,
+                            default_active_pane_id: Vec::new(),
                             runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
                             panes: vec![],
                             runtime_revision: 1,
@@ -3271,6 +3275,8 @@ mod tests {
                     request_id: msg2.request_id,
                     payload: Some(v3::server_envelope::Payload::RuntimeSnapshot(
                         v3::RuntimeSnapshot {
+                            tree: None,
+                            default_active_pane_id: Vec::new(),
                             runtime_id: rttx_proto::uuid_to_bytes(attached_runtime_id),
                             panes: vec![],
                             runtime_revision: 1,

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -1107,9 +1107,14 @@ impl Window {
                     );
                 }
             }
+            // Tree-delta and viewport events are consumed by the
+            // server-authoritative client view in RFC-031 Step 4 (#1001).
             Payload::PaneResized(_)
             | Payload::PaneCreated(_)
             | Payload::PaneClosed(_)
+            | Payload::PaneSplit(_)
+            | Payload::SplitResized(_)
+            | Payload::FocusChanged(_)
             | Payload::RuntimeList(_)
             | Payload::RuntimeCreated(_)
             | Payload::RuntimeSnapshot(_)

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -2703,6 +2703,8 @@ fn managed_workspace_recovery_does_not_steal_visible_session_from_selected_row()
         workspace_id: recovered_session.uuid.clone(),
         runtime_id: runtime_id.to_string(),
         snapshot: rttx_proto::v3::RuntimeSnapshot {
+            tree: None,
+            default_active_pane_id: Vec::new(),
             runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
             runtime_revision: 7,
             client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
@@ -3266,6 +3268,8 @@ fn retry_workspace_connection_sets_connecting_and_rebuilds_on_open() {
         workspace_id: session_state.uuid.clone(),
         runtime_id: runtime_id.to_string(),
         snapshot: rttx_proto::v3::RuntimeSnapshot {
+            tree: None,
+            default_active_pane_id: Vec::new(),
             runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
             runtime_revision: 5,
             client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
@@ -7256,6 +7260,8 @@ fn workspace_resynced_event_restores_pane_content() {
         workspace_id: session_state.uuid.clone(),
         runtime_id: runtime_id.to_string(),
         snapshot: rttx_proto::v3::RuntimeSnapshot {
+            tree: None,
+            default_active_pane_id: Vec::new(),
             runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
             runtime_revision: 7,
             client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,
@@ -7281,6 +7287,8 @@ fn workspace_resynced_event_restores_pane_content() {
         workspace_id: session_state.uuid.clone(),
         runtime_id: runtime_id.to_string(),
         snapshot: rttx_proto::v3::RuntimeSnapshot {
+            tree: None,
+            default_active_pane_id: Vec::new(),
             runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
             runtime_revision: 8,
             client_role: rttx_proto::v3::RuntimeClientRole::Writer as i32,

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -656,6 +656,8 @@ mod tests {
 
     fn snapshot(runtime_id: &str, panes: Vec<v3::PaneSnapshot>) -> v3::RuntimeSnapshot {
         v3::RuntimeSnapshot {
+            tree: None,
+            default_active_pane_id: Vec::new(),
             runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
             panes,
             runtime_revision: 7,
@@ -1497,6 +1499,8 @@ mod tests {
             workspace_id: "ws-1".into(),
             runtime_id: runtime_id.clone(),
             snapshot: v3::RuntimeSnapshot {
+                tree: None,
+                default_active_pane_id: Vec::new(),
                 runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
                 panes: vec![v3::PaneSnapshot {
                     pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane_id).unwrap()),

--- a/clients/rttx/tests/pane_reverse_index.rs
+++ b/clients/rttx/tests/pane_reverse_index.rs
@@ -82,6 +82,8 @@ fn snapshot(
     panes: Vec<rttx_proto::v3::PaneSnapshot>,
 ) -> rttx_proto::v3::RuntimeSnapshot {
     rttx_proto::v3::RuntimeSnapshot {
+        tree: None,
+        default_active_pane_id: Vec::new(),
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
         panes,
         runtime_revision: 1,

--- a/clients/rttx/tests/reconnect_layout_stability.rs
+++ b/clients/rttx/tests/reconnect_layout_stability.rs
@@ -39,6 +39,8 @@ fn snapshot(
     panes: Vec<rttx_proto::v3::PaneSnapshot>,
 ) -> rttx_proto::v3::RuntimeSnapshot {
     rttx_proto::v3::RuntimeSnapshot {
+        tree: None,
+        default_active_pane_id: Vec::new(),
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
         panes,
         runtime_revision: 1,

--- a/clients/rttx/tests/stale_terminal_cleanup.rs
+++ b/clients/rttx/tests/stale_terminal_cleanup.rs
@@ -40,6 +40,8 @@ fn snapshot(
     panes: Vec<rttx_proto::v3::PaneSnapshot>,
 ) -> rttx_proto::v3::RuntimeSnapshot {
     rttx_proto::v3::RuntimeSnapshot {
+        tree: None,
+        default_active_pane_id: Vec::new(),
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
         panes,
         runtime_revision: 1,

--- a/clients/rttx/tests/stream_overflow_resync.rs
+++ b/clients/rttx/tests/stream_overflow_resync.rs
@@ -47,6 +47,8 @@ fn snapshot(
     panes: Vec<rttx_proto::v3::PaneSnapshot>,
 ) -> rttx_proto::v3::RuntimeSnapshot {
     rttx_proto::v3::RuntimeSnapshot {
+        tree: None,
+        default_active_pane_id: Vec::new(),
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(runtime_id).unwrap()),
         panes,
         runtime_revision: 1,

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -933,6 +933,8 @@ fn split_pane_cwd_propagates_through_reconciliation_create_request() {
         workspace_id: state.workspaces[0].uuid.clone(),
         runtime_id: runtime_id.clone(),
         snapshot: rttx_proto::v3::RuntimeSnapshot {
+            tree: None,
+            default_active_pane_id: Vec::new(),
             runtime_id: rttx_proto::uuid_to_bytes(runtime_id.parse().unwrap()),
             panes: vec![rttx_proto::v3::PaneSnapshot {
                 pane_id: rttx_proto::uuid_to_bytes(first_uuid.parse().unwrap()),
@@ -1090,6 +1092,8 @@ fn workspace_opened_with_new_runtime_id_updates_session_state() {
         workspace_id: state.workspaces[0].uuid.clone(),
         runtime_id: new_runtime.to_string(),
         snapshot: rttx_proto::v3::RuntimeSnapshot {
+            tree: None,
+            default_active_pane_id: Vec::new(),
             runtime_id: rttx_proto::uuid_to_bytes(new_runtime),
             panes: vec![rttx_proto::v3::PaneSnapshot {
                 pane_id: rttx_proto::uuid_to_bytes(pane_id),
@@ -1309,6 +1313,8 @@ fn v3_snapshot_terminal_modes_propagate_through_reconciliation() {
     let ws_id = state.workspaces[0].uuid.clone();
 
     let snapshot = rttx_proto::v3::RuntimeSnapshot {
+        tree: None,
+        default_active_pane_id: Vec::new(),
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
         panes: vec![rttx_proto::v3::PaneSnapshot {
             pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane_id).unwrap()),
@@ -1376,6 +1382,8 @@ fn v3_snapshot_focus_and_cursor_modes_propagate_through_reconciliation() {
     let ws_id = state.workspaces[0].uuid.clone();
 
     let snapshot = rttx_proto::v3::RuntimeSnapshot {
+        tree: None,
+        default_active_pane_id: Vec::new(),
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
         panes: vec![rttx_proto::v3::PaneSnapshot {
             pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane_id).unwrap()),

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.6',
+  version: '0.9.7',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/proto/rttx-v3.proto
+++ b/protocols/rttx-proto/proto/rttx-v3.proto
@@ -261,6 +261,45 @@ message PaneInfo {
   bool no_persist = 8;
 }
 
+// ─── Workspace tree (RFC-031 §2, §5) ─────────────────────────────────
+
+// Orientation of a split node in the authoritative workspace tree.
+enum PaneSplitAxis {
+  PANE_SPLIT_AXIS_UNSPECIFIED = 0;
+  // Children placed side by side (a vertical divider between them).
+  PANE_SPLIT_AXIS_HORIZONTAL = 1;
+  // Children stacked top and bottom (a horizontal divider between them).
+  PANE_SPLIT_AXIS_VERTICAL = 2;
+}
+
+// One step when addressing a split node by its path from the tree root.
+enum PaneTreeSide {
+  PANE_TREE_SIDE_UNSPECIFIED = 0;
+  PANE_TREE_SIDE_FIRST = 1;
+  PANE_TREE_SIDE_SECOND = 2;
+}
+
+// A node in the server-authoritative pane tree: either a leaf naming one
+// pane or a split joining two subtrees with a logical ratio.
+message PaneTreeNode {
+  oneof node {
+    PaneTreeLeaf leaf = 1;
+    PaneTreeSplit split = 2;
+  }
+}
+
+message PaneTreeLeaf {
+  bytes pane_id = 1;
+}
+
+message PaneTreeSplit {
+  PaneSplitAxis axis = 1;
+  // Fraction of space allocated to `first`, in the open interval (0, 1).
+  float ratio = 2;
+  PaneTreeNode first = 3;
+  PaneTreeNode second = 4;
+}
+
 // ─── Snapshots ───────────────────────────────────────────────────────
 
 message RuntimeSnapshot {
@@ -268,6 +307,12 @@ message RuntimeSnapshot {
   uint64 runtime_revision = 2;
   RuntimeClientRole client_role = 3;
   repeated PaneSnapshot panes = 4;
+  // Authoritative workspace structure (RFC-031). Absent only for an empty
+  // workspace with no panes.
+  PaneTreeNode tree = 5;
+  // Fallback focus pane for a fresh attach (RFC-031 §2). Empty when the
+  // workspace has no panes.
+  bytes default_active_pane_id = 6;
 }
 
 message PaneSnapshot {
@@ -319,6 +364,56 @@ message SetPaneNoPersist {
   bool no_persist = 3;
 }
 
+// ─── Tree mutations (RFC-031 §5) ─────────────────────────────────────
+//
+// Structural mutations are server-authoritative: the server applies them to
+// the workspace tree, persists the result, and reports a tree delta. Pane
+// identity is always server-assigned (RFC-031 G1).
+
+// Split the leaf holding `target_pane_id`, adding a server-minted pane as the
+// second child. Replaces the client-identity CreatePane for tree growth.
+message SplitPane {
+  bytes runtime_id = 1;
+  bytes target_pane_id = 2;
+  PaneSplitAxis axis = 3;
+  // Fraction of space allocated to the existing pane, in (0, 1).
+  float ratio = 4;
+  optional string cwd = 5;
+  optional bool dark_background = 6;
+  uint32 cols = 7;
+  uint32 rows = 8;
+  optional bool no_persist = 9;
+}
+
+// Set the logical ratio of the split addressed by `path` from the tree root.
+message ResizeSplit {
+  bytes runtime_id = 1;
+  repeated PaneTreeSide path = 2;
+  float ratio = 3;
+}
+
+// ─── Viewport messages (RFC-031 §3–§5) ───────────────────────────────
+//
+// Per-client viewport state. SetFocus updates the server's fallback focus
+// (default-active) pane; ReportClientSize drives the multi-client PTY
+// min-size policy (RFC-031 §4).
+
+message SetFocus {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+}
+
+message ClientPaneSize {
+  bytes pane_id = 1;
+  uint32 cols = 2;
+  uint32 rows = 3;
+}
+
+message ReportClientSize {
+  bytes runtime_id = 1;
+  repeated ClientPaneSize panes = 2;
+}
+
 // ─── Pane lifecycle — events ─────────────────────────────────────────
 
 message PaneCreated {
@@ -365,6 +460,34 @@ message CwdChanged {
 message Bell {
   bytes runtime_id = 1;
   bytes pane_id = 2;
+}
+
+// ─── Tree mutation events (RFC-031 §5) ───────────────────────────────
+
+// A split was applied to the workspace tree. The new pane id is
+// server-assigned; the target/axis/ratio describe where it landed.
+message PaneSplit {
+  bytes runtime_id = 1;
+  bytes target_pane_id = 2;
+  bytes new_pane_id = 3;
+  PaneSplitAxis axis = 4;
+  float ratio = 5;
+  uint64 runtime_revision = 6;
+}
+
+// A split's logical ratio changed.
+message SplitResized {
+  bytes runtime_id = 1;
+  repeated PaneTreeSide path = 2;
+  float ratio = 3;
+  uint64 runtime_revision = 4;
+}
+
+// The fallback focus (default-active) pane changed.
+message FocusChanged {
+  bytes runtime_id = 1;
+  bytes pane_id = 2;
+  uint64 runtime_revision = 3;
 }
 
 // ─── Recovery (OPT_RESYNC) ──────────────────────────────────────────
@@ -469,6 +592,14 @@ message ClientEnvelope {
     SetPaneTitle set_pane_title = 33;
     SetPaneNoPersist set_pane_no_persist = 34;
 
+    // Tree mutations (RFC-031 §5)
+    SplitPane split_pane = 35;
+    ResizeSplit resize_split = 36;
+
+    // Viewport (RFC-031 §3–§5)
+    SetFocus set_focus = 37;
+    ReportClientSize report_client_size = 38;
+
     // Recovery (OPT_RESYNC)
     ResyncRuntime resync_runtime = 50;
 
@@ -510,6 +641,11 @@ message ServerEnvelope {
     TitleChanged title_changed = 34;
     CwdChanged cwd_changed = 35;
     Bell bell = 36;
+
+    // Tree mutation events (RFC-031 §5)
+    PaneSplit pane_split = 37;
+    SplitResized split_resized = 38;
+    FocusChanged focus_changed = 39;
 
     // Recovery events (OPT_RESYNC)
     StreamOverflow stream_overflow = 50;

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -33,6 +33,9 @@ pub mod v3_error;
 /// V3 snapshot and output delta: builders and helpers (RFC-021 Sections 7–8).
 pub mod v3_snapshot;
 
+/// V3 workspace tree: server-authoritative tree, mutations, and viewport messages (RFC-031 §5).
+pub mod v3_tree;
+
 /// V3 chunked scrollback: builders, validation, and capability gating (RFC-021 Section 8, `OPT_CHUNKED_SCROLLBACK`).
 pub mod v3_scrollback;
 
@@ -358,6 +361,8 @@ mod v3_tests {
                 total_scrollback_bytes: 4096,
                 scrollback_complete: false,
             }],
+            tree: None,
+            default_active_pane_id: Vec::new(),
         };
         let mut buf = BytesMut::new();
         encode_frame(&msg, &mut buf).unwrap();
@@ -610,6 +615,8 @@ mod v3_envelope_tests {
                     runtime_revision: 10,
                     client_role: v3::RuntimeClientRole::Writer as i32,
                     panes: vec![],
+                    tree: None,
+                    default_active_pane_id: Vec::new(),
                 })),
             },
             v3::ServerEnvelope {

--- a/protocols/rttx-proto/src/v3_envelope.rs
+++ b/protocols/rttx-proto/src/v3_envelope.rs
@@ -49,6 +49,7 @@ pub fn is_fire_and_forget(command: &v3::client_envelope::Command) -> bool {
             | v3::client_envelope::Command::ResizePane(_)
             | v3::client_envelope::Command::SetPaneTitle(_)
             | v3::client_envelope::Command::SetPaneNoPersist(_)
+            | v3::client_envelope::Command::ReportClientSize(_)
             | v3::client_envelope::Command::Shutdown(_)
     )
 }

--- a/protocols/rttx-proto/src/v3_snapshot.rs
+++ b/protocols/rttx-proto/src/v3_snapshot.rs
@@ -54,6 +54,9 @@ pub fn build_pane_snapshot(params: PaneSnapshotParams) -> v3::PaneSnapshot {
 }
 
 /// Build a `RuntimeSnapshot` response for a successful attach.
+///
+/// The workspace tree is left empty; use [`build_runtime_snapshot_with_tree`]
+/// to carry the authoritative structure (RFC-031).
 #[must_use]
 pub fn build_runtime_snapshot(
     runtime_id: uuid::Uuid,
@@ -66,6 +69,29 @@ pub fn build_runtime_snapshot(
         runtime_revision,
         client_role: client_role as i32,
         panes,
+        tree: None,
+        default_active_pane_id: Vec::new(),
+    }
+}
+
+/// Build a `RuntimeSnapshot` carrying the authoritative workspace tree and
+/// fallback-focus pane (RFC-031 §5).
+#[must_use]
+pub fn build_runtime_snapshot_with_tree(
+    runtime_id: uuid::Uuid,
+    runtime_revision: u64,
+    client_role: v3::RuntimeClientRole,
+    panes: Vec<v3::PaneSnapshot>,
+    tree: Option<v3::PaneTreeNode>,
+    default_active_pane_id: Vec<u8>,
+) -> v3::RuntimeSnapshot {
+    v3::RuntimeSnapshot {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        runtime_revision,
+        client_role: client_role as i32,
+        panes,
+        tree,
+        default_active_pane_id,
     }
 }
 

--- a/protocols/rttx-proto/src/v3_tree.rs
+++ b/protocols/rttx-proto/src/v3_tree.rs
@@ -173,12 +173,8 @@ mod tests {
     fn split_node_carries_axis_ratio_and_children() {
         let a = pid();
         let b = pid();
-        let node = pane_tree_split(
-            v3::PaneSplitAxis::Vertical,
-            0.3,
-            pane_tree_leaf(a),
-            pane_tree_leaf(b),
-        );
+        let node =
+            pane_tree_split(v3::PaneSplitAxis::Vertical, 0.3, pane_tree_leaf(a), pane_tree_leaf(b));
         let Some(v3::pane_tree_node::Node::Split(split)) = node.node else {
             panic!("expected split");
         };
@@ -220,8 +216,14 @@ mod tests {
 
     #[test]
     fn pane_split_push_has_zero_request_id() {
-        let env =
-            build_pane_split_push(build_pane_split(pid(), pid(), pid(), v3::PaneSplitAxis::Vertical, 0.6, 9));
+        let env = build_pane_split_push(build_pane_split(
+            pid(),
+            pid(),
+            pid(),
+            v3::PaneSplitAxis::Vertical,
+            0.6,
+            9,
+        ));
         assert_eq!(env.request_id, 0);
         assert!(crate::v3_envelope::is_push_event(&env));
     }
@@ -242,10 +244,7 @@ mod tests {
         let Some(v3::server_envelope::Payload::SplitResized(r)) = decoded.payload else {
             panic!("expected SplitResized");
         };
-        assert_eq!(r.path, vec![
-            v3::PaneTreeSide::Second as i32,
-            v3::PaneTreeSide::First as i32,
-        ]);
+        assert_eq!(r.path, vec![v3::PaneTreeSide::Second as i32, v3::PaneTreeSide::First as i32,]);
         assert!((r.ratio - 0.25).abs() < f32::EPSILON);
     }
 

--- a/protocols/rttx-proto/src/v3_tree.rs
+++ b/protocols/rttx-proto/src/v3_tree.rs
@@ -1,0 +1,276 @@
+//! V3 workspace-tree messages: builders for the server-authoritative pane
+//! tree, its structural mutations, and viewport messages (RFC-031 §5).
+//!
+//! The wire tree ([`v3::PaneTreeNode`]) mirrors the server's authoritative
+//! `WorkspaceTree`: a binary tree whose leaves name panes and whose internal
+//! nodes are splits carrying a logical ratio. Pane identity is always
+//! server-assigned (RFC-031 G1); these builders never mint identity.
+
+use crate::v3;
+
+/// Build a leaf node naming a single pane.
+#[must_use]
+pub fn pane_tree_leaf(pane_id: uuid::Uuid) -> v3::PaneTreeNode {
+    v3::PaneTreeNode {
+        node: Some(v3::pane_tree_node::Node::Leaf(v3::PaneTreeLeaf {
+            pane_id: crate::uuid_to_bytes(pane_id),
+        })),
+    }
+}
+
+/// Build a split node joining two subtrees with a logical `ratio`.
+#[must_use]
+pub fn pane_tree_split(
+    axis: v3::PaneSplitAxis,
+    ratio: f32,
+    first: v3::PaneTreeNode,
+    second: v3::PaneTreeNode,
+) -> v3::PaneTreeNode {
+    v3::PaneTreeNode {
+        node: Some(v3::pane_tree_node::Node::Split(Box::new(v3::PaneTreeSplit {
+            axis: axis as i32,
+            ratio,
+            first: Some(Box::new(first)),
+            second: Some(Box::new(second)),
+        }))),
+    }
+}
+
+/// Build a `PaneSplit` tree-delta event.
+#[must_use]
+pub fn build_pane_split(
+    runtime_id: uuid::Uuid,
+    target_pane_id: uuid::Uuid,
+    new_pane_id: uuid::Uuid,
+    axis: v3::PaneSplitAxis,
+    ratio: f32,
+    runtime_revision: u64,
+) -> v3::PaneSplit {
+    v3::PaneSplit {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        target_pane_id: crate::uuid_to_bytes(target_pane_id),
+        new_pane_id: crate::uuid_to_bytes(new_pane_id),
+        axis: axis as i32,
+        ratio,
+        runtime_revision,
+    }
+}
+
+/// Build a `ServerEnvelope` response carrying a `PaneSplit`.
+#[must_use]
+pub fn build_pane_split_response(request_id: u64, split: v3::PaneSplit) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_response_envelope(
+        request_id,
+        v3::server_envelope::Payload::PaneSplit(split),
+    )
+}
+
+/// Build a `ServerEnvelope` push event carrying a `PaneSplit`.
+#[must_use]
+pub fn build_pane_split_push(split: v3::PaneSplit) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_push_envelope(v3::server_envelope::Payload::PaneSplit(split))
+}
+
+/// Build a `SplitResized` event.
+#[must_use]
+pub fn build_split_resized(
+    runtime_id: uuid::Uuid,
+    path: Vec<v3::PaneTreeSide>,
+    ratio: f32,
+    runtime_revision: u64,
+) -> v3::SplitResized {
+    v3::SplitResized {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        path: path.into_iter().map(|s| s as i32).collect(),
+        ratio,
+        runtime_revision,
+    }
+}
+
+/// Build a `ServerEnvelope` response carrying a `SplitResized`.
+#[must_use]
+pub fn build_split_resized_response(
+    request_id: u64,
+    resized: v3::SplitResized,
+) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_response_envelope(
+        request_id,
+        v3::server_envelope::Payload::SplitResized(resized),
+    )
+}
+
+/// Build a `ServerEnvelope` push event carrying a `SplitResized`.
+#[must_use]
+pub fn build_split_resized_push(resized: v3::SplitResized) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_push_envelope(v3::server_envelope::Payload::SplitResized(resized))
+}
+
+/// Build a `FocusChanged` event.
+#[must_use]
+pub fn build_focus_changed(
+    runtime_id: uuid::Uuid,
+    pane_id: uuid::Uuid,
+    runtime_revision: u64,
+) -> v3::FocusChanged {
+    v3::FocusChanged {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        pane_id: crate::uuid_to_bytes(pane_id),
+        runtime_revision,
+    }
+}
+
+/// Build a `ServerEnvelope` response carrying a `FocusChanged`.
+#[must_use]
+pub fn build_focus_changed_response(
+    request_id: u64,
+    changed: v3::FocusChanged,
+) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_response_envelope(
+        request_id,
+        v3::server_envelope::Payload::FocusChanged(changed),
+    )
+}
+
+/// Build a `ServerEnvelope` push event carrying a `FocusChanged`.
+#[must_use]
+pub fn build_focus_changed_push(changed: v3::FocusChanged) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_push_envelope(v3::server_envelope::Payload::FocusChanged(changed))
+}
+
+/// Decode a repeated `PaneTreeSide` path into a typed list, dropping any
+/// `UNSPECIFIED` or out-of-range entries (which never address a real split
+/// branch).
+#[must_use]
+pub fn decode_side_path(raw: &[i32]) -> Vec<v3::PaneTreeSide> {
+    raw.iter()
+        .copied()
+        .filter_map(|v| v3::PaneTreeSide::try_from(v).ok())
+        .filter(|s| !matches!(s, v3::PaneTreeSide::Unspecified))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{decode_frame, encode_frame, uuid_to_bytes};
+    use bytes::BytesMut;
+
+    fn pid() -> uuid::Uuid {
+        uuid::Uuid::new_v4()
+    }
+
+    #[test]
+    fn leaf_node_carries_pane_id() {
+        let p = pid();
+        let node = pane_tree_leaf(p);
+        let Some(v3::pane_tree_node::Node::Leaf(leaf)) = node.node else {
+            panic!("expected leaf");
+        };
+        assert_eq!(leaf.pane_id, uuid_to_bytes(p));
+    }
+
+    #[test]
+    fn split_node_carries_axis_ratio_and_children() {
+        let a = pid();
+        let b = pid();
+        let node = pane_tree_split(
+            v3::PaneSplitAxis::Vertical,
+            0.3,
+            pane_tree_leaf(a),
+            pane_tree_leaf(b),
+        );
+        let Some(v3::pane_tree_node::Node::Split(split)) = node.node else {
+            panic!("expected split");
+        };
+        assert_eq!(split.axis, v3::PaneSplitAxis::Vertical as i32);
+        assert!((split.ratio - 0.3).abs() < f32::EPSILON);
+        assert!(split.first.is_some());
+        assert!(split.second.is_some());
+    }
+
+    #[test]
+    fn nested_tree_round_trips_on_the_wire() {
+        let (a, b, c) = (pid(), pid(), pid());
+        // Split(a, Split(b, c))
+        let tree = pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(a),
+            pane_tree_split(v3::PaneSplitAxis::Vertical, 0.4, pane_tree_leaf(b), pane_tree_leaf(c)),
+        );
+        let mut buf = BytesMut::new();
+        encode_frame(&tree, &mut buf).unwrap();
+        let decoded: v3::PaneTreeNode = decode_frame(&mut buf).unwrap();
+        assert_eq!(tree, decoded);
+    }
+
+    #[test]
+    fn pane_split_event_is_a_response_not_a_push() {
+        let env = build_pane_split_response(
+            7,
+            build_pane_split(pid(), pid(), pid(), v3::PaneSplitAxis::Horizontal, 0.5, 3),
+        );
+        assert_eq!(env.request_id, 7);
+        assert!(!crate::v3_envelope::is_push_event(&env));
+        let Some(v3::server_envelope::Payload::PaneSplit(p)) = env.payload else {
+            panic!("expected PaneSplit");
+        };
+        assert_eq!(p.runtime_revision, 3);
+    }
+
+    #[test]
+    fn pane_split_push_has_zero_request_id() {
+        let env =
+            build_pane_split_push(build_pane_split(pid(), pid(), pid(), v3::PaneSplitAxis::Vertical, 0.6, 9));
+        assert_eq!(env.request_id, 0);
+        assert!(crate::v3_envelope::is_push_event(&env));
+    }
+
+    #[test]
+    fn split_resized_round_trips_path_and_ratio() {
+        let resized = build_split_resized(
+            pid(),
+            vec![v3::PaneTreeSide::Second, v3::PaneTreeSide::First],
+            0.25,
+            12,
+        );
+        let env = build_split_resized_response(4, resized);
+        let mut buf = BytesMut::new();
+        encode_frame(&env, &mut buf).unwrap();
+        let decoded: v3::ServerEnvelope = decode_frame(&mut buf).unwrap();
+        assert_eq!(env, decoded);
+        let Some(v3::server_envelope::Payload::SplitResized(r)) = decoded.payload else {
+            panic!("expected SplitResized");
+        };
+        assert_eq!(r.path, vec![
+            v3::PaneTreeSide::Second as i32,
+            v3::PaneTreeSide::First as i32,
+        ]);
+        assert!((r.ratio - 0.25).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn focus_changed_carries_pane_and_revision() {
+        let p = pid();
+        let env = build_focus_changed_response(1, build_focus_changed(pid(), p, 5));
+        let Some(v3::server_envelope::Payload::FocusChanged(f)) = env.payload else {
+            panic!("expected FocusChanged");
+        };
+        assert_eq!(f.pane_id, uuid_to_bytes(p));
+        assert_eq!(f.runtime_revision, 5);
+    }
+
+    #[test]
+    fn decode_side_path_keeps_only_real_branches() {
+        let raw = vec![
+            v3::PaneTreeSide::First as i32,
+            v3::PaneTreeSide::Unspecified as i32,
+            v3::PaneTreeSide::Second as i32,
+            99, // out of range
+        ];
+        // Unspecified and out-of-range entries are dropped; only First/Second
+        // (which address real split branches) survive.
+        let decoded = decode_side_path(&raw);
+        assert_eq!(decoded, vec![v3::PaneTreeSide::First, v3::PaneTreeSide::Second]);
+    }
+}

--- a/services/rttx-server/src/protocol.rs
+++ b/services/rttx-server/src/protocol.rs
@@ -2,6 +2,7 @@
 //!
 //! Convenience functions for constructing server response messages.
 
+use crate::pane_tree::{PaneId, PaneTree, Side, SplitAxis, WorkspaceTree};
 use crate::runtime::{ClientRole, Runtime, TerminationReason};
 use rttx_proto::{uuid_to_bytes, v3};
 use uuid::Uuid;
@@ -96,6 +97,93 @@ pub fn v3_runtime_terminated(
     ))
 }
 
+// ── Workspace tree conversions (RFC-031 §5) ─────────────────────
+
+/// Map a server split axis to its wire enum.
+#[must_use]
+pub const fn split_axis_to_proto(axis: SplitAxis) -> v3::PaneSplitAxis {
+    match axis {
+        SplitAxis::Horizontal => v3::PaneSplitAxis::Horizontal,
+        SplitAxis::Vertical => v3::PaneSplitAxis::Vertical,
+    }
+}
+
+/// Map a wire split axis to the server axis. An unspecified axis defaults to
+/// horizontal (the daemon's even-split convention).
+#[must_use]
+pub const fn proto_axis_to_split(axis: v3::PaneSplitAxis) -> SplitAxis {
+    match axis {
+        v3::PaneSplitAxis::Vertical => SplitAxis::Vertical,
+        v3::PaneSplitAxis::Unspecified | v3::PaneSplitAxis::Horizontal => SplitAxis::Horizontal,
+    }
+}
+
+/// Map a wire tree side to the server `Side`, dropping the unspecified value
+/// (which never addresses a real split branch).
+#[must_use]
+pub const fn proto_side_to_side(side: v3::PaneTreeSide) -> Option<Side> {
+    match side {
+        v3::PaneTreeSide::First => Some(Side::First),
+        v3::PaneTreeSide::Second => Some(Side::Second),
+        v3::PaneTreeSide::Unspecified => None,
+    }
+}
+
+/// Decode a wire side path into a server path. Any unspecified or out-of-range
+/// step makes the whole path unaddressable and yields `None`.
+#[must_use]
+pub fn decode_side_path(raw: &[i32]) -> Option<Vec<Side>> {
+    raw.iter().map(|&v| v3::PaneTreeSide::try_from(v).ok().and_then(proto_side_to_side)).collect()
+}
+
+fn pane_tree_to_proto(node: &PaneTree) -> v3::PaneTreeNode {
+    match node {
+        PaneTree::Leaf { pane } => rttx_proto::v3_tree::pane_tree_leaf(pane.uuid()),
+        PaneTree::Split { axis, ratio, first, second } => rttx_proto::v3_tree::pane_tree_split(
+            split_axis_to_proto(*axis),
+            *ratio,
+            pane_tree_to_proto(first),
+            pane_tree_to_proto(second),
+        ),
+    }
+}
+
+/// Build the wire representation of a workspace tree, or `None` for an empty
+/// workspace.
+#[must_use]
+pub fn workspace_tree_to_proto(tree: &WorkspaceTree) -> Option<v3::PaneTreeNode> {
+    tree.root().map(pane_tree_to_proto)
+}
+
+/// The wire bytes of the tree's default-active pane, or empty when there is
+/// none.
+#[must_use]
+pub fn default_active_bytes(tree: &WorkspaceTree) -> Vec<u8> {
+    tree.default_active().map(PaneId::uuid).map(uuid_to_bytes).unwrap_or_default()
+}
+
+/// The PTY size for a pane shared by multiple clients: the per-axis minimum of
+/// every client's reported render size, so no client sees truncated output
+/// (RFC-031 §4). Zero dimensions are ignored. Returns `None` when no client has
+/// reported a usable size on the corresponding axis.
+#[must_use]
+pub fn min_client_pane_size<I>(sizes: I) -> Option<(u16, u16)>
+where
+    I: IntoIterator<Item = (u16, u16)>,
+{
+    let mut min_cols: Option<u16> = None;
+    let mut min_rows: Option<u16> = None;
+    for (cols, rows) in sizes {
+        if cols > 0 {
+            min_cols = Some(min_cols.map_or(cols, |m| m.min(cols)));
+        }
+        if rows > 0 {
+            min_rows = Some(min_rows.map_or(rows, |m| m.min(rows)));
+        }
+    }
+    Some((min_cols?, min_rows?))
+}
+
 /// Build a v3 `RuntimeSnapshot` from a runtime's current state.
 #[must_use]
 pub fn build_v3_runtime_snapshot(
@@ -127,7 +215,14 @@ pub fn build_v3_runtime_snapshot(
             )
         })
         .collect();
-    rttx_proto::v3_snapshot::build_runtime_snapshot(runtime_id, rt.revision(), client_role, panes)
+    rttx_proto::v3_snapshot::build_runtime_snapshot_with_tree(
+        runtime_id,
+        rt.revision(),
+        client_role,
+        panes,
+        workspace_tree_to_proto(&rt.tree),
+        default_active_bytes(&rt.tree),
+    )
 }
 
 /// Build a v3 runtime inventory for `ListRuntimes`.
@@ -311,5 +406,79 @@ mod tests {
         };
         assert_eq!(t.final_revision, 3);
         assert_eq!(t.reason, v3::RuntimeTerminationReason::EphemeralDetach as i32);
+    }
+
+    // ── Workspace tree conversions (RFC-031 §5) ──
+
+    #[test]
+    fn split_axis_round_trips_through_proto() {
+        for axis in [SplitAxis::Horizontal, SplitAxis::Vertical] {
+            assert_eq!(proto_axis_to_split(split_axis_to_proto(axis)), axis);
+        }
+        // An unspecified wire axis defaults to horizontal.
+        assert_eq!(proto_axis_to_split(v3::PaneSplitAxis::Unspecified), SplitAxis::Horizontal);
+    }
+
+    #[test]
+    fn decode_side_path_rejects_unaddressable_steps() {
+        assert_eq!(
+            decode_side_path(&[v3::PaneTreeSide::First as i32, v3::PaneTreeSide::Second as i32,]),
+            Some(vec![Side::First, Side::Second])
+        );
+        // An unspecified step makes the whole path unaddressable.
+        assert_eq!(decode_side_path(&[v3::PaneTreeSide::Unspecified as i32]), None);
+        assert_eq!(decode_side_path(&[42]), None);
+        // The empty path addresses the root split and is valid.
+        assert_eq!(decode_side_path(&[]), Some(vec![]));
+    }
+
+    #[test]
+    fn empty_workspace_tree_has_no_proto_node() {
+        let tree = WorkspaceTree::new();
+        assert!(workspace_tree_to_proto(&tree).is_none());
+        assert!(default_active_bytes(&tree).is_empty());
+    }
+
+    #[test]
+    fn workspace_tree_converts_to_matching_proto_structure() {
+        let mut tree = WorkspaceTree::new();
+        let a = PaneId::new();
+        let b = PaneId::new();
+        tree.insert_root(a);
+        assert!(tree.split(a, b, SplitAxis::Vertical, 0.25));
+
+        let node = workspace_tree_to_proto(&tree).expect("non-empty tree");
+        let Some(v3::pane_tree_node::Node::Split(split)) = node.node else {
+            panic!("expected a split at the root");
+        };
+        assert_eq!(split.axis, v3::PaneSplitAxis::Vertical as i32);
+        assert!((split.ratio - 0.25).abs() < f32::EPSILON);
+        // default-active is the first pane, encoded as its raw uuid bytes.
+        assert_eq!(default_active_bytes(&tree), uuid_to_bytes(a.uuid()));
+    }
+
+    // ── Multi-client PTY min-size policy (RFC-031 §4) ──
+
+    #[test]
+    fn min_pane_size_is_per_axis_minimum() {
+        assert_eq!(min_client_pane_size([(100, 40), (80, 50), (120, 24)]), Some((80, 24)));
+    }
+
+    #[test]
+    fn min_pane_size_ignores_zero_dimensions() {
+        // A client reporting 0 on an axis (not yet rendered) is ignored on
+        // that axis but can still constrain the other.
+        assert_eq!(min_client_pane_size([(100, 0), (0, 30)]), Some((100, 30)));
+    }
+
+    #[test]
+    fn min_pane_size_single_client_tracks_that_client() {
+        assert_eq!(min_client_pane_size([(90, 30)]), Some((90, 30)));
+    }
+
+    #[test]
+    fn min_pane_size_none_when_no_usable_dimensions() {
+        assert_eq!(min_client_pane_size(std::iter::empty()), None);
+        assert_eq!(min_client_pane_size([(0, 0)]), None);
     }
 }

--- a/services/rttx-server/src/runtime.rs
+++ b/services/rttx-server/src/runtime.rs
@@ -246,6 +246,32 @@ impl Runtime {
         }
     }
 
+    /// Add `pane` to the workspace by splitting the leaf holding `target`.
+    ///
+    /// The new pane's identity is server-assigned and immutable (RFC-031 G1).
+    /// Returns the new revision on success, or `None` (no change, pane not
+    /// inserted) if `target` is absent, the ratio is invalid, or the new pane
+    /// id already exists. The pane is added to the map only when the tree
+    /// mutation succeeds, so structure and pane state never diverge.
+    pub fn split_pane(
+        &mut self,
+        target: Uuid,
+        pane: Pane,
+        axis: SplitAxis,
+        ratio: f32,
+    ) -> Option<u64> {
+        let new = PaneId::from_uuid(pane.id);
+        if !self.tree.split(PaneId::from_uuid(target), new, axis, ratio) {
+            return None;
+        }
+        if self.active_pane_id.is_none() {
+            self.active_pane_id = Some(pane.id);
+        }
+        self.panes.insert(pane.id, pane);
+        self.bump_revision();
+        Some(self.revision())
+    }
+
     /// Remove a pane from this runtime.
     ///
     /// The pane is dropped from the authoritative tree, collapsing its parent
@@ -991,6 +1017,58 @@ mod tests {
         // Invalid ratio is rejected without bumping the revision.
         assert_eq!(runtime.resize_split(&[], 1.0), None);
         assert_eq!(runtime.revision(), before + 1);
+    }
+
+    #[test]
+    fn split_pane_targets_explicit_leaf_with_axis_and_ratio() {
+        let mut runtime = Runtime::new("test".into());
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        runtime.add_pane(Pane::new(a, 80, 24));
+        let before = runtime.revision();
+
+        let rev = runtime.split_pane(a, Pane::new(b, 80, 24), SplitAxis::Vertical, 0.3);
+        assert_eq!(rev, Some(before + 1));
+        assert_eq!(runtime.tree.leaf_count(), 2);
+        assert!(runtime.panes.contains_key(&b));
+        // The target keeps its identity and stays default-active after a split.
+        assert!(runtime.tree.contains(PaneId::from_uuid(a)));
+        assert_eq!(runtime.tree.default_active(), Some(PaneId::from_uuid(a)));
+        assert!(runtime.tree.validate().is_ok());
+    }
+
+    #[test]
+    fn split_pane_rejects_unknown_target_without_inserting_pane() {
+        let mut runtime = Runtime::new("test".into());
+        let a = Uuid::new_v4();
+        runtime.add_pane(Pane::new(a, 80, 24));
+        let before = runtime.revision();
+
+        let orphan = Uuid::new_v4();
+        // Target is not in the tree: the split is rejected and the candidate
+        // pane is never added to the map (structure/state never diverge).
+        assert_eq!(
+            runtime.split_pane(
+                Uuid::new_v4(),
+                Pane::new(orphan, 80, 24),
+                SplitAxis::Horizontal,
+                0.5
+            ),
+            None
+        );
+        assert!(!runtime.panes.contains_key(&orphan));
+        assert_eq!(runtime.tree.leaf_count(), 1);
+        assert_eq!(runtime.revision(), before);
+    }
+
+    #[test]
+    fn split_pane_rejects_invalid_ratio() {
+        let mut runtime = Runtime::new("test".into());
+        let a = Uuid::new_v4();
+        runtime.add_pane(Pane::new(a, 80, 24));
+        let b = Uuid::new_v4();
+        assert_eq!(runtime.split_pane(a, Pane::new(b, 80, 24), SplitAxis::Horizontal, 1.5), None);
+        assert!(!runtime.panes.contains_key(&b));
     }
 
     #[test]

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -115,6 +115,10 @@ pub struct Server {
     pty_writers: HashMap<Uuid, Arc<tokio::sync::Mutex<pty_process::OwnedWritePty>>>,
     /// Per-pane kill signals to cancel PTY read loops.
     pty_kill_senders: HashMap<Uuid, oneshot::Sender<()>>,
+    /// Per-client, per-pane render sizes reported via `ReportClientSize`.
+    /// Drives the multi-client PTY min-size policy (RFC-031 §4). Ephemeral:
+    /// cleared when the client disconnects.
+    client_pane_sizes: HashMap<Uuid, HashMap<Uuid, (u16, u16)>>,
     /// Cooperative shutdown signal — set to `true` to stop the server.
     shutdown_tx: watch::Sender<bool>,
 }
@@ -140,6 +144,7 @@ impl Server {
             client_protocols: HashMap::new(),
             pty_writers: HashMap::new(),
             pty_kill_senders: HashMap::new(),
+            client_pane_sizes: HashMap::new(),
             shutdown_tx,
         }
     }
@@ -743,6 +748,18 @@ impl Server {
             v3::client_envelope::Command::SetPaneNoPersist(req) => {
                 Self::handle_v3_set_pane_no_persist(server, client_id, req, metrics).await
             }
+            v3::client_envelope::Command::SplitPane(req) => {
+                Self::handle_v3_split_pane(server, client_id, request_id, req, metrics).await
+            }
+            v3::client_envelope::Command::ResizeSplit(req) => {
+                Self::handle_v3_resize_split(server, client_id, request_id, req, metrics).await
+            }
+            v3::client_envelope::Command::SetFocus(req) => {
+                Self::handle_v3_set_focus(server, client_id, request_id, req, metrics).await
+            }
+            v3::client_envelope::Command::ReportClientSize(req) => {
+                Self::handle_v3_report_client_size(server, client_id, req, metrics).await
+            }
 
             v3::client_envelope::Command::RenameRuntime(req) => {
                 let runtime_id = match bytes_to_uuid(&req.runtime_id) {
@@ -1279,20 +1296,13 @@ impl Server {
                 ));
             }
             let label = format!("\"{}\" ({})", rt.name, short_id(runtime_id));
-            let mut env = vec![];
-            if no_persist {
-                env.push(("HISTFILE".into(), "/dev/null".into()));
-            } else {
-                let hist =
-                    crate::state::layout::history_file(&s.os.state_dir(), runtime_id, pane_id);
-                if let Some(parent) = hist.parent() {
-                    let _ = std::fs::create_dir_all(parent);
-                }
-                env.push(("HISTFILE".into(), hist.to_string_lossy().into_owned()));
-                env.push(("PROMPT_COMMAND".into(), "history -a".into()));
-            }
-            let colorfgbg = if req.dark_background.unwrap_or(true) { "15;0" } else { "0;15" };
-            env.push(("COLORFGBG".into(), colorfgbg.into()));
+            let env = pane_spawn_env(
+                &s.os.state_dir(),
+                runtime_id,
+                pane_id,
+                no_persist,
+                req.dark_background.unwrap_or(true),
+            );
             let cols = if req.cols > 0 { req.cols as u16 } else { 80 };
             let rows = if req.rows > 0 { req.rows as u16 } else { 24 };
             let cwd = req.cwd.or_else(|| rt.any_pane_cwd());
@@ -1580,6 +1590,349 @@ impl Server {
         let _ = rt.set_pane_no_persist(pane_id, req.no_persist);
         None
     }
+
+    // ── Tree mutations and viewport (RFC-031 §5) ────────────────
+
+    /// Split the leaf holding `target_pane_id`, spawning a shell in a
+    /// server-minted pane (RFC-031 G1). Replaces the client-identity
+    /// `CreatePane` for tree growth.
+    async fn handle_v3_split_pane(
+        server: &Arc<Mutex<Self>>,
+        client_id: Uuid,
+        request_id: u64,
+        req: v3::SplitPane,
+        metrics: &Arc<crate::metrics::DaemonMetrics>,
+    ) -> Option<v3::ServerEnvelope> {
+        let err = |kind, msg: &str| {
+            Some(rttx_proto::v3_error::build_error_response(
+                request_id,
+                rttx_proto::v3_error::build_error(kind, msg, "SplitPane"),
+            ))
+        };
+        let Ok(runtime_id) = bytes_to_uuid(&req.runtime_id) else {
+            return err(v3::ErrorKind::InvalidArgument, "invalid runtime id");
+        };
+        let Ok(target_pane_id) = bytes_to_uuid(&req.target_pane_id) else {
+            return err(v3::ErrorKind::InvalidArgument, "invalid target pane id");
+        };
+        let axis = protocol::proto_axis_to_split(
+            v3::PaneSplitAxis::try_from(req.axis).unwrap_or(v3::PaneSplitAxis::Horizontal),
+        );
+        // A client that omits the ratio gets an even split rather than a rejection.
+        let ratio = if crate::pane_tree::ratio_is_valid(req.ratio) { req.ratio } else { 0.5 };
+        let pane_id = Uuid::new_v4();
+        let no_persist = req.no_persist.unwrap_or(false);
+
+        let (pty_result, cols, rows, initial_cwd) = {
+            let s = crate::instrument::lock_server(server, metrics).await;
+            let Some(rt_lock) = s.runtimes.get(&runtime_id) else {
+                return err(v3::ErrorKind::RuntimeNotFound, "runtime not found");
+            };
+            let rt = crate::instrument::lock_runtime(rt_lock, metrics).await;
+            if !rt.client_has_write_access(client_id) {
+                return err(
+                    v3::ErrorKind::OwnershipConflict,
+                    "runtime is currently owned by another client",
+                );
+            }
+            if !rt.tree.contains(crate::pane_tree::PaneId::from_uuid(target_pane_id)) {
+                return err(v3::ErrorKind::PaneNotFound, "split target pane not found");
+            }
+            let env = pane_spawn_env(
+                &s.os.state_dir(),
+                runtime_id,
+                pane_id,
+                no_persist,
+                req.dark_background.unwrap_or(true),
+            );
+            let cols = if req.cols > 0 { req.cols as u16 } else { 80 };
+            let rows = if req.rows > 0 { req.rows as u16 } else { 24 };
+            // Inherit the working directory from the pane being split.
+            let cwd = req
+                .cwd
+                .clone()
+                .or_else(|| rt.panes.get(&target_pane_id).and_then(Pane::effective_cwd))
+                .or_else(|| rt.any_pane_cwd());
+            let config = PaneSpawnConfig { command: vec![], cwd: cwd.clone(), env, cols, rows };
+            (s.engine.spawn_pane(pane_id, &config), cols, rows, cwd)
+        };
+
+        let pty = match pty_result {
+            Ok(pty) => pty,
+            Err(e) => {
+                tracing::error!("Failed to spawn PTY for split pane {}: {e}", short_id(pane_id));
+                return err(v3::ErrorKind::Internal, &format!("failed to spawn pane: {e}"));
+            }
+        };
+        let child_pid = pty.pid();
+        let (reader, writer, mut child) = pty.into_parts();
+        let (kill_tx, kill_rx) = oneshot::channel();
+
+        let (revision, runtime_name, read_metrics, ring) = {
+            let mut s = crate::instrument::lock_server(server, metrics).await;
+            let Some(rt_lock) = s.runtimes.get(&runtime_id).cloned() else {
+                let _ = child.start_kill();
+                return err(v3::ErrorKind::RuntimeNotFound, "runtime not found");
+            };
+            let split = {
+                let mut rt = crate::instrument::lock_runtime(&rt_lock, metrics).await;
+                let mut pane = Pane::new(pane_id, cols, rows);
+                pane.child_pid = child_pid;
+                pane.no_persist = no_persist;
+                pane.cwd = initial_cwd;
+                rt.split_pane(target_pane_id, pane, axis, ratio).map(|revision| {
+                    (
+                        revision,
+                        rt.name.clone(),
+                        rt.attached_clients.keys().copied().collect::<Vec<_>>(),
+                    )
+                })
+            };
+            let Some((revision, name, attached)) = split else {
+                // The target vanished between phases; do not leak the shell.
+                let _ = child.start_kill();
+                return err(v3::ErrorKind::PaneNotFound, "split target pane not found");
+            };
+            s.pty_writers.insert(pane_id, Arc::new(tokio::sync::Mutex::new(writer)));
+            s.pty_kill_senders.insert(pane_id, kill_tx);
+            let evt = rttx_proto::v3_tree::build_pane_split(
+                runtime_id,
+                target_pane_id,
+                pane_id,
+                protocol::split_axis_to_proto(axis),
+                ratio,
+                revision,
+            );
+            s.broadcast_to_clients(
+                attached.iter().copied(),
+                Some(client_id),
+                &rttx_proto::v3_tree::build_pane_split_push(evt),
+            );
+            (revision, name, s.metrics.clone(), Arc::clone(&s.ring))
+        };
+
+        spawn_pty_read_loop(
+            Arc::clone(server),
+            runtime_id,
+            pane_id,
+            &runtime_name,
+            reader,
+            child,
+            kill_rx,
+            read_metrics,
+            ring,
+        );
+        tracing::info!(
+            "Pane {} split from {} in runtime \"{}\" ({})",
+            short_id(pane_id),
+            short_id(target_pane_id),
+            runtime_name,
+            short_id(runtime_id),
+        );
+        Some(rttx_proto::v3_tree::build_pane_split_response(
+            request_id,
+            rttx_proto::v3_tree::build_pane_split(
+                runtime_id,
+                target_pane_id,
+                pane_id,
+                protocol::split_axis_to_proto(axis),
+                ratio,
+                revision,
+            ),
+        ))
+    }
+
+    /// Set the logical ratio of the split addressed by `path` (RFC-031 §5).
+    async fn handle_v3_resize_split(
+        server: &Arc<Mutex<Self>>,
+        client_id: Uuid,
+        request_id: u64,
+        req: v3::ResizeSplit,
+        metrics: &Arc<crate::metrics::DaemonMetrics>,
+    ) -> Option<v3::ServerEnvelope> {
+        let err = |kind, msg: &str| {
+            Some(rttx_proto::v3_error::build_error_response(
+                request_id,
+                rttx_proto::v3_error::build_error(kind, msg, "ResizeSplit"),
+            ))
+        };
+        let Ok(runtime_id) = bytes_to_uuid(&req.runtime_id) else {
+            return err(v3::ErrorKind::InvalidArgument, "invalid runtime id");
+        };
+        let Some(path) = protocol::decode_side_path(&req.path) else {
+            return err(v3::ErrorKind::InvalidArgument, "invalid split path");
+        };
+        let mut s = crate::instrument::lock_server(server, metrics).await;
+        let Some(rt_lock) = s.runtimes.get(&runtime_id).cloned() else {
+            return err(v3::ErrorKind::RuntimeNotFound, "runtime not found");
+        };
+        let result = {
+            let mut rt = crate::instrument::lock_runtime(&rt_lock, metrics).await;
+            if !rt.client_has_write_access(client_id) {
+                return err(
+                    v3::ErrorKind::OwnershipConflict,
+                    "runtime is currently owned by another client",
+                );
+            }
+            rt.resize_split(&path, req.ratio)
+                .map(|revision| (revision, rt.attached_clients.keys().copied().collect::<Vec<_>>()))
+        };
+        let Some((revision, attached)) = result else {
+            return err(v3::ErrorKind::InvalidArgument, "split not found or invalid ratio");
+        };
+        let wire_path = rttx_proto::v3_tree::decode_side_path(&req.path);
+        let evt =
+            rttx_proto::v3_tree::build_split_resized(runtime_id, wire_path, req.ratio, revision);
+        s.broadcast_to_clients(
+            attached.iter().copied(),
+            Some(client_id),
+            &rttx_proto::v3_tree::build_split_resized_push(evt.clone()),
+        );
+        Some(rttx_proto::v3_tree::build_split_resized_response(request_id, evt))
+    }
+
+    /// Update the fallback focus (default-active) pane (RFC-031 §3, §5).
+    async fn handle_v3_set_focus(
+        server: &Arc<Mutex<Self>>,
+        client_id: Uuid,
+        request_id: u64,
+        req: v3::SetFocus,
+        metrics: &Arc<crate::metrics::DaemonMetrics>,
+    ) -> Option<v3::ServerEnvelope> {
+        let err = |kind, msg: &str| {
+            Some(rttx_proto::v3_error::build_error_response(
+                request_id,
+                rttx_proto::v3_error::build_error(kind, msg, "SetFocus"),
+            ))
+        };
+        let Ok(runtime_id) = bytes_to_uuid(&req.runtime_id) else {
+            return err(v3::ErrorKind::InvalidArgument, "invalid runtime id");
+        };
+        let Ok(pane_id) = bytes_to_uuid(&req.pane_id) else {
+            return err(v3::ErrorKind::InvalidArgument, "invalid pane id");
+        };
+        let mut s = crate::instrument::lock_server(server, metrics).await;
+        let Some(rt_lock) = s.runtimes.get(&runtime_id).cloned() else {
+            return err(v3::ErrorKind::RuntimeNotFound, "runtime not found");
+        };
+        let result = {
+            let mut rt = crate::instrument::lock_runtime(&rt_lock, metrics).await;
+            if !rt.client_has_write_access(client_id) {
+                return err(
+                    v3::ErrorKind::OwnershipConflict,
+                    "runtime is currently owned by another client",
+                );
+            }
+            rt.set_default_active_pane(pane_id)
+                .map(|revision| (revision, rt.attached_clients.keys().copied().collect::<Vec<_>>()))
+        };
+        let Some((revision, attached)) = result else {
+            return err(v3::ErrorKind::PaneNotFound, "pane not found");
+        };
+        let evt = rttx_proto::v3_tree::build_focus_changed(runtime_id, pane_id, revision);
+        s.broadcast_to_clients(
+            attached.iter().copied(),
+            Some(client_id),
+            &rttx_proto::v3_tree::build_focus_changed_push(evt.clone()),
+        );
+        Some(rttx_proto::v3_tree::build_focus_changed_response(request_id, evt))
+    }
+
+    /// Record a client's per-pane render sizes and apply the multi-client PTY
+    /// min-size policy (RFC-031 §4). Ephemeral viewport state — no response.
+    async fn handle_v3_report_client_size(
+        server: &Arc<Mutex<Self>>,
+        client_id: Uuid,
+        req: v3::ReportClientSize,
+        metrics: &Arc<crate::metrics::DaemonMetrics>,
+    ) -> Option<v3::ServerEnvelope> {
+        let Ok(runtime_id) = bytes_to_uuid(&req.runtime_id) else { return None };
+        let reported: Vec<(Uuid, u16, u16)> = req
+            .panes
+            .iter()
+            .filter_map(|p| {
+                let id = bytes_to_uuid(&p.pane_id).ok()?;
+                Some((id, u16::try_from(p.cols).unwrap_or(0), u16::try_from(p.rows).unwrap_or(0)))
+            })
+            .collect();
+        if reported.is_empty() {
+            return None;
+        }
+
+        // Phase 1: record sizes, then resolve the new min size per pane.
+        let mut targets: Vec<(
+            Uuid,
+            u16,
+            u16,
+            Arc<tokio::sync::Mutex<pty_process::OwnedWritePty>>,
+        )> = Vec::new();
+        {
+            let mut s = crate::instrument::lock_server(server, metrics).await;
+            let rt_lock = s.runtimes.get(&runtime_id).cloned()?;
+            {
+                let rt = crate::instrument::lock_runtime(&rt_lock, metrics).await;
+                rt.client_role(client_id)?;
+            }
+            let entry = s.client_pane_sizes.entry(client_id).or_default();
+            for (id, cols, rows) in &reported {
+                entry.insert(*id, (*cols, *rows));
+            }
+            for (id, _, _) in &reported {
+                let sizes = s.client_pane_sizes.values().filter_map(|m| m.get(id).copied());
+                if let (Some((cols, rows)), Some(writer)) =
+                    (protocol::min_client_pane_size(sizes), s.pty_writers.get(id).cloned())
+                {
+                    targets.push((*id, cols, rows, writer));
+                }
+            }
+        }
+
+        // Phase 2: apply PTY resizes (writer lock is async; held without the
+        // server lock), then record the new pane dimensions.
+        for (id, cols, rows, writer) in targets {
+            {
+                let w = writer.lock().await;
+                if let Err(e) = w.resize(pty_process::Size::new(rows, cols)) {
+                    tracing::warn!("min-size PTY resize failed for pane {}: {e}", short_id(id));
+                    continue;
+                }
+            }
+            let rt_lock = {
+                let s = crate::instrument::lock_server(server, metrics).await;
+                s.runtimes.get(&runtime_id).cloned()
+            };
+            if let Some(rt_lock) = rt_lock {
+                let mut rt = crate::instrument::lock_runtime(&rt_lock, metrics).await;
+                let _ = rt.resize_pane(id, cols, rows);
+            }
+        }
+        None
+    }
+}
+
+/// Build the environment for a freshly spawned pane shell: history file (or
+/// `/dev/null` when non-persistent) and the light/dark `COLORFGBG` hint.
+fn pane_spawn_env(
+    state_dir: &std::path::Path,
+    runtime_id: Uuid,
+    pane_id: Uuid,
+    no_persist: bool,
+    dark_background: bool,
+) -> Vec<(String, String)> {
+    let mut env = vec![];
+    if no_persist {
+        env.push(("HISTFILE".into(), "/dev/null".into()));
+    } else {
+        let hist = crate::state::layout::history_file(state_dir, runtime_id, pane_id);
+        if let Some(parent) = hist.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        env.push(("HISTFILE".into(), hist.to_string_lossy().into_owned()));
+        env.push(("PROMPT_COMMAND".into(), "history -a".into()));
+    }
+    let colorfgbg = if dark_background { "15;0" } else { "0;15" };
+    env.push(("COLORFGBG".into(), colorfgbg.into()));
+    env
 }
 const COALESCE_MAX_BYTES: usize = 64 * 1024;
 
@@ -2243,6 +2596,10 @@ const fn v3_msg_type(envelope: &v3::ClientEnvelope) -> &'static str {
         Some(v3::client_envelope::Command::ResizePane(_)) => "ResizePane",
         Some(v3::client_envelope::Command::SetPaneTitle(_)) => "SetPaneTitle",
         Some(v3::client_envelope::Command::SetPaneNoPersist(_)) => "SetPaneNoPersist",
+        Some(v3::client_envelope::Command::SplitPane(_)) => "SplitPane",
+        Some(v3::client_envelope::Command::ResizeSplit(_)) => "ResizeSplit",
+        Some(v3::client_envelope::Command::SetFocus(_)) => "SetFocus",
+        Some(v3::client_envelope::Command::ReportClientSize(_)) => "ReportClientSize",
         Some(v3::client_envelope::Command::Shutdown(_)) => "Shutdown",
         Some(v3::client_envelope::Command::GetDiagnostics(_)) => "GetDiagnostics",
         Some(v3::client_envelope::Command::RenameRuntime(_)) => "RenameRuntime",
@@ -2339,6 +2696,7 @@ where
         s.client_senders.remove(&client_id);
         s.client_resp_senders.remove(&client_id);
         s.client_protocols.remove(&client_id);
+        s.client_pane_sizes.remove(&client_id);
         if handshake_completed {
             let rt_locks: Vec<RuntimeLock> = s.runtimes.values().cloned().collect();
             drop(s);

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -493,3 +493,108 @@ pub async fn send_input(client: &mut TestClient, runtime_id: &[u8], pane_id: &[u
 
 /// Alias for backward compatibility with tests that imported `TestV3Client`.
 pub type TestV3Client = TestClient;
+
+// ── RFC-031 §5 tree-protocol helpers ────────────────────────────────
+
+/// Split `target_pane_id`, returning the server's `PaneSplit` delta (carrying
+/// the server-assigned new pane id).
+pub async fn split_pane(
+    client: &mut TestClient,
+    runtime_id: &[u8],
+    target_pane_id: &[u8],
+    axis: v3::PaneSplitAxis,
+    ratio: f32,
+) -> v3::PaneSplit {
+    let reply = client
+        .request(v3::client_envelope::Command::SplitPane(v3::SplitPane {
+            runtime_id: runtime_id.to_vec(),
+            target_pane_id: target_pane_id.to_vec(),
+            axis: axis as i32,
+            ratio,
+            cwd: None,
+            dark_background: None,
+            cols: 0,
+            rows: 0,
+            no_persist: None,
+        }))
+        .await;
+    match reply.payload {
+        Some(v3::server_envelope::Payload::PaneSplit(p)) => p,
+        other => panic!("expected PaneSplit, got {other:?}"),
+    }
+}
+
+/// Resize the split addressed by `path`, returning the `SplitResized` delta.
+pub async fn resize_split(
+    client: &mut TestClient,
+    runtime_id: &[u8],
+    path: &[v3::PaneTreeSide],
+    ratio: f32,
+) -> v3::SplitResized {
+    let reply = client
+        .request(v3::client_envelope::Command::ResizeSplit(v3::ResizeSplit {
+            runtime_id: runtime_id.to_vec(),
+            path: path.iter().map(|s| *s as i32).collect(),
+            ratio,
+        }))
+        .await;
+    match reply.payload {
+        Some(v3::server_envelope::Payload::SplitResized(r)) => r,
+        other => panic!("expected SplitResized, got {other:?}"),
+    }
+}
+
+/// Set the fallback focus pane, returning the `FocusChanged` delta.
+pub async fn set_focus(
+    client: &mut TestClient,
+    runtime_id: &[u8],
+    pane_id: &[u8],
+) -> v3::FocusChanged {
+    let reply = client
+        .request(v3::client_envelope::Command::SetFocus(v3::SetFocus {
+            runtime_id: runtime_id.to_vec(),
+            pane_id: pane_id.to_vec(),
+        }))
+        .await;
+    match reply.payload {
+        Some(v3::server_envelope::Payload::FocusChanged(f)) => f,
+        other => panic!("expected FocusChanged, got {other:?}"),
+    }
+}
+
+/// Report per-pane render sizes (fire-and-forget) and barrier on a ping so the
+/// min-size policy has been applied before the caller observes its effect.
+pub async fn report_client_size(
+    client: &mut TestClient,
+    runtime_id: &[u8],
+    panes: &[(Vec<u8>, u32, u32)],
+) {
+    client
+        .send_cmd(v3::client_envelope::Command::ReportClientSize(v3::ReportClientSize {
+            runtime_id: runtime_id.to_vec(),
+            panes: panes
+                .iter()
+                .map(|(id, cols, rows)| v3::ClientPaneSize {
+                    pane_id: id.clone(),
+                    cols: *cols,
+                    rows: *rows,
+                })
+                .collect(),
+        }))
+        .await;
+    client.ping().await;
+}
+
+/// Reattach (resync) and return a fresh snapshot carrying the authoritative
+/// tree.
+pub async fn resync(client: &mut TestClient, runtime_id: &[u8]) -> v3::RuntimeSnapshot {
+    let reply = client
+        .request(v3::client_envelope::Command::ResyncRuntime(v3::ResyncRuntime {
+            runtime_id: runtime_id.to_vec(),
+        }))
+        .await;
+    match reply.payload {
+        Some(v3::server_envelope::Payload::RuntimeSnapshot(s)) => s,
+        other => panic!("expected RuntimeSnapshot, got {other:?}"),
+    }
+}

--- a/services/rttx-server/tests/tree_protocol.rs
+++ b/services/rttx-server/tests/tree_protocol.rs
@@ -1,0 +1,244 @@
+//! Integration coverage for the server-authoritative tree protocol
+//! (RFC-031 §5, issue #1000).
+//!
+//! These tests drive the daemon over the real v3 wire protocol and assert the
+//! behavior the protocol step must guarantee: attach returns the full
+//! authoritative tree, structural mutations mint stable server-assigned pane
+//! ids and emit correct deltas, and the multi-client PTY min-size policy keeps
+//! a shared pane no larger than its smallest viewer.
+
+mod common;
+
+use common::{
+    TestClient, attach_ro, attach_rw, create_pane, create_runtime, report_client_size,
+    resize_split, resync, set_focus, split_pane, start_test_server,
+};
+use rttx_proto::v3;
+use std::time::Duration;
+
+/// Collect every leaf pane id in the proto tree, left to right.
+fn leaf_ids(node: &v3::PaneTreeNode) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    collect(node, &mut out);
+    out
+}
+
+fn collect(node: &v3::PaneTreeNode, out: &mut Vec<Vec<u8>>) {
+    match node.node.as_ref() {
+        Some(v3::pane_tree_node::Node::Leaf(leaf)) => out.push(leaf.pane_id.clone()),
+        Some(v3::pane_tree_node::Node::Split(split)) => {
+            if let Some(first) = split.first.as_ref() {
+                collect(first, out);
+            }
+            if let Some(second) = split.second.as_ref() {
+                collect(second, out);
+            }
+        }
+        None => {}
+    }
+}
+
+fn root_split(snapshot: &v3::RuntimeSnapshot) -> v3::PaneTreeSplit {
+    let node = snapshot.tree.as_ref().expect("snapshot must carry a tree");
+    match node.node.as_ref() {
+        Some(v3::pane_tree_node::Node::Split(split)) => (**split).clone(),
+        other => panic!("expected a split at the tree root, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn attach_snapshot_carries_authoritative_tree() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+    let runtime_id = create_runtime(&mut client, "tree", v3::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &runtime_id).await;
+    let pane_a = create_pane(&mut client, &runtime_id).await;
+    let split =
+        split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Horizontal, 0.5).await;
+    let pane_b = split.new_pane_id.clone();
+
+    let snapshot = resync(&mut client, &runtime_id).await;
+    let tree = snapshot.tree.as_ref().expect("attach must return the full tree");
+    let ids = leaf_ids(tree);
+    assert_eq!(ids.len(), 2, "both panes must appear in the tree");
+    assert!(ids.contains(&pane_a), "the original pane is in the tree");
+    assert!(ids.contains(&pane_b), "the split pane is in the tree");
+    // The split target stays the fallback focus.
+    assert_eq!(snapshot.default_active_pane_id, pane_a);
+    assert_eq!(snapshot.panes.len(), 2);
+}
+
+#[tokio::test]
+async fn split_assigns_stable_server_pane_id_and_delta() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+    let runtime_id = create_runtime(&mut client, "split", v3::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &runtime_id).await;
+    let pane_a = create_pane(&mut client, &runtime_id).await;
+
+    let split =
+        split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Vertical, 0.3).await;
+    // The delta describes where the split landed; the new id is server-minted.
+    assert_eq!(split.target_pane_id, pane_a);
+    assert_eq!(split.axis, v3::PaneSplitAxis::Vertical as i32);
+    assert!((split.ratio - 0.3).abs() < f32::EPSILON);
+    assert_ne!(split.new_pane_id, pane_a, "server mints a fresh pane id");
+    assert_eq!(split.new_pane_id.len(), 16, "pane id is a 16-byte uuid");
+    assert!(split.runtime_revision > 0);
+
+    // The server-assigned id is stable: it is exactly what the tree reports.
+    let snapshot = resync(&mut client, &runtime_id).await;
+    let ids = leaf_ids(snapshot.tree.as_ref().unwrap());
+    assert!(ids.contains(&split.new_pane_id), "the minted id persists in the tree");
+}
+
+#[tokio::test]
+async fn close_pane_collapses_the_tree() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+    let runtime_id = create_runtime(&mut client, "close", v3::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &runtime_id).await;
+    let pane_a = create_pane(&mut client, &runtime_id).await;
+    let split =
+        split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Horizontal, 0.5).await;
+    let pane_b = split.new_pane_id.clone();
+
+    common::close_pane(&mut client, &runtime_id, &pane_b).await;
+
+    let snapshot = resync(&mut client, &runtime_id).await;
+    let tree = snapshot.tree.as_ref().expect("tree present after close");
+    // The parent split collapses into the surviving leaf.
+    assert!(
+        matches!(tree.node.as_ref(), Some(v3::pane_tree_node::Node::Leaf(_))),
+        "closing one of two panes collapses the split into a leaf",
+    );
+    assert_eq!(leaf_ids(tree), vec![pane_a]);
+    assert_eq!(snapshot.panes.len(), 1);
+}
+
+#[tokio::test]
+async fn resize_split_updates_logical_ratio() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+    let runtime_id = create_runtime(&mut client, "resize", v3::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &runtime_id).await;
+    let pane_a = create_pane(&mut client, &runtime_id).await;
+    split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Horizontal, 0.5).await;
+
+    // The root split is addressed by the empty path.
+    let resized = resize_split(&mut client, &runtime_id, &[], 0.2).await;
+    assert!((resized.ratio - 0.2).abs() < f32::EPSILON);
+    assert!(resized.runtime_revision > 0);
+
+    let snapshot = resync(&mut client, &runtime_id).await;
+    let split = root_split(&snapshot);
+    assert!((split.ratio - 0.2).abs() < f32::EPSILON, "the durable ratio is updated");
+}
+
+#[tokio::test]
+async fn resize_split_rejects_unaddressable_path() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+    let runtime_id = create_runtime(&mut client, "resize-bad", v3::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &runtime_id).await;
+    let pane_a = create_pane(&mut client, &runtime_id).await;
+    split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Horizontal, 0.5).await;
+
+    // root.first is a leaf, not a split — the resize must be rejected.
+    let reply = client
+        .request(v3::client_envelope::Command::ResizeSplit(v3::ResizeSplit {
+            runtime_id: runtime_id.clone(),
+            path: vec![v3::PaneTreeSide::First as i32],
+            ratio: 0.4,
+        }))
+        .await;
+    assert!(
+        matches!(reply.payload, Some(v3::server_envelope::Payload::Error(_))),
+        "resizing a non-split node is an error, got {:?}",
+        reply.payload,
+    );
+}
+
+#[tokio::test]
+async fn set_focus_updates_default_active() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+    let runtime_id = create_runtime(&mut client, "focus", v3::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &runtime_id).await;
+    let pane_a = create_pane(&mut client, &runtime_id).await;
+    let split =
+        split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Horizontal, 0.5).await;
+    let pane_b = split.new_pane_id.clone();
+
+    let changed = set_focus(&mut client, &runtime_id, &pane_b).await;
+    assert_eq!(changed.pane_id, pane_b);
+
+    let snapshot = resync(&mut client, &runtime_id).await;
+    assert_eq!(snapshot.default_active_pane_id, pane_b, "focus moved to the second pane");
+}
+
+#[tokio::test]
+async fn multi_client_pty_size_is_the_minimum_across_clients() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    // Writer creates the runtime and a pane.
+    let mut writer = TestClient::connect(&sock).await;
+    writer.handshake().await;
+    let runtime_id = create_runtime(&mut writer, "min-size", v3::RuntimePolicy::Persistent).await;
+    attach_rw(&mut writer, &runtime_id).await;
+    let pane = create_pane(&mut writer, &runtime_id).await;
+
+    // A second client attaches read-only and shares the pane.
+    let mut reader = TestClient::connect(&sock).await;
+    reader.handshake().await;
+    attach_ro(&mut reader, &runtime_id).await;
+
+    // The writer renders large; the reader renders small.
+    report_client_size(&mut writer, &runtime_id, &[(pane.clone(), 120, 50)]).await;
+    report_client_size(&mut reader, &runtime_id, &[(pane.clone(), 90, 30)]).await;
+
+    // The PTY (reflected in the pane snapshot) tracks the per-axis minimum so
+    // neither client sees truncated output (RFC-031 §4).
+    let snapshot = resync(&mut writer, &runtime_id).await;
+    let pane_snap =
+        snapshot.panes.iter().find(|p| p.pane_id == pane).expect("pane present in snapshot");
+    assert_eq!((pane_snap.cols, pane_snap.rows), (90, 30));
+}
+
+#[tokio::test]
+async fn single_client_pty_tracks_that_client_size() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+    let runtime_id = create_runtime(&mut client, "solo-size", v3::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &runtime_id).await;
+    let pane = create_pane(&mut client, &runtime_id).await;
+
+    report_client_size(&mut client, &runtime_id, &[(pane.clone(), 100, 40)]).await;
+    let _ = client.drain(Duration::from_millis(50)).await;
+
+    let snapshot = resync(&mut client, &runtime_id).await;
+    let pane_snap = snapshot.panes.iter().find(|p| p.pane_id == pane).expect("pane present");
+    assert_eq!((pane_snap.cols, pane_snap.rows), (100, 40));
+}

--- a/services/rttx-server/tests/v3_proto_integration.rs
+++ b/services/rttx-server/tests/v3_proto_integration.rs
@@ -1601,6 +1601,8 @@ fn v3_core_runtime_lifecycle_end_to_end() {
     let resp = v3_envelope::build_response_envelope(
         req.request_id,
         v3::server_envelope::Payload::RuntimeSnapshot(v3::RuntimeSnapshot {
+            tree: None,
+            default_active_pane_id: Vec::new(),
             runtime_id: runtime_id.clone(),
             runtime_revision: 2,
             client_role: v3::RuntimeClientRole::Writer as i32,


### PR DESCRIPTION
## What & why

RFC-031 Step 3 (#1000): the v3 wire protocol for the **server-authoritative
workspace tree**. The daemon already owns an immutable `PaneId` and a
`WorkspaceTree` (Step 1, #1006) and persists it (Step 2, #1008). This step
exposes that authoritative structure over the protocol and implements the
server handlers for it.

### Protocol additions (`rttx-proto`)
- `RuntimeSnapshot` now carries the authoritative `tree` (`PaneTreeNode`:
  leaf/split with axis + logical ratio) and `default_active_pane_id`, so a
  client builds its entire render layout from the attach snapshot.
- Tree mutations: `SplitPane` (server mints a fresh immutable `PaneId`),
  `ResizeSplit`; `ClosePane` already collapses the tree.
- Viewport messages: `SetFocus`, `ReportClientSize` (+ `ClientPaneSize`).
- Delta events: `PaneSplit`, `SplitResized`, `FocusChanged`.
- New `v3_tree` builder module with wire round-trip tests.

### Server (`rttx-server`)
- Attach/resync snapshots include the tree and default-active pane.
- `SplitPane` mints the id, spawns the shell, splits the tree at the target
  leaf, and returns/broadcasts a `PaneSplit` delta. `Runtime::split_pane`
  only inserts the pane when the tree mutation succeeds, so structure and
  pane state never diverge.
- `ResizeSplit`/`SetFocus` apply durable tree mutations and emit deltas.
- `ReportClientSize` records per-client render sizes and applies the
  multi-client PTY **min-size** policy (RFC-031 §4) so no client sees
  truncated output; sizes are cleared on disconnect.

## Scope note (deferred to Step 4)
The unported client still uses the flat-pane messages, so the
**client-identity `CreatePane` is retained** for now and removed with the
server-authoritative client view in Step 4 (#1001). Removing it here would
break the build, contrary to the RFC's own staged plan (Step 3 protocol →
Step 4 client). The new client-side payloads are routed to no-ops so the
workspace compiles.

## Tests added
- `rttx-proto`: `v3_tree` builder + nested-tree wire round-trip + event
  push/response classification + side-path decode (9 tests); `ReportClientSize`
  fire-and-forget classification.
- `rttx-server` unit: `Runtime::split_pane` (target/ratio/reject paths);
  `protocol` tree conversions, side-path decode, and `min_client_pane_size`
  policy (pure-state).
- `rttx-server` integration (`tree_protocol.rs`, 8 tests): attach returns the
  full tree; split assigns a stable server-minted id and a correct delta;
  close collapses the tree; resize updates the durable ratio; bad path is
  rejected; set-focus moves default-active; multi-client PTY min-size; single
  client tracks its own size.

## Verification (all local)
- `cargo build --workspace` (client `--no-default-features --features vte-0_76`) — clean
- `cargo test -p rttx-proto` — pass; `cargo test -p rttx-server` — pass (incl. new suites)
- `bash .github/scripts/run-clippy.sh` — clean (pedantic + nursery, `-D warnings`)
- `bash .github/scripts/run-quality-tests.sh` — pass; GTK ignored tests ran and
  passed under Broadway
- `./run_ui_tests.sh` — the AT-SPI/weston behavioral suite fails identically on
  clean `mainline` in this environment (0 TERMINAL accessibility nodes even on
  launch); it is a pre-existing environmental limitation, **not** a regression
  from this change (which is server-side + no-op client routing).

## Acceptance criteria
- [x] Integration tests: attach returns full tree; split/close/resize produce correct deltas; new pane id is server-assigned and stable.
- [x] Multi-client PTY sizing (min-size) covered by a test.
- [ ] No client-identity `CreatePane` remains — **deferred to Step 4 (#1001)** (see scope note).
- [x] clippy `-D warnings` clean; runtime-behavior gate satisfied (pure-state + integration).

Refs #1000
