### PR TITLE
fix(client): Send SplitPane (not CreatePane) for managed splits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.12"
+version = "0.9.13"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/daemon_bridge.rs
+++ b/clients/rttx/src/daemon_bridge.rs
@@ -140,6 +140,22 @@ enum EndpointCommand {
         rows: u32,
         no_persist: bool,
     },
+    SplitPane {
+        workspace_id: String,
+        runtime_id: String,
+        /// Server pane id of the pane being split (the split target).
+        target_pane_id: String,
+        /// Client layout uuid of the new pane, bound to the server-minted id
+        /// once the daemon replies with the `PaneSplit` delta.
+        layout_terminal_uuid: String,
+        axis: i32,
+        ratio: f32,
+        cwd: Option<String>,
+        dark_background: bool,
+        cols: u32,
+        rows: u32,
+        no_persist: bool,
+    },
     ClosePane {
         workspace_id: String,
         runtime_id: String,
@@ -317,6 +333,43 @@ impl EndpointConnectionManager {
             workspace_id: workspace_id.to_string(),
             runtime_id: runtime_id.to_string(),
             layout_terminal_uuid: layout_terminal_uuid.to_string(),
+            cwd,
+            dark_background,
+            cols: initial_size.0,
+            rows: initial_size.1,
+            no_persist,
+        });
+    }
+
+    /// Split an existing pane inside an attached runtime (RFC-031 §5).
+    ///
+    /// Unlike [`create_pane`](Self::create_pane), this records the real split
+    /// structure in the daemon's authoritative tree: `target_pane_id` is the
+    /// server pane being split and `axis` is its orientation. The daemon mints
+    /// the new pane id and returns it in the `PaneSplit` delta, which binds the
+    /// `layout_terminal_uuid` exactly like a created pane.
+    #[allow(clippy::too_many_arguments)]
+    pub fn split_pane(
+        &self,
+        workspace_id: &str,
+        endpoint: &RuntimeEndpoint,
+        runtime_id: &str,
+        target_pane_id: &str,
+        layout_terminal_uuid: &str,
+        axis: i32,
+        ratio: f32,
+        cwd: Option<String>,
+        dark_background: bool,
+        initial_size: (u32, u32),
+        no_persist: bool,
+    ) {
+        let _ = self.endpoint_handle(endpoint).try_send(EndpointCommand::SplitPane {
+            workspace_id: workspace_id.to_string(),
+            runtime_id: runtime_id.to_string(),
+            target_pane_id: target_pane_id.to_string(),
+            layout_terminal_uuid: layout_terminal_uuid.to_string(),
+            axis,
+            ratio,
             cwd,
             dark_background,
             cols: initial_size.0,
@@ -815,6 +868,95 @@ impl EndpointActor {
                     Ok(response) => match response.payload {
                         Some(v3::server_envelope::Payload::PaneCreated(created)) => {
                             if let Ok(pane_id) = rttx_proto::bytes_to_uuid(&created.pane_id) {
+                                let _ = self.event_tx.try_send(EndpointEvent::PaneCreated {
+                                    workspace_id: workspace_id.clone(),
+                                    layout_terminal_uuid,
+                                    runtime_id,
+                                    runtime_pane_id: pane_id.to_string(),
+                                });
+                                self.emit_status(&workspace_id, ConnectionStatus::Connected);
+                            }
+                        }
+                        Some(v3::server_envelope::Payload::Error(e)) => {
+                            self.handle_command_error(
+                                &workspace_id,
+                                ManagerOperation::CreatePane,
+                                &protocol_error_to_daemon(e),
+                            );
+                        }
+                        _ => {
+                            self.handle_command_error(
+                                &workspace_id,
+                                ManagerOperation::CreatePane,
+                                &DaemonError::UnexpectedMessage,
+                            );
+                        }
+                    },
+                    Err(error) => {
+                        self.handle_command_error(
+                            &workspace_id,
+                            ManagerOperation::CreatePane,
+                            &error,
+                        );
+                    }
+                }
+            }
+            EndpointCommand::SplitPane {
+                workspace_id,
+                runtime_id,
+                target_pane_id,
+                layout_terminal_uuid,
+                axis,
+                ratio,
+                cwd,
+                dark_background,
+                cols,
+                rows,
+                no_persist,
+            } => {
+                if let Err(problem) = self.ensure_connected(&workspace_id).await {
+                    if !problem.is_transient() {
+                        self.emit_error(
+                            &workspace_id,
+                            ManagerOperation::CreatePane,
+                            problem.clone(),
+                            problem.label(),
+                        );
+                    }
+                    return;
+                }
+
+                let Some(runtime_uuid) = parse_uuid(
+                    &workspace_id,
+                    ManagerOperation::CreatePane,
+                    &runtime_id,
+                    &self.event_tx,
+                ) else {
+                    return;
+                };
+                let Some(target_uuid) = parse_uuid(
+                    &workspace_id,
+                    ManagerOperation::CreatePane,
+                    &target_pane_id,
+                    &self.event_tx,
+                ) else {
+                    return;
+                };
+                let msg = v3::client_envelope::Command::SplitPane(build_split_pane_request(
+                    runtime_uuid,
+                    target_uuid,
+                    axis,
+                    ratio,
+                    cwd,
+                    dark_background,
+                    cols,
+                    rows,
+                    no_persist,
+                ));
+                match self.send_and_read(msg, false).await {
+                    Ok(response) => match response.payload {
+                        Some(v3::server_envelope::Payload::PaneSplit(split)) => {
+                            if let Ok(pane_id) = rttx_proto::bytes_to_uuid(&split.new_pane_id) {
                                 let _ = self.event_tx.try_send(EndpointEvent::PaneCreated {
                                     workspace_id: workspace_id.clone(),
                                     layout_terminal_uuid,
@@ -1871,6 +2013,35 @@ impl EndpointActor {
     }
 }
 
+/// Build the wire `SplitPane` request for a managed split (RFC-031 §5).
+///
+/// Pure mapping kept separate from the async command handler so the
+/// target/axis/ratio/no-persist encoding can be unit-tested.
+#[allow(clippy::too_many_arguments)]
+fn build_split_pane_request(
+    runtime_uuid: Uuid,
+    target_uuid: Uuid,
+    axis: i32,
+    ratio: f32,
+    cwd: Option<String>,
+    dark_background: bool,
+    cols: u32,
+    rows: u32,
+    no_persist: bool,
+) -> v3::SplitPane {
+    v3::SplitPane {
+        runtime_id: rttx_proto::uuid_to_bytes(runtime_uuid),
+        target_pane_id: rttx_proto::uuid_to_bytes(target_uuid),
+        axis,
+        ratio,
+        cwd,
+        dark_background: Some(dark_background),
+        cols,
+        rows,
+        no_persist: if no_persist { Some(true) } else { None },
+    }
+}
+
 fn parse_uuid(
     workspace_id: &str,
     operation: ManagerOperation,
@@ -1905,6 +2076,47 @@ mod tests {
     use bytes::BytesMut;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::sync::mpsc::error::TryRecvError;
+
+    #[test]
+    fn split_pane_request_carries_target_axis_ratio_and_persistence() {
+        let runtime = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let req = build_split_pane_request(
+            runtime,
+            target,
+            v3::PaneSplitAxis::Vertical as i32,
+            0.5,
+            None,
+            true,
+            80,
+            24,
+            false,
+        );
+        assert_eq!(req.runtime_id, rttx_proto::uuid_to_bytes(runtime));
+        // The split must target the server pane being split, not mint a fresh
+        // pane out of structure — this is the whole point of SplitPane vs
+        // CreatePane (RFC-031 §5).
+        assert_eq!(req.target_pane_id, rttx_proto::uuid_to_bytes(target));
+        assert_eq!(req.axis, v3::PaneSplitAxis::Vertical as i32);
+        assert!((req.ratio - 0.5).abs() < f32::EPSILON);
+        assert_eq!(req.dark_background, Some(true));
+        // A persistent pane omits the flag; a non-persistent one sets it.
+        assert_eq!(req.no_persist, None);
+
+        let ephemeral = build_split_pane_request(
+            runtime,
+            target,
+            v3::PaneSplitAxis::Horizontal as i32,
+            0.3,
+            None,
+            false,
+            0,
+            0,
+            true,
+        );
+        assert_eq!(ephemeral.axis, v3::PaneSplitAxis::Horizontal as i32);
+        assert_eq!(ephemeral.no_persist, Some(true));
+    }
 
     fn split_duplex_connection() -> ((DaemonReader, DaemonWriter), tokio::io::DuplexStream) {
         let (client, server) = tokio::io::duplex(4096);

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -492,12 +492,8 @@ impl Window {
                 state.workspaces.iter().position(|s| s.layout.contains_terminal(terminal_uuid));
             let Some(idx) = workspace_idx else { return };
 
-            if state.workspaces[idx].uses_managed_runtime()
-                && state.workspaces[idx].layout.terminal_count() > 1
-                && let Some(runtime_id) = state.workspaces[idx].runtime.runtime_id.clone()
-                && let Some(runtime_pane_id) =
-                    state.workspaces[idx].runtime.pane_bindings.get(terminal_uuid).cloned()
-                && runtime_pane_id != terminal_uuid
+            if let Some((runtime_id, runtime_pane_id)) =
+                state.workspaces[idx].managed_close_target(terminal_uuid)
             {
                 let workspace_id = state.workspaces[idx].uuid.clone();
                 let endpoint = state.workspaces[idx].runtime.endpoint.clone();

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+/// Map a client split orientation to the wire split axis (RFC-031 §5).
+///
+/// This is the inverse of the daemon-tree consumer's `orientation_from_axis`,
+/// so a split sent to the daemon round-trips through the authoritative tree
+/// with its orientation preserved when the client later adopts that tree.
+const fn orientation_to_axis(orientation: SplitOrientation) -> i32 {
+    match orientation {
+        SplitOrientation::Vertical => rttx_proto::v3::PaneSplitAxis::Vertical as i32,
+        SplitOrientation::Horizontal => rttx_proto::v3::PaneSplitAxis::Horizontal as i32,
+    }
+}
+
 impl Window {
     pub(super) fn materialize_terminal(
         &self,
@@ -327,11 +339,20 @@ impl Window {
                     && let Some(manager) = self.imp().connection_manager.borrow().as_ref()
                 {
                     let size = self.persistent_terminal_size(terminal_uuid);
-                    manager.create_pane(
+                    let target_pane_id = session_state
+                        .runtime
+                        .pane_bindings
+                        .get(terminal_uuid)
+                        .cloned()
+                        .unwrap_or_else(|| terminal_uuid.to_string());
+                    manager.split_pane(
                         &session_uuid,
                         &session_state.runtime.endpoint,
                         runtime_id,
+                        &target_pane_id,
                         &new_terminal_uuid,
+                        orientation_to_axis(orientation),
+                        0.5,
                         source_cwd,
                         adw::StyleManager::default().is_dark(),
                         size,
@@ -419,11 +440,20 @@ impl Window {
             && let Some(manager) = self.imp().connection_manager.borrow().as_ref()
         {
             let size = self.persistent_terminal_size(terminal_uuid);
-            manager.create_pane(
+            let target_pane_id = session_state
+                .runtime
+                .pane_bindings
+                .get(terminal_uuid)
+                .cloned()
+                .unwrap_or_else(|| terminal_uuid.to_string());
+            manager.split_pane(
                 &session_uuid,
                 &session_state.runtime.endpoint,
                 runtime_id,
+                &target_pane_id,
                 &new_terminal_uuid,
+                orientation_to_axis(orientation),
+                0.5,
                 source_cwd,
                 adw::StyleManager::default().is_dark(),
                 size,

--- a/clients/rttx/src/workspace/state.rs
+++ b/clients/rttx/src/workspace/state.rs
@@ -191,6 +191,31 @@ impl WorkspaceState {
         self.active_terminal_uuid = self.layout.terminal_uuids().into_iter().next();
     }
 
+    /// Resolve where closing `terminal_uuid` must take effect.
+    ///
+    /// Returns `Some((runtime_id, runtime_pane_id))` when the close must be sent
+    /// to the daemon — a managed workspace with more than one pane whose target
+    /// is bound to a real daemon pane. Returns `None` when the close stays
+    /// client-local: an unmanaged workspace, the final pane (which closes the
+    /// whole workspace), or a pane still pending its daemon assignment.
+    ///
+    /// Critically this keys on pending state, **not** on whether the binding is
+    /// an identity map: once the client adopts the server tree (RFC-031), every
+    /// layout uuid equals its server pane id, so an identity binding is the
+    /// normal case for a live daemon pane and must still be closed remotely.
+    #[must_use]
+    pub fn managed_close_target(&self, terminal_uuid: &str) -> Option<(String, String)> {
+        if !self.uses_managed_runtime() || self.layout.terminal_count() <= 1 {
+            return None;
+        }
+        if self.runtime.is_layout_pane_pending(terminal_uuid) {
+            return None;
+        }
+        let runtime_id = self.runtime.runtime_id.clone()?;
+        let runtime_pane_id = self.runtime.pane_bindings.get(terminal_uuid).cloned()?;
+        Some((runtime_id, runtime_pane_id))
+    }
+
     pub fn replace_terminal_uuid(&mut self, old_uuid: &str, new_uuid: &str) -> bool {
         if old_uuid == new_uuid || !self.layout.replace_terminal_uuid(old_uuid, new_uuid) {
             return false;

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -877,6 +877,67 @@ mod tests {
         assert!(!session.runtime.is_layout_pane_pending(&left.to_string()));
     }
 
+    #[test]
+    fn adopted_pane_close_targets_the_daemon_not_local_only() {
+        use rttx_proto::v3_tree::{pane_tree_leaf, pane_tree_split};
+
+        // Regression for the close/reconnect drift: after adopting the server
+        // tree, layout uuids equal their server pane ids (identity bindings).
+        // Closing such a pane must still be sent to the daemon, otherwise the
+        // daemon keeps the pane and it resurrects on the next restart.
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+        let session = managed_session_with_runtime(
+            "ws-1",
+            "Workspace",
+            term("stale"),
+            RuntimeEndpoint::Local,
+            WorkspacePolicy::Persistent,
+            Some(runtime_id),
+        );
+        let mut state = window_state(vec![session]);
+
+        let left = uuid::Uuid::new_v4();
+        let right = uuid::Uuid::new_v4();
+        let mut snap = snapshot(
+            runtime_id,
+            vec![
+                pane_snapshot(&left.to_string(), "l", "", b""),
+                pane_snapshot(&right.to_string(), "r", "", b""),
+            ],
+        );
+        snap.tree = Some(pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(left),
+            pane_tree_leaf(right),
+        ));
+        state.apply_managed_workspace_opened("ws-1", runtime_id, &snap).expect("adopts tree");
+
+        let session = &state.workspaces[0];
+        assert_eq!(
+            session.managed_close_target(&left.to_string()),
+            Some((runtime_id.to_string(), left.to_string())),
+            "an adopted (identity-bound) pane must close on the daemon",
+        );
+    }
+
+    #[test]
+    fn pending_or_single_pane_close_stays_local() {
+        // A fresh managed workspace has placeholder (pending) bindings and no
+        // daemon runtime id yet: closes stay client-local.
+        let state =
+            window_state(vec![managed_session("ws-1", "Workspace", hsplit(term("a"), term("b")))]);
+        assert_eq!(
+            state.workspaces[0].managed_close_target("a"),
+            None,
+            "a pending/unbound pane closes locally",
+        );
+
+        // A single-pane workspace closes the whole workspace, not one pane.
+        let single = window_state(vec![managed_session("ws-2", "Workspace", term("only"))]);
+        assert_eq!(single.workspaces[0].managed_close_target("only"), None);
+    }
+
     fn pane_info(pane_id: &str, title: &str, cwd: &str) -> v3::PaneInfo {
         v3::PaneInfo {
             id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(pane_id).unwrap()),

--- a/clients/rttx/tests/render_from_server_tree.rs
+++ b/clients/rttx/tests/render_from_server_tree.rs
@@ -191,3 +191,77 @@ fn attach_adopts_server_tree_through_the_window_state_flow() {
     assert_eq!(transition.pane_snapshot_restores.len(), 2);
     assert_eq!(rebuilt.active_terminal_uuid.as_deref(), Some(pane_b.to_string().as_str()));
 }
+
+/// Reproduces the CI count-drift scenario at the state-machine level: adopt a
+/// 2-pane split, close one pane, then reconnect to a 1-pane daemon tree. The
+/// visible pane count must stay at one (no drift).
+#[test]
+fn close_after_adopt_then_reconnect_keeps_single_pane() {
+    use rttx::daemon_bridge::EndpointEvent;
+    use rttx::runtime::{WorkspacePolicy, WorkspaceRuntime};
+    use rttx::workspace::{WindowState, WorkspaceState};
+
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let mut session =
+        WorkspaceState::new_managed_local("Home".into(), WorkspacePolicy::Persistent, None);
+    session.uuid = "ws-1".into();
+    session.runtime = WorkspaceRuntime::managed_local(
+        WorkspacePolicy::Persistent,
+        &session.layout.terminal_uuids(),
+    );
+    session.runtime.runtime_id = Some(runtime_id.into());
+    let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };
+
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let rt_bytes = rttx_proto::uuid_to_bytes(Uuid::parse_str(runtime_id).unwrap());
+
+    // First reconnect after a split: adopt H(A, B) -> two panes.
+    let mut snap = snapshot_with_tree(Some(pane_tree_split(
+        v3::PaneSplitAxis::Horizontal,
+        0.5,
+        pane_tree_leaf(a),
+        pane_tree_leaf(b),
+    )));
+    snap.runtime_id = rt_bytes.clone();
+    snap.default_active_pane_id = rttx_proto::uuid_to_bytes(a);
+    let _ = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+        workspace_id: "ws-1".into(),
+        runtime_id: runtime_id.into(),
+        snapshot: snap,
+    });
+    assert_eq!(
+        state.workspaces[0].layout.terminal_uuids().len(),
+        2,
+        "two panes after adopting split"
+    );
+
+    // Close pane A.
+    let _ = state.reconcile_endpoint_event(&EndpointEvent::PaneClosed {
+        workspace_id: "ws-1".into(),
+        layout_terminal_uuid: a.to_string(),
+        runtime_id: runtime_id.into(),
+        runtime_pane_id: a.to_string(),
+    });
+    assert_eq!(
+        state.workspaces[0].layout.terminal_uuids(),
+        vec![b.to_string()],
+        "one pane after close"
+    );
+
+    // Second reconnect: the daemon tree is now just [B]. Adopting it must not
+    // resurrect the closed pane.
+    let mut snap2 = snapshot_with_tree(Some(pane_tree_leaf(b)));
+    snap2.runtime_id = rt_bytes;
+    snap2.default_active_pane_id = rttx_proto::uuid_to_bytes(b);
+    let _ = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
+        workspace_id: "ws-1".into(),
+        runtime_id: runtime_id.into(),
+        snapshot: snap2,
+    });
+    assert_eq!(
+        state.workspaces[0].layout.terminal_uuids(),
+        vec![b.to_string()],
+        "still one pane after the second reconnect"
+    );
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.12',
+  version: '0.9.13',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/services/rttx-server/tests/close_survives_restart.rs
+++ b/services/rttx-server/tests/close_survives_restart.rs
@@ -1,6 +1,10 @@
 //! Decisive daemon-level check for the close+restart pane-count drift: a pane
-//! closed before a daemon restart must not resurrect when the workspace tree is
-//! reconstructed from persisted state.
+//! closed before a *graceful* daemon shutdown must not resurrect when the
+//! workspace tree is reconstructed from persisted state.
+//!
+//! Uses the real graceful shutdown path (the `Shutdown` command -> the run
+//! loop's `persist_and_cleanup`), not a periodic-flush wait, so it mirrors what
+//! `rttx-server stop` does in the GUI repro.
 
 mod common;
 
@@ -21,11 +25,28 @@ fn leaf_count(node: &v3::PaneTreeNode) -> usize {
     }
 }
 
+/// Send the graceful `Shutdown` command and wait for `run()` to finish, which
+/// guarantees `persist_and_cleanup` has flushed state to disk.
+async fn graceful_shutdown(
+    client: &mut TestClient,
+    handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+) {
+    client
+        .send(&v3::ClientEnvelope {
+            request_id: 0,
+            command: Some(v3::client_envelope::Command::Shutdown(v3::Shutdown {})),
+        })
+        .await;
+    let _ = tokio::time::timeout(Duration::from_secs(10), handle).await;
+}
+
 #[tokio::test]
-async fn closed_pane_does_not_resurrect_after_daemon_restart() {
+async fn closed_pane_does_not_resurrect_after_graceful_restart() {
     let tmp = tempfile::TempDir::new().unwrap();
     let runtime_id;
+    let pane_a;
 
+    // Phase 1: create a 2-pane workspace, then gracefully shut down.
     {
         let (sock, handle) = start_test_server(tmp.path()).await;
         let mut client = TestClient::connect(&sock).await;
@@ -33,22 +54,27 @@ async fn closed_pane_does_not_resurrect_after_daemon_restart() {
         runtime_id =
             create_workspace(&mut client, "close-restart", v3::WorkspacePolicy::Persistent).await;
         attach_rw(&mut client, &runtime_id).await;
-
-        let pane_a = create_pane(&mut client, &runtime_id).await;
-        // Split A -> B, then close A; only B should remain in the tree.
+        pane_a = create_pane(&mut client, &runtime_id).await;
         let _pane_b =
             split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Horizontal, 0.5)
                 .await
                 .new_pane_id;
-        close_pane(&mut client, &runtime_id, &pane_a).await;
-
-        // Let the 1s persistence ticker flush the collapsed (1-pane) tree before
-        // the daemon goes away, mirroring a graceful restart.
-        tokio::time::sleep(Duration::from_millis(1500)).await;
-        handle.abort();
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        graceful_shutdown(&mut client, handle).await;
     }
 
+    // Phase 2: reattach to the reconstructed workspace, close pane A, shut down.
+    {
+        let (sock, handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&sock).await;
+        client.handshake().await;
+        let snapshot = attach_rw(&mut client, &runtime_id).await;
+        assert_eq!(leaf_count(snapshot.tree.as_ref().unwrap()), 2, "two panes restored");
+
+        close_pane(&mut client, &runtime_id, &pane_a).await;
+        graceful_shutdown(&mut client, handle).await;
+    }
+
+    // Phase 3: reattach — the closed pane must not resurrect.
     {
         let (sock, _handle) = start_test_server(tmp.path()).await;
         let mut client = TestClient::connect(&sock).await;
@@ -58,7 +84,7 @@ async fn closed_pane_does_not_resurrect_after_daemon_restart() {
         assert_eq!(
             leaf_count(tree),
             1,
-            "the closed pane must not resurrect after the daemon restart"
+            "a pane closed before a graceful restart must not resurrect"
         );
     }
 }

--- a/services/rttx-server/tests/close_survives_restart.rs
+++ b/services/rttx-server/tests/close_survives_restart.rs
@@ -1,0 +1,64 @@
+//! Decisive daemon-level check for the close+restart pane-count drift: a pane
+//! closed before a daemon restart must not resurrect when the workspace tree is
+//! reconstructed from persisted state.
+
+mod common;
+
+use common::{
+    TestClient, attach_rw, close_pane, create_pane, create_workspace, split_pane, start_test_server,
+};
+use rttx_proto::v3;
+use std::time::Duration;
+
+fn leaf_count(node: &v3::PaneTreeNode) -> usize {
+    match node.node.as_ref() {
+        Some(v3::pane_tree_node::Node::Leaf(_)) => 1,
+        Some(v3::pane_tree_node::Node::Split(split)) => {
+            split.first.as_ref().map_or(0, |n| leaf_count(n))
+                + split.second.as_ref().map_or(0, |n| leaf_count(n))
+        }
+        None => 0,
+    }
+}
+
+#[tokio::test]
+async fn closed_pane_does_not_resurrect_after_daemon_restart() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let runtime_id;
+
+    {
+        let (sock, handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&sock).await;
+        client.handshake().await;
+        runtime_id =
+            create_workspace(&mut client, "close-restart", v3::WorkspacePolicy::Persistent).await;
+        attach_rw(&mut client, &runtime_id).await;
+
+        let pane_a = create_pane(&mut client, &runtime_id).await;
+        // Split A -> B, then close A; only B should remain in the tree.
+        let _pane_b =
+            split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Horizontal, 0.5)
+                .await
+                .new_pane_id;
+        close_pane(&mut client, &runtime_id, &pane_a).await;
+
+        // Let the 1s persistence ticker flush the collapsed (1-pane) tree before
+        // the daemon goes away, mirroring a graceful restart.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        handle.abort();
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    {
+        let (sock, _handle) = start_test_server(tmp.path()).await;
+        let mut client = TestClient::connect(&sock).await;
+        client.handshake().await;
+        let snapshot = attach_rw(&mut client, &runtime_id).await;
+        let tree = snapshot.tree.as_ref().expect("reconstructed workspace must carry a tree");
+        assert_eq!(
+            leaf_count(tree),
+            1,
+            "the closed pane must not resurrect after the daemon restart"
+        );
+    }
+}

--- a/services/rttx-server/tests/tree_protocol.rs
+++ b/services/rttx-server/tests/tree_protocol.rs
@@ -245,3 +245,67 @@ async fn single_client_pty_tracks_that_client_size() {
     let pane_snap = snapshot.panes.iter().find(|p| p.pane_id == pane).expect("pane present");
     assert_eq!((pane_snap.cols, pane_snap.rows), (100, 40));
 }
+
+/// Mirrors the GUI repro that exposed the client-as-view bug: split a pane,
+/// then split the *same* pane again on a different axis. The daemon tree must
+/// stay correctly nested — `outer(inner(a, c), b)` — instead of flattening into
+/// a row of three. (The client regression was sending `CreatePane` instead of
+/// `SplitPane`, so the daemon never learned the structure; this guards the
+/// daemon contract the pure-view client now depends on.)
+#[tokio::test]
+async fn nested_splits_keep_a_correctly_structured_tree() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sock, _handle) = start_test_server(tmp.path()).await;
+
+    let mut client = TestClient::connect(&sock).await;
+    client.handshake().await;
+    let runtime_id = create_workspace(&mut client, "nested", v3::WorkspacePolicy::Persistent).await;
+    attach_rw(&mut client, &runtime_id).await;
+    let pane_a = create_pane(&mut client, &runtime_id).await;
+
+    // Split A horizontally -> B. Tree: H(A, B).
+    let pane_b = split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Horizontal, 0.5)
+        .await
+        .new_pane_id;
+    // Split A again, vertically -> C. Tree must nest: H(V(A, C), B).
+    let pane_c = split_pane(&mut client, &runtime_id, &pane_a, v3::PaneSplitAxis::Vertical, 0.5)
+        .await
+        .new_pane_id;
+
+    let snapshot = resync(&mut client, &runtime_id).await;
+    assert_eq!(
+        leaf_ids(snapshot.tree.as_ref().unwrap()).len(),
+        3,
+        "all three panes are present in the tree"
+    );
+
+    let root = root_split(&snapshot);
+    assert_eq!(
+        root.axis,
+        v3::PaneSplitAxis::Horizontal as i32,
+        "the outer split keeps the original horizontal axis, not a flattened row"
+    );
+
+    let first = root.first.expect("outer split has a first child");
+    let second = root.second.expect("outer split has a second child");
+
+    // One child is the lone leaf B; the other is the vertical split over {A, C}.
+    let first_is_split = matches!(first.node, Some(v3::pane_tree_node::Node::Split(_)));
+    let (nested, lone) = if first_is_split { (first, second) } else { (second, first) };
+
+    assert_eq!(leaf_ids(&lone), vec![pane_b.clone()], "the un-split branch is pane B");
+
+    let Some(v3::pane_tree_node::Node::Split(nested_split)) = nested.node.as_ref() else {
+        panic!("one child of the outer split must itself be a split, not a flat row");
+    };
+    assert_eq!(
+        nested_split.axis,
+        v3::PaneSplitAxis::Vertical as i32,
+        "the inner split keeps the vertical axis"
+    );
+    let mut nested_leaves = leaf_ids(&nested);
+    nested_leaves.sort();
+    let mut expected = vec![pane_a.clone(), pane_c.clone()];
+    expected.sort();
+    assert_eq!(nested_leaves, expected, "the inner split holds exactly A and C");
+}


### PR DESCRIPTION
## What
Managed splits now send `SplitPane(target_pane_id, axis, ratio)` to the daemon instead of `CreatePane`, so the daemon's authoritative pane tree reflects the real split structure.

## Why
After #1022 (client adopts the server tree on attach), splitting panes then restarting the daemon rendered the wrong structure — e.g. `[left|right]` over `bottom` collapsed to a single row `left | right | bottom` after reconnect. Root cause: the split path sent `CreatePane` (no target/axis), so the daemon appended panes by default placement and never learned the structure. The pre-#1022 client masked this by rendering its own layout.

## Change
- `daemon_bridge`: `EndpointCommand::SplitPane` + `manager.split_pane()` + handler that sends `v3::SplitPane` and binds the new pane uuid on the `PaneSplit` response (reusing the `PaneCreated` event).
- `window/terminal.rs`: both managed-split sites call `split_pane` with the target server pane id (resolved from `pane_bindings`) and `orientation_to_axis(orientation)`; the initial-pane creation still uses `create_pane`.

## Tested (locally, vte-0_76)
- Pure-state unit (`daemon_bridge::split_pane_request_carries_target_axis_ratio_and_persistence`).
- Behavior (`tree_protocol::nested_splits_keep_a_correctly_structured_tree`): split A, then split A again on another axis → daemon tree is `H(V(A,C), B)`, not a flat row.
- 823 client lib tests + workspace_lifecycle (47) / render_from_server_tree (6) / reconnect_layout_stability / gtk_boundary_contracts (46) green; clippy `-D warnings` clean; runtime-behavior gate passes.

## Reviewer GUI check
Reproduces the user's flow: split a pane, split one of the halves on the other axis, restart the daemon — the nested layout must be preserved (not flattened). Expected to also clear the close/reconnect pane-count drift from #1022.

Step 1c of epic #997 (RFC-031). Fixes #1023