### PR TITLE
refactor(client): Remove config backward-compat migrations (legacy-free)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.13"
+version = "0.9.14"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/commands.rs
+++ b/clients/rttx/src/commands.rs
@@ -146,15 +146,6 @@ pub fn visible_for_host(saved: &[SavedCommand], host_key: &str) -> Vec<SavedComm
     saved.iter().filter(|c| is_visible_on(c, host_key)).cloned().collect()
 }
 
-/// Migrate legacy commands that lack host tags by tagging them with `"local"`.
-pub fn migrate_legacy(commands: &mut [SavedCommand]) {
-    for command in commands.iter_mut() {
-        if command.host_tags.is_empty() {
-            command.host_tags.push(crate::host::LOCAL_KEY.into());
-        }
-    }
-}
-
 /// Move the item with `source_uuid` to the position of `target_uuid`.
 pub fn reorder(items: &mut Vec<SavedCommand>, source_uuid: &str, target_uuid: &str) {
     let Some(src) = items.iter().position(|c| c.uuid == source_uuid) else {
@@ -405,23 +396,6 @@ mod tests {
     fn visible_for_host_with_no_commands_returns_empty() {
         let visible = visible_for_host(&[], "local");
         assert!(visible.is_empty());
-    }
-
-    #[test]
-    fn migrate_legacy_tags_untagged_commands_with_local() {
-        let mut commands = vec![SavedCommand::new("A", "echo a"), SavedCommand::new("B", "echo b")];
-        migrate_legacy(&mut commands);
-        assert_eq!(commands[0].host_tags, vec!["local"]);
-        assert_eq!(commands[1].host_tags, vec!["local"]);
-    }
-
-    #[test]
-    fn migrate_legacy_preserves_existing_tags() {
-        let mut command = SavedCommand::new("Tagged", "echo tagged");
-        command.host_tags = vec!["example.com".into()];
-        let mut commands = vec![command];
-        migrate_legacy(&mut commands);
-        assert_eq!(commands[0].host_tags, vec!["example.com"]);
     }
 
     // ── Parameters ──────────────────────────────────────────────

--- a/clients/rttx/src/preferences.rs
+++ b/clients/rttx/src/preferences.rs
@@ -20,27 +20,6 @@ pub enum DefaultSessionFolder {
     Custom(String),
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "kebab-case")]
-pub enum PaneNavigationKeys {
-    #[default]
-    AltArrow,
-    CtrlShiftArrow,
-}
-
-impl PaneNavigationKeys {
-    /// GTK accelerator strings for (left, right, up, down).
-    #[must_use]
-    pub const fn accels(&self) -> (&str, &str, &str, &str) {
-        match self {
-            Self::AltArrow => ("<Alt>Left", "<Alt>Right", "<Alt>Up", "<Alt>Down"),
-            Self::CtrlShiftArrow => {
-                ("<Ctrl><Shift>Left", "<Ctrl><Shift>Right", "<Ctrl><Shift>Up", "<Ctrl><Shift>Down")
-            }
-        }
-    }
-}
-
 const fn default_session_folder() -> DefaultSessionFolder {
     DefaultSessionFolder::Home
 }
@@ -49,9 +28,6 @@ const fn default_session_folder() -> DefaultSessionFolder {
 pub struct Preferences {
     #[serde(default = "default_font")]
     pub font: String,
-    /// Legacy single-scheme preference kept for backward-compatible loading.
-    #[serde(default = "default_color_scheme")]
-    pub color_scheme: String,
     #[serde(default = "default_terminal_theme_mode")]
     pub terminal_theme_mode: TerminalThemeMode,
     #[serde(default = "default_light_color_scheme")]
@@ -77,8 +53,6 @@ pub struct Preferences {
     #[serde(default = "default_session_folder")]
     pub default_session_folder: DefaultSessionFolder,
     #[serde(default)]
-    pub pane_navigation_keys: PaneNavigationKeys,
-    #[serde(default)]
     pub keyboard_shortcuts: BTreeMap<String, Vec<String>>,
     #[serde(default = "default_true")]
     pub auto_start_daemon: bool,
@@ -92,9 +66,6 @@ pub struct Preferences {
 
 fn default_font() -> String {
     "Monospace 12".into()
-}
-fn default_color_scheme() -> String {
-    "default".into()
 }
 const fn default_terminal_theme_mode() -> TerminalThemeMode {
     TerminalThemeMode::System
@@ -122,7 +93,6 @@ impl Default for Preferences {
     fn default() -> Self {
         Self {
             font: default_font(),
-            color_scheme: default_color_scheme(),
             terminal_theme_mode: default_terminal_theme_mode(),
             light_color_scheme: default_light_color_scheme(),
             dark_color_scheme: default_dark_color_scheme(),
@@ -135,7 +105,6 @@ impl Default for Preferences {
             smart_clipboard: false,
             trim_trailing_whitespace_on_copy: false,
             default_session_folder: default_session_folder(),
-            pane_navigation_keys: PaneNavigationKeys::default(),
             keyboard_shortcuts: BTreeMap::new(),
             auto_start_daemon: true,
             reconnect_delay_secs: default_reconnect_delay_secs(),
@@ -166,8 +135,6 @@ impl Preferences {
 struct PreferencesDisk {
     #[serde(default = "default_font")]
     font: String,
-    #[serde(default = "default_color_scheme")]
-    color_scheme: String,
     #[serde(default = "default_terminal_theme_mode")]
     terminal_theme_mode: TerminalThemeMode,
     #[serde(default)]
@@ -193,8 +160,6 @@ struct PreferencesDisk {
     #[serde(default = "default_session_folder")]
     default_session_folder: DefaultSessionFolder,
     #[serde(default)]
-    pane_navigation_keys: PaneNavigationKeys,
-    #[serde(default)]
     keyboard_shortcuts: BTreeMap<String, Vec<String>>,
     #[serde(default = "default_true")]
     auto_start_daemon: bool,
@@ -208,30 +173,11 @@ struct PreferencesDisk {
 
 impl From<PreferencesDisk> for Preferences {
     fn from(raw: PreferencesDisk) -> Self {
-        let legacy_override = if raw.color_scheme == default_color_scheme() {
-            None
-        } else {
-            Some(raw.color_scheme.clone())
-        };
-
-        let mut keyboard_shortcuts = raw.keyboard_shortcuts;
-        crate::shortcuts::migrate_pane_navigation(
-            &raw.pane_navigation_keys,
-            &mut keyboard_shortcuts,
-        );
-
         Self {
             font: raw.font,
-            color_scheme: raw.color_scheme,
             terminal_theme_mode: raw.terminal_theme_mode,
-            light_color_scheme: raw
-                .light_color_scheme
-                .or_else(|| legacy_override.clone())
-                .unwrap_or_else(default_light_color_scheme),
-            dark_color_scheme: raw
-                .dark_color_scheme
-                .or(legacy_override)
-                .unwrap_or_else(default_dark_color_scheme),
+            light_color_scheme: raw.light_color_scheme.unwrap_or_else(default_light_color_scheme),
+            dark_color_scheme: raw.dark_color_scheme.unwrap_or_else(default_dark_color_scheme),
             scrollback_lines: raw.scrollback_lines,
             show_headerbar: raw.show_headerbar,
             scroll_on_keystroke: raw.scroll_on_keystroke,
@@ -241,8 +187,7 @@ impl From<PreferencesDisk> for Preferences {
             smart_clipboard: raw.smart_clipboard,
             trim_trailing_whitespace_on_copy: raw.trim_trailing_whitespace_on_copy,
             default_session_folder: raw.default_session_folder,
-            pane_navigation_keys: raw.pane_navigation_keys,
-            keyboard_shortcuts,
+            keyboard_shortcuts: raw.keyboard_shortcuts,
             auto_start_daemon: raw.auto_start_daemon,
             reconnect_delay_secs: raw.reconnect_delay_secs,
             paste_guard: raw.paste_guard,
@@ -327,13 +272,6 @@ mod tests {
     }
 
     #[test]
-    fn legacy_single_color_scheme_populates_light_and_dark() {
-        let loaded = parse_preferences_json(r#"{"color_scheme": "Solarized Dark"}"#);
-        assert_eq!(loaded.light_color_scheme, "Solarized Dark");
-        assert_eq!(loaded.dark_color_scheme, "Solarized Dark");
-    }
-
-    #[test]
     fn effective_color_scheme_tracks_mode() {
         let prefs = Preferences {
             terminal_theme_mode: TerminalThemeMode::System,
@@ -387,27 +325,6 @@ mod tests {
     fn missing_session_folder_defaults_to_home() {
         let loaded = parse_preferences_json("{}");
         assert_eq!(loaded.default_session_folder, DefaultSessionFolder::Home);
-    }
-
-    #[test]
-    fn pane_navigation_keys_defaults_to_alt_arrow() {
-        let prefs = Preferences::default();
-        assert_eq!(prefs.pane_navigation_keys, PaneNavigationKeys::AltArrow);
-    }
-
-    #[test]
-    fn pane_navigation_keys_roundtrips() {
-        let prefs = Preferences {
-            pane_navigation_keys: PaneNavigationKeys::CtrlShiftArrow,
-            ..Default::default()
-        };
-        assert_eq!(roundtrip(&prefs).pane_navigation_keys, PaneNavigationKeys::CtrlShiftArrow);
-    }
-
-    #[test]
-    fn missing_pane_navigation_keys_defaults_to_alt_arrow() {
-        let loaded = parse_preferences_json("{}");
-        assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::AltArrow);
     }
 
     #[test]

--- a/clients/rttx/src/preferences_window.rs
+++ b/clients/rttx/src/preferences_window.rs
@@ -21,7 +21,6 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
 
     let appearance_group = adw::PreferencesGroup::new();
     appearance_group.set_title("Appearance");
-    let legacy_color_scheme = prefs.color_scheme.clone();
 
     let font_desc = gtk4::pango::FontDescription::from_string(&prefs.font);
     let font_dialog = gtk4::FontDialog::new();
@@ -235,7 +234,6 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
         };
         let new_prefs = Preferences {
             font: font_button.font_desc().map_or_else(|| prefs.font.clone(), |d| d.to_string()),
-            color_scheme: legacy_color_scheme.clone(),
             terminal_theme_mode,
             light_color_scheme: light_scheme_row
                 .selected_item()
@@ -264,7 +262,6 @@ pub fn show(parent: &impl IsA<gtk4::Window>) {
                 2 => DefaultSessionFolder::Custom(custom_folder_row.text().to_string()),
                 _ => DefaultSessionFolder::Home,
             },
-            pane_navigation_keys: prefs.pane_navigation_keys,
             keyboard_shortcuts: shortcut_overrides.borrow().clone(),
             auto_start_daemon: prefs.auto_start_daemon,
             reconnect_delay_secs: prefs.reconnect_delay_secs,

--- a/clients/rttx/src/shortcuts.rs
+++ b/clients/rttx/src/shortcuts.rs
@@ -132,30 +132,6 @@ pub fn default_accels(action: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Migrate legacy `PaneNavigationKeys` into shortcut overrides.
-///
-/// If the user had `CtrlShiftArrow` selected and no explicit overrides exist
-/// for the navigation actions, populate them.
-pub fn migrate_pane_navigation(
-    legacy: &crate::preferences::PaneNavigationKeys,
-    shortcuts: &mut BTreeMap<String, Vec<String>>,
-) {
-    use crate::preferences::PaneNavigationKeys;
-    if *legacy == PaneNavigationKeys::AltArrow {
-        return; // default — nothing to migrate
-    }
-    let (left, right, up, down) = legacy.accels();
-    let nav = [
-        ("navigate-left", left),
-        ("navigate-right", right),
-        ("navigate-up", up),
-        ("navigate-down", down),
-    ];
-    for (action, accel) in nav {
-        shortcuts.entry(action.to_string()).or_insert_with(|| vec![accel.to_string()]);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,35 +185,6 @@ mod tests {
         for def in DEFAULT_SHORTCUTS {
             assert!(!def.label.is_empty(), "empty label for action: {}", def.action);
         }
-    }
-
-    #[test]
-    fn migrate_pane_navigation_noop_for_alt_arrow() {
-        use crate::preferences::PaneNavigationKeys;
-        let mut shortcuts = BTreeMap::new();
-        migrate_pane_navigation(&PaneNavigationKeys::AltArrow, &mut shortcuts);
-        assert!(shortcuts.is_empty());
-    }
-
-    #[test]
-    fn migrate_pane_navigation_populates_ctrl_shift_arrow() {
-        use crate::preferences::PaneNavigationKeys;
-        let mut shortcuts = BTreeMap::new();
-        migrate_pane_navigation(&PaneNavigationKeys::CtrlShiftArrow, &mut shortcuts);
-        assert_eq!(shortcuts["navigate-left"], vec!["<Ctrl><Shift>Left"]);
-        assert_eq!(shortcuts["navigate-right"], vec!["<Ctrl><Shift>Right"]);
-        assert_eq!(shortcuts["navigate-up"], vec!["<Ctrl><Shift>Up"]);
-        assert_eq!(shortcuts["navigate-down"], vec!["<Ctrl><Shift>Down"]);
-    }
-
-    #[test]
-    fn migrate_pane_navigation_does_not_overwrite_existing() {
-        use crate::preferences::PaneNavigationKeys;
-        let mut shortcuts = BTreeMap::new();
-        shortcuts.insert("navigate-left".into(), vec!["<Alt>h".into()]);
-        migrate_pane_navigation(&PaneNavigationKeys::CtrlShiftArrow, &mut shortcuts);
-        assert_eq!(shortcuts["navigate-left"], vec!["<Alt>h"]);
-        assert_eq!(shortcuts["navigate-right"], vec!["<Ctrl><Shift>Right"]);
     }
 
     #[test]

--- a/clients/rttx/src/store/models/preferences.rs
+++ b/clients/rttx/src/store/models/preferences.rs
@@ -26,14 +26,6 @@ pub enum DefaultSessionFolder {
     Custom(String),
 }
 
-/// Pane navigation key binding style.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub enum PaneNavigationKeys {
-    AltArrow,
-    CtrlShiftArrow,
-}
-
 /// Durable user preferences — no workspace layout, connection status, or runtime inventory.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PreferencesV1 {
@@ -63,8 +55,6 @@ pub struct PreferencesV1 {
     pub trim_trailing_whitespace_on_copy: bool,
     #[serde(default = "default_session_folder")]
     pub default_session_folder: DefaultSessionFolder,
-    #[serde(default = "default_pane_navigation_keys")]
-    pub pane_navigation_keys: PaneNavigationKeys,
     #[serde(default)]
     pub keyboard_shortcuts: BTreeMap<String, Vec<String>>,
     #[serde(default = "default_true")]
@@ -93,7 +83,6 @@ impl Default for PreferencesV1 {
             smart_clipboard: false,
             trim_trailing_whitespace_on_copy: false,
             default_session_folder: default_session_folder(),
-            pane_navigation_keys: default_pane_navigation_keys(),
             keyboard_shortcuts: BTreeMap::new(),
             auto_start_daemon: true,
             reconnect_delay_secs: default_reconnect_delay_secs(),
@@ -131,10 +120,6 @@ const fn default_session_folder() -> DefaultSessionFolder {
     DefaultSessionFolder::Home
 }
 
-const fn default_pane_navigation_keys() -> PaneNavigationKeys {
-    PaneNavigationKeys::AltArrow
-}
-
 const fn default_reconnect_delay_secs() -> u32 {
     3
 }
@@ -149,7 +134,6 @@ impl From<PreferencesV1> for crate::preferences::Preferences {
     fn from(v1: PreferencesV1) -> Self {
         Self {
             font: v1.font,
-            color_scheme: "default".into(),
             terminal_theme_mode: match v1.terminal_theme_mode {
                 TerminalThemeMode::System => crate::preferences::TerminalThemeMode::System,
                 TerminalThemeMode::Light => crate::preferences::TerminalThemeMode::Light,
@@ -172,12 +156,6 @@ impl From<PreferencesV1> for crate::preferences::Preferences {
                 }
                 DefaultSessionFolder::Custom(s) => {
                     crate::preferences::DefaultSessionFolder::Custom(s)
-                }
-            },
-            pane_navigation_keys: match v1.pane_navigation_keys {
-                PaneNavigationKeys::AltArrow => crate::preferences::PaneNavigationKeys::AltArrow,
-                PaneNavigationKeys::CtrlShiftArrow => {
-                    crate::preferences::PaneNavigationKeys::CtrlShiftArrow
                 }
             },
             keyboard_shortcuts: v1.keyboard_shortcuts,
@@ -215,12 +193,6 @@ impl From<&crate::preferences::Preferences> for PreferencesV1 {
                 }
                 crate::preferences::DefaultSessionFolder::Custom(s) => {
                     DefaultSessionFolder::Custom(s.clone())
-                }
-            },
-            pane_navigation_keys: match prefs.pane_navigation_keys {
-                crate::preferences::PaneNavigationKeys::AltArrow => PaneNavigationKeys::AltArrow,
-                crate::preferences::PaneNavigationKeys::CtrlShiftArrow => {
-                    PaneNavigationKeys::CtrlShiftArrow
                 }
             },
             keyboard_shortcuts: prefs.keyboard_shortcuts.clone(),

--- a/clients/rttx/tests/commands_integration.rs
+++ b/clients/rttx/tests/commands_integration.rs
@@ -37,26 +37,6 @@ fn commands_with_host_tags_roundtrip() {
 }
 
 #[test]
-fn legacy_commands_without_host_tags_deserialize_and_migrate() {
-    let json = r#"[{
-        "uuid": "abc-123",
-        "title": "Old command",
-        "body": "echo hello",
-        "default_run_mode": "run"
-    }]"#;
-
-    let mut loaded: Vec<SavedCommand> = serde_json::from_str(json).unwrap();
-    assert!(loaded[0].host_tags.is_empty(), "legacy commands load with empty tags");
-
-    commands::migrate_legacy(&mut loaded);
-    assert_eq!(loaded[0].host_tags, vec!["local"], "migration tags with local");
-
-    let json2 = serde_json::to_string(&loaded).unwrap();
-    let reloaded: Vec<SavedCommand> = serde_json::from_str(&json2).unwrap();
-    assert_eq!(reloaded[0].host_tags, vec!["local"], "migrated tags persist");
-}
-
-#[test]
 fn commands_with_parameters_roundtrip() {
     let (_tmp, store) = test_store();
 

--- a/clients/rttx/tests/preferences_integration.rs
+++ b/clients/rttx/tests/preferences_integration.rs
@@ -1,7 +1,7 @@
 /// Integration tests for preferences persistence.
 use std::collections::BTreeMap;
 
-use rttx::preferences::{DefaultSessionFolder, PaneNavigationKeys, Preferences, TerminalThemeMode};
+use rttx::preferences::{DefaultSessionFolder, Preferences, TerminalThemeMode};
 use rttx::store::{ClientStore, StorePaths};
 use tempfile::TempDir;
 
@@ -52,13 +52,11 @@ fn preferences_roundtrip_all_fields() {
         smart_clipboard: true,
         trim_trailing_whitespace_on_copy: true,
         default_session_folder: DefaultSessionFolder::Custom("/home/user/dev".into()),
-        pane_navigation_keys: PaneNavigationKeys::AltArrow,
         keyboard_shortcuts: BTreeMap::new(),
         auto_start_daemon: true,
         reconnect_delay_secs: 10,
         paste_guard: false,
         paste_guard_threshold: 2048,
-        ..Default::default()
     };
 
     store.save_preferences(&prefs).unwrap();
@@ -189,19 +187,6 @@ fn custom_title_backward_compat_null() {
     {
         assert_eq!(*custom_title, None);
     }
-}
-
-#[test]
-fn pane_navigation_keys_persists_through_store() {
-    let (_tmp, store) = test_store();
-
-    let prefs = Preferences {
-        pane_navigation_keys: PaneNavigationKeys::CtrlShiftArrow,
-        ..Default::default()
-    };
-    store.save_preferences(&prefs).unwrap();
-    let loaded = store.load_preferences().into_value().unwrap();
-    assert_eq!(loaded.pane_navigation_keys, PaneNavigationKeys::CtrlShiftArrow);
 }
 
 #[test]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.13',
+  version: '0.9.14',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )


### PR DESCRIPTION
## What
Removes the client's config backward-compat migration machinery for a legacy-free v1:
- `commands::migrate_legacy` (dead — only called from tests).
- The single `color_scheme` preference + `legacy_override` fallback (superseded by `light_color_scheme`/`dark_color_scheme`; no edit UI, only carried through on round-trip).
- `pane_navigation_keys` + `shortcuts::migrate_pane_navigation` (legacy bridge from the old pane-nav preference into `keyboard_shortcuts`; no edit UI, superseded by direct shortcut editing).
- Matching fields/enum in the store document model (`PreferencesV1`) and the obsolete migration tests.

## Why
No release was ever tagged, so no installed base has these pre-release config formats. Light/dark themes and `keyboard_shortcuts` are the sole mechanisms. Serde default-tolerant deserialization (optional absent fields) is unchanged — this removes *migrations*, not general robustness.

## Tested (vte-0_76)
816 client lib tests + preferences_integration (17), commands_integration (15), color_scheme_compat (3), document_models (30), import_validation (3) all green; clippy `-D warnings` clean. Version bumped 0.9.13 → 0.9.14 (5 source files).

Fixes #1029