### PR TITLE
fix(release): Fix first-run failures in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,17 @@ jobs:
         run: cargo install cargo-deb
 
       - name: Build release binaries
-        run: cargo build --release -p rttx -p rttx-server
+        run: |
+          # vte4-sys requires vte >= 0.78 by default; fall back to the vte-0_76
+          # feature when the runner ships an older vte (mirrors the quality CI).
+          vte_version=$(pkg-config --modversion vte-2.91-gtk4 2>/dev/null || echo "0.78")
+          if printf '%s\n' "0.78" "${vte_version}" | sort -V | head -n1 | grep -q "^0\.78"; then
+            client_features=()
+          else
+            client_features=(--no-default-features --features vte-0_76)
+          fi
+          cargo build --release -p rttx-server
+          cargo build --release -p rttx "${client_features[@]}"
 
       - name: Strip binaries
         run: strip target/release/rttx target/release/rttx-server
@@ -134,7 +144,17 @@ jobs:
         run: cargo install cargo-generate-rpm
 
       - name: Build release binaries
-        run: cargo build --release -p rttx -p rttx-server
+        run: |
+          # vte4-sys requires vte >= 0.78 by default; fall back to the vte-0_76
+          # feature when the runner ships an older vte (mirrors the quality CI).
+          vte_version=$(pkg-config --modversion vte-2.91-gtk4 2>/dev/null || echo "0.78")
+          if printf '%s\n' "0.78" "${vte_version}" | sort -V | head -n1 | grep -q "^0\.78"; then
+            client_features=()
+          else
+            client_features=(--no-default-features --features vte-0_76)
+          fi
+          cargo build --release -p rttx-server
+          cargo build --release -p rttx "${client_features[@]}"
 
       - name: Strip binaries
         run: strip target/release/rttx target/release/rttx-server

--- a/packaging/rttx/flatpak/build-bundle.sh
+++ b/packaging/rttx/flatpak/build-bundle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "${repo_root}"
 
 rm -rf b repo rttx.flatpak


### PR DESCRIPTION
The v1.0.0 tag triggered the release pipeline for the first time and surfaced three latent bugs (all builds failed; nothing was published — `github-release`/COPR were skipped):

- **Flatpak**: `build-bundle.sh` resolved `repo_root` with `../..` but is three levels deep, so the manifest path doubled (`packaging/packaging/...`). Fixed to `../../..`.
- **DEB & RPM**: ran a plain `cargo build --release` without the `vte-0_76` feature → failed on the runners' vte 0.76. Now detect the vte version and use `--no-default-features --features vte-0_76` for the client (matching the quality CI), building the server separately.

Verified locally that both release build commands succeed with vte 0.76. Release-tooling only; no code/test changes.

After merge, the `v1.0.0` tag will be re-pointed to the fixed commit to re-run the release (the original tag published nothing).