### PR TITLE
feat: one-time orphaned-histfile salvage utility (RFC-031 Step 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `PROMPT_COMMAND` can no longer disable capture); zsh uses a generated
   `ZDOTDIR` with `INC_APPEND_HISTORY`; fish selects a per-pane history session;
   other shells set `HISTFILE` best-effort.
+- One-time orphaned-histfile salvage utility (RFC-031 Step 7): the new
+  `rttx-server salvage-history` subcommand performs a read-only scan of the
+  daemon state directory for per-pane history files left unreferenced by the
+  pre-RFC-031 layout and copies them into a recovery directory (`--dry-run` to
+  preview, `--dest` to choose the target). It is strictly opt-in and never
+  touches live runtime state, so it adds no compatibility code to normal daemon
+  operation.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.8"
+version = "0.9.9"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/designs/RFC-031-server-authoritative-workspace-tree.md
+++ b/designs/RFC-031-server-authoritative-workspace-tree.md
@@ -308,7 +308,7 @@ no compatibility shims.
   `PaneId`; crash-survival integration tests for bash/zsh/fish. *(prereq: Step 1)*
 - [ ] **Step 6** — Delete dead paths (§8); `Runtime`→`Workspace` rename;
   crash-recovery integration test asserting **zero** orphaned state. *(prereq: 1–5)*
