### PR TITLE
fix(release): Restore metainfo screenshot

### DIFF
--- a/clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml
+++ b/clients/rttx/data/io.github.IllyaYalovyy.rttx.metainfo.xml
@@ -21,6 +21,12 @@
   <url type="homepage">https://github.com/IllyaYalovyy/rttx</url>
   <url type="bugtracker">https://github.com/IllyaYalovyy/rttx/issues</url>
   <url type="vcs-browser">https://github.com/IllyaYalovyy/rttx</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>rttx with split panes and workspace sidebar</caption>
+      <image>https://raw.githubusercontent.com/IllyaYalovyy/rttx/mainline/clients/rttx/data/screenshots/rttx-main.png</image>
+    </screenshot>
+  </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
     <release version="1.0.0" date="2026-06-29">


### PR DESCRIPTION
Undo the screenshot removal from #1046. That removal was based on a wrong hypothesis — the real cause of the appstream compose `file-read-error` was the missing `librsvg2-common` on the host (fixed in #1047), not the screenshot. Since appstream compose runs on the host (which has network), the remote screenshot resolves fine.

After merge, `v1.0.0` will be re-tagged to re-publish a clean release that includes the screenshot, which also verifies the flatpak composes with both the screenshot and the librsvg fix.