### PR TITLE
[rttx-server] Replace orphan-sweep with close-driven pane cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   migration path. The obsolete `command_history` field is gone.
 - Replaced the bash-only `PROMPT_COMMAND=history -a` environment hack with
   shell-aware history initialization (see Added, RFC-031 Step 5).
+- Removed the startup orphan-sweep that masked the history-loss bug by
+  relocating unreferenced runtime directories into `runtimes/.orphans/`.
+  Cleanup is now explicit and close-driven, keyed on pane-tree membership: when
+  a pane is closed it leaves the tree and its durable artifacts (screen
+  snapshot, scrollback log, history file, shell-init dir) are removed
+  (RFC-031 Step 6).
 
 ## [0.9.0] - 2026-05-26
 

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -214,15 +214,6 @@ impl Server {
                 self.runtimes.insert(rt.id, Arc::new(Mutex::new(rt)));
             }
 
-            // Sweep orphaned runtime directories (RFC-022 §7).
-            let known_ids: std::collections::HashSet<Uuid> = result
-                .runtimes
-                .iter()
-                .map(|rf| rf.spec.id)
-                .chain(result.failed_ids.iter().copied())
-                .collect();
-            crate::state::cleanup::sweep_orphans(&state_dir, &known_ids);
-
             if total > 0 || result.failed_ids.is_empty() {
                 return;
             }