-- [ ] **Step 7** — One-time histfile salvage utility (separate binary/subcommand,
+- [x] **Step 7** — One-time histfile salvage utility (separate binary/subcommand,
   not a runtime code path) for users upgrading from the old layout. *(prereq: Step 2)*
 
 ---

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.8',
+  version: '0.9.9',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/src/lib.rs
+++ b/services/rttx-server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod profiling;
 pub mod protocol;
 pub mod pty;
 pub mod runtime;
+pub mod salvage;
 pub mod screen;
 pub mod server;
 pub mod shell_init;

--- a/services/rttx-server/src/main.rs
+++ b/services/rttx-server/src/main.rs
@@ -50,6 +50,20 @@ enum Command {
     Diagnostics,
     /// Show resolved paths and configuration
     Config,
+    /// Recover orphaned shell-history files left by the pre-RFC-031 layout
+    ///
+    /// One-time, opt-in utility. Scans the daemon state directory read-only for
+    /// history files no longer referenced by any current pane and copies them
+    /// into a recovery directory. Never modifies live runtime state.
+    SalvageHistory {
+        /// Recovery directory to copy salvaged history into
+        /// (default: <cache>/salvaged-history)
+        #[arg(long)]
+        dest: Option<std::path::PathBuf>,
+        /// List what would be salvaged without copying anything
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Show profiling report from flight recorder data
     Profile {
         /// Dump all ring buffer events chronologically
@@ -86,6 +100,7 @@ fn main() -> anyhow::Result<()> {
             config();
             Ok(())
         }
+        Command::SalvageHistory { dest, dry_run } => salvage_history(dest, dry_run),
         Command::Profile { dump, last_crash, json, watch } => {
             profile(&ProfileOpts { dump, last_crash, json, watch })
         }
@@ -267,6 +282,47 @@ fn config() {
     println!("Scrollback: {}", scrollback.display());
     println!("Logs: {}", log_dir.display());
     println!("Protocol version: {}", rttx_proto::v3_handshake::V3_PROTOCOL_VERSION);
+}
+
+/// Recover orphaned shell-history files (RFC-031 §9 / Step 7).
+///
+/// Read-only scan of the daemon state directory; copies unreferenced history
+/// into a recovery directory. Safe to run while the daemon is up — it never
+/// touches live runtime files.
+fn salvage_history(dest: Option<std::path::PathBuf>, dry_run: bool) -> anyhow::Result<()> {
+    let os = UnixOs;
+    let state_dir = os.state_dir();
+
+    let orphans = rttx_server::salvage::scan_orphans(&state_dir);
+    if orphans.is_empty() {
+        println!("No orphaned history files found in {}", state_dir.display());
+        return Ok(());
+    }
+
+    println!("Found {} orphaned history file(s):", orphans.len());
+    for orphan in &orphans {
+        println!(
+            "  runtime {} pane {} ({} bytes)",
+            &orphan.runtime_id.to_string()[..8],
+            &orphan.pane_id.to_string()[..8],
+            orphan.bytes,
+        );
+    }
+
+    if dry_run {
+        println!("Dry run: nothing copied. Re-run without --dry-run to recover.");
+        return Ok(());
+    }
+
+    let dest = dest.unwrap_or_else(|| os.cache_dir().join("salvaged-history"));
+    let report = rttx_server::salvage::export_orphans(&orphans, &dest)?;
+    println!(
+        "Recovered {} file(s) ({} bytes) into {}",
+        report.exported.len(),
+        report.total_bytes,
+        report.dest.display(),
+    );
+    Ok(())
 }
 
 /// Connect to the daemon socket and perform a v3 handshake.
@@ -722,6 +778,37 @@ mod tests {
     fn cli_parses_config_command() {
         let cli = Cli::try_parse_from(["rttx-server", "config"]).unwrap();
         assert!(matches!(cli.command, Some(Command::Config)));
+    }
+
+    #[test]
+    fn cli_parses_salvage_history_defaults() {
+        let cli = Cli::try_parse_from(["rttx-server", "salvage-history"]).unwrap();
+        match cli.command {
+            Some(Command::SalvageHistory { dest, dry_run }) => {
+                assert!(dest.is_none());
+                assert!(!dry_run);
+            }
+            _ => panic!("expected SalvageHistory command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_salvage_history_with_dest_and_dry_run() {
+        let cli = Cli::try_parse_from([
+            "rttx-server",
+            "salvage-history",
+            "--dest",
+            "/tmp/recovery",
+            "--dry-run",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Command::SalvageHistory { dest, dry_run }) => {
+                assert_eq!(dest, Some(std::path::PathBuf::from("/tmp/recovery")));
+                assert!(dry_run);
+            }
+            _ => panic!("expected SalvageHistory command"),
+        }
     }
 
     #[test]

--- a/services/rttx-server/src/salvage.rs
+++ b/services/rttx-server/src/salvage.rs
@@ -1,0 +1,331 @@
+//! One-time orphaned-histfile salvage utility (RFC-031 §9 / Step 7).
+//!
+//! Standalone, opt-in recovery for shell-history files left unreferenced by the
+//! pre-RFC-031 random-pane-id bug, where durable state keyed on a
+//! process-ephemeral pane id was silently orphaned when the id changed.
+//!
+//! This is **not** a daemon runtime code path. It is invoked only by the
+//! `rttx-server salvage-history` subcommand. It performs a read-only scan of the
+//! daemon state directory and copies orphaned history into a *separate* recovery
+//! directory. It never mutates, removes, or reconciles live runtime state, so it
+//! cannot interfere with a running daemon and reintroduces no compatibility code
+//! into normal operation.
+
+use crate::pane_tree::PaneId;
+use crate::state::layout;
+use crate::state::migrations::peek_schema_version;
+use crate::state::types::{RUNTIME_FILE_SCHEMA_VERSION, WorkspaceFileV2};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+/// An orphaned per-pane shell-history file: present on disk under a runtime's
+/// `history/` directory but not referenced by that runtime's current pane tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrphanHistfile {
+    /// Runtime directory the file was found under.
+    pub runtime_id: Uuid,
+    /// Pane id encoded in the file name (`<pane_id>.hist`).
+    pub pane_id: Uuid,
+    /// Absolute path to the orphaned history file.
+    pub path: PathBuf,
+    /// File size in bytes.
+    pub bytes: u64,
+}
+
+/// Outcome of an export run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SalvageReport {
+    /// The orphans that were copied into the recovery directory.
+    pub exported: Vec<OrphanHistfile>,
+    /// Recovery directory the files were written to.
+    pub dest: PathBuf,
+    /// Total bytes copied.
+    pub total_bytes: u64,
+}
+
+/// Scan the daemon state directory for orphaned history files.
+///
+/// A `history/<pane_id>.hist` file is orphaned when its `<pane_id>` is not
+/// referenced by the runtime's current-schema pane tree. Runtimes whose
+/// `runtime.json` is old-schema, corrupt, or missing reference no panes, so all
+/// of their history files are reported. Empty files are skipped — there is
+/// nothing to recover.
+///
+/// The scan is strictly read-only: it never removes old-schema runtimes the way
+/// the daemon's clean-break loader does.
+#[must_use]
+pub fn scan_orphans(state_dir: &Path) -> Vec<OrphanHistfile> {
+    let mut orphans = Vec::new();
+
+    let Ok(entries) = std::fs::read_dir(layout::runtimes_dir(state_dir)) else {
+        return orphans;
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Ok(runtime_id) = Uuid::parse_str(name) else { continue };
+
+        let referenced = referenced_pane_ids(state_dir, runtime_id);
+        collect_runtime_orphans(state_dir, runtime_id, &referenced, &mut orphans);
+    }
+
+    orphans.sort_by_key(|o| (o.runtime_id, o.pane_id));
+    orphans
+}
+
+/// Copy orphaned history files into a recovery directory, preserving provenance
+/// as `<dest>/<runtime_id>/<pane_id>.hist`.
+///
+/// The destination is expected to live outside the daemon's `runtimes/` tree so
+/// the live runtime path is never touched.
+///
+/// # Errors
+///
+/// Returns the first I/O error encountered while creating directories or copying
+/// a file.
+pub fn export_orphans(orphans: &[OrphanHistfile], dest_dir: &Path) -> std::io::Result<SalvageReport> {
+    let mut exported = Vec::new();
+    let mut total_bytes = 0u64;
+
+    for orphan in orphans {
+        let runtime_dir = dest_dir.join(orphan.runtime_id.to_string());
+        std::fs::create_dir_all(&runtime_dir)?;
+        let target = runtime_dir.join(format!("{}.hist", orphan.pane_id));
+        total_bytes += std::fs::copy(&orphan.path, &target)?;
+        exported.push(orphan.clone());
+    }
+
+    Ok(SalvageReport { exported, dest: dest_dir.to_path_buf(), total_bytes })
+}
+
+/// Pane ids referenced by a runtime's current-schema tree. Empty when the
+/// runtime file is absent, corrupt, or an older schema (clean-break) — in which
+/// case every history file under that runtime is considered orphaned.
+fn referenced_pane_ids(state_dir: &Path, runtime_id: Uuid) -> BTreeSet<Uuid> {
+    let path = layout::runtime_file(state_dir, runtime_id);
+    let Ok(json) = std::fs::read_to_string(&path) else {
+        return BTreeSet::new();
+    };
+    if peek_schema_version(&json).ok() != Some(RUNTIME_FILE_SCHEMA_VERSION) {
+        return BTreeSet::new();
+    }
+    let Ok(workspace) = serde_json::from_str::<WorkspaceFileV2>(&json) else {
+        return BTreeSet::new();
+    };
+    workspace
+        .spec
+        .tree
+        .panes()
+        .into_iter()
+        .map(PaneId::uuid)
+        .chain(workspace.spec.panes.iter().map(|p| p.id.uuid()))
+        .collect()
+}
+
+/// Append every non-empty, unreferenced `*.hist` file under one runtime to `out`.
+fn collect_runtime_orphans(
+    state_dir: &Path,
+    runtime_id: Uuid,
+    referenced: &BTreeSet<Uuid>,
+    out: &mut Vec<OrphanHistfile>,
+) {
+    let history_dir = layout::runtime_dir(state_dir, runtime_id).join("history");
+    let Ok(files) = std::fs::read_dir(&history_dir) else { return };
+
+    for file in files.flatten() {
+        let path = file.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("hist") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else { continue };
+        let Ok(pane_id) = Uuid::parse_str(stem) else { continue };
+        if referenced.contains(&pane_id) {
+            continue;
+        }
+        let bytes = file.metadata().map(|m| m.len()).unwrap_or_default();
+        if bytes == 0 {
+            continue;
+        }
+        out.push(OrphanHistfile { runtime_id, pane_id, path, bytes });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pane_tree::WorkspaceTree;
+    use crate::runtime::RuntimePolicy;
+    use crate::state::persistence::{save_daemon_index, save_runtime};
+    use crate::state::types::{
+        PaneSpecV2, RUNTIME_FILE_SCHEMA_VERSION, RuntimeInstanceV1, WorkspaceFileV2,
+        WorkspaceSpecV2,
+    };
+    use std::time::SystemTime;
+    use tempfile::TempDir;
+
+    /// Write a current-schema single-pane runtime referencing `pane_id`.
+    fn persist_runtime(state_dir: &Path, runtime_id: Uuid, pane_id: PaneId) {
+        let mut tree = WorkspaceTree::new();
+        tree.insert_root(pane_id);
+        let workspace = WorkspaceFileV2 {
+            schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+            spec: WorkspaceSpecV2 {
+                id: runtime_id,
+                name: "ws".into(),
+                policy: RuntimePolicy::Persistent,
+                created_at: SystemTime::now(),
+                tree,
+                panes: vec![PaneSpecV2 {
+                    id: pane_id,
+                    cwd: None,
+                    title: None,
+                    exit_status: None,
+                    cols: 80,
+                    rows: 24,
+                    no_persist: false,
+                }],
+            },
+            instance: RuntimeInstanceV1 {
+                revision: 1,
+                last_active_at: SystemTime::now(),
+                last_snapshot_at: SystemTime::now(),
+            },
+        };
+        save_daemon_index(state_dir, &[runtime_id]).unwrap();
+        save_runtime(state_dir, &workspace).unwrap();
+    }
+
+    fn write_hist(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid, contents: &str) -> PathBuf {
+        let path = layout::history_file(state_dir, runtime_id, pane_id);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn referenced_histfile_is_not_orphaned() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        let rt = Uuid::new_v4();
+        let live = PaneId::new();
+        persist_runtime(state, rt, live);
+        write_hist(state, rt, live.uuid(), "echo live\n");
+
+        assert!(scan_orphans(state).is_empty(), "a referenced pane's history is not an orphan");
+    }
+
+    #[test]
+    fn unreferenced_histfile_in_live_runtime_is_orphaned() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        let rt = Uuid::new_v4();
+        let live = PaneId::new();
+        persist_runtime(state, rt, live);
+        write_hist(state, rt, live.uuid(), "echo live\n");
+        // A leftover history file from an old random pane id under the same dir.
+        let stale = Uuid::new_v4();
+        write_hist(state, rt, stale, "echo recover me\n");
+
+        let orphans = scan_orphans(state);
+        assert_eq!(orphans.len(), 1);
+        assert_eq!(orphans[0].pane_id, stale);
+        assert_eq!(orphans[0].runtime_id, rt);
+    }
+
+    #[test]
+    fn old_schema_runtime_orphans_all_history() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        let rt = Uuid::new_v4();
+        // A v1 (old-schema) runtime.json: clean-break, references no panes.
+        let path = layout::runtime_file(state, rt);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, r#"{"schema_version":1,"spec":{},"instance":{}}"#).unwrap();
+        let p1 = Uuid::new_v4();
+        let p2 = Uuid::new_v4();
+        write_hist(state, rt, p1, "history one\n");
+        write_hist(state, rt, p2, "history two\n");
+
+        let mut ids: Vec<_> = scan_orphans(state).into_iter().map(|o| o.pane_id).collect();
+        ids.sort();
+        let mut expected = vec![p1, p2];
+        expected.sort();
+        assert_eq!(ids, expected, "every history file under an old-schema runtime is orphaned");
+    }
+
+    #[test]
+    fn empty_histfiles_are_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        let rt = Uuid::new_v4();
+        persist_runtime(state, rt, PaneId::new());
+        write_hist(state, rt, Uuid::new_v4(), "");
+
+        assert!(scan_orphans(state).is_empty(), "empty history files carry nothing to recover");
+    }
+
+    #[test]
+    fn non_hist_and_non_uuid_files_are_ignored() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        let rt = Uuid::new_v4();
+        persist_runtime(state, rt, PaneId::new());
+        let hist_dir = layout::runtime_dir(state, rt).join("history");
+        std::fs::create_dir_all(&hist_dir).unwrap();
+        std::fs::write(hist_dir.join("notes.txt"), "not history\n").unwrap();
+        std::fs::write(hist_dir.join("not-a-uuid.hist"), "garbage\n").unwrap();
+
+        assert!(scan_orphans(state).is_empty());
+    }
+
+    #[test]
+    fn scan_returns_empty_when_state_dir_missing() {
+        let tmp = TempDir::new().unwrap();
+        assert!(scan_orphans(&tmp.path().join("nope")).is_empty());
+    }
+
+    #[test]
+    fn export_copies_orphans_into_recovery_dir_preserving_provenance() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path().join("state");
+        let rt = Uuid::new_v4();
+        persist_runtime(&state, rt, PaneId::new());
+        let stale = Uuid::new_v4();
+        write_hist(&state, rt, stale, "echo recover me\n");
+
+        let orphans = scan_orphans(&state);
+        assert_eq!(orphans.len(), 1);
+
+        let dest = tmp.path().join("recovery");
+        let report = export_orphans(&orphans, &dest).unwrap();
+
+        let copied = dest.join(rt.to_string()).join(format!("{stale}.hist"));
+        assert!(copied.exists(), "orphan must be copied under <dest>/<runtime>/<pane>.hist");
+        assert_eq!(std::fs::read_to_string(&copied).unwrap(), "echo recover me\n");
+        assert_eq!(report.exported.len(), 1);
+        assert_eq!(report.total_bytes, "echo recover me\n".len() as u64);
+        assert_eq!(report.dest, dest);
+    }
+
+    #[test]
+    fn export_never_touches_the_source_runtime_directory() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path().join("state");
+        let rt = Uuid::new_v4();
+        let live = PaneId::new();
+        persist_runtime(&state, rt, live);
+        let live_hist = write_hist(&state, rt, live.uuid(), "echo live\n");
+        let stale = Uuid::new_v4();
+        let stale_hist = write_hist(&state, rt, stale, "echo stale\n");
+
+        let orphans = scan_orphans(&state);
+        export_orphans(&orphans, &tmp.path().join("recovery")).unwrap();
+
+        // Both the live and orphaned source files are left exactly as they were.
+        assert!(live_hist.exists());
+        assert!(stale_hist.exists());
+        assert_eq!(std::fs::read_to_string(&stale_hist).unwrap(), "echo stale\n");
+    }
+}

