### PR TITLE
fix(release): Drop metainfo screenshot to unblock flatpak appstream compose

### DIFF
--- a/clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml
+++ b/clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml
@@ -22,12 +22,6 @@
   <url type="bugtracker">https://github.com/IllyaYalovyy/rttx/issues</url>
   <url type="vcs-browser">https://github.com/IllyaYalovyy/rttx</url>
   <content_rating type="oars-1.1"/>
-  <screenshots>
-    <screenshot type="default">
-      <caption>rttx with split panes and workspace sidebar</caption>
-      <image>https://raw.githubusercontent.com/IllyaYalovyy/rttx/mainline/clients/rttx/data/screenshots/rttx-main.png</image>
-    </screenshot>
-  </screenshots>
   <releases>
     <release version="1.0.0" date="2026-06-29">
       <description>

--- a/packaging/rttx/io.github.IllyaYalovyy.rttx.json
+++ b/packaging/rttx/io.github.IllyaYalovyy.rttx.json
@@ -68,9 +68,6 @@
                     "type": "dir",
                     "path": "../../"
                 }
-            ],
-            "post-install": [
-                "sed -i '/<screenshots>/,/<\\/screenshots>/d' /app/share/metainfo/io.github.IllyaYalovyy.rttx.metainfo.xml"
             ]
         }
     ]


### PR DESCRIPTION
The post-install strip in #1045 didn't run (flatpak-builder's command wrapping), so appstream compose still fails on the offline screenshot fetch. Remove the `<screenshots>` element outright — the reliable, verified fix (appstreamcli validate still passes, pedantic: 1).

The app itself has built and installed cleanly for two runs now; this is the last compose blocker. **DEB ✓ RPM ✓ COPR ✓** already succeed.

Follow-up (documented in commit): re-add screenshots when wiring Flathub — Flathub's builders provide network + screenshot mirroring, so remote screenshots compose correctly there.