### PR TITLE
fix(release): Allow network in flatpak build for appstream screenshots

### DIFF
--- a/packaging/rttx/io.github.IllyaYalovyy.rttx.json
+++ b/packaging/rttx/io.github.IllyaYalovyy.rttx.json
@@ -19,7 +19,10 @@
         "env": {
             "CARGO_HOME": "/run/build/rttx/cargo",
             "PROTOC": "/app/bin/protoc"
-        }
+        },
+        "build-args": [
+            "--share=network"
+        ]
     },
     "modules": [
         {


### PR DESCRIPTION
Sixth (and expected final) first-run flatpak fix. With protoc, the flatpak now **fully builds and installs** rttx (binary → /app/bin, plus desktop/metainfo/icons/man). The only remaining failure is flatpak-builder's last step:

```
Running appstreamcli compose
  E: file-read-error
Error: appstreamcli compose failed
```

appstream compose fetches the remote screenshot from the metainfo, but the build sandbox has no network (the screenshot file exists and its URL returns 200). Add `--share=network` to `build-options` so compose can download it.

Note: Flathub disallows build-time network, so a future Flathub submission would rely on Flathub's screenshot mirroring instead — this only affects our self-built .flatpak bundle.