--- a/services/rttx-server/src/salvage.rs
+++ b/services/rttx-server/src/salvage.rs
@@ -85,7 +85,10 @@ pub fn scan_orphans(state_dir: &Path) -> Vec<OrphanHistfile> {
 ///
 /// Returns the first I/O error encountered while creating directories or copying
 /// a file.
-pub fn export_orphans(orphans: &[OrphanHistfile], dest_dir: &Path) -> std::io::Result<SalvageReport> {
+pub fn export_orphans(
+    orphans: &[OrphanHistfile],
+    dest_dir: &Path,
+) -> std::io::Result<SalvageReport> {
     let mut exported = Vec::new();
     let mut total_bytes = 0u64;
 

--- a/services/rttx-server/tests/salvage_history.rs
+++ b/services/rttx-server/tests/salvage_history.rs
@@ -87,8 +87,7 @@ fn salvage_recovers_every_orphan_without_touching_live_state() {
     // Scan: three orphans (stale in A, old1 + old2 in B); the live pane is not
     // reported.
     let orphans = scan_orphans(&state_dir);
-    let recovered: std::collections::BTreeSet<Uuid> =
-        orphans.iter().map(|o| o.pane_id).collect();
+    let recovered: std::collections::BTreeSet<Uuid> = orphans.iter().map(|o| o.pane_id).collect();
     assert_eq!(orphans.len(), 3, "found: {orphans:?}");
     assert!(recovered.contains(&stale));
     assert!(recovered.contains(&old1));

--- a/services/rttx-server/tests/salvage_history.rs
+++ b/services/rttx-server/tests/salvage_history.rs
@@ -1,0 +1,132 @@
+//! Integration coverage for the one-time orphaned-histfile salvage utility
+//! (RFC-031 §9 / Step 7, issue #1004).
+//!
+//! Builds a synthetic daemon state directory that mirrors a real upgrade: one
+//! current-schema runtime that still has a live pane plus a stale history file
+//! left by the pre-RFC-031 random-pane-id bug, and one old-schema runtime whose
+//! `runtime.json` references no current panes. The salvage scan must find every
+//! orphan, ignore the live pane's history, and export recovered files into a
+//! separate recovery directory without disturbing the source state.
+
+use rttx_server::pane_tree::{PaneId, WorkspaceTree};
+use rttx_server::runtime::RuntimePolicy;
+use rttx_server::salvage::{export_orphans, scan_orphans};
+use rttx_server::state::layout;
+use rttx_server::state::persistence::{save_daemon_index, save_runtime};
+use rttx_server::state::types::{
+    PaneSpecV2, RUNTIME_FILE_SCHEMA_VERSION, RuntimeInstanceV1, WorkspaceFileV2, WorkspaceSpecV2,
+};
+use std::path::Path;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+fn write_hist(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid, contents: &str) {
+    let path = layout::history_file(state_dir, runtime_id, pane_id);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, contents).unwrap();
+}
+
+/// Persist a current-schema runtime with a single live pane.
+fn persist_current_runtime(state_dir: &Path, runtime_id: Uuid, live: PaneId) {
+    let mut tree = WorkspaceTree::new();
+    tree.insert_root(live);
+    let workspace = WorkspaceFileV2 {
+        schema_version: RUNTIME_FILE_SCHEMA_VERSION,
+        spec: WorkspaceSpecV2 {
+            id: runtime_id,
+            name: "upgraded".into(),
+            policy: RuntimePolicy::Persistent,
+            created_at: SystemTime::now(),
+            tree,
+            panes: vec![PaneSpecV2 {
+                id: live,
+                cwd: Some("/home/user/project".into()),
+                title: Some("bash".into()),
+                exit_status: None,
+                cols: 80,
+                rows: 24,
+                no_persist: false,
+            }],
+        },
+        instance: RuntimeInstanceV1 {
+            revision: 1,
+            last_active_at: SystemTime::now(),
+            last_snapshot_at: SystemTime::now(),
+        },
+    };
+    save_runtime(state_dir, &workspace).unwrap();
+}
+
+#[test]
+fn salvage_recovers_every_orphan_without_touching_live_state() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state/rttx/daemon");
+
+    // Runtime A: current schema, one live pane plus one stale orphan from the
+    // pre-refactor random-id bug.
+    let rt_a = Uuid::new_v4();
+    let live = PaneId::new();
+    persist_current_runtime(&state_dir, rt_a, live);
+    write_hist(&state_dir, rt_a, live.uuid(), "echo still here\n");
+    let stale = Uuid::new_v4();
+    write_hist(&state_dir, rt_a, stale, "echo orphaned by reconnect\n");
+
+    // Runtime B: old-schema runtime.json (clean-break) with two history files
+    // that the daemon would otherwise discard on first start.
+    let rt_b = Uuid::new_v4();
+    let rt_b_file = layout::runtime_file(&state_dir, rt_b);
+    std::fs::create_dir_all(rt_b_file.parent().unwrap()).unwrap();
+    std::fs::write(&rt_b_file, r#"{"schema_version":1,"spec":{},"instance":{}}"#).unwrap();
+    let old1 = Uuid::new_v4();
+    let old2 = Uuid::new_v4();
+    write_hist(&state_dir, rt_b, old1, "fg\n");
+    write_hist(&state_dir, rt_b, old2, "make release\n");
+
+    save_daemon_index(&state_dir, &[rt_a, rt_b]).unwrap();
+
+    // Scan: three orphans (stale in A, old1 + old2 in B); the live pane is not
+    // reported.
+    let orphans = scan_orphans(&state_dir);
+    let recovered: std::collections::BTreeSet<Uuid> =
+        orphans.iter().map(|o| o.pane_id).collect();
+    assert_eq!(orphans.len(), 3, "found: {orphans:?}");
+    assert!(recovered.contains(&stale));
+    assert!(recovered.contains(&old1));
+    assert!(recovered.contains(&old2));
+    assert!(!recovered.contains(&live.uuid()), "the live pane's history must not be salvaged");
+
+    // Export into a recovery directory outside runtimes/.
+    let dest = tmp.path().join("recovery");
+    let report = export_orphans(&orphans, &dest).unwrap();
+    assert_eq!(report.exported.len(), 3);
+
+    assert_eq!(
+        std::fs::read_to_string(dest.join(rt_a.to_string()).join(format!("{stale}.hist"))).unwrap(),
+        "echo orphaned by reconnect\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dest.join(rt_b.to_string()).join(format!("{old2}.hist"))).unwrap(),
+        "make release\n"
+    );
+
+    // Source state is untouched: the live history and the orphan sources remain.
+    assert!(layout::history_file(&state_dir, rt_a, live.uuid()).exists());
+    assert!(layout::history_file(&state_dir, rt_a, stale).exists());
+    assert!(layout::history_file(&state_dir, rt_b, old1).exists());
+}
+
+#[test]
+fn salvage_reports_nothing_for_a_clean_install() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state/rttx/daemon");
+    let rt = Uuid::new_v4();
+    let live = PaneId::new();
+    persist_current_runtime(&state_dir, rt, live);
+    write_hist(&state_dir, rt, live.uuid(), "echo hello\n");
+    save_daemon_index(&state_dir, &[rt]).unwrap();
+
+    assert!(
+        scan_orphans(&state_dir).is_empty(),
+        "a state dir with only referenced history has nothing to salvage"
+    );
+}


### PR DESCRIPTION
## What & why

Implements RFC-031 §9 / Step 7 (issue #1004). Adds a standalone, opt-in
`rttx-server salvage-history` subcommand that recovers per-pane shell history
orphaned by the pre-RFC-031 random-pane-id layout (durable state was keyed on a
process-ephemeral pane id and silently orphaned when the id changed on
reconnect).

Key design points (per acceptance criteria):
- **Not a runtime code path.** Lives in a dedicated `salvage` module, invoked only
  by the subcommand. The daemon's normal operation gains no compatibility code.
- **Read-only on the source.** Scans `runtimes/<id>/history/<pane_id>.hist`, finds
  files not referenced by the runtime's current-schema pane tree, and copies them
  into a separate recovery directory (`<dest>/<runtime_id>/<pane_id>.hist`). It
  never mutates, removes, or reconciles live runtime state — safe to run while the
  daemon is up.
- **Old-schema handling.** A runtime whose `runtime.json` is old-schema, corrupt,
  or missing references no panes, so all its history is recoverable (the daemon's
  clean-break loader would otherwise discard it).
- Empty files and non-`.hist`/non-UUID files are skipped.

CLI:
- `rttx-server salvage-history` — scan + copy to `<cache>/salvaged-history`
- `--dry-run` — list what would be salvaged without copying
- `--dest <dir>` — choose the recovery directory

Workspace version bumped 0.9.8 → 0.9.9 (new user-facing subcommand).

## How to manually verify

```bash
# Build the daemon
cargo build -p rttx-server

# Create a synthetic orphan under the state dir, then:
./target/debug/rttx-server salvage-history --dry-run   # lists orphans, copies nothing
./target/debug/rttx-server salvage-history             # copies into <cache>/salvaged-history
```

## Tests added

Unit (`services/rttx-server/src/salvage.rs`):
- `referenced_histfile_is_not_orphaned`
- `unreferenced_histfile_in_live_runtime_is_orphaned`
- `old_schema_runtime_orphans_all_history`
- `empty_histfiles_are_skipped`
- `non_hist_and_non_uuid_files_are_ignored`
- `scan_returns_empty_when_state_dir_missing`
- `export_copies_orphans_into_recovery_dir_preserving_provenance`
- `export_never_touches_the_source_runtime_directory`

CLI parse (`services/rttx-server/src/main.rs`):
- `cli_parses_salvage_history_defaults`
- `cli_parses_salvage_history_with_dest_and_dry_run`

Integration (`services/rttx-server/tests/salvage_history.rs`):
- `salvage_recovers_every_orphan_without_touching_live_state`
- `salvage_reports_nothing_for_a_clean_install`

## Tests run (local, all green)

- `cargo build -p rttx-server` ✅
- `cargo test -p rttx-server` ✅ (all unit + integration, incl. 12 salvage tests)
- `bash .github/scripts/run-clippy.sh` ✅ (pedantic + nursery, -D warnings)
- `bash .github/scripts/run-quality-tests.sh` ✅ (full matrix incl. GTK tests via Broadway; 510 `test result: ok` groups, 0 failed; all 12 salvage tests pass)

## Remaining limitations / follow-ups

- Best-effort cwd/recency *merge* into a matching new pane's histfile (mentioned in
  the issue) is intentionally not implemented: export-to-recovery-dir is the safer,
  non-destructive default and fully satisfies the acceptance criteria. Merge can be
  a follow-up if requested.
- `run_ui_tests.sh` not run: change is a daemon subcommand and touches no GTK
  layout/widget/split/sidebar/UX paths.

Fixes #1004