@@ -1446,6 +1437,8 @@ impl Server {
         if let Some(kill_tx) = s.pty_kill_senders.remove(&pane_id) {
             let _ = kill_tx.send(());
         }
+        // The pane left the tree: sweep its durable artifacts (RFC-031 §8).
+        crate::state::cleanup::remove_pane_state_background(&s.os.state_dir(), runtime_id, pane_id);
         tracing::info!("Pane {} closed in runtime {runtime_label}", short_id(pane_id));
         Some(rttx_proto::v3_envelope::build_response_envelope(
             request_id,

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1073,6 +1073,55 @@ async fn terminate_runtime_removes_state_directory() {
     assert!(!dir.exists());
 }
 
+#[tokio::test]
+#[traced_test]
+async fn close_pane_removes_its_durable_state() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let os = temp_os(tmp.path());
+    let state_dir = os.state_dir();
+    let metrics = test_metrics();
+    let mut server = Server::new(Box::new(os), metrics.clone(), test_ring());
+
+    // Runtime with a single pane, owned by a read-write client.
+    let mut rt = Runtime::new("close-cleanup".into());
+    let runtime_id = rt.id;
+    let pane = Pane::new(Uuid::new_v4(), 80, 24);
+    let pane_id = pane.id;
+    rt.add_pane(pane);
+    let client_id = Uuid::new_v4();
+    let _ = rt.attach_client(client_id, AttachMode::ReadWrite);
+    server.runtimes.insert(runtime_id, Arc::new(Mutex::new(rt)));
+
+    // Seed the pane's durable artifacts on disk.
+    let screen = crate::state::layout::screen_snapshot(&state_dir, runtime_id, pane_id);
+    let scroll = crate::state::layout::scrollback_log(&state_dir, runtime_id, pane_id);
+    let hist = crate::state::layout::history_file(&state_dir, runtime_id, pane_id);
+    for f in [&screen, &scroll, &hist] {
+        std::fs::create_dir_all(f.parent().unwrap()).unwrap();
+        std::fs::write(f, b"x").unwrap();
+    }
+
+    let server = Arc::new(Mutex::new(server));
+    let req = rttx_proto::v3::ClosePane {
+        runtime_id: rttx_proto::uuid_to_bytes(runtime_id),
+        pane_id: rttx_proto::uuid_to_bytes(pane_id),
+    };
+    let resp = Server::handle_v3_close_pane(&server, client_id, 1, req, &metrics).await;
+    assert!(
+        matches!(
+            resp.and_then(|e| e.payload),
+            Some(rttx_proto::v3::server_envelope::Payload::PaneClosed(_))
+        ),
+        "ClosePane must succeed for the owning client"
+    );
+
+    // The close-driven cleanup runs in the background.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    assert!(!screen.exists(), "screen snapshot must be removed when the pane is closed");
+    assert!(!scroll.exists(), "scrollback log must be removed when the pane is closed");
+    assert!(!hist.exists(), "history file must be removed when the pane is closed");
+}
+
 #[test]
 #[traced_test]
 fn fresh_start_log_includes_state_directory_path() {

--- a/services/rttx-server/src/server/tests.rs
+++ b/services/rttx-server/src/server/tests.rs
@@ -1075,56 +1075,6 @@ async fn terminate_runtime_removes_state_directory() {
 
 #[test]
 #[traced_test]
-fn load_persisted_state_sweeps_orphans() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let os = temp_os(tmp.path());
-    let state_dir = os.state_dir();
-
-    let known_id = Uuid::new_v4();
-    let orphan_id = Uuid::new_v4();
-
-    // Create runtime files for both.
-    let known_rf = crate::state::types::WorkspaceFileV2 {
-        schema_version: crate::state::types::RUNTIME_FILE_SCHEMA_VERSION,
-        spec: crate::state::types::WorkspaceSpecV2 {
-            id: known_id,
-            name: "known".into(),
-            policy: RuntimePolicy::Persistent,
-            created_at: std::time::SystemTime::now(),
-            tree: crate::pane_tree::WorkspaceTree::new(),
-            panes: vec![],
-        },
-        instance: crate::state::types::RuntimeInstanceV1 {
-            revision: 1,
-            last_active_at: std::time::SystemTime::now(),
-            last_snapshot_at: std::time::SystemTime::now(),
-        },
-    };
-    crate::state::persistence::save_runtime(&state_dir, &known_rf).unwrap();
-
-    // Create orphan directory (not in daemon index).
-    let orphan_dir = crate::state::layout::runtime_dir(&state_dir, orphan_id);
-    std::fs::create_dir_all(&orphan_dir).unwrap();
-    std::fs::write(orphan_dir.join("runtime.json"), "{}").unwrap();
-
-    // Save daemon index referencing only the known runtime.
-    crate::state::persistence::save_daemon_index(&state_dir, &[known_id]).unwrap();
-
-    let mut server =
-        Server::new(Box::new(os), Arc::new(crate::metrics::DaemonMetrics::new()), test_ring());
-    server.load_persisted_state();
-
-    // Known runtime should be loaded.
-    assert!(server.runtimes.contains_key(&known_id));
-
-    // Orphan should have been moved to .orphans/.
-    assert!(!orphan_dir.exists());
-    let orphan_dest = crate::state::layout::orphans_dir(&state_dir).join(orphan_id.to_string());
-    assert!(orphan_dest.exists());
-}
-
-#[test]
-#[traced_test]
 fn fresh_start_log_includes_state_directory_path() {
     let tmp = tempfile::TempDir::new().unwrap();
     let os = temp_os(tmp.path());

--- a/services/rttx-server/src/state/cleanup.rs
+++ b/services/rttx-server/src/state/cleanup.rs
@@ -1,18 +1,19 @@
-//! Runtime directory cleanup and orphan sweep (RFC-022 §7).
+//! Runtime and pane directory cleanup (RFC-022 §7, RFC-031 §8).
 //!
-//! On runtime delete: remove `runtimes/<id>/` in a background task.
-//! On startup: move unreferenced runtime directories to `runtimes/.orphans/`.
-//! Prune `.orphans/` entries older than 30 days.
+//! Cleanup is explicit and close-driven, keyed on pane-tree membership:
+//!
+//! - On runtime delete: remove `runtimes/<id>/` in a background task.
+//! - On pane close: remove that pane's durable artifacts (screen snapshot,
+//!   scrollback log, history file, generated shell-init dir) in a background
+//!   task. A pane that leaves the tree leaves nothing behind.
+//!
+//! There is no startup orphan sweep. With server-authoritative, immutable
+//! `PaneId`s (RFC-031) nothing is ever left unreferenced, so a sweep would only
+//! mask bugs rather than fix them.
 
 use crate::state::layout;
-use std::collections::HashSet;
-use std::hash::BuildHasher;
 use std::path::Path;
-use std::time::{Duration, SystemTime};
 use uuid::Uuid;
-
-/// How long orphaned directories are kept before pruning.
-const ORPHAN_RETENTION: Duration = Duration::from_hours(30 * 24);
 
 /// Remove a runtime's directory in a background task.
 ///
@@ -34,107 +35,42 @@ pub fn remove_runtime_dir_background(state_dir: &Path, runtime_id: Uuid) {
     });
 }
 
-/// Move unreferenced runtime directories to `.orphans/` and prune old orphans.
+/// Remove a single pane's durable artifacts in a background task.
 ///
-/// Called once on startup after loading the daemon index. `known_ids` is the
-/// set of runtime IDs that the daemon index references (both successfully
-/// loaded and failed-to-load runtimes are considered "known").
-pub fn sweep_orphans<S: BuildHasher>(state_dir: &Path, known_ids: &HashSet<Uuid, S>) {
-    let runtimes = layout::runtimes_dir(state_dir);
-    if !runtimes.exists() {
-        return;
-    }
-
-    let orphans = layout::orphans_dir(state_dir);
-
-    // Phase 1: move unreferenced runtime dirs to .orphans/
-    let entries = match std::fs::read_dir(&runtimes) {
-        Ok(entries) => entries,
-        Err(e) => {
-            tracing::error!("Failed to read runtimes directory: {e}");
-            return;
-        }
-    };
-
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-
-        // Skip the .orphans directory itself.
-        if name_str == ".orphans" {
-            continue;
-        }
-
-        // Only consider directories that look like UUIDs.
-        let Ok(id) = Uuid::parse_str(&name_str) else {
-            continue;
-        };
-
-        if known_ids.contains(&id) {
-            continue;
-        }
-
-        // Move to .orphans/
-        if let Err(e) = std::fs::create_dir_all(&orphans) {
-            tracing::error!("Failed to create orphans directory: {e}");
-            return;
-        }
-        let dest = orphans.join(&name);
-        match std::fs::rename(entry.path(), &dest) {
-            Ok(()) => {
-                tracing::info!("Moved orphaned runtime {} to .orphans/", &name_str[..8]);
-            }
-            Err(e) => {
-                tracing::error!("Failed to move orphaned runtime {}: {e}", &name_str[..8]);
-            }
-        }
-    }
-
-    // Phase 2: prune old orphans.
-    prune_old_orphans(&orphans);
+/// Called when a pane is closed and thus leaves the workspace tree. The caller
+/// holds the server lock, so the file I/O is deferred to a background thread.
+pub fn remove_pane_state_background(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) {
+    let state_dir = state_dir.to_path_buf();
+    std::thread::spawn(move || {
+        remove_pane_state(&state_dir, runtime_id, pane_id);
+    });
 }
 
-/// Remove orphan entries older than [`ORPHAN_RETENTION`].
-fn prune_old_orphans(orphans_dir: &Path) {
-    if !orphans_dir.exists() {
-        return;
+/// Remove every durable artifact keyed on `pane_id`: screen snapshot,
+/// scrollback log, history file, and the generated shell-init directory.
+///
+/// Missing entries are not an error. Failures are logged but never propagate.
+pub fn remove_pane_state(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) {
+    let short = &pane_id.to_string()[..8];
+    remove_file_if_present(&layout::screen_snapshot(state_dir, runtime_id, pane_id), short);
+    remove_file_if_present(&layout::scrollback_log(state_dir, runtime_id, pane_id), short);
+    remove_file_if_present(&layout::history_file(state_dir, runtime_id, pane_id), short);
+
+    let shell_init = layout::shell_init_dir(state_dir, runtime_id, pane_id);
+    if shell_init.exists()
+        && let Err(e) = std::fs::remove_dir_all(&shell_init)
+    {
+        tracing::error!("Failed to remove shell-init dir for pane {short}: {e}");
     }
+    tracing::info!("Removed durable state for closed pane {short}");
+}
 
-    let now = SystemTime::now();
-    let entries = match std::fs::read_dir(orphans_dir) {
-        Ok(entries) => entries,
-        Err(e) => {
-            tracing::error!("Failed to read orphans directory: {e}");
-            return;
-        }
-    };
-
-    for entry in entries.flatten() {
-        let age = entry
-            .metadata()
-            .ok()
-            .and_then(|m| m.modified().ok())
-            .and_then(|mtime| now.duration_since(mtime).ok());
-
-        let Some(age) = age else {
-            continue;
-        };
-
-        if age > ORPHAN_RETENTION {
-            let name = entry.file_name();
-            let short = &name.to_string_lossy()[..8.min(name.len())];
-            match std::fs::remove_dir_all(entry.path()) {
-                Ok(()) => {
-                    tracing::info!(
-                        "Pruned old orphan {short} (age: {} days)",
-                        age.as_secs() / 86400
-                    );
-                }
-                Err(e) => {
-                    tracing::error!("Failed to prune orphan {short}: {e}");
-                }
-            }
-        }
+/// Remove a file if it exists, logging any failure.
+fn remove_file_if_present(path: &Path, short_pane: &str) {
+    if path.exists()
+        && let Err(e) = std::fs::remove_file(path)
+    {
+        tracing::error!("Failed to remove {} for pane {short_pane}: {e}", path.display());
     }
 }
 
@@ -145,8 +81,9 @@ mod tests {
     use crate::state::layout;
     use crate::state::persistence;
     use crate::state::types::*;
-    use std::collections::HashSet;
+    use std::time::{Duration, SystemTime};
     use tempfile::TempDir;
+    use uuid::Uuid;
 
     fn sample_runtime_file(id: Uuid) -> WorkspaceFileV2 {
         WorkspaceFileV2 {
@@ -165,6 +102,27 @@ mod tests {
                 last_snapshot_at: SystemTime::now(),
             },
         }
+    }
+
+    /// Create the four durable artifacts for a pane on disk.
+    fn seed_pane_state(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) {
+        let screen = layout::screen_snapshot(state_dir, runtime_id, pane_id);
+        let scroll = layout::scrollback_log(state_dir, runtime_id, pane_id);
+        let hist = layout::history_file(state_dir, runtime_id, pane_id);
+        let shell_init = layout::shell_init_dir(state_dir, runtime_id, pane_id);
+        for f in [&screen, &scroll, &hist] {
+            std::fs::create_dir_all(f.parent().unwrap()).unwrap();
+            std::fs::write(f, b"x").unwrap();
+        }
+        std::fs::create_dir_all(&shell_init).unwrap();
+        std::fs::write(shell_init.join("rcfile"), b"x").unwrap();
+    }
+
+    fn pane_state_exists(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) -> bool {
+        layout::screen_snapshot(state_dir, runtime_id, pane_id).exists()
+            || layout::scrollback_log(state_dir, runtime_id, pane_id).exists()
+            || layout::history_file(state_dir, runtime_id, pane_id).exists()
+            || layout::shell_init_dir(state_dir, runtime_id, pane_id).exists()
     }
 
     #[test]
@@ -194,121 +152,61 @@ mod tests {
     }
 
     #[test]
-    fn sweep_orphans_moves_unreferenced_dirs() {
+    fn remove_pane_state_removes_all_durable_artifacts() {
         let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path();
+        let runtime_id = Uuid::new_v4();
+        let pane_id = Uuid::new_v4();
 
-        let known_id = Uuid::new_v4();
-        let orphan_id = Uuid::new_v4();
+        seed_pane_state(state_dir, runtime_id, pane_id);
+        assert!(pane_state_exists(state_dir, runtime_id, pane_id));
 
-        // Create directories for both.
-        persistence::save_runtime(state_dir, &sample_runtime_file(known_id)).unwrap();
-        persistence::save_runtime(state_dir, &sample_runtime_file(orphan_id)).unwrap();
+        remove_pane_state(state_dir, runtime_id, pane_id);
 
-        let known_ids: HashSet<Uuid> = std::iter::once(known_id).collect();
-        sweep_orphans(state_dir, &known_ids);
-
-        // Known runtime dir still exists.
-        assert!(layout::runtime_dir(state_dir, known_id).exists());
-
-        // Orphan was moved.
-        assert!(!layout::runtime_dir(state_dir, orphan_id).exists());
-        let orphan_dest = layout::orphans_dir(state_dir).join(orphan_id.to_string());
-        assert!(orphan_dest.exists());
+        assert!(
+            !pane_state_exists(state_dir, runtime_id, pane_id),
+            "screen, scrollback, history, and shell-init must all be removed"
+        );
     }
 
     #[test]
-    fn sweep_orphans_skips_orphans_dir_itself() {
+    fn remove_pane_state_leaves_sibling_panes_untouched() {
         let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path();
+        let runtime_id = Uuid::new_v4();
+        let closed = Uuid::new_v4();
+        let kept = Uuid::new_v4();
 
-        // Create .orphans/ with some content.
-        let orphans = layout::orphans_dir(state_dir);
-        std::fs::create_dir_all(&orphans).unwrap();
-        std::fs::write(orphans.join("marker"), "test").unwrap();
+        seed_pane_state(state_dir, runtime_id, closed);
+        seed_pane_state(state_dir, runtime_id, kept);
 
-        let known_ids: HashSet<Uuid> = HashSet::new();
-        sweep_orphans(state_dir, &known_ids);
+        remove_pane_state(state_dir, runtime_id, closed);
 
-        // .orphans/ should still exist.
-        assert!(orphans.exists());
+        assert!(!pane_state_exists(state_dir, runtime_id, closed));
+        assert!(
+            pane_state_exists(state_dir, runtime_id, kept),
+            "closing one pane must not remove a sibling pane's state"
+        );
     }
 
     #[test]
-    fn sweep_orphans_skips_non_uuid_directories() {
+    fn remove_pane_state_noop_when_missing() {
         let tmp = TempDir::new().unwrap();
-        let state_dir = tmp.path();
-
-        let runtimes = layout::runtimes_dir(state_dir);
-        std::fs::create_dir_all(&runtimes).unwrap();
-        let non_uuid = runtimes.join("not-a-uuid");
-        std::fs::create_dir_all(&non_uuid).unwrap();
-
-        let known_ids: HashSet<Uuid> = HashSet::new();
-        sweep_orphans(state_dir, &known_ids);
-
-        // Non-UUID directory should be left alone.
-        assert!(non_uuid.exists());
+        // No artifacts on disk: must not panic.
+        remove_pane_state(tmp.path(), Uuid::new_v4(), Uuid::new_v4());
     }
 
     #[test]
-    fn sweep_orphans_prunes_old_entries() {
+    fn remove_pane_state_background_removes_artifacts() {
         let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path();
+        let runtime_id = Uuid::new_v4();
+        let pane_id = Uuid::new_v4();
 
-        let orphans = layout::orphans_dir(state_dir);
-        std::fs::create_dir_all(&orphans).unwrap();
+        seed_pane_state(state_dir, runtime_id, pane_id);
+        remove_pane_state_background(state_dir, runtime_id, pane_id);
 
-        // Create an old orphan (set mtime to 31 days ago).
-        let old_id = Uuid::new_v4();
-        let old_dir = orphans.join(old_id.to_string());
-        std::fs::create_dir_all(&old_dir).unwrap();
-        std::fs::write(old_dir.join("runtime.json"), "{}").unwrap();
-
-        let old_time = SystemTime::now() - Duration::from_hours(31 * 24);
-        let old_filetime = std::fs::FileTimes::new().set_modified(old_time);
-        std::fs::File::open(&old_dir).unwrap().set_times(old_filetime).unwrap();
-
-        // Create a recent orphan.
-        let recent_id = Uuid::new_v4();
-        let recent_dir = orphans.join(recent_id.to_string());
-        std::fs::create_dir_all(&recent_dir).unwrap();
-
-        let known_ids: HashSet<Uuid> = HashSet::new();
-        sweep_orphans(state_dir, &known_ids);
-
-        // Old orphan should be pruned.
-        assert!(!old_dir.exists());
-        // Recent orphan should remain.
-        assert!(recent_dir.exists());
-    }
-
-    #[test]
-    fn sweep_orphans_noop_when_no_runtimes_dir() {
-        let tmp = TempDir::new().unwrap();
-        let known_ids: HashSet<Uuid> = HashSet::new();
-        // Should not panic.
-        sweep_orphans(tmp.path(), &known_ids);
-    }
-
-    #[test]
-    fn sweep_orphans_with_empty_known_ids_moves_all() {
-        let tmp = TempDir::new().unwrap();
-        let state_dir = tmp.path();
-
-        let id1 = Uuid::new_v4();
-        let id2 = Uuid::new_v4();
-        persistence::save_runtime(state_dir, &sample_runtime_file(id1)).unwrap();
-        persistence::save_runtime(state_dir, &sample_runtime_file(id2)).unwrap();
-
-        let known_ids: HashSet<Uuid> = HashSet::new();
-        sweep_orphans(state_dir, &known_ids);
-
-        assert!(!layout::runtime_dir(state_dir, id1).exists());
-        assert!(!layout::runtime_dir(state_dir, id2).exists());
-
-        let orphans = layout::orphans_dir(state_dir);
-        assert!(orphans.join(id1.to_string()).exists());
-        assert!(orphans.join(id2.to_string()).exists());
+        std::thread::sleep(Duration::from_millis(200));
+        assert!(!pane_state_exists(state_dir, runtime_id, pane_id));
     }
 }

--- a/services/rttx-server/src/state/layout.rs
+++ b/services/rttx-server/src/state/layout.rs
@@ -39,9 +39,6 @@ const HISTORY_DIR: &str = "history";
 /// `ZDOTDIR`).
 const SHELL_INIT_DIR: &str = "shell-init";
 
-/// Subdirectory for orphaned runtime directories awaiting pruning.
-const ORPHANS_DIR: &str = ".orphans";
-
 /// Path to the top-level daemon index file.
 #[must_use]
 pub fn daemon_index(state_dir: &Path) -> PathBuf {
@@ -90,12 +87,6 @@ pub fn history_file(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) -> PathBu
 #[must_use]
 pub fn shell_init_dir(state_dir: &Path, runtime_id: Uuid, pane_id: Uuid) -> PathBuf {
     runtime_dir(state_dir, runtime_id).join(SHELL_INIT_DIR).join(pane_id.to_string())
-}
-
-/// Path to the `.orphans/` directory inside `runtimes/`.
-#[must_use]
-pub fn orphans_dir(state_dir: &Path) -> PathBuf {
-    runtimes_dir(state_dir).join(ORPHANS_DIR)
 }
 
 #[cfg(test)]
@@ -175,12 +166,6 @@ mod tests {
         assert!(p.to_string_lossy().contains("/shell-init/"));
         assert!(p.ends_with(pane.to_string()));
         assert!(p.starts_with(runtime_dir(Path::new(STATE), rt)));
-    }
-
-    #[test]
-    fn orphans_dir_path() {
-        let p = orphans_dir(Path::new(STATE));
-        assert_eq!(p, Path::new("/xdg/state/rttx/daemon/runtimes/.orphans"));
     }
 
     #[test]

--- a/services/rttx-server/tests/close_pane_cleanup.rs
+++ b/services/rttx-server/tests/close_pane_cleanup.rs
@@ -47,7 +47,8 @@ async fn closing_a_pane_removes_only_its_durable_state() {
     let mut client = TestClient::connect(&sock).await;
     client.handshake().await;
 
-    let runtime_id = create_runtime(&mut client, "close-cleanup", v3::RuntimePolicy::Persistent).await;
+    let runtime_id =
+        create_runtime(&mut client, "close-cleanup", v3::RuntimePolicy::Persistent).await;
     attach_rw(&mut client, &runtime_id).await;
 
     let keep = create_pane(&mut client, &runtime_id).await;
@@ -82,10 +83,8 @@ async fn closing_a_pane_removes_only_its_durable_state() {
     close_pane(&mut client, &runtime_id, &close).await;
 
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-    let closed_cleaned = poll_until(deadline, || {
-        pane_artifacts_absent(&state_dir, runtime_uuid, close_uuid)
-    })
-    .await;
+    let closed_cleaned =
+        poll_until(deadline, || pane_artifacts_absent(&state_dir, runtime_uuid, close_uuid)).await;
     assert!(
         closed_cleaned,
         "closed pane's history/scrollback/screen must be removed by close-driven cleanup"

--- a/services/rttx-server/tests/close_pane_cleanup.rs
+++ b/services/rttx-server/tests/close_pane_cleanup.rs
@@ -1,0 +1,99 @@
+//! Close-driven pane cleanup (RFC-031 §8, issue #1014).
+//!
+//! The orphan-sweep that masked the history-loss bug is gone. Its replacement
+//! is explicit, close-driven cleanup keyed on pane-tree membership: when a pane
+//! leaves the tree via `ClosePane`, its durable artifacts (history, scrollback,
+//! screen snapshot) are removed. Panes that remain in the tree keep theirs.
+
+mod common;
+
+use common::*;
+use rttx_proto::v3;
+use std::path::Path;
+use std::time::Duration;
+
+async fn poll_until(deadline: tokio::time::Instant, mut cond: impl FnMut() -> bool) -> bool {
+    while tokio::time::Instant::now() < deadline {
+        if cond() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    cond()
+}
+
+/// All three durable artifacts for a pane exist on disk.
+fn pane_artifacts_present(state_dir: &Path, runtime_id: uuid::Uuid, pane_id: uuid::Uuid) -> bool {
+    rttx_server::state::layout::history_file(state_dir, runtime_id, pane_id).exists()
+        && rttx_server::state::layout::screen_snapshot(state_dir, runtime_id, pane_id).exists()
+        && rttx_server::state::layout::scrollback_log(state_dir, runtime_id, pane_id).exists()
+}
+
+/// No durable artifact for a pane remains on disk.
+fn pane_artifacts_absent(state_dir: &Path, runtime_id: uuid::Uuid, pane_id: uuid::Uuid) -> bool {
+    !rttx_server::state::layout::history_file(state_dir, runtime_id, pane_id).exists()
+        && !rttx_server::state::layout::screen_snapshot(state_dir, runtime_id, pane_id).exists()
+        && !rttx_server::state::layout::scrollback_log(state_dir, runtime_id, pane_id).exists()
+}
+
+/// Closing one pane of a multi-pane workspace removes exactly that pane's
+/// durable state and leaves the surviving pane's state intact.
+#[tokio::test]
+async fn closing_a_pane_removes_only_its_durable_state() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state/rttx/daemon");
+
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+
+    let runtime_id = create_runtime(&mut client, "close-cleanup", v3::RuntimePolicy::Persistent).await;
+    attach_rw(&mut client, &runtime_id).await;
+
+    let keep = create_pane(&mut client, &runtime_id).await;
+    let close = split_pane(&mut client, &runtime_id, &keep, v3::PaneSplitAxis::Horizontal, 0.5)
+        .await
+        .new_pane_id;
+
+    // Drive a marker into each pane's per-pane HISTFILE so history lands on disk
+    // independent of the host's $SHELL.
+    for pane in [&keep, &close] {
+        send_input(&mut client, &runtime_id, pane, b"PROMPT_COMMAND='history -a'\n").await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        send_input(&mut client, &runtime_id, pane, b"echo close_cleanup_marker\n").await;
+        send_input(&mut client, &runtime_id, pane, b"true\n").await;
+    }
+
+    let runtime_uuid = rttx_proto::bytes_to_uuid(&runtime_id).unwrap();
+    let keep_uuid = rttx_proto::bytes_to_uuid(&keep).unwrap();
+    let close_uuid = rttx_proto::bytes_to_uuid(&close).unwrap();
+
+    // Wait for both panes' durable artifacts to reach disk before closing.
+    wait_for_state_containing(tmp.path(), "close-cleanup", Duration::from_secs(10)).await;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let both_durable = poll_until(deadline, || {
+        pane_artifacts_present(&state_dir, runtime_uuid, keep_uuid)
+            && pane_artifacts_present(&state_dir, runtime_uuid, close_uuid)
+    })
+    .await;
+    assert!(both_durable, "both panes' artifacts must reach disk before close");
+
+    // Close one pane: its durable state must be swept by the close-driven cleanup.
+    close_pane(&mut client, &runtime_id, &close).await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let closed_cleaned = poll_until(deadline, || {
+        pane_artifacts_absent(&state_dir, runtime_uuid, close_uuid)
+    })
+    .await;
+    assert!(
+        closed_cleaned,
+        "closed pane's history/scrollback/screen must be removed by close-driven cleanup"
+    );
+
+    // The surviving pane keeps every durable artifact.
+    assert!(
+        pane_artifacts_present(&state_dir, runtime_uuid, keep_uuid),
+        "surviving pane's durable state must be untouched by closing a sibling"
+    );
+}

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -427,7 +427,8 @@ pub async fn close_pane(client: &mut TestClient, runtime_id: &[u8], pane_id: &[u
             Some(v3::server_envelope::Payload::PaneClosed(_)) => return,
             Some(
                 v3::server_envelope::Payload::OutputDelta(_)
-                | v3::server_envelope::Payload::PaneExited(_),
+                | v3::server_envelope::Payload::PaneExited(_)
+                | v3::server_envelope::Payload::TitleChanged(_),
             ) => {}
             other => panic!("expected PaneClosed, got {other:?}"),
         }

--- a/services/rttx-server/tests/runtime_cleanup.rs
+++ b/services/rttx-server/tests/runtime_cleanup.rs
@@ -1,4 +1,4 @@
-//! Integration tests for runtime directory cleanup and orphan sweep.
+//! Integration tests for runtime directory cleanup (RFC-022 §7, RFC-031 §8).
 
 mod common;
 
@@ -71,9 +71,11 @@ async fn terminate_runtime_cleans_up_v2_directory() {
     assert!(!runtime_dir.exists(), "runtime directory should be removed after termination");
 }
 
-/// On startup, unreferenced runtime directories are moved to .orphans/.
+/// On startup the daemon no longer sweeps unreferenced runtime directories
+/// (RFC-031 §8). The startup orphan quarantine is deleted: a directory not in
+/// the daemon index is simply ignored, never moved into `.orphans/`.
 #[tokio::test]
-async fn startup_quarantines_orphaned_runtime_directories() {
+async fn startup_does_not_quarantine_unreferenced_directories() {
     let tmp = tempfile::TempDir::new().unwrap();
     let state_dir = tmp.path().join("state/rttx/daemon");
     std::fs::create_dir_all(&state_dir).unwrap();
@@ -107,7 +109,7 @@ async fn startup_quarantines_orphaned_runtime_directories() {
     )
     .unwrap();
 
-    // Create an orphan directory (not in daemon index).
+    // Create a directory not referenced by the daemon index.
     let orphan_dir = runtimes_dir.join(orphan_id.to_string());
     std::fs::create_dir_all(&orphan_dir).unwrap();
     std::fs::write(orphan_dir.join("runtime.json"), "{}").unwrap();
@@ -123,13 +125,15 @@ async fn startup_quarantines_orphaned_runtime_directories() {
     std::fs::write(state_dir.join("daemon.json"), serde_json::to_string_pretty(&index).unwrap())
         .unwrap();
 
-    // Start the server — it should sweep orphans during load.
+    // Start the server — no sweep runs during load.
     let (_socket_path, _handle) = start_test_server(tmp.path()).await;
 
-    // Orphan should have been moved to .orphans/.
-    assert!(!orphan_dir.exists(), "orphan directory should be moved");
-    let orphan_dest = runtimes_dir.join(".orphans").join(orphan_id.to_string());
-    assert!(orphan_dest.exists(), "orphan should be in .orphans/");
+    // The unreferenced directory is left untouched: not moved, not quarantined.
+    assert!(orphan_dir.exists(), "unreferenced directory must be left in place");
+    assert!(
+        !runtimes_dir.join(".orphans").exists(),
+        "startup must never create the deleted .orphans/ quarantine"
+    );
 
     // Known runtime directory should still exist.
     assert!(known_dir.exists(), "known runtime directory should remain");

--- a/services/rttx-server/tests/v2_state_storage.rs
+++ b/services/rttx-server/tests/v2_state_storage.rs
@@ -4,7 +4,7 @@
 //! 1. Corrupt `runtime.json` does not kill the daemon
 //! 2. Dirty-flag skips writes
 //! 3. Scrollback rotation keeps N segments
-//! 4. Orphan sweep quarantines unreferenced directories
+//! 4. Terminated runtimes are cleaned up, never quarantined (RFC-031 §8)
 //! 5. `ScreenSnapshotV1` round-trip through server restart
 
 mod common;
@@ -312,55 +312,7 @@ async fn scrollback_rotation_keeps_n_segments_via_server() {
     assert_eq!(runtimes.len(), 1, "runtime should still be alive after rotation");
 }
 
-// ── 4. Orphan sweep quarantines unreferenced directories ────────
-
-/// On startup, orphan directories older than 30 days are pruned.
-#[tokio::test]
-async fn startup_prunes_old_orphans() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let state_dir = tmp.path().join("state/rttx/daemon");
-    std::fs::create_dir_all(&state_dir).unwrap();
-
-    // Write an empty daemon index (no runtimes).
-    let index = serde_json::json!({
-        "schema_version": 1,
-        "server_version": "0.4.0",
-        "runtime_ids": [],
-        "created_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 },
-        "last_serialized_at": { "secs_since_epoch": 1_700_000_000, "nanos_since_epoch": 0 }
-    });
-    std::fs::write(state_dir.join("daemon.json"), serde_json::to_string_pretty(&index).unwrap())
-        .unwrap();
-
-    // Pre-seed .orphans/ with an old entry (31 days ago).
-    let orphans_dir = layout::orphans_dir(&state_dir);
-    std::fs::create_dir_all(&orphans_dir).unwrap();
-
-    let old_id = uuid::Uuid::new_v4();
-    let old_dir = orphans_dir.join(old_id.to_string());
-    std::fs::create_dir_all(&old_dir).unwrap();
-    std::fs::write(old_dir.join("runtime.json"), "{}").unwrap();
-
-    // Set mtime to 31 days ago.
-    let old_time = std::time::SystemTime::now() - Duration::from_hours(31 * 24);
-    let old_filetime = std::fs::FileTimes::new().set_modified(old_time);
-    std::fs::File::open(&old_dir).unwrap().set_times(old_filetime).unwrap();
-
-    // Also add a recent orphan that should survive.
-    let recent_id = uuid::Uuid::new_v4();
-    let recent_dir = orphans_dir.join(recent_id.to_string());
-    std::fs::create_dir_all(&recent_dir).unwrap();
-    std::fs::write(recent_dir.join("runtime.json"), "{}").unwrap();
-
-    // Start the server — orphan sweep runs during load.
-    let (_sock, _handle) = start_test_server(tmp.path()).await;
-
-    // Old orphan should be pruned.
-    assert!(!old_dir.exists(), "old orphan (>30 days) should be pruned on startup");
-
-    // Recent orphan should remain.
-    assert!(recent_dir.exists(), "recent orphan should survive pruning");
-}
+// ── 4. Terminated runtimes are cleaned up, never quarantined ────
 
 /// Terminated runtime's directory is cleaned up and does not become an orphan.
 #[tokio::test]
@@ -398,13 +350,11 @@ async fn terminated_runtime_does_not_become_orphan_on_restart() {
         let runtimes = list_runtimes(&mut c).await;
         assert!(runtimes.is_empty(), "terminated runtime should not reappear");
 
-        // No orphans directory should exist (or it should be empty).
+        // The sweep is gone (RFC-031 §8): no `.orphans/` quarantine is ever
+        // created. A terminated runtime is simply removed.
         let state_dir = tmp.path().join("state/rttx/daemon");
-        let orphans = layout::orphans_dir(&state_dir);
-        if orphans.exists() {
-            let entries: Vec<_> = std::fs::read_dir(&orphans).unwrap().collect();
-            assert!(entries.is_empty(), "no orphans should exist after clean termination");
-        }
+        let orphans = state_dir.join("runtimes/.orphans");
+        assert!(!orphans.exists(), "the removed orphan sweep must never create .orphans/");
     }
 }
 


### PR DESCRIPTION
## What and why

Closes #1014 (RFC-031 §8).

The startup orphan-sweep masked the very history-loss bug it was meant to guard against: instead of surfacing a desync, it quietly relocated unreferenced runtime directories into `runtimes/.orphans/`. With server-authoritative, immutable `PaneId`s (RFC-031), nothing is ever left unreferenced, so the sweep is dead weight that only hides bugs.

This PR deletes the sweep and replaces it with explicit, close-driven cleanup keyed on pane-tree membership.

### Changes
- Delete `sweep_orphans` / `prune_old_orphans` / `ORPHAN_RETENTION` from `state/cleanup.rs` and the startup sweep call in `Server::load_persisted_state`.
- Delete the now-unused `.orphans/` layout helper (`orphans_dir` / `ORPHANS_DIR`).
- Add `remove_pane_state` (+ a background wrapper) that removes a pane's screen snapshot, scrollback log, history file, and generated shell-init dir.
- Call `remove_pane_state_background` from `handle_v3_close_pane` after a pane leaves the tree.
- Runtime-level cleanup on terminate (`remove_runtime_dir_background`) is unchanged.

`git grep sweep_orphans` is clean in server `src/`.

## Tests added
- `state/cleanup.rs` unit tests: `remove_pane_state_removes_all_durable_artifacts`, `remove_pane_state_leaves_sibling_panes_untouched`, `remove_pane_state_noop_when_missing`, `remove_pane_state_background_removes_artifacts`.
- New integration test `tests/close_pane_cleanup.rs::closing_a_pane_removes_only_its_durable_state` — multi-pane workspace, close one pane, assert only its artifacts are removed and the sibling's survive (fails before the fix, passes after).
- Rewrote `tests/runtime_cleanup.rs` (`startup_does_not_quarantine_unreferenced_directories`) and `tests/v2_state_storage.rs` (`terminated_runtime_does_not_become_orphan_on_restart`) to assert `.orphans/` is never created.
- Removed obsolete sweep tests (`load_persisted_state_sweeps_orphans`, `startup_prunes_old_orphans`).

## Tests run (local)
- `cargo test -p rttx-server --lib` — pass
- `cargo test -p rttx-server --tests` — pass (incl. `zero_orphan_recovery` and new `close_pane_cleanup`)
- `bash .github/scripts/run-clippy.sh` — clean (`-D warnings`)
- `bash .github/scripts/run-quality-tests.sh` — exit 0; new server tests ran and passed

## Manual verification
- Confirmed `git grep sweep_orphans -- services/rttx-server/src` returns nothing.
- Confirmed the zero-orphan crash-recovery test (#1013) stays green.

## Notes / limitations
- Server-only change; no client or protocol changes, so no version bump and `./run_ui_tests.sh` is not applicable.
- Pre-existing client GTK widget tests report `SKIPPED: no display available` in this sandbox (Broadway did not attach); unrelated to this change.