### PR TITLE
fix(release): Install flatpak vte into lib so meson finds it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+**/target/
 /build
 /build-local
 /build_test

--- a/packaging/rttx/io.github.IllyaYalovyy.rttx.json
+++ b/packaging/rttx/io.github.IllyaYalovyy.rttx.json
@@ -3,7 +3,9 @@
     "runtime": "org.gnome.Platform",
     "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
-    "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
     "command": "rttx",
     "finish-args": [
         "--share=ipc",
@@ -28,7 +30,8 @@
                 "-Ddocs=false",
                 "-Dgir=false",
                 "-Dglade=false",
-                "-Dvapi=false"
+                "-Dvapi=false",
+                "-Dlibdir=lib"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Fourth first-run release fix. The re-tagged run got **DEB ✓, RPM ✓, COPR ✓** (skips cleanly with no secrets), and flatpak now resolves sources and runs meson — but fails at:

```
meson.build:28: ERROR: Dependency "vte-2.91-gtk4" not found
```

The bundled `vte` module installs `vte-2.91-gtk4.pc` into `/app/lib64/pkgconfig`, but rttx's meson looks in `/app/lib/pkgconfig`. Pass `-Dlibdir=lib` to the vte module so it installs where meson looks.

Also re-adds the `**/target/` gitignore rule that #1041 intended but dropped (never staged).

After merge, `v1.0.0` will be re-pointed here to re-run.