### PR TITLE
feat(client): Adopt server pane tree on attach (RFC-031 Step 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.11"
+version = "0.9.12"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -391,6 +391,82 @@ impl WindowState {
         Some(result)
     }
 
+    /// Adopt the daemon's authoritative pane tree as the client's render
+    /// layout (RFC-031 §3, Step 4). The render leaf uuids are the durable
+    /// server pane ids, so the layout and the daemon share one identity and the
+    /// client neither mints structure nor creates panes to match the daemon.
+    fn adopt_server_tree(
+        &mut self,
+        workspace_id: &str,
+        runtime_id: &str,
+        layout: LayoutNode,
+        snapshot: &v3::WorkspaceSnapshot,
+    ) -> Option<ManagedWorkspaceOpenResult> {
+        let session = self.workspaces.iter_mut().find(|session| session.uuid == workspace_id)?;
+        session.runtime.runtime_id = Some(runtime_id.to_string());
+
+        let previous_layout_terminals = session.layout.terminal_uuids();
+        session.layout = layout;
+        let layout_terminal_uuids = session.layout.terminal_uuids();
+
+        // Bindings degenerate to an identity map over the server pane ids
+        // (removed entirely in a later step); keep them coherent so the
+        // pane-resolution path stays correct in the meantime.
+        session.runtime.pane_bindings =
+            layout_terminal_uuids.iter().map(|id| (id.clone(), id.clone())).collect();
+        session.runtime.pending_layout_panes.clear();
+
+        // The server names the fallback focus pane (RFC-031 §2).
+        if let Some(active) = rttx_proto::bytes_to_uuid(&snapshot.default_active_pane_id)
+            .ok()
+            .map(|uuid| uuid.to_string())
+            .filter(|id| layout_terminal_uuids.contains(id))
+        {
+            session.active_terminal_uuid = Some(active);
+        }
+        session.normalize_active_terminal();
+
+        // Pane content restores map 1:1 to layout terminals by pane id.
+        let snapshot_restores = snapshot
+            .panes
+            .iter()
+            .filter_map(|pane_snapshot| {
+                let pane_id = snapshot_pane_id(pane_snapshot)?;
+                layout_terminal_uuids.contains(&pane_id).then(|| WorkspacePaneRestore {
+                    layout_terminal_uuid: pane_id,
+                    title: pane_snapshot.title.clone(),
+                    cwd: pane_snapshot.cwd.clone(),
+                    pane_output_seq: pane_snapshot.pane_output_seq,
+                    scrollback_tail: pane_snapshot.scrollback_tail.clone(),
+                    scrollback_complete: pane_snapshot.scrollback_complete,
+                    cols: pane_snapshot.cols as u16,
+                    rows: pane_snapshot.rows as u16,
+                    terminal_modes: pane_snapshot.terminal_modes,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // Carry the daemon's current CWD into the adopted layout.
+        for restore in &snapshot_restores {
+            if !restore.cwd.is_empty() {
+                session
+                    .layout
+                    .set_terminal_cwd(&restore.layout_terminal_uuid, Some(restore.cwd.clone()));
+            }
+        }
+
+        let session_state = session.clone();
+        self.rebuild_pane_reverse_index();
+
+        Some(ManagedWorkspaceOpenResult {
+            session_state,
+            panes_to_create: Vec::new(),
+            snapshot_restores,
+            skipped_runtime_panes: Vec::new(),
+            previous_layout_terminals,
+        })
+    }
+
     /// Apply the state mutation for attaching/reconciling a managed runtime snapshot.
     pub fn apply_managed_workspace_opened(
         &mut self,
@@ -398,6 +474,18 @@ impl WindowState {
         runtime_id: &str,
         snapshot: &v3::WorkspaceSnapshot,
     ) -> Option<ManagedWorkspaceOpenResult> {
+        // RFC-031 §3 (Step 4): when the daemon provides its authoritative pane
+        // tree, the client adopts it wholesale and renders as a pure view. The
+        // tree's leaf uuids are the durable server pane ids, so layout terminal
+        // uuid == pane id with no client-side binding translation, and the
+        // client never mints structure nor creates panes to "match" the daemon.
+        if let Some(layout) = render_layout_from_snapshot(snapshot) {
+            return self.adopt_server_tree(workspace_id, runtime_id, layout, snapshot);
+        }
+
+        // Legacy fallback for a tree-less snapshot (an empty workspace, or a
+        // pre-tree daemon): reconcile the client-owned layout against the flat
+        // pane list. Removed once the daemon guarantees a tree per workspace.
         let session = self.workspaces.iter_mut().find(|session| session.uuid == workspace_id)?;
 
         let had_runtime_id = session.runtime.runtime_id.is_some();
@@ -708,6 +796,85 @@ mod tests {
         assert_eq!(orientation, SplitOrientation::Horizontal);
         assert_eq!(first.terminal_uuids(), vec![left.to_string()]);
         assert_eq!(second.terminal_uuids(), vec![right.to_string()]);
+    }
+
+    #[test]
+    fn apply_managed_workspace_opened_adopts_server_tree_as_pure_view() {
+        use rttx_proto::v3_tree::{pane_tree_leaf, pane_tree_split};
+
+        // The client starts with a stale single-pane layout that does not match
+        // the server tree.
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+        let session = managed_session_with_runtime(
+            "workspace-1",
+            "Workspace",
+            term("stale-old-pane"),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some(runtime_id),
+        );
+        let mut state = window_state(vec![session]);
+
+        // Server tree: a horizontal split of two server-minted pane ids.
+        let left = uuid::Uuid::new_v4();
+        let right = uuid::Uuid::new_v4();
+        let mut snap = snapshot(
+            runtime_id,
+            vec![
+                pane_snapshot(&left.to_string(), "left", "/work/left", b"L"),
+                pane_snapshot(&right.to_string(), "right", "/work/right", b"R"),
+            ],
+        );
+        snap.tree = Some(pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(left),
+            pane_tree_leaf(right),
+        ));
+        snap.default_active_pane_id = rttx_proto::uuid_to_bytes(right);
+
+        let result = state
+            .apply_managed_workspace_opened("workspace-1", runtime_id, &snap)
+            .expect("adopts the server tree");
+
+        // The client discards its stale layout and renders the server tree.
+        let uuids = result.session_state.layout.terminal_uuids();
+        assert_eq!(uuids.len(), 2, "layout is rebuilt from the two server panes");
+        assert!(uuids.contains(&left.to_string()), "left server pane is rendered");
+        assert!(uuids.contains(&right.to_string()), "right server pane is rendered");
+        assert!(
+            !uuids.contains(&"stale-old-pane".to_string()),
+            "the stale client-owned pane is discarded",
+        );
+
+        // A pure view never mints structure or creates panes to match the daemon.
+        assert!(result.panes_to_create.is_empty(), "pure view creates no panes");
+        assert!(result.skipped_runtime_panes.is_empty());
+        assert!(
+            result.previous_layout_terminals.contains(&"stale-old-pane".to_string()),
+            "the discarded layout terminal is reported so its widget is torn down",
+        );
+
+        // Restores map 1:1 to layout terminals by pane id (identity).
+        assert_eq!(result.snapshot_restores.len(), 2);
+        assert!(result.snapshot_restores.iter().all(|r| {
+            r.layout_terminal_uuid == left.to_string()
+                || r.layout_terminal_uuid == right.to_string()
+        }));
+
+        let session = &state.workspaces[0];
+        // Bindings degenerate to an identity map over the server pane ids.
+        assert_eq!(
+            session.runtime.pane_bindings.get(&left.to_string()).map(String::as_str),
+            Some(left.to_string().as_str()),
+        );
+        assert_eq!(
+            session.runtime.pane_bindings.get(&right.to_string()).map(String::as_str),
+            Some(right.to_string().as_str()),
+        );
+        // Active pane follows the server's fallback focus, and nothing is pending.
+        assert_eq!(session.active_terminal_uuid.as_deref(), Some(right.to_string().as_str()));
+        assert!(!session.runtime.is_layout_pane_pending(&left.to_string()));
     }
 
     fn pane_info(pane_id: &str, title: &str, cwd: &str) -> v3::PaneInfo {

--- a/clients/rttx/tests/render_from_server_tree.rs
+++ b/clients/rttx/tests/render_from_server_tree.rs
@@ -103,3 +103,91 @@ fn snapshot_with_tree_renders_full_layout() {
     expected.sort();
     assert_eq!(ids, expected);
 }
+
+fn pane_snapshot(pane_id: Uuid, title: &str) -> v3::PaneSnapshot {
+    v3::PaneSnapshot {
+        pane_id: rttx_proto::uuid_to_bytes(pane_id),
+        pane_output_seq: 0,
+        title: title.to_string(),
+        cwd: String::new(),
+        cols: 80,
+        rows: 24,
+        exit_status: None,
+        terminal_modes: None,
+        scrollback_tail: bytes::Bytes::new(),
+        total_scrollback_bytes: 0,
+        scrollback_complete: true,
+    }
+}
+
+/// The attach path (`reconcile_endpoint_event` → `WorkspaceOpened`) adopts the
+/// server tree wholesale: the client discards its own stale layout, renders the
+/// server pane ids, reports the discarded terminal for teardown, and — as a
+/// pure view — never asks the daemon to create panes to "match".
+#[test]
+fn attach_adopts_server_tree_through_the_window_state_flow() {
+    use rttx::daemon_bridge::EndpointEvent;
+    use rttx::runtime::{WorkspacePolicy, WorkspaceRuntime};
+    use rttx::workspace::{WindowState, WorkspaceState};
+
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+
+    // The client holds a stale single-pane layout with a client-minted id.
+    let mut session =
+        WorkspaceState::new_managed_local("Home".into(), WorkspacePolicy::Persistent, None);
+    session.uuid = "ws-1".into();
+    session.layout = LayoutNode::Terminal {
+        uuid: "stale-client-pane".into(),
+        profile: None,
+        cwd: None,
+        custom_title: None,
+    };
+    session.runtime = WorkspaceRuntime::managed_local(
+        WorkspacePolicy::Persistent,
+        &session.layout.terminal_uuids(),
+    );
+    session.runtime.runtime_id = Some(runtime_id.into());
+
+    let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };
+
+    // The daemon's authoritative tree: a horizontal split of two server panes.
+    let pane_a = Uuid::new_v4();
+    let pane_b = Uuid::new_v4();
+    let mut snapshot = snapshot_with_tree(Some(pane_tree_split(
+        v3::PaneSplitAxis::Horizontal,
+        0.5,
+        pane_tree_leaf(pane_a),
+        pane_tree_leaf(pane_b),
+    )));
+    snapshot.runtime_id = rttx_proto::uuid_to_bytes(Uuid::parse_str(runtime_id).unwrap());
+    snapshot.default_active_pane_id = rttx_proto::uuid_to_bytes(pane_b);
+    snapshot.panes = vec![pane_snapshot(pane_a, "Shell"), pane_snapshot(pane_b, "Logs")];
+
+    let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+        workspace_id: "ws-1".into(),
+        runtime_id: runtime_id.into(),
+        snapshot,
+    });
+
+    // The workspace is rebuilt with the server tree's structure.
+    assert_eq!(transition.rebuilt_workspaces.len(), 1);
+    let rebuilt = &transition.rebuilt_workspaces[0].session_state;
+    let mut ids = rebuilt.layout.terminal_uuids();
+    ids.sort();
+    let mut expected = vec![pane_a.to_string(), pane_b.to_string()];
+    expected.sort();
+    assert_eq!(ids, expected, "the layout adopts the server tree's pane ids");
+
+    // The stale client-owned pane is discarded and reported for widget teardown.
+    assert!(
+        transition.removed_layout_terminals.contains(&"stale-client-pane".to_string()),
+        "the stale client layout terminal is torn down",
+    );
+    // A pure view never asks the daemon to create panes to match.
+    assert!(transition.pane_create_requests.is_empty(), "pure view requests no pane creation");
+    assert!(transition.skipped_runtime_panes.is_empty());
+    // Pane content restores are addressed by the durable server pane id, and the
+    // active pane follows the server's fallback focus.
+    assert_eq!(transition.pane_snapshot_restores.len(), 2);
+    assert_eq!(rebuilt.active_terminal_uuid.as_deref(), Some(pane_b.to_string().as_str()));
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.11',
+  version: '0.9.12',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What

`apply_managed_workspace_opened` now adopts the daemon's authoritative pane tree (`WorkspaceSnapshot.tree`) wholesale instead of reconciling the client-owned layout against the flat pane list. #1010 added `render_layout_from_snapshot` but left it unwired; this wires it into the attach path so the client renders as a pure view.

When the snapshot carries a tree:
- the layout is rebuilt from the tree (leaf uuids are the durable server pane ids);
- the active pane follows `default_active_pane_id`;
- pane content restores map 1:1 by pane id;
- **no panes are created** to "match" the daemon.

A tree-less snapshot (empty workspace / pre-tree daemon) still falls back to the legacy reconciliation path. `pane_bindings` degenerates to an identity map for now and is removed in a later step (so the resolve path stays correct meanwhile).

## Why
Step 1b of the RFC-031 client-as-view (epic #997). The daemon already owns the tree and (after #1020) fans out a delta on every mutation; this makes the client consume that tree on attach.

## Tested (locally, with the vte-0_76 feature)
- Unit: `apply_managed_workspace_opened_adopts_server_tree_as_pure_view`.
- Integration: `render_from_server_tree::attach_adopts_server_tree_through_the_window_state_flow` (full `reconcile_endpoint_event` attach: stale layout discarded + reported for teardown, tree adopted, no pane creation, restores/active follow server).
- Regression: 822 lib unit tests + reconnect_layout_stability / workspace_lifecycle (47) / stale_terminal_cleanup / reconnect_scheduling (11) / pane_reverse_index all green; client clippy `-D warnings` clean; runtime-behavior gate passes.

## GUI smoke-test for reviewer
Attach a client to a multi-pane workspace (and a second client to the same workspace); confirm the layout renders correctly from the server and that splitting/closing from one client is reflected. Does not fully close #1001 (binding removal is a later step).

Fixes #1021