### PR TITLE
fix(server): Broadcast PaneClosed to other attached clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.10"
+version = "0.9.11"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.10',
+  version: '0.9.11',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/src/v3_tree.rs
+++ b/protocols/rttx-proto/src/v3_tree.rs
@@ -137,6 +137,35 @@ pub fn build_focus_changed_push(changed: v3::FocusChanged) -> v3::ServerEnvelope
     crate::v3_envelope::build_push_envelope(v3::server_envelope::Payload::FocusChanged(changed))
 }
 
+/// Build a `PaneClosed` tree-delta event.
+#[must_use]
+pub fn build_pane_closed(
+    runtime_id: uuid::Uuid,
+    pane_id: uuid::Uuid,
+    workspace_revision: u64,
+) -> v3::PaneClosed {
+    v3::PaneClosed {
+        runtime_id: crate::uuid_to_bytes(runtime_id),
+        pane_id: crate::uuid_to_bytes(pane_id),
+        workspace_revision,
+    }
+}
+
+/// Build a `ServerEnvelope` response carrying a `PaneClosed`.
+#[must_use]
+pub fn build_pane_closed_response(request_id: u64, closed: v3::PaneClosed) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_response_envelope(
+        request_id,
+        v3::server_envelope::Payload::PaneClosed(closed),
+    )
+}
+
+/// Build a `ServerEnvelope` push event carrying a `PaneClosed`.
+#[must_use]
+pub fn build_pane_closed_push(closed: v3::PaneClosed) -> v3::ServerEnvelope {
+    crate::v3_envelope::build_push_envelope(v3::server_envelope::Payload::PaneClosed(closed))
+}
+
 /// Decode a repeated `PaneTreeSide` path into a typed list, dropping any
 /// `UNSPECIFIED` or out-of-range entries (which never address a real split
 /// branch).
@@ -257,6 +286,26 @@ mod tests {
         };
         assert_eq!(f.pane_id, uuid_to_bytes(p));
         assert_eq!(f.workspace_revision, 5);
+    }
+
+    #[test]
+    fn pane_closed_response_is_addressed_not_a_push() {
+        let p = pid();
+        let env = build_pane_closed_response(7, build_pane_closed(pid(), p, 4));
+        assert_eq!(env.request_id, 7);
+        assert!(!crate::v3_envelope::is_push_event(&env));
+        let Some(v3::server_envelope::Payload::PaneClosed(c)) = env.payload else {
+            panic!("expected PaneClosed");
+        };
+        assert_eq!(c.pane_id, uuid_to_bytes(p));
+        assert_eq!(c.workspace_revision, 4);
+    }
+
+    #[test]
+    fn pane_closed_push_has_zero_request_id() {
+        let env = build_pane_closed_push(build_pane_closed(pid(), pid(), 9));
+        assert_eq!(env.request_id, 0);
+        assert!(crate::v3_envelope::is_push_event(&env));
     }
 
     #[test]

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -1437,6 +1437,10 @@ impl Server {
         }
         let revision = rt.revision();
         let workspace_label = format!("\"{}\" ({})", rt.name, short_id(runtime_id));
