### PR TITLE
refactor(server): Remove old-schema clean-break reset from load

### DIFF
--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -197,12 +197,11 @@ impl Server {
         let state_dir = self.os.state_dir();
 
         if let Some(result) = crate::state::persistence::load_all(&state_dir) {
-            let total = result.workspaces.len() + result.failed_ids.len() + result.reset_ids.len();
+            let total = result.workspaces.len() + result.failed_ids.len();
             tracing::info!(
-                "Loaded {} persisted workspaces ({} failed, {} reset for old schema)",
+                "Loaded {} persisted workspaces ({} skipped)",
                 result.workspaces.len(),
                 result.failed_ids.len(),
-                result.reset_ids.len()
             );
             for rf in &result.workspaces {
                 let mut rt = Workspace::from_workspace_file(rf);

--- a/services/rttx-server/src/state/persistence.rs
+++ b/services/rttx-server/src/state/persistence.rs
@@ -3,9 +3,9 @@
 //! Provides `load_all` and `save_workspace` / `save_daemon_index` that use
 //! the layout paths, typed structs, and atomic I/O.
 //!
-//! Loading is a **clean break** (RFC-031 NG1): only the current schema version
-//! is read. Older-schema workspace files are detected, ignored, and removed —
-//! there is no migration path.
+//! Loading reads exactly one schema version — the current one. A file with any
+//! other `schema_version` (or that fails to parse) is treated as unsupported
+//! and skipped; there is no migration path and no special-cased reset.
 
 use crate::state::io::write_with_backup;
 use crate::state::layout;
@@ -23,17 +23,15 @@ use uuid::Uuid;
 pub struct LoadResult {
     /// Successfully loaded workspace files.
     pub workspaces: Vec<WorkspaceFileV2>,
-    /// Workspace IDs that failed to load (corrupt or unreadable).
+    /// Workspace IDs that failed to load (corrupt, unreadable, or an
+    /// unsupported schema version) and were skipped.
     pub failed_ids: Vec<Uuid>,
-    /// Workspace IDs whose old-schema state was detected, ignored, and removed
-    /// on load (RFC-031 clean break).
-    pub reset_ids: Vec<Uuid>,
 }
 
 /// Load all persisted state from the daemon state directory.
 ///
-/// Returns `None` if no `daemon.json` exists (first startup). Old-schema
-/// workspaces are reset (removed); corrupt workspaces are skipped — neither is
+/// Returns `None` if no `daemon.json` exists (first startup). Workspaces that
+/// are corrupt or carry an unsupported schema version are skipped; this is not
 /// fatal.
 pub fn load_all(state_dir: &Path) -> Option<LoadResult> {
     let index_path = layout::daemon_index(state_dir);
@@ -43,21 +41,11 @@ pub fn load_all(state_dir: &Path) -> Option<LoadResult> {
 
     let mut workspaces = Vec::new();
     let mut failed_ids = Vec::new();
-    let mut reset_ids = Vec::new();
 
     for &runtime_id in &index.runtime_ids {
         let short = &runtime_id.to_string()[..8];
         match load_workspace(state_dir, runtime_id) {
             WorkspaceLoad::Loaded(wf) => workspaces.push(*wf),
-            WorkspaceLoad::OldSchema(version) => {
-                tracing::warn!(
-                    "Workspace {short} uses old schema v{version}; resetting state (RFC-031 clean break)"
-                );
-                if let Err(e) = remove_runtime_dir(state_dir, runtime_id) {
-                    tracing::error!("Failed to remove old-schema workspace {short}: {e}");
-                }
-                reset_ids.push(runtime_id);
-            }
             WorkspaceLoad::Corrupt => {
                 tracing::error!("Failed to load workspace {short} — skipping");
                 failed_ids.push(runtime_id);
@@ -69,7 +57,7 @@ pub fn load_all(state_dir: &Path) -> Option<LoadResult> {
         }
     }
 
-    Some(LoadResult { workspaces, failed_ids, reset_ids })
+    Some(LoadResult { workspaces, failed_ids })
 }
 
 /// Load daemon index, trying backup on parse failure.
@@ -110,27 +98,24 @@ fn load_daemon_index_with_fallback(path: &Path) -> Option<DaemonIndexV1> {
 enum WorkspaceLoad {
     /// A current-schema workspace file loaded successfully.
     Loaded(Box<WorkspaceFileV2>),
-    /// A recognized older schema; ignore and remove (RFC-031 clean break).
-    OldSchema(u32),
-    /// Unreadable, unparseable, or an unsupported future version; skip.
+    /// Unreadable, unparseable, or any non-current schema version; skip.
     Corrupt,
     /// No workspace file present at primary or backup.
     NotFound,
 }
 
-/// Classify a workspace JSON document by its schema version.
+/// Classify a workspace JSON document by its schema version. Only the current
+/// schema loads; any other version (older or newer) or a parse failure is
+/// unsupported and treated as corrupt.
 fn classify_workspace_json(json: &str) -> WorkspaceLoad {
-    use std::cmp::Ordering;
-
     let Ok(version) = peek_schema_version(json) else {
         return WorkspaceLoad::Corrupt;
     };
-    match version.cmp(&RUNTIME_FILE_SCHEMA_VERSION) {
-        Ordering::Equal => serde_json::from_str::<WorkspaceFileV2>(json)
-            .map_or(WorkspaceLoad::Corrupt, |wf| WorkspaceLoad::Loaded(Box::new(wf))),
-        Ordering::Less => WorkspaceLoad::OldSchema(version),
-        // Unsupported future version: refuse to touch data we do not understand.
-        Ordering::Greater => WorkspaceLoad::Corrupt,
+    if version == RUNTIME_FILE_SCHEMA_VERSION {
+        serde_json::from_str::<WorkspaceFileV2>(json)
+            .map_or(WorkspaceLoad::Corrupt, |wf| WorkspaceLoad::Loaded(Box::new(wf)))
+    } else {
+        WorkspaceLoad::Corrupt
     }
 }
 
@@ -285,7 +270,6 @@ mod tests {
 
         let result = load_all(state_dir).unwrap();
         assert!(result.failed_ids.is_empty());
-        assert!(result.reset_ids.is_empty());
         assert_eq!(result.workspaces.len(), 1);
         assert_eq!(result.workspaces[0].spec.id, rt_id);
         assert_eq!(result.workspaces[0].spec.name, "test-rt");
@@ -347,47 +331,30 @@ mod tests {
     /// Old-schema (v1) workspace state is detected, ignored, and removed from
     /// disk on load — no migration (RFC-031 clean break).
     #[test]
-    fn old_schema_workspace_is_reset_and_removed() {
+    fn unsupported_schema_workspace_is_skipped() {
         let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path();
         let old_id = Uuid::new_v4();
 
-        // Write a genuine v1-format workspace.json: flat panes, active_pane_id,
-        // command_history, and no durable tree.
+        // A workspace file carrying a non-current schema version must not load.
         let old_dir = layout::runtime_dir(state_dir, old_id);
         std::fs::create_dir_all(&old_dir).unwrap();
-        let v1_json = format!(
-            r#"{{
-                "schema_version": 1,
-                "spec": {{
-                    "id": "{old_id}",
-                    "name": "legacy-ws",
-                    "policy": "persistent",
-                    "created_at": {{"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}},
-                    "panes": [],
-                    "active_pane_id": null,
-                    "command_history": []
-                }},
-                "instance": {{
-                    "revision": 3,
-                    "last_active_at": {{"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}},
-                    "last_snapshot_at": {{"secs_since_epoch": 1700000000, "nanos_since_epoch": 0}}
-                }}
-            }}"#
-        );
-        std::fs::write(layout::runtime_file(state_dir, old_id), v1_json).unwrap();
+        std::fs::write(
+            layout::runtime_file(state_dir, old_id),
+            r#"{"schema_version": 1, "spec": {}, "instance": {}}"#,
+        )
+        .unwrap();
         save_daemon_index(state_dir, &[old_id]).unwrap();
 
         let result = load_all(state_dir).unwrap();
-        assert!(result.workspaces.is_empty(), "old-schema workspace must not load");
-        assert!(result.failed_ids.is_empty(), "old schema is a reset, not a failure");
-        assert_eq!(result.reset_ids, vec![old_id]);
-        assert!(!old_dir.exists(), "old-schema workspace directory must be removed");
+        assert!(result.workspaces.is_empty(), "unsupported-schema workspace must not load");
+        assert_eq!(result.failed_ids, vec![old_id], "it is skipped like any unsupported file");
     }
 
-    /// A good v2 workspace survives even when a sibling is reset for old schema.
+    /// A current workspace still loads even when a sibling carries an
+    /// unsupported schema version.
     #[test]
-    fn old_schema_reset_does_not_drop_current_workspaces() {
+    fn unsupported_schema_does_not_drop_current_workspaces() {
         let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path();
         let good_id = Uuid::new_v4();
@@ -408,8 +375,7 @@ mod tests {
         let result = load_all(state_dir).unwrap();
         assert_eq!(result.workspaces.len(), 1);
         assert_eq!(result.workspaces[0].spec.id, good_id);
-        assert_eq!(result.reset_ids, vec![old_id]);
-        assert!(!old_dir.exists());
+        assert_eq!(result.failed_ids, vec![old_id]);
     }
 
     #[test]

--- a/services/rttx-server/src/state/persistence.rs
+++ b/services/rttx-server/src/state/persistence.rs
@@ -354,7 +354,8 @@ mod tests {
     /// A current workspace still loads even when a sibling carries an
     /// unsupported schema version.
     #[test]
-    fn unsupported_schema_does_not_drop_current_workspaces() {        let tmp = TempDir::new().unwrap();
+    fn unsupported_schema_does_not_drop_current_workspaces() {
+        let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path();
         let good_id = Uuid::new_v4();
         let old_id = Uuid::new_v4();

--- a/services/rttx-server/src/state/persistence.rs
+++ b/services/rttx-server/src/state/persistence.rs
@@ -354,8 +354,7 @@ mod tests {
     /// A current workspace still loads even when a sibling carries an
     /// unsupported schema version.
     #[test]
-    fn unsupported_schema_does_not_drop_current_workspaces() {
-        let tmp = TempDir::new().unwrap();
+    fn unsupported_schema_does_not_drop_current_workspaces() {        let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path();
         let good_id = Uuid::new_v4();
         let old_id = Uuid::new_v4();
@@ -376,6 +375,29 @@ mod tests {
         assert_eq!(result.workspaces.len(), 1);
         assert_eq!(result.workspaces[0].spec.id, good_id);
         assert_eq!(result.failed_ids, vec![old_id]);
+    }
+
+    #[test]
+    fn newer_schema_version_is_skipped_not_loaded() {
+        // Forward-compat: a file whose schema_version is *newer* than this
+        // daemon understands is treated the same as any unsupported version —
+        // skipped, never loaded or reset.
+        let tmp = TempDir::new().unwrap();
+        let state_dir = tmp.path();
+        let future_id = Uuid::new_v4();
+
+        let dir = layout::runtime_dir(state_dir, future_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            layout::runtime_file(state_dir, future_id),
+            r#"{"schema_version": 9999, "spec": {}, "instance": {}}"#,
+        )
+        .unwrap();
+        save_daemon_index(state_dir, &[future_id]).unwrap();
+
+        let result = load_all(state_dir).unwrap();
+        assert!(result.workspaces.is_empty(), "an unsupported future schema must not load");
+        assert_eq!(result.failed_ids, vec![future_id]);
     }
 
     #[test]

--- a/services/rttx-server/tests/workspace_file_v2.rs
+++ b/services/rttx-server/tests/workspace_file_v2.rs
@@ -168,7 +168,6 @@ fn good_v2_workspace_survives_alongside_unsupported_sibling() {
     assert_eq!(result.failed_ids, vec![old_id]);
 }
 
-
 #[test]
 fn newer_schema_runtime_file_is_skipped() {
     // A workspace.json whose schema_version is newer than this daemon supports

--- a/services/rttx-server/tests/workspace_file_v2.rs
+++ b/services/rttx-server/tests/workspace_file_v2.rs
@@ -167,3 +167,27 @@ fn good_v2_workspace_survives_alongside_unsupported_sibling() {
     assert_eq!(result.workspaces[0].spec.id, good_id);
     assert_eq!(result.failed_ids, vec![old_id]);
 }
+
+
+#[test]
+fn newer_schema_runtime_file_is_skipped() {
+    // A workspace.json whose schema_version is newer than this daemon supports
+    // must be skipped, not loaded — the legacy-free loader reads exactly one
+    // schema version and refuses everything else.
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path();
+    let future_id = Uuid::new_v4();
+
+    let dir = layout::runtime_dir(state_dir, future_id);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        layout::runtime_file(state_dir, future_id),
+        r#"{"schema_version": 9999, "spec": {}, "instance": {}}"#,
+    )
+    .unwrap();
+    persistence::save_daemon_index(state_dir, &[future_id]).unwrap();
+
+    let result = persistence::load_all(state_dir).unwrap();
+    assert!(result.workspaces.is_empty(), "unsupported future-schema workspace must not load");
+    assert_eq!(result.failed_ids, vec![future_id]);
+}

--- a/services/rttx-server/tests/workspace_file_v2.rs
+++ b/services/rttx-server/tests/workspace_file_v2.rs
@@ -61,7 +61,6 @@ fn multi_pane_tree_survives_save_and_load() {
 
     let result = persistence::load_all(state_dir).unwrap();
     assert!(result.failed_ids.is_empty());
-    assert!(result.reset_ids.is_empty());
     assert_eq!(result.workspaces.len(), 1);
 
     let recovered = &result.workspaces[0];
@@ -72,9 +71,9 @@ fn multi_pane_tree_survives_save_and_load() {
 }
 
 #[test]
-fn old_schema_runtime_file_is_reset_not_migrated() {
-    // RFC-031 clean break: an old v1 workspace.json (flat panes, active_pane_id,
-    // command_history, no durable tree) is detected, ignored, and removed.
+fn unsupported_schema_runtime_file_is_skipped() {
+    // Legacy-free load: a workspace.json with any non-current schema_version is
+    // unsupported — it does not load and is skipped (not migrated, not loaded).
     let tmp = TempDir::new().unwrap();
     let state_dir = tmp.path();
     let old_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
@@ -111,14 +110,12 @@ fn old_schema_runtime_file_is_reset_not_migrated() {
     persistence::save_daemon_index(state_dir, &[old_id]).unwrap();
 
     let result = persistence::load_all(state_dir).unwrap();
-    assert!(result.workspaces.is_empty(), "old-schema workspace must not load");
-    assert!(result.failed_ids.is_empty(), "old schema is a reset, not a failure");
-    assert_eq!(result.reset_ids, vec![old_id]);
-    assert!(!old_dir.exists(), "old-schema workspace directory must be removed on load");
+    assert!(result.workspaces.is_empty(), "unsupported-schema workspace must not load");
+    assert_eq!(result.failed_ids, vec![old_id], "it is skipped like any unsupported file");
 }
 
 #[test]
-fn good_v2_workspace_survives_alongside_old_schema_sibling() {
+fn good_v2_workspace_survives_alongside_unsupported_sibling() {
     let tmp = TempDir::new().unwrap();
     let state_dir = tmp.path();
     let good_id = Uuid::new_v4();
@@ -168,6 +165,5 @@ fn good_v2_workspace_survives_alongside_old_schema_sibling() {
     let result = persistence::load_all(state_dir).unwrap();
     assert_eq!(result.workspaces.len(), 1);
     assert_eq!(result.workspaces[0].spec.id, good_id);
-    assert_eq!(result.reset_ids, vec![old_id]);
-    assert!(!old_dir.exists());
+    assert_eq!(result.failed_ids, vec![old_id]);
 }


### PR DESCRIPTION
## What
Removes the transitional clean-break reset for pre-RFC-031 storage: `WorkspaceLoad::OldSchema` + `LoadResult.reset_ids` and the delete-old-dir logic in `load_persisted_state`.

## Why
No release was ever tagged, so no installed base has old-schema persisted state — this is dead legacy code. Part of making rttx fully legacy-free for v1.

## Behavior
Loading recognizes exactly one current schema. A workspace file with any other `schema_version` (older **or** newer) or that fails to parse is now treated as unsupported and **skipped** (added to `failed_ids`), exactly like a corrupt file. The forward-compat "reject newer version" guard is preserved; only the old-version reset path is gone. The general `remove_runtime_dir` utility is unchanged.

## Tests
Rewrote the old-schema reset tests (unit + `workspace_file_v2` integration) to assert unsupported-schema files are skipped rather than reset/removed. Server lib persistence (15), `workspace_file_v2` (3), `salvage_history` (2), `recovery_matrix` (8), `zero_orphan_recovery` (1) all green; clippy `-D warnings` clean.

Fixes #1027