### PR TITLE
fix(release): Make flatpak appstream compose succeed offline

### DIFF
--- a/packaging/rttx/io.github.IllyaYalovyy.rttx.json
+++ b/packaging/rttx/io.github.IllyaYalovyy.rttx.json
@@ -19,10 +19,7 @@
         "env": {
             "CARGO_HOME": "/run/build/rttx/cargo",
             "PROTOC": "/app/bin/protoc"
-        },
-        "build-args": [
-            "--share=network"
-        ]
+        }
     },
     "modules": [
         {
@@ -71,6 +68,9 @@
                     "type": "dir",
                     "path": "../../"
                 }
+            ],
+            "post-install": [
+                "sed -i '/<screenshots>/,/<\\/screenshots>/d' /app/share/metainfo/io.github.IllyaYalovyy.rttx.metainfo.xml"
             ]
         }
     ]


### PR DESCRIPTION
Seventh first-run flatpak fix (this is the last build step). The flatpak now **fully builds and installs** rttx; the only failure is flatpak-builder's final `appstreamcli compose`, which runs in a network-less sandbox (`flatpak build --nofilesystem=host`) and can't fetch the remote screenshot → `file-read-error` (confirmed why `--share=network` had no effect — it doesn't reach that step).

- Strip `<screenshots>` from the flatpak's **installed** metainfo via a `post-install` step so the offline compose has nothing remote to fetch. Verified the exact command strips screenshots while keeping releases and valid XML.
- The **source** metainfo keeps its screenshot, so deb/rpm and a future Flathub submission (Flathub provides network + screenshot mirroring) are unaffected.
- Drop the ineffective `--share=network` build-arg (would block Flathub).