+        // Capture the fan-out set before releasing the workspace lock so the
+        // close delta can reach every *other* attached client (RFC-031 §5):
+        // their view must collapse the tree when a peer closes a pane.
+        let attached = rt.attached_clients.keys().copied().collect::<Vec<_>>();
         drop(rt);
         s.pty_writers.remove(&pane_id);
         if let Some(kill_tx) = s.pty_kill_senders.remove(&pane_id) {
@@ -1445,14 +1449,13 @@ impl Server {
         // The pane left the tree: sweep its durable artifacts (RFC-031 §8).
         crate::state::cleanup::remove_pane_state_background(&s.os.state_dir(), runtime_id, pane_id);
         tracing::info!("Pane {} closed in workspace {workspace_label}", short_id(pane_id));
-        Some(rttx_proto::v3_envelope::build_response_envelope(
-            request_id,
-            v3::server_envelope::Payload::PaneClosed(v3::PaneClosed {
-                runtime_id: uuid_to_bytes(runtime_id),
-                pane_id: uuid_to_bytes(pane_id),
-                workspace_revision: revision,
-            }),
-        ))
+        let closed = rttx_proto::v3_tree::build_pane_closed(runtime_id, pane_id, revision);
+        s.broadcast_to_clients(
+            attached.iter().copied(),
+            Some(client_id),
+            &rttx_proto::v3_tree::build_pane_closed_push(closed.clone()),
+        );
+        Some(rttx_proto::v3_tree::build_pane_closed_response(request_id, closed))
     }
 
     async fn handle_v3_terminal_input(

--- a/services/rttx-server/tests/tree_delta_broadcast.rs
+++ b/services/rttx-server/tests/tree_delta_broadcast.rs
@@ -1,0 +1,64 @@
+//! Integration test: workspace-tree mutations by one client are broadcast as
+//! deltas to *other* attached clients (RFC-031 §5).
+//!
+//! This is the server-side foundation the client-as-view depends on (step 1a):
+//! when one client splits or closes a pane, every other attached client must
+//! receive the corresponding tree delta (`PaneSplit` / `PaneClosed`) as a push
+//! event so it can update its view without re-attaching.
+
+mod common;
+
+use common::{
+    attach_ro, attach_rw, close_pane, create_pane, create_workspace, split_pane,
+    start_test_server, TestClient,
+};
+use rttx_proto::v3;
+use std::time::Duration;
+
+#[tokio::test]
+async fn split_and_close_are_broadcast_to_other_attached_clients() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    // Writer client: owns the workspace and one pane.
+    let mut writer = TestClient::connect(&sock).await;
+    writer.handshake().await;
+    let runtime_id =
+        create_workspace(&mut writer, "tree-fanout", v3::WorkspacePolicy::Persistent).await;
+    attach_rw(&mut writer, &runtime_id).await;
+    let pane_a = create_pane(&mut writer, &runtime_id).await;
+
+    // Observer client: attaches read-only to the same workspace.
+    let mut observer = TestClient::connect(&sock).await;
+    observer.handshake().await;
+    attach_ro(&mut observer, &runtime_id).await;
+
+    // Drain shell startup output so it can't mask the deltas under test.
+    let _ = writer.drain(Duration::from_millis(300)).await;
+    let _ = observer.drain(Duration::from_millis(300)).await;
+
+    // The writer splits its pane. The observer must receive the PaneSplit delta.
+    let split =
+        split_pane(&mut writer, &runtime_id, &pane_a, v3::PaneSplitAxis::Vertical, 0.4).await;
+    let env = observer
+        .recv_matching(|p| matches!(p, v3::server_envelope::Payload::PaneSplit(_)))
+        .await;
+    let Some(v3::server_envelope::Payload::PaneSplit(observed)) = env.payload else {
+        unreachable!("recv_matching guaranteed PaneSplit");
+    };
+    assert_eq!(observed.new_pane_id, split.new_pane_id, "observer sees the same new pane id");
+    assert_eq!(observed.target_pane_id, pane_a, "split targeted pane_a");
+    assert_eq!(observed.axis, v3::PaneSplitAxis::Vertical as i32);
+    assert_eq!(env.request_id, 0, "a broadcast push carries request_id 0");
+
+    // The writer closes the new pane. The observer must receive a PaneClosed delta.
+    close_pane(&mut writer, &runtime_id, &split.new_pane_id).await;
+    let env = observer
+        .recv_matching(|p| matches!(p, v3::server_envelope::Payload::PaneClosed(_)))
+        .await;
+    let Some(v3::server_envelope::Payload::PaneClosed(closed)) = env.payload else {
+        unreachable!("recv_matching guaranteed PaneClosed");
+    };
+    assert_eq!(closed.pane_id, split.new_pane_id, "observer sees the closed pane id");
+    assert_eq!(env.request_id, 0, "a broadcast push carries request_id 0");
+}

--- a/services/rttx-server/tests/tree_delta_broadcast.rs
+++ b/services/rttx-server/tests/tree_delta_broadcast.rs
@@ -9,8 +9,8 @@
 mod common;
 
 use common::{
-    attach_ro, attach_rw, close_pane, create_pane, create_workspace, split_pane,
-    start_test_server, TestClient,
+    TestClient, attach_ro, attach_rw, close_pane, create_pane, create_workspace, split_pane,
+    start_test_server,
 };
 use rttx_proto::v3;
 use std::time::Duration;
@@ -40,9 +40,8 @@ async fn split_and_close_are_broadcast_to_other_attached_clients() {
     // The writer splits its pane. The observer must receive the PaneSplit delta.
     let split =
         split_pane(&mut writer, &runtime_id, &pane_a, v3::PaneSplitAxis::Vertical, 0.4).await;
-    let env = observer
-        .recv_matching(|p| matches!(p, v3::server_envelope::Payload::PaneSplit(_)))
-        .await;
+    let env =
+        observer.recv_matching(|p| matches!(p, v3::server_envelope::Payload::PaneSplit(_))).await;
     let Some(v3::server_envelope::Payload::PaneSplit(observed)) = env.payload else {
         unreachable!("recv_matching guaranteed PaneSplit");
     };
@@ -53,9 +52,8 @@ async fn split_and_close_are_broadcast_to_other_attached_clients() {
 
     // The writer closes the new pane. The observer must receive a PaneClosed delta.
     close_pane(&mut writer, &runtime_id, &split.new_pane_id).await;
-    let env = observer
-        .recv_matching(|p| matches!(p, v3::server_envelope::Payload::PaneClosed(_)))
-        .await;
+    let env =
+        observer.recv_matching(|p| matches!(p, v3::server_envelope::Payload::PaneClosed(_))).await;
     let Some(v3::server_envelope::Payload::PaneClosed(closed)) = env.payload else {
         unreachable!("recv_matching guaranteed PaneClosed");
     };


### PR DESCRIPTION
## What

`handle_v3_close_pane` only returned `PaneClosed` to the closing client and never broadcast it to other attached clients. The split (`PaneSplit`), resize (`SplitResized`), and focus (`FocusChanged`) handlers already fan their deltas out per RFC-031 §5; close was the gap. An observer's view would keep a stale, closed pane in its tree.

## Change
- Broadcast `PaneClosed` as a push event to the other attached clients (excluding the closer), mirroring `handle_v3_split_pane`.
- Add `build_pane_closed` / `build_pane_closed_response` / `build_pane_closed_push` to `rttx_proto::v3_tree` for consistency with the other tree-delta events.

## Why
This is step 1a of finalizing the RFC-031 client-as-view (epic #997): the daemon must push a tree delta on *every* structural mutation so the client can render purely from the server tree. Close was the one mutation that didn't fan out.

## Tested
- Pure-state unit tests: `pane_closed_response_is_addressed_not_a_push`, `pane_closed_push_has_zero_request_id`.
- New integration test `tree_delta_broadcast`: an observer client receives both `PaneSplit` and `PaneClosed` when a peer mutates the tree (previously timed out on close).
- `cargo build`/`clippy`/relevant integration suites green locally; runtime-behavior gate passes.

Fixes #1019