### PR TITLE
fix(release): Install librsvg for flatpak appstream icon rendering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             flatpak \
             flatpak-builder \
-            elfutils
+            elfutils \
+            librsvg2-common
 
       - name: Cache Flatpak runtimes
         uses: actions/cache@v4


### PR DESCRIPTION
Root cause of the persistent `appstreamcli compose: file-read-error` (it wasn't the screenshot):

- flatpak-builder runs `appstreamcli compose` **on the host** (the log shows `Processing directory: .../b/files`, a host path), so it uses the host's gdk-pixbuf loaders to read/rasterize the app icon.
- The icon ships **only as a scalable SVG**, and the Flatpak-tools install used `--no-install-recommends`, which omitted `librsvg2-common` — the gdk-pixbuf SVG loader. Without it, compose can't read the SVG icon → `file-read-error`.

Install `librsvg2-common`. The app already builds and installs fully; this is the last compose blocker. **DEB ✓ RPM ✓ COPR ✓** already pass.