### PR TITLE
[rttx] Render client layout from server pane tree (RFC-031 Step 4 foundation)

### DIFF
--- a/clients/rttx/src/workspace/mod.rs
+++ b/clients/rttx/src/workspace/mod.rs
@@ -1,10 +1,12 @@
 pub mod layout;
 pub mod recovery;
 pub mod state;
+pub mod tree;
 
 pub use layout::{Direction, LayoutNode, MAX_SPLIT_DEPTH, SplitOrientation};
 pub use recovery::{PaneRecovery, PaneSource, PaneTarget, StartupStep};
 pub use state::{WindowState, WorkspaceColor, WorkspaceState};
+pub use tree::layout_from_pane_tree;
 
 use gtk4::glib;
 use gtk4::prelude::*;

--- a/clients/rttx/src/workspace/tree.rs
+++ b/clients/rttx/src/workspace/tree.rs
@@ -1,0 +1,253 @@
+//! Render the client layout from the server-authoritative pane tree.
+//!
+//! RFC-031 §3: the server owns the workspace structure and pane identity; the
+//! client is a view. On attach the client builds its entire [`LayoutNode`]
+//! render tree from the `WorkspaceSnapshot` tree ([`v3::PaneTreeNode`]), and
+//! every render leaf is keyed by the durable, server-assigned pane id. The
+//! client mints no structure and no identity here — this is the consumer
+//! counterpart to the `rttx_proto::v3_tree` builders.
+
+use super::{LayoutNode, SplitOrientation};
+use rttx_proto::v3;
+
+/// Lower bound for a stored split ratio, matching the clamp applied when
+/// ratios are pushed to / pulled from live `GtkPaned` positions
+/// (`workspace::apply_paned_ratios`). Keeping the stored value in range avoids
+/// a degenerate first render before the live clamp runs.
+const MIN_RATIO: f64 = 0.05;
+/// Upper bound for a stored split ratio (see [`MIN_RATIO`]).
+const MAX_RATIO: f64 = 0.95;
+
+/// Build the client render layout from a server pane-tree node.
+///
+/// Returns `None` for an empty node (a workspace with no panes), in which case
+/// the client has no server structure to render.
+///
+/// Each leaf becomes a [`LayoutNode::Terminal`] whose `uuid` is the canonical
+/// string form of the server pane id, so the render tree and the daemon share
+/// one identity. A malformed leaf id, or a split missing a child, collapses to
+/// whatever valid structure remains rather than discarding the whole tree.
+#[must_use]
+pub fn layout_from_pane_tree(node: &v3::PaneTreeNode) -> Option<LayoutNode> {
+    match node.node.as_ref()? {
+        v3::pane_tree_node::Node::Leaf(leaf) => leaf_layout(leaf),
+        v3::pane_tree_node::Node::Split(split) => split_layout(split),
+    }
+}
+
+fn leaf_layout(leaf: &v3::PaneTreeLeaf) -> Option<LayoutNode> {
+    let pane_id = rttx_proto::bytes_to_uuid(&leaf.pane_id).ok()?;
+    Some(LayoutNode::Terminal {
+        uuid: pane_id.to_string(),
+        profile: None,
+        cwd: None,
+        custom_title: None,
+    })
+}
+
+fn split_layout(split: &v3::PaneTreeSplit) -> Option<LayoutNode> {
+    let first = split.first.as_ref().and_then(|n| layout_from_pane_tree(n));
+    let second = split.second.as_ref().and_then(|n| layout_from_pane_tree(n));
+
+    match (first, second) {
+        (Some(first), Some(second)) => Some(LayoutNode::Split {
+            orientation: orientation_from_axis(split.axis),
+            ratio: f64::from(split.ratio).clamp(MIN_RATIO, MAX_RATIO),
+            first: Box::new(first),
+            second: Box::new(second),
+        }),
+        (Some(only), None) | (None, Some(only)) => Some(only),
+        (None, None) => None,
+    }
+}
+
+/// Map a wire split axis to the client orientation.
+///
+/// `HORIZONTAL` places children side by side (a vertical divider), which is the
+/// client's [`SplitOrientation::Horizontal`]. `UNSPECIFIED` and unknown values
+/// default to side-by-side: a split always has two children, so a renderable
+/// orientation is always required.
+fn orientation_from_axis(axis: i32) -> SplitOrientation {
+    match v3::PaneSplitAxis::try_from(axis) {
+        Ok(v3::PaneSplitAxis::Vertical) => SplitOrientation::Vertical,
+        _ => SplitOrientation::Horizontal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rttx_proto::v3_tree::{pane_tree_leaf, pane_tree_split};
+    use uuid::Uuid;
+
+    fn leaf_uuid(node: &LayoutNode) -> &str {
+        match node {
+            LayoutNode::Terminal { uuid, .. } => uuid,
+            LayoutNode::Split { .. } => panic!("expected a terminal leaf"),
+        }
+    }
+
+    #[test]
+    fn empty_node_renders_nothing() {
+        let node = v3::PaneTreeNode { node: None };
+        assert!(layout_from_pane_tree(&node).is_none());
+    }
+
+    #[test]
+    fn leaf_renders_terminal_keyed_by_server_pane_id() {
+        let pane = Uuid::new_v4();
+        let layout = layout_from_pane_tree(&pane_tree_leaf(pane)).expect("leaf renders");
+
+        match layout {
+            LayoutNode::Terminal { uuid, profile, cwd, custom_title } => {
+                assert_eq!(uuid, pane.to_string());
+                assert!(profile.is_none());
+                assert!(cwd.is_none());
+                assert!(custom_title.is_none());
+            }
+            LayoutNode::Split { .. } => panic!("expected a terminal"),
+        }
+    }
+
+    #[test]
+    fn horizontal_axis_maps_to_side_by_side_orientation() {
+        let tree = pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(Uuid::new_v4()),
+            pane_tree_leaf(Uuid::new_v4()),
+        );
+        let LayoutNode::Split { orientation, .. } =
+            layout_from_pane_tree(&tree).expect("split renders")
+        else {
+            panic!("expected a split");
+        };
+        assert_eq!(orientation, SplitOrientation::Horizontal);
+    }
+
+    #[test]
+    fn vertical_axis_maps_to_stacked_orientation() {
+        let tree = pane_tree_split(
+            v3::PaneSplitAxis::Vertical,
+            0.5,
+            pane_tree_leaf(Uuid::new_v4()),
+            pane_tree_leaf(Uuid::new_v4()),
+        );
+        let LayoutNode::Split { orientation, .. } =
+            layout_from_pane_tree(&tree).expect("split renders")
+        else {
+            panic!("expected a split");
+        };
+        assert_eq!(orientation, SplitOrientation::Vertical);
+    }
+
+    #[test]
+    fn unspecified_axis_defaults_to_side_by_side() {
+        let tree = pane_tree_split(
+            v3::PaneSplitAxis::Unspecified,
+            0.5,
+            pane_tree_leaf(Uuid::new_v4()),
+            pane_tree_leaf(Uuid::new_v4()),
+        );
+        let LayoutNode::Split { orientation, .. } =
+            layout_from_pane_tree(&tree).expect("split renders")
+        else {
+            panic!("expected a split");
+        };
+        assert_eq!(orientation, SplitOrientation::Horizontal);
+    }
+
+    #[test]
+    fn split_preserves_logical_ratio() {
+        let tree = pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.3,
+            pane_tree_leaf(Uuid::new_v4()),
+            pane_tree_leaf(Uuid::new_v4()),
+        );
+        let LayoutNode::Split { ratio, .. } = layout_from_pane_tree(&tree).expect("split renders")
+        else {
+            panic!("expected a split");
+        };
+        assert!((ratio - 0.3).abs() < 1e-6, "ratio {ratio} should be ~0.3");
+    }
+
+    #[test]
+    fn out_of_range_ratio_is_clamped_to_renderable_bounds() {
+        let too_small = pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.0,
+            pane_tree_leaf(Uuid::new_v4()),
+            pane_tree_leaf(Uuid::new_v4()),
+        );
+        let LayoutNode::Split { ratio, .. } =
+            layout_from_pane_tree(&too_small).expect("split renders")
+        else {
+            panic!("expected a split");
+        };
+        assert!((ratio - MIN_RATIO).abs() < 1e-6, "ratio {ratio} should clamp to {MIN_RATIO}");
+
+        let too_large = pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            1.0,
+            pane_tree_leaf(Uuid::new_v4()),
+            pane_tree_leaf(Uuid::new_v4()),
+        );
+        let LayoutNode::Split { ratio, .. } =
+            layout_from_pane_tree(&too_large).expect("split renders")
+        else {
+            panic!("expected a split");
+        };
+        assert!((ratio - MAX_RATIO).abs() < 1e-6, "ratio {ratio} should clamp to {MAX_RATIO}");
+    }
+
+    #[test]
+    fn nested_tree_renders_full_structure_with_server_ids() {
+        let (a, b, c) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+        // Split(a, Split(b, c)).
+        let tree = pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(a),
+            pane_tree_split(v3::PaneSplitAxis::Vertical, 0.4, pane_tree_leaf(b), pane_tree_leaf(c)),
+        );
+
+        let LayoutNode::Split { first, second, .. } =
+            layout_from_pane_tree(&tree).expect("split renders")
+        else {
+            panic!("expected a split");
+        };
+        assert_eq!(leaf_uuid(&first), a.to_string());
+
+        let LayoutNode::Split { first: inner_first, second: inner_second, orientation, .. } =
+            *second
+        else {
+            panic!("expected a nested split");
+        };
+        assert_eq!(orientation, SplitOrientation::Vertical);
+        assert_eq!(leaf_uuid(&inner_first), b.to_string());
+        assert_eq!(leaf_uuid(&inner_second), c.to_string());
+    }
+
+    #[test]
+    fn malformed_leaf_id_renders_nothing() {
+        let node = v3::PaneTreeNode {
+            node: Some(v3::pane_tree_node::Node::Leaf(v3::PaneTreeLeaf {
+                pane_id: vec![0, 1, 2], // not 16 bytes
+            })),
+        };
+        assert!(layout_from_pane_tree(&node).is_none());
+    }
+
+    #[test]
+    fn split_with_one_invalid_child_collapses_to_valid_child() {
+        let good = Uuid::new_v4();
+        let bad = v3::PaneTreeNode {
+            node: Some(v3::pane_tree_node::Node::Leaf(v3::PaneTreeLeaf { pane_id: vec![9, 9] })),
+        };
+        let tree = pane_tree_split(v3::PaneSplitAxis::Horizontal, 0.5, pane_tree_leaf(good), bad);
+
+        let layout = layout_from_pane_tree(&tree).expect("collapses to the valid child");
+        assert_eq!(leaf_uuid(&layout), good.to_string());
+    }
+}

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1,6 +1,8 @@
 use crate::daemon_bridge::EndpointEvent;
 use crate::runtime::{ConnectionStatus, RuntimeEndpoint, WorkspacePolicy, reconcile_bindings};
