### PR TITLE
refactor(proto): Rename inventory capability, dropping V2/RUNTIME naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rttx"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "bytes",
  "gtk4",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-proto"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "bytes",
  "proptest",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rttx-server"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.14"
+version = "0.9.15"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clients/rttx/src/daemon.rs
+++ b/clients/rttx/src/daemon.rs
@@ -116,7 +116,7 @@ const CLIENT_CAPABILITIES: &[v3::Capability] = &[
     v3::Capability::CoreTerminalModes,
     v3::Capability::CorePasteIntent,
     v3::Capability::CoreFocusEvents,
-    v3::Capability::OptWorkspaceInventoryV2,
+    v3::Capability::OptWorkspaceInventory,
     v3::Capability::OptResync,
     v3::Capability::OptChunkedScrollback,
     v3::Capability::OptDiagnostics,

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rttx',
-  version: '0.9.14',
+  version: '0.9.15',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59',
 )

--- a/protocols/rttx-proto/proto/rttx-v3.proto
+++ b/protocols/rttx-proto/proto/rttx-v3.proto
@@ -13,7 +13,7 @@ enum Capability {
   CORE_PASTE_INTENT = 5;
   CORE_FOCUS_EVENTS = 6;
   // Optional — values 100+
-  OPT_WORKSPACE_INVENTORY_V2 = 100;
+  OPT_WORKSPACE_INVENTORY = 100;
   OPT_WORKSPACE_TAKEOVER = 101;
   OPT_RESYNC = 102;
   OPT_CHUNKED_SCROLLBACK = 103;
@@ -243,7 +243,7 @@ message WorkspaceInfo {
   WorkspaceClientRole current_client_role = 7;
   uint64 workspace_revision = 8;
   bool reconstructed = 9;
-  // OPT_WORKSPACE_INVENTORY_V2 fields
+  // OPT_WORKSPACE_INVENTORY fields
   string active_pane_summary = 10;
   bool takeover_eligible = 11;
   string disabled_reason = 12;

--- a/protocols/rttx-proto/src/lib.rs
+++ b/protocols/rttx-proto/src/lib.rs
@@ -42,7 +42,7 @@ pub mod v3_scrollback;
 /// V3 resync: capability gating, builders, and overflow handling (RFC-021 Section 8, `OPT_RESYNC`).
 pub mod v3_resync;
 
-/// V3 workspace inventory: capability gating, builders, and field stripping (RFC-021 Section 9, `OPT_RUNTIME_INVENTORY_V2`).
+/// V3 workspace inventory: capability gating, builders, and field stripping (RFC-021 Section 9, `OPT_WORKSPACE_INVENTORY`).
 pub mod v3_inventory;
 
 /// V3 workspace takeover: capability gating, builders, and lease events (RFC-021 Section 10, `OPT_RUNTIME_TAKEOVER`).
@@ -163,7 +163,7 @@ mod tests {
         assert_eq!(v3::WorkspaceTerminationReason::Explicit as i32, 1);
         assert_eq!(v3::WorkspaceTerminationReason::EphemeralDetach as i32, 2);
         assert_eq!(v3::Capability::CoreWorkspaceLifecycle as i32, 1);
-        assert_eq!(v3::Capability::OptWorkspaceInventoryV2 as i32, 100);
+        assert_eq!(v3::Capability::OptWorkspaceInventory as i32, 100);
         assert_eq!(v3::Capability::OptWorkspaceTakeover as i32, 101);
         assert_eq!(v3::ErrorKind::WorkspaceNotFound as i32, 4);
     }
@@ -252,7 +252,7 @@ mod v3_tests {
         assert_eq!(v3::Capability::CoreTerminalModes as i32, 4);
         assert_eq!(v3::Capability::CorePasteIntent as i32, 5);
         assert_eq!(v3::Capability::CoreFocusEvents as i32, 6);
-        assert_eq!(v3::Capability::OptWorkspaceInventoryV2 as i32, 100);
+        assert_eq!(v3::Capability::OptWorkspaceInventory as i32, 100);
         assert_eq!(v3::Capability::OptWorkspaceTakeover as i32, 101);
         assert_eq!(v3::Capability::OptResync as i32, 102);
         assert_eq!(v3::Capability::OptChunkedScrollback as i32, 103);

--- a/protocols/rttx-proto/src/v3_handshake.rs
+++ b/protocols/rttx-proto/src/v3_handshake.rs
@@ -116,7 +116,7 @@ pub fn missing_capabilities_error(missing: &[v3::Capability]) -> v3::ProtocolErr
             other => {
                 // Optional capabilities should not appear here, but handle gracefully
                 match *other as i32 {
-                    100 => "OPT_RUNTIME_INVENTORY_V2",
+                    100 => "OPT_WORKSPACE_INVENTORY",
                     101 => "OPT_RUNTIME_TAKEOVER",
                     102 => "OPT_RESYNC",
                     103 => "OPT_CHUNKED_SCROLLBACK",

--- a/protocols/rttx-proto/src/v3_inventory.rs
+++ b/protocols/rttx-proto/src/v3_inventory.rs
@@ -170,6 +170,15 @@ pub fn build_list_workspaces_envelope(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn renamed_inventory_capability_keeps_wire_value_100() {
+        // The rename dropped the meaningless "V2" from the symbol; the wire
+        // value must stay 100 so negotiation remains compatible.
+        assert_eq!(v3::Capability::OptWorkspaceInventory as i32, 100);
+        assert!(is_supported(&[v3::Capability::OptWorkspaceInventory as i32]));
+        assert!(!is_supported(&[]));
+    }
     use crate::{decode_frame, encode_frame, uuid_to_bytes, v3_envelope::RequestIdGenerator};
     use bytes::BytesMut;
 

--- a/protocols/rttx-proto/src/v3_inventory.rs
+++ b/protocols/rttx-proto/src/v3_inventory.rs
@@ -1,9 +1,9 @@
 //! V3 workspace inventory: capability gating, builders, and field stripping.
 //!
-//! Implements RFC-021 Section 9 (`OPT_RUNTIME_INVENTORY_V2`).
+//! Implements RFC-021 Section 9 (`OPT_WORKSPACE_INVENTORY`).
 //!
 //! `ListWorkspaces` always returns core fields (id, name, policy, pane_count,
-//! ownership, revision). When `OPT_RUNTIME_INVENTORY_V2` is negotiated, the
+//! ownership, revision). When `OPT_WORKSPACE_INVENTORY` is negotiated, the
 //! server additionally populates `active_pane_summary`, `takeover_eligible`,
 //! `disabled_reason`, and `panes`.
 //!
@@ -13,10 +13,10 @@
 
 use crate::v3;
 
-/// Check whether `OPT_RUNTIME_INVENTORY_V2` is in the effective capability set.
+/// Check whether `OPT_WORKSPACE_INVENTORY` is in the effective capability set.
 #[must_use]
 pub fn is_supported(effective_caps: &[i32]) -> bool {
-    effective_caps.contains(&(v3::Capability::OptWorkspaceInventoryV2 as i32))
+    effective_caps.contains(&(v3::Capability::OptWorkspaceInventory as i32))
 }
 
 /// Parameters for building a `PaneInfo`.
@@ -59,8 +59,8 @@ pub struct WorkspaceInfoParams {
     pub reconstructed: bool,
 }
 
-/// V2 enrichment fields for `WorkspaceInfo`.
-pub struct WorkspaceInfoV2Fields {
+/// Enriched fields for `WorkspaceInfo`.
+pub struct WorkspaceInfoEnrichedFields {
     pub active_pane_summary: String,
     pub takeover_eligible: bool,
     pub disabled_reason: String,
@@ -87,11 +87,11 @@ pub fn build_workspace_info(params: WorkspaceInfoParams) -> v3::WorkspaceInfo {
     }
 }
 
-/// Build a `WorkspaceInfo` with V2 enriched fields.
+/// Build a `WorkspaceInfo` with enriched fields.
 #[must_use]
-pub fn build_workspace_info_v2(
+pub fn build_workspace_info_enriched(
     params: WorkspaceInfoParams,
-    v2: WorkspaceInfoV2Fields,
+    enriched: WorkspaceInfoEnrichedFields,
 ) -> v3::WorkspaceInfo {
     v3::WorkspaceInfo {
         id: crate::uuid_to_bytes(params.id),
@@ -103,18 +103,18 @@ pub fn build_workspace_info_v2(
         current_client_role: params.current_client_role as i32,
         workspace_revision: params.workspace_revision,
         reconstructed: params.reconstructed,
-        active_pane_summary: v2.active_pane_summary,
-        takeover_eligible: v2.takeover_eligible,
-        disabled_reason: v2.disabled_reason,
-        panes: v2.panes,
+        active_pane_summary: enriched.active_pane_summary,
+        takeover_eligible: enriched.takeover_eligible,
+        disabled_reason: enriched.disabled_reason,
+        panes: enriched.panes,
     }
 }
 
-/// Strip V2 fields from a `WorkspaceInfo`, leaving only core fields.
+/// Strip enriched fields from a `WorkspaceInfo`, leaving only core fields.
 ///
 /// Used by the server when the client did not negotiate
-/// `OPT_RUNTIME_INVENTORY_V2`.
-pub fn strip_inventory_v2_fields(info: &mut v3::WorkspaceInfo) {
+/// `OPT_WORKSPACE_INVENTORY`.
+pub fn strip_enriched_inventory_fields(info: &mut v3::WorkspaceInfo) {
     info.active_pane_summary.clear();
     info.takeover_eligible = false;
     info.disabled_reason.clear();
@@ -214,7 +214,7 @@ mod tests {
     fn supported_when_capability_present() {
         let caps = vec![
             v3::Capability::CoreWorkspaceLifecycle as i32,
-            v3::Capability::OptWorkspaceInventoryV2 as i32,
+            v3::Capability::OptWorkspaceInventory as i32,
         ];
         assert!(is_supported(&caps));
     }
@@ -330,7 +330,7 @@ mod tests {
         assert_eq!(info.current_client_role, v3::WorkspaceClientRole::Writer as i32);
         assert_eq!(info.workspace_revision, 42);
         assert!(!info.reconstructed);
-        // V2 fields are empty/default
+        // enriched fields are empty/default
         assert!(info.active_pane_summary.is_empty());
         assert!(!info.takeover_eligible);
         assert!(info.disabled_reason.is_empty());
@@ -356,13 +356,13 @@ mod tests {
         assert_eq!(info, decoded);
     }
 
-    // ── build_workspace_info_v2 ──
+    // ── build_workspace_info_enriched ──
 
     #[test]
-    fn workspace_info_v2_populates_all_fields() {
+    fn workspace_info_enriched_populates_all_fields() {
         let r = rt();
         let pane = test_pane("bash", "/home", None);
-        let info = build_workspace_info_v2(
+        let info = build_workspace_info_enriched(
             WorkspaceInfoParams {
                 id: r,
                 name: "dev".into(),
@@ -374,7 +374,7 @@ mod tests {
                 workspace_revision: 10,
                 reconstructed: false,
             },
-            WorkspaceInfoV2Fields {
+            WorkspaceInfoEnrichedFields {
                 active_pane_summary: "bash".into(),
                 takeover_eligible: true,
                 disabled_reason: String::new(),
@@ -389,8 +389,8 @@ mod tests {
     }
 
     #[test]
-    fn workspace_info_v2_with_disabled_reason() {
-        let info = build_workspace_info_v2(
+    fn workspace_info_enriched_with_disabled_reason() {
+        let info = build_workspace_info_enriched(
             WorkspaceInfoParams {
                 id: rt(),
                 name: "busy".into(),
@@ -402,7 +402,7 @@ mod tests {
                 workspace_revision: 5,
                 reconstructed: false,
             },
-            WorkspaceInfoV2Fields {
+            WorkspaceInfoEnrichedFields {
                 active_pane_summary: "vim".into(),
                 takeover_eligible: false,
                 disabled_reason: "owned by another client".into(),
@@ -414,9 +414,9 @@ mod tests {
     }
 
     #[test]
-    fn workspace_info_v2_wire_roundtrip() {
+    fn workspace_info_enriched_wire_roundtrip() {
         let pane = test_pane("htop", "/", None);
-        let info = build_workspace_info_v2(
+        let info = build_workspace_info_enriched(
             WorkspaceInfoParams {
                 id: rt(),
                 name: "monitor".into(),
@@ -428,7 +428,7 @@ mod tests {
                 workspace_revision: 99,
                 reconstructed: true,
             },
-            WorkspaceInfoV2Fields {
+            WorkspaceInfoEnrichedFields {
                 active_pane_summary: "htop".into(),
                 takeover_eligible: true,
                 disabled_reason: String::new(),
@@ -441,12 +441,12 @@ mod tests {
         assert_eq!(info, decoded);
     }
 
-    // ── strip_inventory_v2_fields ──
+    // ── strip_enriched_inventory_fields ──
 
     #[test]
-    fn strip_clears_v2_fields() {
+    fn strip_clears_enriched_fields() {
         let pane = test_pane("bash", "/home", None);
-        let mut info = build_workspace_info_v2(
+        let mut info = build_workspace_info_enriched(
             WorkspaceInfoParams {
                 id: rt(),
                 name: "ws".into(),
@@ -458,14 +458,14 @@ mod tests {
                 workspace_revision: 1,
                 reconstructed: false,
             },
-            WorkspaceInfoV2Fields {
+            WorkspaceInfoEnrichedFields {
                 active_pane_summary: "bash".into(),
                 takeover_eligible: true,
                 disabled_reason: "busy".into(),
                 panes: vec![pane],
             },
         );
-        strip_inventory_v2_fields(&mut info);
+        strip_enriched_inventory_fields(&mut info);
         assert!(info.active_pane_summary.is_empty());
         assert!(!info.takeover_eligible);
         assert!(info.disabled_reason.is_empty());
@@ -479,8 +479,8 @@ mod tests {
     #[test]
     fn strip_is_idempotent() {
         let mut info = build_workspace_info(core_params("empty"));
-        strip_inventory_v2_fields(&mut info);
-        strip_inventory_v2_fields(&mut info);
+        strip_enriched_inventory_fields(&mut info);
+        strip_enriched_inventory_fields(&mut info);
         assert!(info.active_pane_summary.is_empty());
         assert!(info.panes.is_empty());
     }
@@ -599,7 +599,7 @@ mod tests {
     #[test]
     fn list_response_wire_roundtrip() {
         let pane = test_pane("bash", "/home", None);
-        let info = build_workspace_info_v2(
+        let info = build_workspace_info_enriched(
             WorkspaceInfoParams {
                 id: rt(),
                 name: "full".into(),
@@ -611,7 +611,7 @@ mod tests {
                 workspace_revision: 10,
                 reconstructed: false,
             },
-            WorkspaceInfoV2Fields {
+            WorkspaceInfoEnrichedFields {
                 active_pane_summary: "bash".into(),
                 takeover_eligible: false,
                 disabled_reason: String::new(),
@@ -655,15 +655,15 @@ mod tests {
         assert_eq!(env, decoded);
     }
 
-    // ── Integration: capability gating strips V2 fields ──
+    // ── Integration: capability gating strips enriched fields ──
 
     #[test]
-    fn capability_gating_strips_v2_when_absent() {
+    fn capability_gating_strips_enriched_when_absent() {
         let caps = vec![v3::Capability::CoreWorkspaceLifecycle as i32];
         assert!(!is_supported(&caps));
 
         let pane = test_pane("bash", "/home", None);
-        let mut info = build_workspace_info_v2(
+        let mut info = build_workspace_info_enriched(
             WorkspaceInfoParams {
                 id: rt(),
                 name: "ws".into(),
@@ -675,7 +675,7 @@ mod tests {
                 workspace_revision: 1,
                 reconstructed: false,
             },
-            WorkspaceInfoV2Fields {
+            WorkspaceInfoEnrichedFields {
                 active_pane_summary: "bash".into(),
                 takeover_eligible: true,
                 disabled_reason: String::new(),
@@ -684,7 +684,7 @@ mod tests {
         );
 
         if !is_supported(&caps) {
-            strip_inventory_v2_fields(&mut info);
+            strip_enriched_inventory_fields(&mut info);
         }
 
         assert!(info.active_pane_summary.is_empty());
@@ -696,15 +696,15 @@ mod tests {
     }
 
     #[test]
-    fn capability_gating_preserves_v2_when_present() {
+    fn capability_gating_preserves_enriched_when_present() {
         let caps = vec![
             v3::Capability::CoreWorkspaceLifecycle as i32,
-            v3::Capability::OptWorkspaceInventoryV2 as i32,
+            v3::Capability::OptWorkspaceInventory as i32,
         ];
         assert!(is_supported(&caps));
 
         let pane = test_pane("vim", "/src", None);
-        let info = build_workspace_info_v2(
+        let info = build_workspace_info_enriched(
             WorkspaceInfoParams {
                 id: rt(),
                 name: "dev".into(),
@@ -716,7 +716,7 @@ mod tests {
                 workspace_revision: 5,
                 reconstructed: false,
             },
-            WorkspaceInfoV2Fields {
+            WorkspaceInfoEnrichedFields {
                 active_pane_summary: "vim".into(),
                 takeover_eligible: true,
                 disabled_reason: String::new(),
@@ -732,10 +732,10 @@ mod tests {
     // ── Integration: unsupported capability error ──
 
     #[test]
-    fn unsupported_capability_error_for_inventory_v2() {
+    fn unsupported_capability_error_for_inventory_enriched() {
         let err = crate::v3_error::build_error(
             v3::ErrorKind::UnsupportedCapability,
-            "OPT_RUNTIME_INVENTORY_V2 not negotiated",
+            "OPT_WORKSPACE_INVENTORY not negotiated",
             "ListWorkspaces",
         );
         let env = crate::v3_error::build_error_response(42, err);
@@ -752,7 +752,7 @@ mod tests {
     // ── Integration: full list flow with multiple workspaces ──
 
     #[test]
-    fn full_list_flow_with_v2_fields() {
+    fn full_list_flow_with_enriched_fields() {
         let id_gen = RequestIdGenerator::new();
 
         let req_env = build_list_workspaces_envelope(&id_gen);
@@ -764,7 +764,7 @@ mod tests {
         let panes = vec![pane1, pane2];
         let summary = build_active_pane_summary(&panes);
 
-        let info = build_workspace_info_v2(
+        let info = build_workspace_info_enriched(
             WorkspaceInfoParams {
                 id: rt(),
                 name: "dev-workspace".into(),
@@ -776,7 +776,7 @@ mod tests {
                 workspace_revision: 42,
                 reconstructed: false,
             },
-            WorkspaceInfoV2Fields {
+            WorkspaceInfoEnrichedFields {
                 active_pane_summary: summary,
                 takeover_eligible: false,
                 disabled_reason: String::new(),
@@ -799,7 +799,7 @@ mod tests {
     }
 
     #[test]
-    fn full_list_flow_without_v2_fields() {
+    fn full_list_flow_without_enriched_fields() {
         let id_gen = RequestIdGenerator::new();
         let caps = vec![v3::Capability::CoreWorkspaceLifecycle as i32];
 
@@ -807,7 +807,7 @@ mod tests {
         let saved_request_id = req_env.request_id;
 
         let pane = test_pane("bash", "/home", None);
-        let mut info = build_workspace_info_v2(
+        let mut info = build_workspace_info_enriched(
             WorkspaceInfoParams {
                 id: rt(),
                 name: "ws".into(),
@@ -819,7 +819,7 @@ mod tests {
                 workspace_revision: 1,
                 reconstructed: false,
             },
-            WorkspaceInfoV2Fields {
+            WorkspaceInfoEnrichedFields {
                 active_pane_summary: "bash".into(),
                 takeover_eligible: true,
                 disabled_reason: String::new(),
@@ -828,7 +828,7 @@ mod tests {
         );
 
         if !is_supported(&caps) {
-            strip_inventory_v2_fields(&mut info);
+            strip_enriched_inventory_fields(&mut info);
         }
 
         let list = build_workspace_list(vec![info]);

--- a/services/rttx-server/src/protocol.rs
+++ b/services/rttx-server/src/protocol.rs
@@ -230,14 +230,14 @@ pub fn build_v3_workspace_snapshot(
 pub fn v3_workspace_inventory_for<'a, I>(
     client_id: Uuid,
     workspaces: I,
-    has_inventory_v2: bool,
+    has_enriched_inventory: bool,
 ) -> Vec<v3::WorkspaceInfo>
 where
     I: IntoIterator<Item = &'a Workspace>,
 {
     let mut inventory: Vec<_> = workspaces
         .into_iter()
-        .map(|rt| v3_workspace_info_for(client_id, rt, has_inventory_v2))
+        .map(|rt| v3_workspace_info_for(client_id, rt, has_enriched_inventory))
         .collect();
     inventory.sort_by(|left, right| left.id.cmp(&right.id));
     inventory
@@ -251,7 +251,7 @@ where
 pub fn v3_workspace_info_for(
     client_id: Uuid,
     rt: &Workspace,
-    has_inventory_v2: bool,
+    has_enriched_inventory: bool,
 ) -> v3::WorkspaceInfo {
     let policy = match rt.policy {
         crate::workspace::WorkspacePolicy::Persistent => v3::WorkspacePolicy::Persistent,
@@ -273,7 +273,7 @@ pub fn v3_workspace_info_for(
         reconstructed: rt.reconstructed,
     };
 
-    if has_inventory_v2 {
+    if has_enriched_inventory {
         let mut panes: Vec<_> = rt
             .panes
             .values()
@@ -293,9 +293,9 @@ pub fn v3_workspace_info_for(
             })
             .collect();
         panes.sort_by(|left, right| left.id.cmp(&right.id));
-        rttx_proto::v3_inventory::build_workspace_info_v2(
+        rttx_proto::v3_inventory::build_workspace_info_enriched(
             params,
-            rttx_proto::v3_inventory::WorkspaceInfoV2Fields {
+            rttx_proto::v3_inventory::WorkspaceInfoEnrichedFields {
                 active_pane_summary: String::new(),
                 takeover_eligible: !rt.has_write_owner(),
                 disabled_reason: String::new(),

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -637,11 +637,15 @@ impl Server {
 
             v3::client_envelope::Command::ListWorkspaces(_) => {
                 let s = crate::instrument::lock_server(server, metrics).await;
-                let has_inventory_v2 = rttx_proto::v3_inventory::is_supported(effective_caps);
+                let has_enriched_inventory = rttx_proto::v3_inventory::is_supported(effective_caps);
                 let mut infos = Vec::with_capacity(s.workspaces.len());
                 for rt_lock in s.workspaces.values() {
                     let rt = crate::instrument::lock_workspace(rt_lock, metrics).await;
-                    infos.push(protocol::v3_workspace_info_for(client_id, &rt, has_inventory_v2));
+                    infos.push(protocol::v3_workspace_info_for(
+                        client_id,
+                        &rt,
+                        has_enriched_inventory,
+                    ));
                 }
                 drop(s);
                 infos.sort_by(|a, b| a.id.cmp(&b.id));
@@ -1006,7 +1010,7 @@ pub const SERVER_CAPABILITIES: &[v3::Capability] = &[
     v3::Capability::CoreTerminalModes,
     v3::Capability::CorePasteIntent,
     v3::Capability::CoreFocusEvents,
-    v3::Capability::OptWorkspaceInventoryV2,
+    v3::Capability::OptWorkspaceInventory,
     v3::Capability::OptResync,
     v3::Capability::OptChunkedScrollback,
     v3::Capability::OptDiagnostics,

--- a/services/rttx-server/tests/common/mod.rs
+++ b/services/rttx-server/tests/common/mod.rs
@@ -97,7 +97,7 @@ impl TestClient {
             v3::Capability::CoreTerminalModes,
             v3::Capability::CorePasteIntent,
             v3::Capability::CoreFocusEvents,
-            v3::Capability::OptWorkspaceInventoryV2,
+            v3::Capability::OptWorkspaceInventory,
             v3::Capability::OptResync,
             v3::Capability::OptChunkedScrollback,
             v3::Capability::OptDiagnostics,

--- a/services/rttx-server/tests/v3_inventory.rs
+++ b/services/rttx-server/tests/v3_inventory.rs
@@ -1,6 +1,6 @@
 //! Integration tests for v3 `OPT_WORKSPACE_INVENTORY` protocol builders.
 //!
-//! Validates the end-to-end flow: build inventory with V2 fields, gate on
+//! Validates the end-to-end flow: build inventory with enriched fields, gate on
 //! capability, strip when absent, and verify wire roundtrip through envelopes.
 
 use rttx_proto::v3;
@@ -172,4 +172,42 @@ fn v3_inventory_disabled_workspace_visible_with_explanation() {
     assert!(!info.takeover_eligible);
     assert_eq!(info.active_pane_summary, "vim");
     assert_eq!(info.panes.len(), 1);
+}
+
+/// Wire-compatibility guard for the capability rename (V2 dropped from the
+/// symbol): the negotiated capability value must remain 100, and the renamed
+/// enriched builder/strip API must round-trip through the crate boundary.
+#[test]
+fn enriched_inventory_capability_is_wire_stable_after_rename() {
+    assert_eq!(
+        v3::Capability::OptWorkspaceInventory as i32,
+        100,
+        "the renamed capability must keep its wire value"
+    );
+
+    let mut info = v3_inventory::build_workspace_info_enriched(
+        WorkspaceInfoParams {
+            id: rt(),
+            name: "ws".into(),
+            policy: v3::WorkspacePolicy::Persistent,
+            pane_count: 1,
+            has_write_owner: true,
+            read_only_client_count: 0,
+            current_client_role: v3::WorkspaceClientRole::Writer,
+            workspace_revision: 1,
+            reconstructed: false,
+        },
+        WorkspaceInfoEnrichedFields {
+            active_pane_summary: "bash".into(),
+            takeover_eligible: true,
+            disabled_reason: String::new(),
+            panes: vec![],
+        },
+    );
+    assert_eq!(info.active_pane_summary, "bash");
+
+    // Stripping when the capability is absent clears the enriched fields.
+    v3_inventory::strip_enriched_inventory_fields(&mut info);
+    assert!(info.active_pane_summary.is_empty());
+    assert!(!info.takeover_eligible);
 }

--- a/services/rttx-server/tests/v3_inventory.rs
+++ b/services/rttx-server/tests/v3_inventory.rs
@@ -1,11 +1,13 @@
-//! Integration tests for v3 `OPT_RUNTIME_INVENTORY_V2` protocol builders.
+//! Integration tests for v3 `OPT_WORKSPACE_INVENTORY` protocol builders.
 //!
 //! Validates the end-to-end flow: build inventory with V2 fields, gate on
 //! capability, strip when absent, and verify wire roundtrip through envelopes.
 
 use rttx_proto::v3;
 use rttx_proto::v3_envelope::RequestIdGenerator;
-use rttx_proto::v3_inventory::{self, PaneInfoParams, WorkspaceInfoParams, WorkspaceInfoV2Fields};
+use rttx_proto::v3_inventory::{
+    self, PaneInfoParams, WorkspaceInfoEnrichedFields, WorkspaceInfoParams,
+};
 use rttx_proto::{decode_frame, encode_frame};
 
 fn rt() -> uuid::Uuid {
@@ -30,7 +32,7 @@ fn test_pane(title: &str, cwd: &str, exit_status: Option<i32>) -> v3::PaneInfo {
 }
 
 #[test]
-fn v3_inventory_list_roundtrip_with_v2_fields() {
+fn v3_inventory_list_roundtrip_with_enriched_fields() {
     let id_gen = RequestIdGenerator::new();
 
     // Client sends ListWorkspaces request
@@ -49,7 +51,7 @@ fn v3_inventory_list_roundtrip_with_v2_fields() {
     let summary = v3_inventory::build_active_pane_summary(&panes);
     assert_eq!(summary, "bash, vim");
 
-    let info = v3_inventory::build_workspace_info_v2(
+    let info = v3_inventory::build_workspace_info_enriched(
         WorkspaceInfoParams {
             id: rt(),
             name: "integration-test".into(),
@@ -61,7 +63,7 @@ fn v3_inventory_list_roundtrip_with_v2_fields() {
             workspace_revision: 42,
             reconstructed: false,
         },
-        WorkspaceInfoV2Fields {
+        WorkspaceInfoEnrichedFields {
             active_pane_summary: summary,
             takeover_eligible: false,
             disabled_reason: String::new(),
@@ -89,15 +91,15 @@ fn v3_inventory_list_roundtrip_with_v2_fields() {
 }
 
 #[test]
-fn v3_inventory_capability_gating_strips_v2_fields_end_to_end() {
-    let caps_without_v2 = vec![
+fn v3_inventory_capability_gating_strips_enriched_fields_end_to_end() {
+    let caps_without_enriched = vec![
         v3::Capability::CoreWorkspaceLifecycle as i32,
         v3::Capability::CorePaneLifecycle as i32,
     ];
-    assert!(!v3_inventory::is_supported(&caps_without_v2));
+    assert!(!v3_inventory::is_supported(&caps_without_enriched));
 
     let pane = test_pane("bash", "/home", None);
-    let mut info = v3_inventory::build_workspace_info_v2(
+    let mut info = v3_inventory::build_workspace_info_enriched(
         WorkspaceInfoParams {
             id: rt(),
             name: "gated".into(),
@@ -109,7 +111,7 @@ fn v3_inventory_capability_gating_strips_v2_fields_end_to_end() {
             workspace_revision: 5,
             reconstructed: false,
         },
-        WorkspaceInfoV2Fields {
+        WorkspaceInfoEnrichedFields {
             active_pane_summary: "bash".into(),
             takeover_eligible: true,
             disabled_reason: String::new(),
@@ -117,7 +119,7 @@ fn v3_inventory_capability_gating_strips_v2_fields_end_to_end() {
         },
     );
 
-    v3_inventory::strip_inventory_v2_fields(&mut info);
+    v3_inventory::strip_enriched_inventory_fields(&mut info);
 
     // V2 fields cleared
     assert!(info.active_pane_summary.is_empty());
@@ -140,13 +142,13 @@ fn v3_inventory_capability_gating_strips_v2_fields_end_to_end() {
 
 #[test]
 fn v3_inventory_disabled_workspace_visible_with_explanation() {
-    let caps_with_v2 = vec![
+    let caps_with_enriched = vec![
         v3::Capability::CoreWorkspaceLifecycle as i32,
-        v3::Capability::OptWorkspaceInventoryV2 as i32,
+        v3::Capability::OptWorkspaceInventory as i32,
     ];
-    assert!(v3_inventory::is_supported(&caps_with_v2));
+    assert!(v3_inventory::is_supported(&caps_with_enriched));
 
-    let info = v3_inventory::build_workspace_info_v2(
+    let info = v3_inventory::build_workspace_info_enriched(
         WorkspaceInfoParams {
             id: rt(),
             name: "busy-workspace".into(),
@@ -158,7 +160,7 @@ fn v3_inventory_disabled_workspace_visible_with_explanation() {
             workspace_revision: 10,
             reconstructed: false,
         },
-        WorkspaceInfoV2Fields {
+        WorkspaceInfoEnrichedFields {
             active_pane_summary: "vim".into(),
             takeover_eligible: false,
             disabled_reason: "owned by another client".into(),

--- a/services/rttx-server/tests/v3_proto_integration.rs
+++ b/services/rttx-server/tests/v3_proto_integration.rs
@@ -1072,7 +1072,7 @@ fn core_only_caps() -> Vec<i32> {
 
 fn all_optional_caps() -> Vec<v3::Capability> {
     vec![
-        v3::Capability::OptWorkspaceInventoryV2,
+        v3::Capability::OptWorkspaceInventory,
         v3::Capability::OptWorkspaceTakeover,
         v3::Capability::OptResync,
         v3::Capability::OptChunkedScrollback,
@@ -1126,7 +1126,7 @@ fn v3_profile_core_plus_individual_optional() {
                 assert!(!v3_inventory::is_supported(&effective));
                 assert!(!v3_takeover::is_supported(&effective));
             }
-            v3::Capability::OptWorkspaceInventoryV2 => {
+            v3::Capability::OptWorkspaceInventory => {
                 assert!(!v3_resync::is_supported(&effective));
                 assert!(!v3_scrollback::is_supported(&effective));
                 assert!(!v3_diagnostics::is_supported(&effective));
@@ -1252,7 +1252,7 @@ fn v3_send_discipline_optional_server_payloads_gated() {
     // TakeoverCompleted/LeaseLost/OwnerDisconnected require OPT_RUNTIME_TAKEOVER
     assert!(!v3_takeover::is_supported(&core_caps));
 
-    // WorkspaceList v2 fields require OPT_RUNTIME_INVENTORY_V2
+    // WorkspaceList enriched fields require OPT_WORKSPACE_INVENTORY
     assert!(!v3_inventory::is_supported(&core_caps));
 }
 
@@ -1547,9 +1547,9 @@ fn v3_wire_compat_unknown_oneof_variant_in_server_envelope() {
 }
 
 #[test]
-fn v3_wire_compat_workspace_info_without_v2_fields() {
-    // A WorkspaceInfo from a server without OPT_RUNTIME_INVENTORY_V2 has
-    // empty v2 fields (default values).
+fn v3_wire_compat_workspace_info_without_enriched_fields() {
+    // A WorkspaceInfo from a server without OPT_WORKSPACE_INVENTORY has
+    // empty enriched fields (default values).
     let info = v3::WorkspaceInfo {
         id: uuid_to_bytes(uuid::Uuid::new_v4()),
         name: "test".into(),
@@ -1560,7 +1560,7 @@ fn v3_wire_compat_workspace_info_without_v2_fields() {
         current_client_role: v3::WorkspaceClientRole::Writer as i32,
         workspace_revision: 5,
         reconstructed: false,
-        // v2 fields left at defaults
+        // enriched fields left at defaults
         active_pane_summary: String::new(),
         takeover_eligible: false,
         disabled_reason: String::new(),
@@ -1888,7 +1888,7 @@ fn v3_core_focus_events_end_to_end() {
 // ── Optional capability absent fallback paths ──
 
 #[test]
-fn v3_opt_inventory_v2_absent_strips_extended_fields() {
+fn v3_opt_enriched_inventory_absent_strips_extended_fields() {
     let effective = core_only_caps();
     assert!(!v3_inventory::is_supported(&effective));
 


### PR DESCRIPTION
## What
Wire-compatible rename of the workspace inventory capability and its builders — the enum value stays **100**, so no protocol break:
- `OPT_WORKSPACE_INVENTORY_V2` / leftover `OPT_RUNTIME_INVENTORY_V2` → `OPT_WORKSPACE_INVENTORY`
- `Capability::OptWorkspaceInventoryV2` → `OptWorkspaceInventory`
- `WorkspaceInfoV2Fields` → `WorkspaceInfoEnrichedFields`
- `build_workspace_info_v2` → `build_workspace_info_enriched`
- `strip_inventory_v2_fields` → `strip_enriched_inventory_fields`

## Why
There is no V1 inventory to contrast — the 'V2' was a historical artifact, and some code still used the pre-rename 'RUNTIME' name. Naming clarity for v1; no behavior change.

## Tested
proto v3_inventory (35), server v3_inventory (4, incl. a new wire-stability guard asserting the capability value is still 100 and the renamed build/strip API round-trips), v3_proto_integration (68), inventory (4); server+proto+client clippy `-D warnings` clean; runtime-behavior gate passes. Version 0.9.14 → 0.9.15.

Fixes #1031