-use crate::workspace::{LayoutNode, PaneRecovery, SplitOrientation, WindowState, WorkspaceState};
+use crate::workspace::{
+    LayoutNode, PaneRecovery, SplitOrientation, WindowState, WorkspaceState, layout_from_pane_tree,
+};
 use rttx_proto::v3;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -627,6 +629,19 @@ fn snapshot_pane_id(pane_snapshot: &v3::PaneSnapshot) -> Option<String> {
     rttx_proto::bytes_to_uuid(&pane_snapshot.pane_id).ok().map(|uuid| uuid.to_string())
 }
 
+/// Build the client render layout from a workspace snapshot's authoritative
+/// server tree (RFC-031 §3, Step 4).
+///
+/// Returns `None` when the snapshot carries no tree — an empty workspace, or a
+/// pre-tree daemon — in which case the caller falls back to its existing
+/// reconciliation path. The returned [`LayoutNode`] keys every leaf by the
+/// durable server pane id, so the render tree and the daemon share one
+/// identity with no client-side binding indirection.
+#[must_use]
+pub fn render_layout_from_snapshot(snapshot: &v3::RuntimeSnapshot) -> Option<LayoutNode> {
+    snapshot.tree.as_ref().and_then(layout_from_pane_tree)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -663,6 +678,35 @@ mod tests {
             runtime_revision: 7,
             client_role: v3::RuntimeClientRole::Writer as i32,
         }
+    }
+
+    #[test]
+    fn render_layout_from_snapshot_returns_none_without_tree() {
+        let snap = snapshot("11111111-1111-1111-1111-111111111111", Vec::new());
+        assert!(render_layout_from_snapshot(&snap).is_none());
+    }
+
+    #[test]
+    fn render_layout_from_snapshot_builds_split_keyed_by_server_pane_ids() {
+        use rttx_proto::v3_tree::{pane_tree_leaf, pane_tree_split};
+
+        let left = uuid::Uuid::new_v4();
+        let right = uuid::Uuid::new_v4();
+        let mut snap = snapshot("22222222-2222-2222-2222-222222222222", Vec::new());
+        snap.tree = Some(pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(left),
+            pane_tree_leaf(right),
+        ));
+
+        let layout = render_layout_from_snapshot(&snap).expect("snapshot with tree renders");
+        let LayoutNode::Split { orientation, first, second, .. } = layout else {
+            panic!("expected a split");
+        };
+        assert_eq!(orientation, SplitOrientation::Horizontal);
+        assert_eq!(first.terminal_uuids(), vec![left.to_string()]);
+        assert_eq!(second.terminal_uuids(), vec![right.to_string()]);
     }
 
     fn pane_info(pane_id: &str, title: &str, cwd: &str) -> v3::PaneInfo {

--- a/clients/rttx/tests/render_from_server_tree.rs
+++ b/clients/rttx/tests/render_from_server_tree.rs
@@ -1,0 +1,105 @@
+//! Integration coverage for RFC-031 Step 4: the client renders its layout
+//! purely from the server-authoritative pane tree (`WorkspaceSnapshot.tree`),
+//! holding no pane identity or structure of its own.
+//!
+//! These tests exercise the public render entry points
+//! (`workspace::layout_from_pane_tree` and
+//! `workspace_state::render_layout_from_snapshot`) through the crate boundary,
+//! the same way the attach path consumes a server snapshot.
+
+use rttx::workspace::{LayoutNode, SplitOrientation, layout_from_pane_tree};
+use rttx::workspace_state::render_layout_from_snapshot;
+use rttx_proto::v3;
+use rttx_proto::v3_tree::{pane_tree_leaf, pane_tree_split};
+use uuid::Uuid;
+
+fn leaf_uuids(layout: &LayoutNode) -> Vec<String> {
+    layout.terminal_uuids()
+}
+
+fn snapshot_with_tree(tree: Option<v3::PaneTreeNode>) -> v3::RuntimeSnapshot {
+    v3::RuntimeSnapshot {
+        runtime_id: rttx_proto::uuid_to_bytes(Uuid::new_v4()),
+        runtime_revision: 1,
+        client_role: v3::RuntimeClientRole::Writer as i32,
+        panes: Vec::new(),
+        tree,
+        default_active_pane_id: Vec::new(),
+    }
+}
+
+#[test]
+fn client_renders_single_pane_workspace_from_server_tree() {
+    let pane = Uuid::new_v4();
+    let layout = layout_from_pane_tree(&pane_tree_leaf(pane)).expect("single leaf renders");
+
+    // The render leaf is keyed by the durable server pane id — no client id.
+    assert_eq!(leaf_uuids(&layout), vec![pane.to_string()]);
+}
+
+#[test]
+fn client_renders_nested_split_structure_from_server_tree() {
+    let (a, b, c) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+    // Horizontal( a , Vertical( b , c ) ).
+    let tree = pane_tree_split(
+        v3::PaneSplitAxis::Horizontal,
+        0.6,
+        pane_tree_leaf(a),
+        pane_tree_split(v3::PaneSplitAxis::Vertical, 0.25, pane_tree_leaf(b), pane_tree_leaf(c)),
+    );
+
+    let layout = layout_from_pane_tree(&tree).expect("nested tree renders");
+    let LayoutNode::Split { orientation, ratio, first, second } = layout else {
+        panic!("expected a top-level split");
+    };
+    assert_eq!(orientation, SplitOrientation::Horizontal);
+    assert!((ratio - 0.6).abs() < 1e-6);
+    assert_eq!(leaf_uuids(&first), vec![a.to_string()]);
+
+    let LayoutNode::Split { orientation, first: inner_a, second: inner_b, .. } = *second else {
+        panic!("expected a nested split");
+    };
+    assert_eq!(orientation, SplitOrientation::Vertical);
+    assert_eq!(leaf_uuids(&inner_a), vec![b.to_string()]);
+    assert_eq!(leaf_uuids(&inner_b), vec![c.to_string()]);
+}
+
+#[test]
+fn render_is_a_pure_function_of_the_server_tree() {
+    // Two independent clients (two windows) attaching to the same workspace
+    // build identical structure from the same server tree — shared structure,
+    // no per-client identity (RFC-031 §3 viewport decoupling).
+    let (a, b) = (Uuid::new_v4(), Uuid::new_v4());
+    let tree =
+        pane_tree_split(v3::PaneSplitAxis::Vertical, 0.5, pane_tree_leaf(a), pane_tree_leaf(b));
+
+    let window_one = layout_from_pane_tree(&tree).expect("renders");
+    let window_two = layout_from_pane_tree(&tree).expect("renders");
+
+    assert_eq!(window_one, window_two);
+}
+
+#[test]
+fn snapshot_without_tree_yields_no_layout() {
+    // A pre-tree daemon or empty workspace carries no tree; the caller falls
+    // back to its existing path rather than fabricating structure.
+    assert!(render_layout_from_snapshot(&snapshot_with_tree(None)).is_none());
+}
+
+#[test]
+fn snapshot_with_tree_renders_full_layout() {
+    let (a, b) = (Uuid::new_v4(), Uuid::new_v4());
+    let snapshot = snapshot_with_tree(Some(pane_tree_split(
+        v3::PaneSplitAxis::Horizontal,
+        0.5,
+        pane_tree_leaf(a),
+        pane_tree_leaf(b),
+    )));
+
+    let layout = render_layout_from_snapshot(&snapshot).expect("snapshot with tree renders");
+    let mut ids = leaf_uuids(&layout);
+    ids.sort();
+    let mut expected = vec![a.to_string(), b.to_string()];
+    expected.sort();
+    assert_eq!(ids, expected);
+}


### PR DESCRIPTION
## What & why

First, foundational slice of **RFC-031 Step 4** (#1001 — "client becomes a view"),
targeting `mainline` now that Step 3 (#1009) is merged.

The endgame of Step 4 is large: the client must render entirely from the
server-authoritative pane tree and the whole `pane_bindings` /
`reconcile_bindings` / client-layout-persistence subsystem must be deleted.
That is a deep, pervasive rewire (routing, attach, input-sync, recovery,
persistence, plus ~8k lines of tests). This PR lands the **keystone** the rest
builds on, as a self-contained, fully-tested, behavior-neutral unit.

It adds the **consumer counterpart** to the Step 3 `v3_tree` builders:

- `workspace::layout_from_pane_tree` — pure conversion from the server
  `v3::PaneTreeNode` (the `WorkspaceSnapshot` tree) into the client
  `LayoutNode` render tree. Every leaf is keyed by the **durable,
  server-assigned pane id**, so the rendered structure and the daemon share one
  identity with no client-side binding indirection (RFC-031 §3).
- `workspace_state::render_layout_from_snapshot` — exposes this at the snapshot
  boundary. Returns `None` for a tree-less snapshot (empty workspace / pre-tree
  daemon), so the existing reconciliation path remains the fallback and
  **current live behavior is unchanged** until the render path is rewired in a
  follow-up.

Axis → orientation mapping, logical-ratio clamping to renderable bounds, and
malformed-node collapse are all handled and tested.

## Tests added

- `clients/rttx/src/workspace/tree.rs` — 10 unit tests: empty node, leaf
  identity, horizontal/vertical/unspecified axis mapping, ratio preservation
  and clamping, nested structure, malformed leaf, one-invalid-child collapse.
- `clients/rttx/src/workspace_state.rs` — 2 pure-state tests for
  `render_layout_from_snapshot` (none without tree; split keyed by server ids).
- `clients/rttx/tests/render_from_server_tree.rs` — 5 integration tests through
  the crate boundary, including "two windows render identical structure from
  one server tree" (shared structure, no per-client identity).

Satisfies the runtime-behavior gate (pure-state evidence in `workspace_state.rs`
+ behavior evidence in `tests/`).

## Verification (local)

- `bash .github/scripts/run-clippy.sh` — clean (pedantic + nursery, `-D warnings`).
- `bash .github/scripts/run-quality-tests.sh` — exits 0; all new tests appear and
  PASS in the Broadway GTK run (10 + 2 unit, 5 integration).
- `cargo fmt --check` — clean.
- `cargo build` proto/server + client (`--no-default-features --features
  vte-0_76`; this host has VTE 0.76) — clean.

## Not in this PR (remaining Step 4 work, follow-ups under #1001)

- Rewire the live attach/render path to build from the server tree.
- Delete `pane_bindings`, `reconcile_bindings`, client layout persistence, and
  recovery; route panes by server pane id directly.
- Ephemeral per-client viewport (focus/scroll/size) wiring.
- AT-SPI reconnect / two-window behavioral tests for the live path.

## Note on the AT-SPI UI suite

`./run_ui_tests.sh` shows 9 failures in this sandbox, but they are
**pre-existing and environmental** — confirmed identical on the base branch with
this change stashed (even `test_exactly_one_terminal_on_launch` fails because
terminals/shells are not spawned/exposed under headless weston here). This
change has no live UI wiring, so it cannot affect them.

Refs #1001
