### PR TITLE
refactor(client): Delete legacy pane-binding machinery (RFC-031)

### DIFF
--- a/clients/rttx/src/runtime.rs
+++ b/clients/rttx/src/runtime.rs
@@ -1,7 +1,6 @@
 use crate::daemon::DaemonError;
 use rttx_proto::v3;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
 
 /// Retention policy for a managed workspace runtime.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -105,89 +104,29 @@ pub struct WorkspaceRuntime {
     /// Live daemon runtime ID, if known.
     #[serde(default)]
     pub runtime_id: Option<String>,
-    /// Stable layout-terminal UUID -> runtime-pane UUID bindings.
-    #[serde(default)]
-    pub pane_bindings: BTreeMap<String, String>,
-    /// Layout panes that still need a daemon pane assignment.
-    #[serde(default)]
-    pub pending_layout_panes: BTreeSet<String>,
 }
 
 impl WorkspaceRuntime {
     /// Create managed local runtime metadata for a new workspace.
     #[must_use]
-    pub fn managed_local(policy: WorkspacePolicy, layout_terminal_uuids: &[String]) -> Self {
-        Self::managed(RuntimeEndpoint::Local, policy, layout_terminal_uuids)
+    pub const fn managed_local(policy: WorkspacePolicy) -> Self {
+        Self::managed(RuntimeEndpoint::Local, policy)
     }
 
     /// Create managed remote runtime metadata for a new workspace.
     #[must_use]
-    pub fn managed_remote(
-        host: &str,
-        policy: WorkspacePolicy,
-        layout_terminal_uuids: &[String],
-    ) -> Self {
-        Self::managed(RuntimeEndpoint::remote(host), policy, layout_terminal_uuids)
+    pub fn managed_remote(host: &str, policy: WorkspacePolicy) -> Self {
+        Self::managed(RuntimeEndpoint::remote(host), policy)
     }
 
-    fn managed(
-        endpoint: RuntimeEndpoint,
-        policy: WorkspacePolicy,
-        layout_terminal_uuids: &[String],
-    ) -> Self {
-        let mut runtime = Self {
-            managed: true,
-            endpoint,
-            policy,
-            runtime_id: None,
-            pane_bindings: BTreeMap::new(),
-            pending_layout_panes: BTreeSet::new(),
-        };
-        runtime.ensure_placeholder_bindings(layout_terminal_uuids);
-        runtime
+    const fn managed(endpoint: RuntimeEndpoint, policy: WorkspacePolicy) -> Self {
+        Self { managed: true, endpoint, policy, runtime_id: None }
     }
 
     /// True when this workspace should use the daemon-backed terminal path.
     #[must_use]
     pub const fn is_managed(&self) -> bool {
         self.managed
-    }
-
-    /// Ensure every layout terminal has at least a self-binding placeholder.
-    pub fn ensure_placeholder_bindings(&mut self, layout_terminal_uuids: &[String]) {
-        for terminal_uuid in layout_terminal_uuids {
-            if !self.pane_bindings.contains_key(terminal_uuid) {
-                self.pane_bindings.insert(terminal_uuid.clone(), terminal_uuid.clone());
-                self.pending_layout_panes.insert(terminal_uuid.clone());
-            }
-        }
-        self.pane_bindings.retain(|layout_uuid, _| layout_terminal_uuids.contains(layout_uuid));
-        self.pending_layout_panes.retain(|layout_uuid| layout_terminal_uuids.contains(layout_uuid));
-    }
-
-    /// Replace a layout terminal UUID while preserving runtime bindings.
-    pub fn replace_layout_terminal_uuid(&mut self, old_uuid: &str, new_uuid: &str) {
-        if old_uuid == new_uuid {
-            return;
-        }
-        if let Some(bound_runtime_uuid) = self.pane_bindings.remove(old_uuid) {
-            self.pane_bindings.insert(new_uuid.to_string(), bound_runtime_uuid);
-        }
-        if self.pending_layout_panes.remove(old_uuid) {
-            self.pending_layout_panes.insert(new_uuid.to_string());
-        }
-    }
-
-    /// Bind a layout pane to a runtime pane.
-    pub fn bind_runtime_pane(&mut self, layout_uuid: &str, runtime_pane_uuid: &str) {
-        self.pane_bindings.insert(layout_uuid.to_string(), runtime_pane_uuid.to_string());
-        self.pending_layout_panes.remove(layout_uuid);
-    }
-
-    /// Whether the layout pane is still waiting for a daemon pane assignment.
-    #[must_use]
-    pub fn is_layout_pane_pending(&self, layout_uuid: &str) -> bool {
-        self.pending_layout_panes.contains(layout_uuid)
     }
 }
 
@@ -583,110 +522,17 @@ fn is_generic_title(title: &str) -> bool {
         || lower == "fish"
 }
 
-/// Deterministic, non-destructive binding reconciliation result.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BindingReconciliation {
-    /// Valid layout -> runtime bindings after reconciliation.
-    pub bindings: BTreeMap<String, String>,
-    /// Workspace panes that still need recovered GUI panes.
-    pub recovered_runtime_panes: Vec<String>,
-    /// Layout panes that have no live runtime pane.
-    pub disconnected_layout_panes: Vec<String>,
-}
-
-/// Reconcile persisted bindings against the live runtime pane inventory.
-///
-/// This never infers bindings by position alone. If a binding is missing,
-/// only an exact same-ID match is accepted automatically.
-#[must_use]
-pub fn reconcile_bindings(
-    layout_terminal_uuids: &[String],
-    persisted_bindings: &BTreeMap<String, String>,
-    runtime_pane_uuids: &[String],
-) -> BindingReconciliation {
-    let layout_set: BTreeSet<_> = layout_terminal_uuids.iter().cloned().collect();
-    let runtime_set: BTreeSet<_> = runtime_pane_uuids.iter().cloned().collect();
-    let mut bindings = BTreeMap::new();
-    let mut claimed_runtime_panes = BTreeSet::new();
-
-    for layout_uuid in layout_terminal_uuids {
-        if let Some(runtime_uuid) = persisted_bindings.get(layout_uuid)
-            && runtime_set.contains(runtime_uuid)
-            && claimed_runtime_panes.insert(runtime_uuid.clone())
-        {
-            bindings.insert(layout_uuid.clone(), runtime_uuid.clone());
-            continue;
-        }
-
-        if runtime_set.contains(layout_uuid) && claimed_runtime_panes.insert(layout_uuid.clone()) {
-            bindings.insert(layout_uuid.clone(), layout_uuid.clone());
-        }
-    }
-
-    let recovered_runtime_panes =
-        runtime_set.difference(&claimed_runtime_panes).cloned().collect::<Vec<_>>();
-    let disconnected_layout_panes =
-        layout_set.difference(&bindings.keys().cloned().collect()).cloned().collect::<Vec<_>>();
-
-    BindingReconciliation { bindings, recovered_runtime_panes, disconnected_layout_panes }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn managed_runtime_initializes_placeholder_bindings() {
-        let runtime = WorkspaceRuntime::managed_local(
-            WorkspacePolicy::Ephemeral,
-            &["pane-a".into(), "pane-b".into()],
-        );
+    fn managed_runtime_sets_managed_flag_and_policy() {
+        let runtime = WorkspaceRuntime::managed_local(WorkspacePolicy::Ephemeral);
 
         assert!(runtime.is_managed());
         assert_eq!(runtime.policy, WorkspacePolicy::Ephemeral);
-        assert_eq!(runtime.pane_bindings["pane-a"], "pane-a");
-        assert_eq!(runtime.pane_bindings["pane-b"], "pane-b");
-        assert!(runtime.is_layout_pane_pending("pane-a"));
-        assert!(runtime.is_layout_pane_pending("pane-b"));
-    }
-
-    #[test]
-    fn replacing_layout_terminal_uuid_preserves_binding() {
-        let mut runtime =
-            WorkspaceRuntime::managed_local(WorkspacePolicy::Persistent, &["old".into()]);
-        runtime.bind_runtime_pane("old", "daemon-pane");
-
-        runtime.replace_layout_terminal_uuid("old", "new");
-
-        assert_eq!(runtime.pane_bindings.get("old"), None);
-        assert_eq!(runtime.pane_bindings.get("new").map(String::as_str), Some("daemon-pane"));
-        assert!(!runtime.is_layout_pane_pending("new"));
-    }
-
-    #[test]
-    fn reconciliation_keeps_explicit_bindings_and_marks_missing_objects() {
-        let layout = vec!["left".into(), "right".into()];
-        let bindings = BTreeMap::from([
-            ("left".into(), "pane-1".into()),
-            ("right".into(), "missing-pane".into()),
-        ]);
-        let runtime_panes = vec!["pane-1".into(), "pane-2".into()];
-
-        let reconciled = reconcile_bindings(&layout, &bindings, &runtime_panes);
-
-        assert_eq!(reconciled.bindings.len(), 1);
-        assert_eq!(reconciled.bindings["left"], "pane-1");
-        assert_eq!(reconciled.recovered_runtime_panes, vec!["pane-2"]);
-        assert_eq!(reconciled.disconnected_layout_panes, vec!["right"]);
-    }
-
-    #[test]
-    fn reconciliation_accepts_same_id_match_without_position_inference() {
-        let layout = vec!["pane-a".into()];
-        let reconciled = reconcile_bindings(&layout, &BTreeMap::new(), &["pane-a".into()]);
-        assert_eq!(reconciled.bindings["pane-a"], "pane-a");
-        assert!(reconciled.recovered_runtime_panes.is_empty());
-        assert!(reconciled.disconnected_layout_panes.is_empty());
+        assert_eq!(runtime.runtime_id, None);
     }
 
     #[test]
@@ -1092,63 +938,11 @@ mod tests {
 
     #[test]
     fn managed_remote_sets_endpoint_and_policy() {
-        let uuids = vec!["t1".into()];
-        let runtime = WorkspaceRuntime::managed_remote(
-            "server.example.com",
-            WorkspacePolicy::Persistent,
-            &uuids,
-        );
+        let runtime =
+            WorkspaceRuntime::managed_remote("server.example.com", WorkspacePolicy::Persistent);
         assert!(runtime.is_managed());
         assert_eq!(runtime.endpoint, RuntimeEndpoint::remote("server.example.com"));
         assert_eq!(runtime.policy, WorkspacePolicy::Persistent);
-        assert!(runtime.pending_layout_panes.contains("t1"));
-    }
-
-    #[test]
-    fn ensure_placeholder_bindings_adds_new_pane_to_remote_runtime() {
-        let mut runtime =
-            WorkspaceRuntime::managed_remote("host", WorkspacePolicy::Persistent, &["t1".into()]);
-
-        runtime.ensure_placeholder_bindings(&["t1".into(), "t2".into()]);
-
-        assert!(runtime.pane_bindings.contains_key("t2"));
-        assert!(runtime.pending_layout_panes.contains("t2"));
-        assert_eq!(runtime.endpoint, RuntimeEndpoint::remote("host"));
-    }
-
-    #[test]
-    fn ensure_placeholder_bindings_removes_closed_pane() {
-        let mut runtime = WorkspaceRuntime::managed_remote(
-            "host",
-            WorkspacePolicy::Persistent,
-            &["t1".into(), "t2".into()],
-        );
-
-        runtime.ensure_placeholder_bindings(&["t1".into()]);
-
-        assert!(!runtime.pane_bindings.contains_key("t2"));
-        assert!(!runtime.pending_layout_panes.contains("t2"));
-        assert!(runtime.pane_bindings.contains_key("t1"));
-    }
-
-    // ── bind_runtime_pane / is_layout_pane_pending ──────────────
-
-    #[test]
-    fn bind_runtime_pane_clears_pending_and_sets_binding() {
-        let mut runtime =
-            WorkspaceRuntime::managed_local(WorkspacePolicy::Persistent, &["t1".into()]);
-        assert!(runtime.is_layout_pane_pending("t1"));
-
-        runtime.bind_runtime_pane("t1", "runtime-pane-abc");
-
-        assert!(!runtime.is_layout_pane_pending("t1"));
-        assert_eq!(runtime.pane_bindings.get("t1").unwrap(), "runtime-pane-abc");
-    }
-
-    #[test]
-    fn is_layout_pane_pending_false_for_unknown_uuid() {
-        let runtime = WorkspaceRuntime::managed_local(WorkspacePolicy::Persistent, &["t1".into()]);
-        assert!(!runtime.is_layout_pane_pending("unknown"));
     }
 
     // ── advance_connection_status ───────────────────────────────

--- a/clients/rttx/src/store/models/workspaces.rs
+++ b/clients/rttx/src/store/models/workspaces.rs
@@ -415,20 +415,15 @@ impl WorkspaceRecord {
         };
 
         let layout: crate::workspace::layout::LayoutNode = (&self.layout).into();
-        let layout_terminal_uuids = layout.terminal_uuids();
 
         let managed = self.endpoint_key != "local" || self.runtime_ref.is_some();
 
-        let mut runtime = WorkspaceRuntime {
+        let runtime = WorkspaceRuntime {
             managed,
             endpoint,
             policy: (&self.policy).into(),
             runtime_id: self.runtime_ref.as_ref().map(|r| r.runtime_id.clone()),
-            ..WorkspaceRuntime::default()
         };
-        if managed {
-            runtime.ensure_placeholder_bindings(&layout_terminal_uuids);
-        }
 
         let mut ws = state::WorkspaceState {
             uuid: self.id.clone(),

--- a/clients/rttx/src/terminal/widget.rs
+++ b/clients/rttx/src/terminal/widget.rs
@@ -342,6 +342,11 @@ impl TerminalWidget {
         self.imp().uuid.borrow().clone()
     }
 
+    /// Update the pane UUID used by the GTK-side session model.
+    pub fn set_uuid(&self, uuid: &str) {
+        self.imp().uuid.replace(uuid.to_string());
+    }
+
     #[must_use]
     pub fn vte(&self) -> &vte4::Terminal {
         &self.imp().vte

--- a/clients/rttx/src/test_helpers.rs
+++ b/clients/rttx/src/test_helpers.rs
@@ -108,7 +108,7 @@ pub fn managed_session_with_runtime(
         .map(|terminal_uuid| (terminal_uuid, PaneRecovery::empty_shell()))
         .collect();
     let active_terminal_uuid = terminal_uuids.first().cloned();
-    let mut session = WorkspaceState {
+    WorkspaceState {
         uuid: id.to_string(),
         name: name.to_string(),
         layout,
@@ -120,15 +120,11 @@ pub fn managed_session_with_runtime(
             endpoint,
             policy,
             runtime_id: runtime_id.map(str::to_string),
-            pane_bindings: std::collections::BTreeMap::default(),
-            pending_layout_panes: std::collections::BTreeSet::default(),
         },
         color: WorkspaceColor::default(),
         zoomed_terminal_uuid: None,
         user_renamed: false,
-    };
-    session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
-    session
+    }
 }
 
 /// Build a window state from workspaces.

--- a/clients/rttx/src/window/mod.rs
+++ b/clients/rttx/src/window/mod.rs
@@ -26,7 +26,7 @@ use crate::workspace::{
     self, Direction, LayoutNode, MAX_SPLIT_DEPTH, PaneRecovery, PaneSource, SplitOrientation,
     StartupStep, WindowState, WorkspaceColor, WorkspaceState,
 };
-use crate::workspace_state::{EndpointEventTransition, WorkspacePaneRestore};
+use crate::workspace_state::{EndpointEventTransition, PaneRekey, WorkspacePaneRestore};
 use std::collections::HashMap;
 use std::time::Duration;
 

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -350,7 +350,6 @@ impl Window {
         session_state: &WorkspaceState,
         pane_view: &PersistentPaneView,
     ) {
-        let terminal_uuid = pane_view.uuid();
         let status = self
             .imp()
             .workspace_connection_status
@@ -362,38 +361,40 @@ impl Window {
         pane_view.set_connection_presentation(&status, &presentation);
 
         let win = self.downgrade();
-        let input_terminal_uuid = terminal_uuid.clone();
+        let input_pane = pane_view.downgrade();
         pane_view.connect_input(move |bytes| {
-            if let Some(win) = win.upgrade() {
-                win.send_managed_terminal_input(&input_terminal_uuid, bytes);
+            if let (Some(win), Some(pane)) = (win.upgrade(), input_pane.upgrade()) {
+                win.send_managed_terminal_input(&pane.uuid(), bytes);
             }
         });
 
         let win = self.downgrade();
-        let resize_terminal_uuid = terminal_uuid.clone();
+        let resize_pane = pane_view.downgrade();
         pane_view.connect_resize(move |cols, rows| {
-            if let Some(win) = win.upgrade() {
-                win.send_managed_terminal_resize(&resize_terminal_uuid, cols, rows);
+            if let (Some(win), Some(pane)) = (win.upgrade(), resize_pane.upgrade()) {
+                win.send_managed_terminal_resize(&pane.uuid(), cols, rows);
             }
         });
 
         let drag_source = gtk4::DragSource::new();
         drag_source.set_actions(gtk4::gdk::DragAction::MOVE);
-        let drag_uuid = terminal_uuid.clone();
+        let drag_pane = pane_view.downgrade();
         drag_source.connect_prepare(move |_, _, _| {
-            Some(gtk4::gdk::ContentProvider::for_value(&drag_uuid.to_value()))
+            let pane = drag_pane.upgrade()?;
+            Some(gtk4::gdk::ContentProvider::for_value(&pane.uuid().to_value()))
         });
         pane_view.header().add_controller(drag_source);
 
         let drop_target = gtk4::DropTarget::new(glib::Type::STRING, gtk4::gdk::DragAction::MOVE);
         let win = self.downgrade();
-        let target_uuid = terminal_uuid.clone();
+        let drop_pane = pane_view.downgrade();
         drop_target.connect_drop(move |_, value, _, _| {
             if let Ok(source_uuid) = value.get::<String>()
-                && source_uuid != target_uuid
+                && let Some(pane) = drop_pane.upgrade()
+                && source_uuid != pane.uuid()
                 && let Some(win) = win.upgrade()
             {
-                win.swap_terminals(&source_uuid, &target_uuid);
+                win.swap_terminals(&source_uuid, &pane.uuid());
                 return true;
             }
             false
@@ -401,10 +402,13 @@ impl Window {
         pane_view.add_controller(drop_target);
 
         let win = self.downgrade();
-        let focus_uuid = terminal_uuid.clone();
+        let focus_pane = pane_view.downgrade();
         let focus_controller = gtk4::EventControllerFocus::new();
         focus_controller.connect_enter(move |_| {
-            let Some(win) = win.upgrade() else { return };
+            let (Some(win), Some(pane)) = (win.upgrade(), focus_pane.upgrade()) else {
+                return;
+            };
+            let focus_uuid = pane.uuid();
             win.set_focused_terminal(Some(&focus_uuid));
             let session_uuid = {
                 let mut state = win.imp().state.borrow_mut();
@@ -426,34 +430,34 @@ impl Window {
         pane_view.vte().add_controller(focus_controller);
 
         let win = self.downgrade();
-        let split_h_uuid = terminal_uuid.clone();
+        let split_h_pane = pane_view.downgrade();
         pane_view.split_h_button().connect_clicked(move |_| {
-            if let Some(win) = win.upgrade() {
-                win.split_terminal(&split_h_uuid, SplitOrientation::Horizontal);
+            if let (Some(win), Some(pane)) = (win.upgrade(), split_h_pane.upgrade()) {
+                win.split_terminal(&pane.uuid(), SplitOrientation::Horizontal);
             }
         });
 
         let win = self.downgrade();
-        let split_v_uuid = terminal_uuid.clone();
+        let split_v_pane = pane_view.downgrade();
         pane_view.split_v_button().connect_clicked(move |_| {
-            if let Some(win) = win.upgrade() {
-                win.split_terminal(&split_v_uuid, SplitOrientation::Vertical);
+            if let (Some(win), Some(pane)) = (win.upgrade(), split_v_pane.upgrade()) {
+                win.split_terminal(&pane.uuid(), SplitOrientation::Vertical);
             }
         });
 
         let win = self.downgrade();
-        let zoom_uuid = terminal_uuid.clone();
-        let close_uuid = terminal_uuid;
+        let close_pane = pane_view.downgrade();
         pane_view.close_button().connect_clicked(move |_| {
-            if let Some(win) = win.upgrade() {
-                win.close_terminal(&close_uuid);
+            if let (Some(win), Some(pane)) = (win.upgrade(), close_pane.upgrade()) {
+                win.close_terminal(&pane.uuid());
             }
         });
 
         let win = self.downgrade();
+        let zoom_pane = pane_view.downgrade();
         pane_view.zoom_button().connect_clicked(move |_| {
-            if let Some(win) = win.upgrade() {
-                win.toggle_pane_zoom_for(Some(&zoom_uuid));
+            if let (Some(win), Some(pane)) = (win.upgrade(), zoom_pane.upgrade()) {
+                win.toggle_pane_zoom_for(Some(&pane.uuid()));
             }
         });
 

--- a/clients/rttx/src/window/runtime.rs
+++ b/clients/rttx/src/window/runtime.rs
@@ -755,6 +755,12 @@ impl Window {
             self.imp().persistent_terminals.borrow_mut().remove(layout_terminal_uuid);
         }
 
+        // Re-key widget maps so they track the identity layout after a
+        // client-minted uuid becomes its server pane id (RFC-031).
+        for rekey in &transition.pane_rekeys {
+            self.rekey_terminal_widgets(rekey);
+        }
+
         for rebuild in &transition.rebuilt_workspaces {
             self.rebuild_session_content(&rebuild.workspace_id, &rebuild.session_state);
         }

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -13,6 +13,29 @@ const fn orientation_to_axis(orientation: SplitOrientation) -> i32 {
 }
 
 impl Window {
+    /// Rename the widget maps when a layout terminal is re-keyed from its
+    /// client-minted uuid to the durable server pane id (RFC-031 identity
+    /// invariant). Keeps `terminals` and `persistent_terminals` (both keyed by
+    /// uuid) consistent with the now-identity layout.
+    pub(super) fn rekey_terminal_widgets(&self, rekey: &PaneRekey) {
+        if rekey.old_uuid == rekey.new_uuid {
+            return;
+        }
+        let imp = self.imp();
+
+        let term = imp.terminals.borrow_mut().remove(&rekey.old_uuid);
+        if let Some(term) = term {
+            term.set_uuid(&rekey.new_uuid);
+            imp.terminals.borrow_mut().insert(rekey.new_uuid.clone(), term);
+        }
+
+        let pane = imp.persistent_terminals.borrow_mut().remove(&rekey.old_uuid);
+        if let Some(pane) = pane {
+            pane.set_uuid(&rekey.new_uuid);
+            imp.persistent_terminals.borrow_mut().insert(rekey.new_uuid.clone(), pane);
+        }
+    }
+
     pub(super) fn materialize_terminal(
         &self,
         session_state: &WorkspaceState,
@@ -316,8 +339,6 @@ impl Window {
                 }
                 state.workspaces[idx].layout = new_layout;
                 state.workspaces[idx].set_recovery(&new_terminal_uuid, PaneRecovery::empty_shell());
-                let layout_terminal_uuids = state.workspaces[idx].layout.terminal_uuids();
-                state.workspaces[idx].runtime.ensure_placeholder_bindings(&layout_terminal_uuids);
                 state.workspaces[idx].normalize_active_terminal();
                 let session_uuid = state.workspaces[idx].uuid.clone();
                 let session_state = state.workspaces[idx].clone();
@@ -339,12 +360,8 @@ impl Window {
                     && let Some(manager) = self.imp().connection_manager.borrow().as_ref()
                 {
                     let size = self.persistent_terminal_size(terminal_uuid);
-                    let target_pane_id = session_state
-                        .runtime
-                        .pane_bindings
-                        .get(terminal_uuid)
-                        .cloned()
-                        .unwrap_or_else(|| terminal_uuid.to_string());
+                    // Identity invariant: the layout uuid *is* the server pane id.
+                    let target_pane_id = terminal_uuid.to_string();
                     manager.split_pane(
                         &session_uuid,
                         &session_state.runtime.endpoint,
@@ -416,8 +433,6 @@ impl Window {
         }
         state.workspaces[idx].layout = new_layout;
         state.workspaces[idx].set_recovery(&new_terminal_uuid, PaneRecovery::empty_shell());
-        let layout_terminal_uuids = state.workspaces[idx].layout.terminal_uuids();
-        state.workspaces[idx].runtime.ensure_placeholder_bindings(&layout_terminal_uuids);
         state.workspaces[idx].normalize_active_terminal();
         let session_uuid = state.workspaces[idx].uuid.clone();
         let session_state = state.workspaces[idx].clone();
@@ -440,12 +455,8 @@ impl Window {
             && let Some(manager) = self.imp().connection_manager.borrow().as_ref()
         {
             let size = self.persistent_terminal_size(terminal_uuid);
-            let target_pane_id = session_state
-                .runtime
-                .pane_bindings
-                .get(terminal_uuid)
-                .cloned()
-                .unwrap_or_else(|| terminal_uuid.to_string());
+            // Identity invariant: the layout uuid *is* the server pane id.
+            let target_pane_id = terminal_uuid.to_string();
             manager.split_pane(
                 &session_uuid,
                 &session_state.runtime.endpoint,
@@ -516,8 +527,6 @@ impl Window {
                 state.workspaces[idx].layout.remove_terminal(terminal_uuid)
             {
                 state.workspaces[idx].layout = new_layout;
-                let layout_terminal_uuids = state.workspaces[idx].layout.terminal_uuids();
-                state.workspaces[idx].runtime.ensure_placeholder_bindings(&layout_terminal_uuids);
                 state.workspaces[idx].normalize_active_terminal();
                 Action::Rebuild {
                     session_uuid: state.workspaces[idx].uuid.clone(),

--- a/clients/rttx/src/window/terminal.rs
+++ b/clients/rttx/src/window/terminal.rs
@@ -34,6 +34,14 @@ impl Window {
             pane.set_uuid(&rekey.new_uuid);
             imp.persistent_terminals.borrow_mut().insert(rekey.new_uuid.clone(), pane);
         }
+
+        // The focused-pane pointer is stored separately from the layout, so it
+        // must follow the re-key too — otherwise focus-driven actions (split,
+        // close, zoom) would target the stale client-minted uuid, which no
+        // longer exists in the layout.
+        if imp.focused_terminal_uuid.borrow().as_deref() == Some(rekey.old_uuid.as_str()) {
+            imp.focused_terminal_uuid.replace(Some(rekey.new_uuid.clone()));
+        }
     }
 
     pub(super) fn materialize_terminal(

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -3081,11 +3081,7 @@ fn save_state_persists_detached_workspace_runtime_binding() {
     assert_eq!(saved_session.runtime.endpoint, RuntimeEndpoint::remote("builder.example"));
     assert_eq!(saved_session.runtime.policy, WorkspacePolicy::Persistent);
     assert_eq!(saved_session.runtime.runtime_id.as_deref(), Some(runtime_id.as_str()));
-    assert_eq!(
-        saved_session.runtime.pane_bindings.get("managed-pane").map(String::as_str),
-        Some("managed-pane")
-    );
-    assert!(saved_session.runtime.pending_layout_panes.contains("managed-pane"));
+    assert!(saved_session.layout.contains_terminal("managed-pane"));
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
@@ -3187,11 +3183,7 @@ fn save_state_persists_terminated_workspace_without_runtime_id() {
     assert_eq!(saved_session.runtime.endpoint, RuntimeEndpoint::remote("builder.example"));
     assert_eq!(saved_session.runtime.policy, WorkspacePolicy::Persistent);
     assert_eq!(saved_session.runtime.runtime_id, None);
-    assert_eq!(
-        saved_session.runtime.pane_bindings.get("managed-pane").map(String::as_str),
-        Some("managed-pane")
-    );
-    assert!(saved_session.runtime.pending_layout_panes.contains("managed-pane"));
+    assert!(saved_session.layout.contains_terminal("managed-pane"));
 
     window.close();
     crate::test_helpers::remove_env("RTTX_DISABLE_SHELL_SPAWN");
@@ -3500,9 +3492,9 @@ fn cwd_changed_updates_layout_node() {
 
     let window = Window::new(&app);
 
-    let layout_uuid = "managed-pane-cwd";
-    let runtime_pane_id = uuid::Uuid::new_v4();
-    let mut session_state = crate::test_helpers::managed_session_with_runtime(
+    let layout_uuid = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let runtime_pane_id = uuid::Uuid::parse_str(layout_uuid).unwrap();
+    let session_state = crate::test_helpers::managed_session_with_runtime(
         "ws-cwd",
         "CWD Test",
         LayoutNode::new_terminal_with_uuid(layout_uuid),
@@ -3510,10 +3502,6 @@ fn cwd_changed_updates_layout_node() {
         WorkspacePolicy::Persistent,
         Some("runtime-cwd"),
     );
-    session_state
-        .runtime
-        .pane_bindings
-        .insert(layout_uuid.to_string(), runtime_pane_id.to_string());
 
     window.imp().state.borrow_mut().workspaces.push(session_state.clone());
     window.build_session(&session_state, false);
@@ -3579,9 +3567,9 @@ fn managed_pane_exit_marks_visible_pane_exited() {
 
     let window = Window::new(&app);
 
-    let layout_uuid = "managed-pane-exit";
-    let runtime_pane_id = uuid::Uuid::new_v4();
-    let mut session_state = crate::test_helpers::managed_session_with_runtime(
+    let layout_uuid = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+    let runtime_pane_id = uuid::Uuid::parse_str(layout_uuid).unwrap();
+    let session_state = crate::test_helpers::managed_session_with_runtime(
         "ws-exit",
         "Exit Test",
         LayoutNode::new_terminal_with_uuid(layout_uuid),
@@ -3589,10 +3577,6 @@ fn managed_pane_exit_marks_visible_pane_exited() {
         WorkspacePolicy::Persistent,
         Some("runtime-exit"),
     );
-    session_state
-        .runtime
-        .pane_bindings
-        .insert(layout_uuid.to_string(), runtime_pane_id.to_string());
 
     window.imp().state.borrow_mut().workspaces.push(session_state.clone());
     window.build_session(&session_state, false);
@@ -6730,8 +6714,9 @@ fn managed_binding_for_terminal_resolves_bound_pane() {
     let window = Window::new(&app);
 
     let layout_uuid = "bound-pane";
-    let runtime_pane_id = "runtime-pane-123";
-    let mut session_state = crate::test_helpers::managed_session_with_runtime(
+    // Identity invariant: the runtime pane id IS the layout terminal uuid.
+    let runtime_pane_id = layout_uuid;
+    let session_state = crate::test_helpers::managed_session_with_runtime(
         "ws-binding",
         "Binding Test",
         LayoutNode::new_terminal_with_uuid(layout_uuid),
@@ -6739,10 +6724,6 @@ fn managed_binding_for_terminal_resolves_bound_pane() {
         WorkspacePolicy::Persistent,
         Some("runtime-binding"),
     );
-    session_state
-        .runtime
-        .pane_bindings
-        .insert(layout_uuid.to_string(), runtime_pane_id.to_string());
     window.imp().state.borrow_mut().workspaces.push(session_state);
 
     let binding = window.managed_binding_for_terminal(layout_uuid);

--- a/clients/rttx/src/window/tests.rs
+++ b/clients/rttx/src/window/tests.rs
@@ -342,6 +342,42 @@ fn top_bar_has_new_connect_direct_buttons() {
     window.close();
 }
 
+// Regression (RFC-031): re-keying a client-minted pane onto its server pane id
+// must also move the window's focused-pane pointer, which is stored outside the
+// layout. Otherwise the next focus-driven action (split, close, zoom) targets
+// the stale uuid that no longer exists in the layout and silently no-ops — e.g.
+// a split that produces no second pane.
+#[test]
+#[ignore = "requires isolated GTK harness"]
+fn rekey_terminal_widgets_moves_focused_pointer_to_server_pane_id() {
+    require_display!();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    crate::test_helpers::set_env("XDG_CONFIG_HOME", tmp.path());
+    crate::test_helpers::set_env("RTTX_DISABLE_SHELL_SPAWN", "1");
+
+    let app =
+        adw::Application::builder().application_id("com.illya.rttx.rekey-focus-tests").build();
+    app.register(gtk4::gio::Cancellable::NONE).unwrap();
+
+    let window = Window::new(&app);
+    window.set_focused_terminal(Some("client-minted-pane"));
+
+    window.rekey_terminal_widgets(&crate::workspace_state::PaneRekey {
+        workspace_id: "ws-1".into(),
+        old_uuid: "client-minted-pane".into(),
+        new_uuid: "server-pane-id".into(),
+    });
+
+    assert_eq!(
+        window.focused_terminal_uuid().as_deref(),
+        Some("server-pane-id"),
+        "focused pointer must follow the re-key to the server pane id"
+    );
+
+    window.close();
+}
+
 #[test]
 #[ignore = "requires isolated GTK harness"]
 fn new_button_menu_model_survives_activation() {

--- a/clients/rttx/src/workspace/state.rs
+++ b/clients/rttx/src/workspace/state.rs
@@ -117,8 +117,7 @@ impl WorkspaceState {
         initial_cwd: Option<String>,
     ) -> Self {
         let mut session = Self::new_with_initial_cwd(name, initial_cwd);
-        let layout_terminal_uuids = session.layout.terminal_uuids();
-        session.runtime = WorkspaceRuntime::managed_local(policy, &layout_terminal_uuids);
+        session.runtime = WorkspaceRuntime::managed_local(policy);
         session
     }
 
@@ -130,8 +129,7 @@ impl WorkspaceState {
         initial_cwd: Option<String>,
     ) -> Self {
         let mut session = Self::new_with_initial_cwd(name, initial_cwd);
-        let layout_terminal_uuids = session.layout.terminal_uuids();
-        session.runtime = WorkspaceRuntime::managed_remote(host, policy, &layout_terminal_uuids);
+        session.runtime = WorkspaceRuntime::managed_remote(host, policy);
         session
     }
 
@@ -195,25 +193,22 @@ impl WorkspaceState {
     ///
     /// Returns `Some((runtime_id, runtime_pane_id))` when the close must be sent
     /// to the daemon — a managed workspace with more than one pane whose target
-    /// is bound to a real daemon pane. Returns `None` when the close stays
-    /// client-local: an unmanaged workspace, the final pane (which closes the
-    /// whole workspace), or a pane still pending its daemon assignment.
+    /// is a live daemon pane. Returns `None` when the close stays client-local:
+    /// an unmanaged workspace, the final pane (which closes the whole
+    /// workspace), or a workspace with no daemon runtime yet.
     ///
-    /// Critically this keys on pending state, **not** on whether the binding is
-    /// an identity map: once the client adopts the server tree (RFC-031), every
-    /// layout uuid equals its server pane id, so an identity binding is the
-    /// normal case for a live daemon pane and must still be closed remotely.
+    /// Under the identity invariant (RFC-031) every layout terminal uuid *is*
+    /// its server pane id, so the runtime pane id is the terminal uuid itself.
     #[must_use]
     pub fn managed_close_target(&self, terminal_uuid: &str) -> Option<(String, String)> {
         if !self.uses_managed_runtime() || self.layout.terminal_count() <= 1 {
             return None;
         }
-        if self.runtime.is_layout_pane_pending(terminal_uuid) {
+        if !self.layout.contains_terminal(terminal_uuid) {
             return None;
         }
         let runtime_id = self.runtime.runtime_id.clone()?;
-        let runtime_pane_id = self.runtime.pane_bindings.get(terminal_uuid).cloned()?;
-        Some((runtime_id, runtime_pane_id))
+        Some((runtime_id, terminal_uuid.to_string()))
     }
 
     pub fn replace_terminal_uuid(&mut self, old_uuid: &str, new_uuid: &str) -> bool {
@@ -224,8 +219,6 @@ impl WorkspaceState {
         if let Some(recovery) = self.terminal_recovery.remove(old_uuid) {
             self.terminal_recovery.insert(new_uuid.to_string(), recovery);
         }
-
-        self.runtime.replace_layout_terminal_uuid(old_uuid, new_uuid);
 
         if self.active_terminal_uuid.as_deref() == Some(old_uuid) {
             self.active_terminal_uuid = Some(new_uuid.to_string());
@@ -315,7 +308,10 @@ impl WindowState {
         format!("{endpoint_key}\0{runtime_pane_id}")
     }
 
-    /// Rebuild the reverse index from all workspace pane bindings.
+    /// Rebuild the reverse index from all workspace layout terminals.
+    ///
+    /// Under the identity invariant every layout terminal uuid *is* its server
+    /// pane id, so each managed layout terminal maps to itself.
     pub fn rebuild_pane_reverse_index(&mut self) {
         self.pane_reverse_index.clear();
         for session in &self.workspaces {
@@ -323,12 +319,9 @@ impl WindowState {
                 continue;
             }
             let endpoint_key = session.runtime.endpoint.key();
-            for (layout_uuid, runtime_pane_id) in &session.runtime.pane_bindings {
-                if session.runtime.is_layout_pane_pending(layout_uuid) {
-                    continue;
-                }
-                let key = Self::pane_index_key(&endpoint_key, runtime_pane_id);
-                self.pane_reverse_index.insert(key, (session.uuid.clone(), layout_uuid.clone()));
+            for layout_uuid in session.layout.terminal_uuids() {
+                let key = Self::pane_index_key(&endpoint_key, &layout_uuid);
+                self.pane_reverse_index.insert(key, (session.uuid.clone(), layout_uuid));
             }
         }
     }
@@ -460,9 +453,7 @@ mod tests {
         assert!(session.uses_managed_runtime());
         assert_eq!(session.runtime.endpoint, RuntimeEndpoint::Local);
         assert_eq!(session.runtime.policy, WorkspacePolicy::Ephemeral);
-        assert_eq!(session.runtime.pane_bindings.len(), 1);
-        let only_binding = session.runtime.pane_bindings.iter().next().unwrap();
-        assert_eq!(only_binding.0, only_binding.1);
+        assert_eq!(session.layout.terminal_uuids().len(), 1);
     }
 
     #[test]

--- a/clients/rttx/src/workspace/state.rs
+++ b/clients/rttx/src/workspace/state.rs
@@ -224,6 +224,10 @@ impl WorkspaceState {
             self.active_terminal_uuid = Some(new_uuid.to_string());
         }
 
+        if self.zoomed_terminal_uuid.as_deref() == Some(old_uuid) {
+            self.zoomed_terminal_uuid = Some(new_uuid.to_string());
+        }
+
         true
     }
 }

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -2218,4 +2218,28 @@ mod tests {
         assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, remote_pane).is_none());
         assert!(state.runtime_pane_target(&remote_endpoint, local_pane).is_none());
     }
+
+    #[test]
+    fn pane_ack_establishes_identity_routing_without_a_binding_table() {
+        // Net-new pure-state coverage (RFC-031): a daemon pane ack re-keys the
+        // client layout terminal onto the server pane id, so routing becomes
+        // the identity of that id and no binding table exists.
+        let mut state =
+            window_state(vec![managed_session("workspace-1", "Workspace", term("client-pane"))]);
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+        let server_pane = "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26";
+
+        let rekey = state
+            .apply_managed_pane_created("workspace-1", "client-pane", runtime_id, server_pane)
+            .expect("pane ack applies to a known layout terminal");
+
+        assert_eq!(rekey.old_uuid, "client-pane");
+        assert_eq!(rekey.new_uuid, server_pane);
+        assert!(state.workspaces[0].layout.contains_terminal(server_pane));
+        assert!(state.managed_terminal_binding("client-pane").is_none());
+        assert_eq!(
+            state.managed_terminal_binding(server_pane).map(|binding| binding.runtime_pane_id),
+            Some(server_pane.to_string()),
+        );
+    }
 }

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -981,6 +981,28 @@ mod tests {
     }
 
     #[test]
+    fn managed_terminal_binding_uses_identity_after_pane_ack() {
+        // After a pane ack re-keys the layout terminal to the server pane id,
+        // the routable binding is the identity of that id — there is no
+        // separate binding table (RFC-031).
+        let mut state =
+            window_state(vec![managed_session("workspace-1", "Workspace", term("pane-1"))]);
+        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+        let server_pane = "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26";
+
+        state
+            .apply_managed_pane_created("workspace-1", "pane-1", runtime_id, server_pane)
+            .expect("pane ack applies");
+
+        // The old client-minted id no longer resolves; the server pane id does,
+        // and resolves to itself (identity).
+        assert!(state.managed_terminal_binding("pane-1").is_none());
+        let binding = state.managed_terminal_binding(server_pane).expect("server pane id resolves");
+        assert_eq!(binding.runtime_pane_id, server_pane);
+        assert_eq!(binding.runtime_id, runtime_id);
+    }
+
+    #[test]
     fn apply_managed_pane_closed_prunes_state_and_preserves_remaining_terminal() {
         let left = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
         let right = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";

--- a/clients/rttx/src/workspace_state.rs
+++ b/clients/rttx/src/workspace_state.rs
@@ -1,10 +1,10 @@
 use crate::daemon_bridge::EndpointEvent;
-use crate::runtime::{ConnectionStatus, RuntimeEndpoint, WorkspacePolicy, reconcile_bindings};
+use crate::runtime::{ConnectionStatus, RuntimeEndpoint, WorkspacePolicy};
 use crate::workspace::{
     LayoutNode, PaneRecovery, SplitOrientation, WindowState, WorkspaceState, layout_from_pane_tree,
 };
 use rttx_proto::v3;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 /// Routing metadata for a daemon-managed terminal pane.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,6 +53,15 @@ pub struct ManagedWorkspaceRebuild {
     pub session_state: WorkspaceState,
 }
 
+/// Records a layout-terminal re-key so the window layer can rename the widget
+/// maps keyed by uuid when a client-minted uuid becomes its server pane id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaneRekey {
+    pub workspace_id: String,
+    pub old_uuid: String,
+    pub new_uuid: String,
+}
+
 /// Pure request to create a missing daemon pane for a layout terminal.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManagedPaneCreateRequest {
@@ -73,6 +82,9 @@ pub struct EndpointEventTransition {
     pub connected_layout_terminals: Vec<String>,
     pub layout_terminals_to_recover: Vec<String>,
     pub removed_layout_terminals: Vec<String>,
+    /// Layout-terminal re-keys (client uuid -> server pane id) that the window
+    /// layer must apply to its widget maps.
+    pub pane_rekeys: Vec<PaneRekey>,
     pub connection_status_updates: Vec<ConnectionStatusUpdate>,
     pub skipped_runtime_panes: Vec<String>,
     pub persist_window_state: bool,
@@ -151,18 +163,23 @@ impl WindowState {
                 runtime_id,
                 runtime_pane_id,
             } => {
-                let applied = self.apply_managed_pane_created(
+                let Some(rekey) = self.apply_managed_pane_created(
                     workspace_id,
                     layout_terminal_uuid,
                     runtime_id,
                     runtime_pane_id,
-                );
-                if !applied {
+                ) else {
                     return transition;
-                }
+                };
 
-                transition.connected_layout_terminals.push(layout_terminal_uuid.clone());
-                transition.layout_terminals_to_recover.push(layout_terminal_uuid.clone());
+                // After the re-key the layout terminal *is* the server pane id,
+                // so downstream recovery/connect steps key on the new uuid.
+                let new_uuid = rekey.new_uuid.clone();
+                if rekey.old_uuid != rekey.new_uuid {
+                    transition.pane_rekeys.push(rekey);
+                }
+                transition.connected_layout_terminals.push(new_uuid.clone());
+                transition.layout_terminals_to_recover.push(new_uuid);
                 transition.connection_status_updates.push(ConnectionStatusUpdate {
                     workspace_id: workspace_id.clone(),
                     status: ConnectionStatus::Connected,
@@ -269,21 +286,21 @@ impl WindowState {
     }
 
     /// Resolve a layout terminal to its managed runtime binding.
+    ///
+    /// Under the identity invariant the runtime pane id *is* the layout
+    /// terminal uuid. Returns `None` when the workspace is unmanaged, lacks a
+    /// live runtime, or does not contain the terminal.
     #[must_use]
     pub fn managed_terminal_binding(&self, terminal_uuid: &str) -> Option<ManagedTerminalBinding> {
         let session = self.workspaces.iter().find(|session| {
             session.uses_managed_runtime() && session.layout.contains_terminal(terminal_uuid)
         })?;
         let runtime_id = session.runtime.runtime_id.clone()?;
-        let runtime_pane_id = session.runtime.pane_bindings.get(terminal_uuid)?.clone();
-        if session.runtime.is_layout_pane_pending(terminal_uuid) {
-            return None;
-        }
         Some(ManagedTerminalBinding {
             workspace_id: session.uuid.clone(),
             endpoint: session.runtime.endpoint.clone(),
             runtime_id,
-            runtime_pane_id,
+            runtime_pane_id: terminal_uuid.to_string(),
         })
     }
 
@@ -307,17 +324,11 @@ impl WindowState {
             .terminal_uuids()
             .into_iter()
             .filter(|uuid| uuid != source_uuid)
-            .filter_map(|uuid| {
-                let pane_id = session.runtime.pane_bindings.get(&uuid)?;
-                if session.runtime.is_layout_pane_pending(&uuid) {
-                    return None;
-                }
-                Some(ManagedTerminalBinding {
-                    workspace_id: session.uuid.clone(),
-                    endpoint: session.runtime.endpoint.clone(),
-                    runtime_id: runtime_id.to_string(),
-                    runtime_pane_id: pane_id.clone(),
-                })
+            .map(|uuid| ManagedTerminalBinding {
+                workspace_id: session.uuid.clone(),
+                endpoint: session.runtime.endpoint.clone(),
+                runtime_id: runtime_id.to_string(),
+                runtime_pane_id: uuid,
             })
             .collect()
     }
@@ -351,25 +362,35 @@ impl WindowState {
     }
 
     /// Apply the state mutation for a daemon pane-create acknowledgement.
+    ///
+    /// Re-keys the layout terminal to the durable server pane id so the
+    /// identity invariant (uuid == pane id) holds. Returns the [`PaneRekey`] so
+    /// the window layer can rename its widget maps, or `None` when the
+    /// workspace or layout terminal is unknown.
     pub fn apply_managed_pane_created(
         &mut self,
         workspace_id: &str,
         layout_terminal_uuid: &str,
         runtime_id: &str,
         runtime_pane_id: &str,
-    ) -> bool {
-        let Some(session) = self.workspaces.iter_mut().find(|session| session.uuid == workspace_id)
-        else {
-            return false;
-        };
+    ) -> Option<PaneRekey> {
+        let session = self.workspaces.iter_mut().find(|session| session.uuid == workspace_id)?;
         if !session.layout.contains_terminal(layout_terminal_uuid) {
-            return false;
+            return None;
         }
 
         session.runtime.runtime_id = Some(runtime_id.to_string());
-        session.runtime.bind_runtime_pane(layout_terminal_uuid, runtime_pane_id);
+        if layout_terminal_uuid != runtime_pane_id {
+            // Re-key layout, recovery and active-terminal state onto the
+            // server pane id (identity invariant).
+            session.replace_terminal_uuid(layout_terminal_uuid, runtime_pane_id);
+        }
         self.rebuild_pane_reverse_index();
-        true
+        Some(PaneRekey {
+            workspace_id: workspace_id.to_string(),
+            old_uuid: layout_terminal_uuid.to_string(),
+            new_uuid: runtime_pane_id.to_string(),
+        })
     }
 
     /// Apply the state mutation for a daemon-acked managed pane close.
@@ -379,11 +400,8 @@ impl WindowState {
         layout_terminal_uuid: &str,
     ) -> Option<WorkspaceState> {
         let session = self.workspaces.iter_mut().find(|session| session.uuid == workspace_id)?;
-        session.runtime.pane_bindings.remove(layout_terminal_uuid);
         let new_layout = session.layout.remove_terminal(layout_terminal_uuid)?;
         session.layout = new_layout;
-        let layout_terminal_uuids = session.layout.terminal_uuids();
-        session.runtime.ensure_placeholder_bindings(&layout_terminal_uuids);
         session.prune_recovery();
         session.normalize_active_terminal();
         let result = session.clone();
@@ -408,13 +426,6 @@ impl WindowState {
         let previous_layout_terminals = session.layout.terminal_uuids();
         session.layout = layout;
         let layout_terminal_uuids = session.layout.terminal_uuids();
-
-        // Bindings degenerate to an identity map over the server pane ids
-        // (removed entirely in a later step); keep them coherent so the
-        // pane-resolution path stays correct in the meantime.
-        session.runtime.pane_bindings =
-            layout_terminal_uuids.iter().map(|id| (id.clone(), id.clone())).collect();
-        session.runtime.pending_layout_panes.clear();
 
         // The server names the fallback focus pane (RFC-031 §2).
         if let Some(active) = rttx_proto::bytes_to_uuid(&snapshot.default_active_pane_id)
@@ -483,133 +494,23 @@ impl WindowState {
             return self.adopt_server_tree(workspace_id, runtime_id, layout, snapshot);
         }
 
-        // Legacy fallback for a tree-less snapshot (an empty workspace, or a
-        // pre-tree daemon): reconcile the client-owned layout against the flat
-        // pane list. Removed once the daemon guarantees a tree per workspace.
+        // Tree-less snapshot: an empty workspace whose daemon runtime has no
+        // panes yet (a pre-tree daemon no longer occurs). There is nothing to
+        // adopt — keep the session's existing placeholder layout and record the
+        // runtime id. The daemon-bridge CreatePane bootstrap creates the first
+        // pane and the subsequent PaneCreated re-key assigns identity.
         let session = self.workspaces.iter_mut().find(|session| session.uuid == workspace_id)?;
-
-        let had_runtime_id = session.runtime.runtime_id.is_some();
         session.runtime.runtime_id = Some(runtime_id.to_string());
 
         let layout_terminal_uuids = session.layout.terminal_uuids();
-        let runtime_pane_uuids =
-            snapshot.panes.iter().filter_map(snapshot_pane_id).collect::<Vec<_>>();
-        let mut reconciliation = reconcile_bindings(
-            &layout_terminal_uuids,
-            &session.runtime.pane_bindings,
-            &runtime_pane_uuids,
-        );
-
-        // Match disconnected layout terminals to unclaimed runtime panes by
-        // position. This covers both placeholder bindings (state saved before
-        // PaneCreated arrived) and stale bindings (daemon restarted with new
-        // pane IDs), preventing layout growth on repeated reconnect cycles.
-        if !reconciliation.disconnected_layout_panes.is_empty()
-            && !reconciliation.recovered_runtime_panes.is_empty()
-        {
-            let mut recovered =
-                reconciliation.recovered_runtime_panes.drain(..).collect::<Vec<_>>();
-            let mut still_disconnected = Vec::new();
-            for layout_uuid in reconciliation.disconnected_layout_panes.drain(..) {
-                if let Some(runtime_pane_id) = recovered.first().cloned() {
-                    recovered.remove(0);
-                    reconciliation.bindings.insert(layout_uuid, runtime_pane_id);
-                } else {
-                    still_disconnected.push(layout_uuid);
-                }
-            }
-            reconciliation.disconnected_layout_panes = still_disconnected;
-            reconciliation.recovered_runtime_panes = recovered;
-        }
-
-        session.runtime.pane_bindings = reconciliation.bindings;
-        session.runtime.pending_layout_panes =
-            reconciliation.disconnected_layout_panes.iter().cloned().collect();
-
-        let panes_to_create = if had_runtime_id {
-            // Reconnecting: create panes for any layout terminals that
-            // couldn't be matched to existing runtime panes (covers both
-            // placeholder-only and stale-binding reconnects).
-            reconciliation.disconnected_layout_panes.clone()
-        } else {
-            let mut placeholders = reconciliation.disconnected_layout_panes.clone();
-            if let Some(initial_terminal_uuid) = layout_terminal_uuids.first() {
-                placeholders
-                    .retain(|layout_terminal_uuid| layout_terminal_uuid != initial_terminal_uuid);
-            }
-            placeholders
-        };
-
-        let mut skipped_runtime_panes = Vec::new();
-        for runtime_pane_id in reconciliation.recovered_runtime_panes {
-            let Some(anchor_uuid) = session.layout.terminal_uuids().last().cloned() else {
-                skipped_runtime_panes.push(runtime_pane_id);
-                continue;
-            };
-            let anchor_cwd = session.layout.terminal_cwd(&anchor_uuid);
-            let Some((mut new_layout, new_terminal_uuid)) = session
-                .layout
-                .split_terminal_with_new_uuid(&anchor_uuid, SplitOrientation::Horizontal)
-            else {
-                skipped_runtime_panes.push(runtime_pane_id);
-                continue;
-            };
-
-            if let Some(cwd) = anchor_cwd {
-                new_layout.set_terminal_cwd(&new_terminal_uuid, Some(cwd));
-            }
-            session.layout = new_layout;
-            session.set_recovery(&new_terminal_uuid, PaneRecovery::empty_shell());
-            session.runtime.bind_runtime_pane(&new_terminal_uuid, &runtime_pane_id);
-            session.normalize_active_terminal();
-        }
-
-        let layout_by_runtime_pane = session
-            .runtime
-            .pane_bindings
-            .iter()
-            .map(|(layout_terminal_uuid, runtime_pane_id)| {
-                (runtime_pane_id.clone(), layout_terminal_uuid.clone())
-            })
-            .collect::<BTreeMap<_, _>>();
-        let snapshot_restores = snapshot
-            .panes
-            .iter()
-            .filter_map(|pane_snapshot| {
-                let runtime_pane_id = snapshot_pane_id(pane_snapshot)?;
-                let layout_terminal_uuid = layout_by_runtime_pane.get(&runtime_pane_id)?.clone();
-                Some(WorkspacePaneRestore {
-                    layout_terminal_uuid,
-                    title: pane_snapshot.title.clone(),
-                    cwd: pane_snapshot.cwd.clone(),
-                    pane_output_seq: pane_snapshot.pane_output_seq,
-                    scrollback_tail: pane_snapshot.scrollback_tail.clone(),
-                    scrollback_complete: pane_snapshot.scrollback_complete,
-                    cols: pane_snapshot.cols as u16,
-                    rows: pane_snapshot.rows as u16,
-                    terminal_modes: pane_snapshot.terminal_modes,
-                })
-            })
-            .collect::<Vec<_>>();
-
-        // Update layout CWDs from the snapshot so the rebuilt session
-        // carries the daemon's current CWD, not stale client-side values.
-        for restore in &snapshot_restores {
-            if !restore.cwd.is_empty() {
-                session
-                    .layout
-                    .set_terminal_cwd(&restore.layout_terminal_uuid, Some(restore.cwd.clone()));
-            }
-        }
-
         let session_state = session.clone();
         self.rebuild_pane_reverse_index();
 
         Some(ManagedWorkspaceOpenResult {
             session_state,
-            panes_to_create,
-            snapshot_restores,
-            skipped_runtime_panes,
+            panes_to_create: Vec::new(),
+            snapshot_restores: Vec::new(),
+            skipped_runtime_panes: Vec::new(),
             previous_layout_terminals: layout_terminal_uuids,
         })
     }
@@ -623,18 +524,16 @@ impl WindowState {
         let Some(session) = self.workspaces.iter().find(|s| s.uuid == workspace_id) else {
             return Vec::new();
         };
-        let layout_by_runtime_pane: BTreeMap<_, _> = session
-            .runtime
-            .pane_bindings
-            .iter()
-            .map(|(layout_uuid, runtime_pane_id)| (runtime_pane_id.clone(), layout_uuid.clone()))
-            .collect();
         snapshot
             .panes
             .iter()
             .filter_map(|pane_snapshot| {
-                let runtime_pane_id = snapshot_pane_id(pane_snapshot)?;
-                let layout_terminal_uuid = layout_by_runtime_pane.get(&runtime_pane_id)?.clone();
+                // Identity invariant: the snapshot pane id *is* the layout
+                // terminal uuid. Only restore panes the layout still contains.
+                let layout_terminal_uuid = snapshot_pane_id(pane_snapshot)?;
+                if !session.layout.contains_terminal(&layout_terminal_uuid) {
+                    return None;
+                }
                 Some(WorkspacePaneRestore {
                     layout_terminal_uuid,
                     title: pane_snapshot.title.clone(),
@@ -675,9 +574,6 @@ fn recovered_managed_workspace(
             .map(|pane_id| (pane_id, PaneRecovery::empty_shell()))
             .collect();
         session.active_terminal_uuid = pane_ids.first().cloned();
-        session.runtime.pane_bindings =
-            pane_ids.iter().cloned().map(|pane_id| (pane_id.clone(), pane_id)).collect();
-        session.runtime.pending_layout_panes.clear();
     }
 
     Some(session)
@@ -738,8 +634,7 @@ mod tests {
     use crate::runtime::ConnectionStatus;
     use crate::runtime::WorkspacePolicy;
     use crate::test_helpers::{
-        hsplit, managed_session, managed_session_with_runtime, term, term_full, window_state,
-        workspace,
+        hsplit, managed_session, managed_session_with_runtime, term, window_state, workspace,
     };
 
     fn pane_snapshot(pane_id: &str, title: &str, cwd: &str, scrollback: &[u8]) -> v3::PaneSnapshot {
@@ -767,6 +662,20 @@ mod tests {
             workspace_revision: 7,
             client_role: v3::WorkspaceClientRole::Writer as i32,
         }
+    }
+
+    /// A single-pane snapshot carrying the daemon's authoritative single-leaf
+    /// tree, so the client adopts a layout whose terminal uuid equals the
+    /// server pane id (identity invariant).
+    fn single_leaf_snapshot(
+        runtime_id: &str,
+        pane_id: &str,
+        pane: v3::PaneSnapshot,
+    ) -> v3::WorkspaceSnapshot {
+        let mut snap = snapshot(runtime_id, vec![pane]);
+        snap.tree =
+            Some(rttx_proto::v3_tree::pane_tree_leaf(uuid::Uuid::parse_str(pane_id).unwrap()));
+        snap
     }
 
     #[test]
@@ -863,18 +772,11 @@ mod tests {
         }));
 
         let session = &state.workspaces[0];
-        // Bindings degenerate to an identity map over the server pane ids.
-        assert_eq!(
-            session.runtime.pane_bindings.get(&left.to_string()).map(String::as_str),
-            Some(left.to_string().as_str()),
-        );
-        assert_eq!(
-            session.runtime.pane_bindings.get(&right.to_string()).map(String::as_str),
-            Some(right.to_string().as_str()),
-        );
-        // Active pane follows the server's fallback focus, and nothing is pending.
+        // Layout terminals ARE the server pane ids (identity invariant).
+        assert!(session.layout.contains_terminal(&left.to_string()));
+        assert!(session.layout.contains_terminal(&right.to_string()));
+        // Active pane follows the server's fallback focus.
         assert_eq!(session.active_terminal_uuid.as_deref(), Some(right.to_string().as_str()));
-        assert!(!session.runtime.is_layout_pane_pending(&left.to_string()));
     }
 
     #[test]
@@ -985,48 +887,40 @@ mod tests {
     }
 
     #[test]
-    fn managed_terminal_binding_ignores_placeholders_and_uses_explicit_runtime_bindings() {
+    fn managed_terminal_binding_returns_identity_once_runtime_present() {
         let runtime_id = uuid::Uuid::new_v4().to_string();
-        let runtime_pane_id = uuid::Uuid::new_v4().to_string();
-        let mut session = managed_session_with_runtime(
-            "workspace-1",
-            "Workspace",
-            term("pane-1"),
-            RuntimeEndpoint::Local,
-            WorkspacePolicy::Persistent,
-            Some(&runtime_id),
-        );
-        let mut state = window_state(vec![session.clone()]);
+        let session = managed_session("workspace-1", "Workspace", term("pane-1"));
+        let mut state = window_state(vec![session]);
 
         assert!(
             state.managed_terminal_binding("pane-1").is_none(),
-            "self-bindings stay unroutable until the daemon assigns a pane id",
+            "a terminal stays unroutable until the workspace has a live runtime",
         );
 
-        session.runtime.bind_runtime_pane("pane-1", &runtime_pane_id);
-        state.workspaces[0] = session;
+        state.workspaces[0].runtime.runtime_id = Some(runtime_id.clone());
+        state.rebuild_pane_reverse_index();
 
         let binding = state
             .managed_terminal_binding("pane-1")
-            .expect("explicit daemon binding should resolve");
+            .expect("identity binding should resolve once a runtime exists");
         assert_eq!(binding.workspace_id, "workspace-1");
         assert_eq!(binding.endpoint, RuntimeEndpoint::Local);
         assert_eq!(binding.runtime_id, runtime_id);
-        assert_eq!(binding.runtime_pane_id, runtime_pane_id);
+        assert_eq!(binding.runtime_pane_id, "pane-1");
     }
 
     #[test]
     fn runtime_lookup_helpers_resolve_workspace_and_pane_targets() {
         let endpoint = RuntimeEndpoint::remote("builder.example");
-        let mut session = managed_session_with_runtime(
+        let pane_id = "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26";
+        let session = managed_session_with_runtime(
             "workspace-1",
             "Workspace",
-            term("pane-1"),
+            term(pane_id),
             endpoint.clone(),
             WorkspacePolicy::Persistent,
             Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
         );
-        session.runtime.bind_runtime_pane("pane-1", "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26");
         let state = window_state(vec![session]);
 
         assert_eq!(
@@ -1034,37 +928,37 @@ mod tests {
             Some("workspace-1".into()),
         );
         assert_eq!(
-            state.runtime_pane_target(&endpoint, "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
-            Some(("workspace-1".into(), "pane-1".into())),
+            state.runtime_pane_target(&endpoint, pane_id),
+            Some(("workspace-1".into(), pane_id.into())),
         );
     }
 
     #[test]
-    fn apply_managed_pane_created_binds_runtime_and_clears_pending_placeholder() {
+    fn apply_managed_pane_created_rekeys_layout_to_server_pane_id() {
         let mut state =
             window_state(vec![managed_session("workspace-1", "Workspace", term("pane-1"))]);
 
-        assert!(state.apply_managed_pane_created(
-            "workspace-1",
-            "pane-1",
-            "d7d04564-b2bf-4302-9495-e65c4df12ac6",
-            "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26",
-        ));
+        let rekey = state
+            .apply_managed_pane_created(
+                "workspace-1",
+                "pane-1",
+                "d7d04564-b2bf-4302-9495-e65c4df12ac6",
+                "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26",
+            )
+            .expect("pane creation for a known layout terminal should apply");
+
+        assert_eq!(rekey.workspace_id, "workspace-1");
+        assert_eq!(rekey.old_uuid, "pane-1");
+        assert_eq!(rekey.new_uuid, "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26");
 
         let session = &state.workspaces[0];
         assert_eq!(
             session.runtime.runtime_id.as_deref(),
             Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
         );
-        assert_eq!(
-            session.runtime.pane_bindings.get("pane-1").map(String::as_str),
-            Some("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
-        );
-        assert!(!session.runtime.is_layout_pane_pending("pane-1"));
-        assert_eq!(
-            session.runtime.runtime_id.as_deref(),
-            Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
-        );
+        // The layout terminal now IS the server pane id (identity invariant).
+        assert!(session.layout.contains_terminal("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"));
+        assert!(!session.layout.contains_terminal("pane-1"));
     }
 
     #[test]
@@ -1073,120 +967,48 @@ mod tests {
             window_state(vec![managed_session("workspace-1", "Workspace", term("pane-1"))]);
         let before = state.clone();
 
-        assert!(!state.apply_managed_pane_created(
-            "workspace-1",
-            "missing-pane",
-            "d7d04564-b2bf-4302-9495-e65c4df12ac6",
-            "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26",
-        ));
+        assert!(
+            state
+                .apply_managed_pane_created(
+                    "workspace-1",
+                    "missing-pane",
+                    "d7d04564-b2bf-4302-9495-e65c4df12ac6",
+                    "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26",
+                )
+                .is_none()
+        );
         assert_eq!(state, before);
     }
 
     #[test]
-    fn apply_managed_pane_closed_prunes_state_and_preserves_remaining_binding() {
+    fn apply_managed_pane_closed_prunes_state_and_preserves_remaining_terminal() {
+        let left = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+        let right = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
         let mut session = managed_session_with_runtime(
             "workspace-1",
             "Workspace",
-            hsplit(term("left"), term("right")),
+            hsplit(term(left), term(right)),
             RuntimeEndpoint::Local,
             WorkspacePolicy::Persistent,
             Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
         );
-        session.runtime.bind_runtime_pane("left", "07fa83b4-9ae3-4354-a1c5-1f685ffab370");
-        session.runtime.bind_runtime_pane("right", "0d88f17f-626d-40b8-a1d3-6a42af628ac9");
-        session.active_terminal_uuid = Some("left".into());
+        session.active_terminal_uuid = Some(left.into());
         let mut state = window_state(vec![session]);
 
         let updated = state
-            .apply_managed_pane_closed("workspace-1", "left")
+            .apply_managed_pane_closed("workspace-1", left)
             .expect("removing one branch of a managed split should preserve the workspace");
 
-        assert_eq!(updated.layout.terminal_uuids(), vec!["right".to_string()]);
-        assert_eq!(updated.active_terminal_uuid.as_deref(), Some("right"));
-        assert_eq!(
-            updated.runtime.pane_bindings.get("right").map(String::as_str),
-            Some("0d88f17f-626d-40b8-a1d3-6a42af628ac9"),
-        );
-        assert!(updated.recovery_for("left").is_none());
-        assert!(updated.recovery_for("right").is_some());
-    }
-
-    #[test]
-    fn apply_managed_workspace_opened_recovers_extra_runtime_panes_in_pure_state() {
-        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
-        let first_runtime_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
-        let second_runtime_pane = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
-        let mut session = managed_session_with_runtime(
-            "workspace-1",
-            "Workspace",
-            term_full("left", "/srv/project", "Left"),
-            RuntimeEndpoint::Local,
-            WorkspacePolicy::Persistent,
-            Some(runtime_id),
-        );
-        session.runtime.bind_runtime_pane("left", first_runtime_pane);
-        let mut state = window_state(vec![session]);
-        let snapshot = snapshot(
-            runtime_id,
-            vec![
-                pane_snapshot(first_runtime_pane, "Shell", "/srv/project", b"shell"),
-                pane_snapshot(second_runtime_pane, "Logs", "/srv/project", b"logs"),
-            ],
-        );
-
-        let opened = state
-            .apply_managed_workspace_opened("workspace-1", runtime_id, &snapshot)
-            .expect("managed workspace open should reconcile state");
-
-        assert!(opened.panes_to_create.is_empty());
-        assert!(opened.skipped_runtime_panes.is_empty());
-        assert_eq!(opened.snapshot_restores.len(), 2);
-        assert_eq!(opened.session_state.layout.terminal_count(), 2);
-
-        let recovered_terminal_uuid = opened
-            .session_state
-            .layout
-            .terminal_uuids()
-            .into_iter()
-            .find(|uuid| uuid != "left")
-            .expect("extra runtime pane should synthesize a recovered layout pane");
-        assert_eq!(
-            opened
-                .session_state
-                .runtime
-                .pane_bindings
-                .get(&recovered_terminal_uuid)
-                .map(String::as_str),
-            Some(second_runtime_pane),
-        );
-        assert_eq!(
-            opened.session_state.layout.terminal_cwd(&recovered_terminal_uuid).as_deref(),
-            Some("/srv/project"),
-            "recovered pane should inherit the anchor cwd in pure state",
-        );
-        assert_eq!(
-            opened
-                .session_state
-                .recovery_for(&recovered_terminal_uuid)
-                .expect("recovered pane should have default recovery"),
-            &PaneRecovery::empty_shell(),
-        );
-        assert!(opened.snapshot_restores.iter().any(|restore| {
-            restore.layout_terminal_uuid == "left"
-                && restore.title == "Shell"
-                && restore.cwd == "/srv/project"
-                && restore.scrollback_tail[..] == b"shell"[..]
-        }));
-        assert!(opened.snapshot_restores.iter().any(|restore| {
-            restore.layout_terminal_uuid == recovered_terminal_uuid
-                && restore.title == "Logs"
-                && restore.cwd == "/srv/project"
-                && restore.scrollback_tail[..] == b"logs"[..]
-        }));
+        assert_eq!(updated.layout.terminal_uuids(), vec![right.to_string()]);
+        assert_eq!(updated.active_terminal_uuid.as_deref(), Some(right));
+        assert!(updated.recovery_for(left).is_none());
+        assert!(updated.recovery_for(right).is_some());
     }
 
     #[test]
     fn recover_managed_workspaces_from_inventory_creates_recoverable_layouts() {
+        use rttx_proto::v3_tree::{pane_tree_leaf, pane_tree_split};
+
         let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
         let first_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
         let second_pane = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
@@ -1215,27 +1037,26 @@ mod tests {
         assert_eq!(session.runtime.policy, WorkspacePolicy::Persistent);
         assert_eq!(session.runtime.runtime_id.as_deref(), Some(runtime_id));
         assert_eq!(session.active_terminal_uuid.as_deref(), Some(first_pane));
+        // The inventory pane ids ARE the layout terminal uuids (identity).
         assert_eq!(
             session.layout.terminal_uuids(),
             vec![first_pane.to_string(), second_pane.to_string()]
         );
-        assert_eq!(
-            session.runtime.pane_bindings.get(first_pane).map(String::as_str),
-            Some(first_pane)
-        );
-        assert_eq!(
-            session.runtime.pane_bindings.get(second_pane).map(String::as_str),
-            Some(second_pane)
-        );
-        assert!(session.runtime.pending_layout_panes.is_empty());
 
-        let snapshot = snapshot(
+        // The daemon sends its authoritative tree on open; the client adopts it.
+        let mut snapshot = snapshot(
             runtime_id,
             vec![
                 pane_snapshot(first_pane, "Shell", "/srv/project", b"shell"),
                 pane_snapshot(second_pane, "Logs", "/srv/project", b"logs"),
             ],
         );
+        snapshot.tree = Some(pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(uuid::Uuid::parse_str(first_pane).unwrap()),
+            pane_tree_leaf(uuid::Uuid::parse_str(second_pane).unwrap()),
+        ));
         let opened = state
             .apply_managed_workspace_opened(&session.uuid, runtime_id, &snapshot)
             .expect("inventory-recovered workspace should reattach cleanly");
@@ -1275,7 +1096,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_managed_workspace_opened_creates_initial_pane_for_empty_inventory_runtime() {
+    fn apply_managed_workspace_opened_empty_runtime_keeps_placeholder_layout() {
         let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
         let mut state = window_state(vec![]);
 
@@ -1292,7 +1113,7 @@ mod tests {
 
         let session =
             recovered.first().expect("inventory should synthesize a placeholder workspace");
-        let placeholder_uuid = session.layout.terminal_uuids()[0].clone();
+        let placeholder_uuids = session.layout.terminal_uuids();
         let opened = state
             .apply_managed_workspace_opened(
                 &session.uuid,
@@ -1301,8 +1122,11 @@ mod tests {
             )
             .expect("empty runtime should still reconcile");
 
-        assert_eq!(opened.panes_to_create, vec![placeholder_uuid]);
+        // A tree-less (empty) snapshot yields a minimal result: the client keeps
+        // its placeholder layout and the daemon-bridge bootstrap creates panes.
+        assert!(opened.panes_to_create.is_empty());
         assert!(opened.snapshot_restores.is_empty());
+        assert_eq!(opened.session_state.layout.terminal_uuids(), placeholder_uuids);
     }
 
     #[test]
@@ -1393,28 +1217,36 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_endpoint_event_workspace_opened_rebuilds_restores_and_requests_missing_panes() {
+    fn reconcile_endpoint_event_workspace_opened_adopts_tree_and_restores() {
+        use rttx_proto::v3_tree::{pane_tree_leaf, pane_tree_split};
+
         let runtime_id = uuid::Uuid::new_v4().to_string();
-        let first_terminal_uuid = uuid::Uuid::new_v4().to_string();
-        let second_terminal_uuid = uuid::Uuid::new_v4().to_string();
+        let left = uuid::Uuid::new_v4();
+        let right = uuid::Uuid::new_v4();
         let mut state = window_state(vec![managed_session(
             "workspace-1",
             "Workspace",
-            hsplit(term(&first_terminal_uuid), term(&second_terminal_uuid)),
+            hsplit(term("client-a"), term("client-b")),
         )]);
+
+        let mut snap = snapshot(
+            &runtime_id,
+            vec![
+                pane_snapshot(&left.to_string(), "Shell", "/srv/project", b"restored output"),
+                pane_snapshot(&right.to_string(), "Logs", "/var/log", b"logs"),
+            ],
+        );
+        snap.tree = Some(pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(left),
+            pane_tree_leaf(right),
+        ));
 
         let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
             workspace_id: "workspace-1".into(),
             runtime_id: runtime_id.clone(),
-            snapshot: snapshot(
-                &runtime_id,
-                vec![pane_snapshot(
-                    &first_terminal_uuid,
-                    "Shell",
-                    "/srv/project",
-                    b"restored output",
-                )],
-            ),
+            snapshot: snap,
         });
 
         assert_eq!(
@@ -1424,30 +1256,19 @@ mod tests {
                 session_state: state.workspaces[0].clone(),
             }],
         );
-        assert_eq!(
-            transition.pane_create_requests,
-            vec![ManagedPaneCreateRequest {
-                workspace_id: "workspace-1".into(),
-                endpoint: RuntimeEndpoint::Local,
-                runtime_id: runtime_id.clone(),
-                layout_terminal_uuid: second_terminal_uuid,
-                cwd: None,
-            }],
+        // Pure view: adopting the tree never mints panes to match the daemon.
+        assert!(transition.pane_create_requests.is_empty());
+        // Restores map 1:1 to the adopted (identity) layout terminals.
+        assert_eq!(transition.pane_snapshot_restores.len(), 2);
+        assert!(
+            transition
+                .pane_snapshot_restores
+                .iter()
+                .any(|r| r.layout_terminal_uuid == left.to_string() && r.title == "Shell")
         );
-        assert_eq!(
-            transition.pane_snapshot_restores,
-            vec![WorkspacePaneRestore {
-                layout_terminal_uuid: first_terminal_uuid,
-                title: "Shell".into(),
-                cwd: "/srv/project".into(),
-                pane_output_seq: 0,
-                scrollback_tail: bytes::Bytes::from_static(b"restored output"),
-                scrollback_complete: true,
-                cols: 120,
-                rows: 40,
-                terminal_modes: None,
-            }],
-        );
+        // The stale client terminals are torn down.
+        assert!(transition.removed_layout_terminals.contains(&"client-a".to_string()));
+        assert!(transition.removed_layout_terminals.contains(&"client-b".to_string()));
         assert_eq!(state.workspaces[0].runtime.runtime_id.as_deref(), Some(runtime_id.as_str()));
     }
 
@@ -1473,7 +1294,7 @@ mod tests {
         let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
             workspace_id: "workspace-1".into(),
             runtime_id: runtime_id.clone(),
-            snapshot: snapshot(&runtime_id, vec![snap]),
+            snapshot: single_leaf_snapshot(&runtime_id, &terminal_uuid, snap),
         });
 
         assert_eq!(transition.pane_snapshot_restores.len(), 1);
@@ -1506,7 +1327,7 @@ mod tests {
         let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
             workspace_id: "workspace-1".into(),
             runtime_id: runtime_id.clone(),
-            snapshot: snapshot(&runtime_id, vec![snap]),
+            snapshot: single_leaf_snapshot(&runtime_id, &terminal_uuid, snap),
         });
 
         let modes =
@@ -1517,7 +1338,7 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_endpoint_event_pane_created_updates_binding_and_requests_recovery() {
+    fn reconcile_endpoint_event_pane_created_rekeys_and_requests_recovery() {
         let mut state =
             window_state(vec![managed_session("workspace-1", "Workspace", term("pane-1"))]);
 
@@ -1528,8 +1349,23 @@ mod tests {
             runtime_pane_id: "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26".into(),
         });
 
-        assert_eq!(transition.connected_layout_terminals, vec!["pane-1".to_string()]);
-        assert_eq!(transition.layout_terminals_to_recover, vec!["pane-1".to_string()]);
+        // After the re-key the layout terminal IS the server pane id.
+        assert_eq!(
+            transition.connected_layout_terminals,
+            vec!["598b80fe-b96b-4fbf-8e2d-f2610b6f4f26".to_string()]
+        );
+        assert_eq!(
+            transition.layout_terminals_to_recover,
+            vec!["598b80fe-b96b-4fbf-8e2d-f2610b6f4f26".to_string()]
+        );
+        assert_eq!(
+            transition.pane_rekeys,
+            vec![PaneRekey {
+                workspace_id: "workspace-1".into(),
+                old_uuid: "pane-1".into(),
+                new_uuid: "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26".into(),
+            }]
+        );
         assert_eq!(
             transition.connection_status_updates,
             vec![ConnectionStatusUpdate {
@@ -1537,36 +1373,35 @@ mod tests {
                 status: ConnectionStatus::Connected,
             }],
         );
-        assert_eq!(
-            state.workspaces[0].runtime.pane_bindings.get("pane-1").map(String::as_str),
-            Some("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
+        assert!(
+            state.workspaces[0].layout.contains_terminal("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26")
         );
     }
 
     #[test]
     fn reconcile_endpoint_event_pane_closed_removes_terminal_and_rebuilds_workspace() {
-        let mut session = managed_session_with_runtime(
+        let left = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+        let right = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
+        let session = managed_session_with_runtime(
             "workspace-1",
             "Workspace",
-            hsplit(term("left"), term("right")),
+            hsplit(term(left), term(right)),
             RuntimeEndpoint::Local,
             WorkspacePolicy::Persistent,
             Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
         );
-        session.runtime.bind_runtime_pane("left", "07fa83b4-9ae3-4354-a1c5-1f685ffab370");
-        session.runtime.bind_runtime_pane("right", "0d88f17f-626d-40b8-a1d3-6a42af628ac9");
         let mut state = window_state(vec![session]);
 
         let transition = state.reconcile_endpoint_event(&EndpointEvent::PaneClosed {
             workspace_id: "workspace-1".into(),
-            layout_terminal_uuid: "right".into(),
+            layout_terminal_uuid: right.into(),
             runtime_id: "d7d04564-b2bf-4302-9495-e65c4df12ac6".into(),
-            runtime_pane_id: "0d88f17f-626d-40b8-a1d3-6a42af628ac9".into(),
+            runtime_pane_id: right.into(),
         });
 
-        assert_eq!(transition.removed_layout_terminals, vec!["right".to_string()]);
+        assert_eq!(transition.removed_layout_terminals, vec![right.to_string()]);
         assert_eq!(transition.rebuilt_workspaces.len(), 1);
-        assert_eq!(state.workspaces[0].layout.terminal_uuids(), vec!["left".to_string()]);
+        assert_eq!(state.workspaces[0].layout.terminal_uuids(), vec![left.to_string()]);
     }
 
     #[test]
@@ -1756,41 +1591,32 @@ mod tests {
 
     #[test]
     fn workspace_opened_preserves_layout_cwd_from_snapshot() {
+        use rttx_proto::v3_tree::pane_tree_leaf;
+
         let runtime_id = uuid::Uuid::new_v4().to_string();
         let pane_id = uuid::Uuid::new_v4().to_string();
+        // The layout terminal IS the server pane id (identity).
         let mut state = window_state(vec![managed_session_with_runtime(
             "ws-1",
             "Work",
-            term("t1"),
+            term(&pane_id),
             RuntimeEndpoint::Local,
             WorkspacePolicy::Persistent,
             Some(&runtime_id),
         )]);
-        state.workspaces[0].layout.set_terminal_cwd("t1", Some("/old/path".into()));
+        state.workspaces[0].layout.set_terminal_cwd(&pane_id, Some("/old/path".into()));
+
+        let mut snap = pane_snapshot(&pane_id, "bash", "/new/project", b"");
+        snap.cols = 80;
+        snap.rows = 24;
+        let mut ws_snap = snapshot(&runtime_id, vec![snap]);
+        ws_snap.workspace_revision = 2;
+        ws_snap.tree = Some(pane_tree_leaf(uuid::Uuid::parse_str(&pane_id).unwrap()));
 
         let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
             workspace_id: "ws-1".into(),
-            runtime_id: runtime_id.clone(),
-            snapshot: v3::WorkspaceSnapshot {
-                tree: None,
-                default_active_pane_id: Vec::new(),
-                runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
-                panes: vec![v3::PaneSnapshot {
-                    pane_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&pane_id).unwrap()),
-                    pane_output_seq: 0,
-                    title: "bash".into(),
-                    cwd: "/new/project".into(),
-                    cols: 80,
-                    rows: 24,
-                    exit_status: None,
-                    terminal_modes: None,
-                    scrollback_tail: bytes::Bytes::new(),
-                    total_scrollback_bytes: 0,
-                    scrollback_complete: true,
-                }],
-                workspace_revision: 2,
-                client_role: v3::WorkspaceClientRole::Writer as i32,
-            },
+            runtime_id,
+            snapshot: ws_snap,
         });
 
         assert!(!transition.pane_snapshot_restores.is_empty());
@@ -1804,135 +1630,6 @@ mod tests {
             Some("/new/project"),
             "layout CWD must be updated from snapshot during workspace opened"
         );
-    }
-
-    /// Pane create requests must carry the layout node's CWD. #297.
-    #[test]
-    fn reconcile_workspace_opened_propagates_layout_cwd_to_pane_create_request() {
-        let runtime_id = uuid::Uuid::new_v4().to_string();
-        let existing_uuid = uuid::Uuid::new_v4().to_string();
-        let new_uuid = uuid::Uuid::new_v4().to_string();
-        let mut state = window_state(vec![managed_session(
-            "ws-1",
-            "Workspace",
-            hsplit(term(&existing_uuid), term_full(&new_uuid, "/srv/project", "Shell")),
-        )]);
-
-        let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
-            workspace_id: "ws-1".into(),
-            runtime_id: runtime_id.clone(),
-            snapshot: snapshot(
-                &runtime_id,
-                vec![pane_snapshot(&existing_uuid, "Shell", "/home", b"")],
-            ),
-        });
-
-        assert_eq!(transition.pane_create_requests.len(), 1);
-        assert_eq!(
-            transition.pane_create_requests[0].cwd.as_deref(),
-            Some("/srv/project"),
-            "pane create request must carry layout CWD"
-        );
-    }
-
-    /// When a workspace has `runtime_id` but only placeholder bindings (e.g.
-    /// state saved before `PaneCreated` events arrived), reattaching to a
-    /// runtime with existing panes must bind disconnected layout terminals
-    /// to unclaimed runtime panes by position instead of leaving them blank.
-    #[test]
-    fn placeholder_bindings_reattach_matches_layout_to_runtime_panes_by_position() {
-        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
-        let runtime_pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
-        let runtime_pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
-
-        // Workspace has runtime_id but only placeholder bindings (left→left, right→right).
-        let session = managed_session_with_runtime(
-            "workspace-1",
-            "Workspace",
-            hsplit(term("left"), term("right")),
-            RuntimeEndpoint::remote("cdt2"),
-            WorkspacePolicy::Persistent,
-            Some(runtime_id),
-        );
-        // managed_session_with_runtime already calls ensure_placeholder_bindings,
-        // so pane_bindings = { "left": "left", "right": "right" }.
-        assert_eq!(session.runtime.pane_bindings.get("left").map(String::as_str), Some("left"));
-        assert_eq!(session.runtime.pane_bindings.get("right").map(String::as_str), Some("right"));
-
-        let mut state = window_state(vec![session]);
-        let snap = snapshot(
-            runtime_id,
-            vec![
-                pane_snapshot(runtime_pane_a, "Shell", "/home", b"$ ls"),
-                pane_snapshot(runtime_pane_b, "Logs", "/var/log", b"tail"),
-            ],
-        );
-
-        let opened = state
-            .apply_managed_workspace_opened("workspace-1", runtime_id, &snap)
-            .expect("workspace open should succeed");
-
-        // Both layout terminals should be bound to runtime panes.
-        assert_eq!(
-            opened.session_state.runtime.pane_bindings.get("left").map(String::as_str),
-            Some(runtime_pane_a),
-            "first layout terminal should bind to first runtime pane by position",
-        );
-        assert_eq!(
-            opened.session_state.runtime.pane_bindings.get("right").map(String::as_str),
-            Some(runtime_pane_b),
-            "second layout terminal should bind to second runtime pane by position",
-        );
-
-        // No new panes should be created — the runtime already has matching panes.
-        assert!(
-            opened.panes_to_create.is_empty(),
-            "should not create new panes when runtime already has panes for each layout terminal",
-        );
-
-        // No runtime panes should be skipped or recovered into new layout terminals.
-        assert!(
-            opened.skipped_runtime_panes.is_empty(),
-            "all runtime panes should be claimed by layout terminals",
-        );
-
-        // Snapshot restores should be emitted for both panes.
-        assert_eq!(opened.snapshot_restores.len(), 2);
-    }
-
-    /// When placeholder-only bindings reattach to a runtime with fewer panes
-    /// than layout terminals, the excess layout terminals must request new
-    /// daemon panes so they don't stay blank.
-    #[test]
-    fn placeholder_bindings_reattach_creates_panes_for_excess_layout_terminals() {
-        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
-        let runtime_pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
-
-        // 2 layout terminals, but runtime only has 1 pane.
-        let session = managed_session_with_runtime(
-            "workspace-1",
-            "Workspace",
-            hsplit(term("left"), term("right")),
-            RuntimeEndpoint::remote("cdt2"),
-            WorkspacePolicy::Persistent,
-            Some(runtime_id),
-        );
-        let mut state = window_state(vec![session]);
-        let snap =
-            snapshot(runtime_id, vec![pane_snapshot(runtime_pane_a, "Shell", "/home", b"$ ls")]);
-
-        let opened = state
-            .apply_managed_workspace_opened("workspace-1", runtime_id, &snap)
-            .expect("workspace open should succeed");
-
-        // First layout terminal should bind to the runtime pane.
-        assert_eq!(
-            opened.session_state.runtime.pane_bindings.get("left").map(String::as_str),
-            Some(runtime_pane_a),
-        );
-
-        // Second layout terminal should request a new pane.
-        assert_eq!(opened.panes_to_create, vec!["right".to_string()]);
     }
 
     #[test]
@@ -1949,7 +1646,7 @@ mod tests {
         let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
             workspace_id: "ws-1".into(),
             runtime_id: runtime_id.clone(),
-            snapshot: snapshot(&runtime_id, vec![snap]),
+            snapshot: single_leaf_snapshot(&runtime_id, &terminal_uuid, snap),
         });
 
         assert_eq!(transition.pane_snapshot_restores.len(), 1);
@@ -1970,19 +1667,17 @@ mod tests {
             Some(&runtime_id),
         );
         session.input_sync = true;
-        session.runtime.bind_runtime_pane("pane-1", "daemon-pane-1");
-        session.runtime.bind_runtime_pane("pane-2", "daemon-pane-2");
         let state = window_state(vec![session]);
 
         let targets = state.input_sync_targets("pane-1");
         assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].runtime_pane_id, "daemon-pane-2");
+        assert_eq!(targets[0].runtime_pane_id, "pane-2");
     }
 
     #[test]
     fn input_sync_targets_empty_when_disabled() {
         let runtime_id = uuid::Uuid::new_v4().to_string();
-        let mut session = managed_session_with_runtime(
+        let session = managed_session_with_runtime(
             "ws-1",
             "Workspace",
             hsplit(term("pane-1"), term("pane-2")),
@@ -1990,27 +1685,6 @@ mod tests {
             WorkspacePolicy::Persistent,
             Some(&runtime_id),
         );
-        session.runtime.bind_runtime_pane("pane-1", "daemon-pane-1");
-        session.runtime.bind_runtime_pane("pane-2", "daemon-pane-2");
-        let state = window_state(vec![session]);
-
-        assert!(state.input_sync_targets("pane-1").is_empty());
-    }
-
-    #[test]
-    fn input_sync_targets_skips_pending_panes() {
-        let runtime_id = uuid::Uuid::new_v4().to_string();
-        let mut session = managed_session_with_runtime(
-            "ws-1",
-            "Workspace",
-            hsplit(term("pane-1"), term("pane-2")),
-            RuntimeEndpoint::Local,
-            WorkspacePolicy::Persistent,
-            Some(&runtime_id),
-        );
-        session.input_sync = true;
-        session.runtime.bind_runtime_pane("pane-1", "daemon-pane-1");
-        // pane-2 stays pending (placeholder binding only)
         let state = window_state(vec![session]);
 
         assert!(state.input_sync_targets("pane-1").is_empty());
@@ -2023,106 +1697,6 @@ mod tests {
         let state = window_state(vec![session]);
 
         assert!(state.input_sync_targets("pane-1").is_empty());
-    }
-
-    /// Regression test for #547: repeated reconnect cycles must not grow the
-    /// layout. When bindings become stale (e.g. daemon restart assigns new
-    /// pane IDs), disconnected layout terminals should be matched to
-    /// unclaimed runtime panes by position instead of creating new splits.
-    #[test]
-    fn repeated_reconnect_cycles_do_not_grow_layout() {
-        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
-
-        let session = managed_session_with_runtime(
-            "workspace-1",
-            "Home",
-            hsplit(term("left"), term("right")),
-            RuntimeEndpoint::Local,
-            WorkspacePolicy::Persistent,
-            Some(runtime_id),
-        );
-        let mut state = window_state(vec![session]);
-
-        // Simulate 5 reconnect cycles, each with fresh daemon pane IDs
-        // (as if the daemon restarted between cycles).
-        for cycle in 0..5 {
-            let pane_a = uuid::Uuid::new_v4().to_string();
-            let pane_b = uuid::Uuid::new_v4().to_string();
-            let snap = snapshot(
-                runtime_id,
-                vec![
-                    pane_snapshot(&pane_a, "Shell", "/home", b"$ ls"),
-                    pane_snapshot(&pane_b, "Logs", "/var/log", b"tail"),
-                ],
-            );
-
-            let opened = state
-                .apply_managed_workspace_opened("workspace-1", runtime_id, &snap)
-                .expect("workspace open should succeed");
-
-            assert_eq!(
-                opened.session_state.layout.terminal_count(),
-                2,
-                "cycle {cycle}: layout must stay at 2 terminals",
-            );
-            assert!(
-                opened.skipped_runtime_panes.is_empty(),
-                "cycle {cycle}: no runtime panes should be skipped",
-            );
-        }
-    }
-
-    /// When stale bindings can't match current runtime panes, disconnected
-    /// layout terminals should be positionally matched to unclaimed runtime
-    /// panes — not left blank while new splits are created.
-    #[test]
-    fn stale_bindings_reconnect_matches_by_position() {
-        let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
-        let old_pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
-        let old_pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
-        let new_pane_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
-        let new_pane_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
-
-        // Workspace has real (non-placeholder) bindings from a previous connection.
-        let mut session = managed_session_with_runtime(
-            "workspace-1",
-            "Workspace",
-            hsplit(term("left"), term("right")),
-            RuntimeEndpoint::Local,
-            WorkspacePolicy::Persistent,
-            Some(runtime_id),
-        );
-        session.runtime.bind_runtime_pane("left", old_pane_a);
-        session.runtime.bind_runtime_pane("right", old_pane_b);
-        let mut state = window_state(vec![session]);
-
-        // Daemon restarted — new pane IDs.
-        let snap = snapshot(
-            runtime_id,
-            vec![
-                pane_snapshot(new_pane_a, "Shell", "/home", b"$ ls"),
-                pane_snapshot(new_pane_b, "Logs", "/var/log", b"tail"),
-            ],
-        );
-
-        let opened = state
-            .apply_managed_workspace_opened("workspace-1", runtime_id, &snap)
-            .expect("workspace open should succeed");
-
-        assert_eq!(
-            opened.session_state.layout.terminal_count(),
-            2,
-            "layout must not grow when daemon pane count matches layout terminal count",
-        );
-        assert_eq!(
-            opened.session_state.runtime.pane_bindings.get("left").map(String::as_str),
-            Some(new_pane_a),
-        );
-        assert_eq!(
-            opened.session_state.runtime.pane_bindings.get("right").map(String::as_str),
-            Some(new_pane_b),
-        );
-        assert!(opened.skipped_runtime_panes.is_empty());
     }
 
     #[test]
@@ -2146,9 +1720,10 @@ mod tests {
 
     #[test]
     fn workspace_opened_returns_previous_layout_terminals() {
+        use rttx_proto::v3_tree::{pane_tree_leaf, pane_tree_split};
+
         let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
-        let first_runtime_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
-        let mut session = managed_session_with_runtime(
+        let session = managed_session_with_runtime(
             "workspace-1",
             "Workspace",
             hsplit(term("left"), term("right")),
@@ -2156,32 +1731,39 @@ mod tests {
             WorkspacePolicy::Persistent,
             Some(runtime_id),
         );
-        session.runtime.bind_runtime_pane("left", first_runtime_pane);
         let mut state = window_state(vec![session]);
 
+        let server_left = uuid::Uuid::new_v4();
+        let server_right = uuid::Uuid::new_v4();
+        let mut snap = snapshot(
+            runtime_id,
+            vec![
+                pane_snapshot(&server_left.to_string(), "Shell", "/srv", b""),
+                pane_snapshot(&server_right.to_string(), "Logs", "/srv", b""),
+            ],
+        );
+        snap.tree = Some(pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(server_left),
+            pane_tree_leaf(server_right),
+        ));
+
         let opened = state
-            .apply_managed_workspace_opened(
-                "workspace-1",
-                runtime_id,
-                &snapshot(
-                    runtime_id,
-                    vec![pane_snapshot(first_runtime_pane, "Shell", "/srv", b"")],
-                ),
-            )
-            .expect("should reconcile");
+            .apply_managed_workspace_opened("workspace-1", runtime_id, &snap)
+            .expect("should adopt the server tree");
 
         assert_eq!(
             opened.previous_layout_terminals,
             vec!["left".to_string(), "right".to_string()],
-            "previous_layout_terminals should capture the pre-reconciliation UUIDs",
+            "previous_layout_terminals should capture the pre-adoption UUIDs",
         );
     }
 
     #[test]
-    fn reconcile_workspace_opened_emits_removed_for_stale_terminals() {
+    fn reconcile_workspace_opened_keeps_layout_for_treeless_snapshot() {
         let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
-        let runtime_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
-        let mut session = managed_session_with_runtime(
+        let session = managed_session_with_runtime(
             "workspace-1",
             "Workspace",
             hsplit(term("left"), term("right")),
@@ -2189,36 +1771,33 @@ mod tests {
             WorkspacePolicy::Persistent,
             Some(runtime_id),
         );
-        session.runtime.bind_runtime_pane("left", runtime_pane);
         let mut state = window_state(vec![session]);
 
         let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
             workspace_id: "workspace-1".into(),
             runtime_id: runtime_id.into(),
-            snapshot: snapshot(runtime_id, vec![pane_snapshot(runtime_pane, "Shell", "/srv", b"")]),
+            // A tree-less snapshot: the client keeps its existing layout and
+            // removes nothing (the daemon-bridge bootstrap creates panes).
+            snapshot: snapshot(runtime_id, vec![]),
         });
 
-        // Both "left" and "right" were in the previous layout. After
-        // reconciliation, "left" is matched to runtime_pane and "right"
-        // stays disconnected but remains in the layout (it gets a
-        // pane_create_request). So no terminals are removed.
         assert!(
             !transition.removed_layout_terminals.contains(&"left".to_string()),
             "matched terminal should not be marked as removed",
         );
         assert!(
             !transition.removed_layout_terminals.contains(&"right".to_string()),
-            "disconnected terminal stays in layout and should not be removed",
+            "existing terminal stays in layout and should not be removed",
         );
         assert_eq!(
             transition.rebuilt_workspaces.len(),
             1,
-            "workspace should be rebuilt after reconciliation",
+            "workspace should be rebuilt after opening",
         );
         assert_eq!(
             transition.rebuilt_workspaces[0].session_state.layout.terminal_uuids(),
             vec!["left".to_string(), "right".to_string()],
-            "both terminals should remain in the reconciled layout",
+            "both terminals should remain in the layout",
         );
     }
 
@@ -2412,32 +1991,32 @@ mod tests {
     #[test]
     fn reverse_index_matches_linear_scan_for_bound_pane() {
         let endpoint = RuntimeEndpoint::remote("builder.example");
-        let runtime_pane_id = "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26";
-        let mut session = managed_session_with_runtime(
+        let pane_id = "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26";
+        let session = managed_session_with_runtime(
             "workspace-1",
             "Workspace",
-            term("pane-1"),
+            term(pane_id),
             endpoint.clone(),
             WorkspacePolicy::Persistent,
             Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
         );
-        session.runtime.bind_runtime_pane("pane-1", runtime_pane_id);
         let state = window_state(vec![session]);
 
         assert_eq!(
-            state.runtime_pane_target(&endpoint, runtime_pane_id),
-            Some(("workspace-1".into(), "pane-1".into())),
+            state.runtime_pane_target(&endpoint, pane_id),
+            Some(("workspace-1".into(), pane_id.into())),
         );
     }
 
     #[test]
-    fn reverse_index_excludes_pending_placeholder_bindings() {
+    fn reverse_index_maps_layout_terminals_by_identity() {
         let state = window_state(vec![managed_session("workspace-1", "Workspace", term("pane-1"))]);
 
-        // Placeholder bindings (self-bindings) are pending — not in the index.
-        assert!(
-            state.runtime_pane_target(&RuntimeEndpoint::Local, "pane-1").is_none(),
-            "pending placeholder bindings must not appear in the reverse index",
+        // Under the identity invariant every managed layout terminal maps to
+        // itself in the reverse index.
+        assert_eq!(
+            state.runtime_pane_target(&RuntimeEndpoint::Local, "pane-1"),
+            Some(("workspace-1".into(), "pane-1".into())),
         );
     }
 
@@ -2453,79 +2032,78 @@ mod tests {
             "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26",
         );
 
+        // After the re-key the layout terminal IS the server pane id.
         assert_eq!(
             state.runtime_pane_target(
                 &RuntimeEndpoint::Local,
                 "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"
             ),
-            Some(("workspace-1".into(), "pane-1".into())),
+            Some(("workspace-1".into(), "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26".into())),
         );
     }
 
     #[test]
     fn reverse_index_consistent_after_pane_close() {
-        let mut session = managed_session_with_runtime(
+        let left = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
+        let right = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
+        let session = managed_session_with_runtime(
             "workspace-1",
             "Workspace",
-            hsplit(term("left"), term("right")),
+            hsplit(term(left), term(right)),
             RuntimeEndpoint::Local,
             WorkspacePolicy::Persistent,
             Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
         );
-        session.runtime.bind_runtime_pane("left", "07fa83b4-9ae3-4354-a1c5-1f685ffab370");
-        session.runtime.bind_runtime_pane("right", "0d88f17f-626d-40b8-a1d3-6a42af628ac9");
         let mut state = window_state(vec![session]);
 
-        state.apply_managed_pane_closed("workspace-1", "left");
+        state.apply_managed_pane_closed("workspace-1", left);
 
         assert!(
-            state
-                .runtime_pane_target(
-                    &RuntimeEndpoint::Local,
-                    "07fa83b4-9ae3-4354-a1c5-1f685ffab370"
-                )
-                .is_none(),
+            state.runtime_pane_target(&RuntimeEndpoint::Local, left).is_none(),
             "closed pane must be removed from the reverse index",
         );
         assert_eq!(
-            state.runtime_pane_target(
-                &RuntimeEndpoint::Local,
-                "0d88f17f-626d-40b8-a1d3-6a42af628ac9"
-            ),
-            Some(("workspace-1".into(), "right".into())),
+            state.runtime_pane_target(&RuntimeEndpoint::Local, right),
+            Some(("workspace-1".into(), right.into())),
         );
     }
 
     #[test]
-    fn reverse_index_consistent_after_workspace_opened_reconciliation() {
+    fn reverse_index_consistent_after_workspace_opened_adoption() {
+        use rttx_proto::v3_tree::{pane_tree_leaf, pane_tree_split};
+
         let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
         let runtime_pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
         let runtime_pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
         let mut state = window_state(vec![managed_session(
             "workspace-1",
             "Workspace",
-            hsplit(term("left"), term("right")),
+            hsplit(term("client-a"), term("client-b")),
         )]);
 
-        state.apply_managed_workspace_opened(
-            "workspace-1",
+        let mut snap = snapshot(
             runtime_id,
-            &snapshot(
-                runtime_id,
-                vec![
-                    pane_snapshot(runtime_pane_a, "Shell", "/home", b""),
-                    pane_snapshot(runtime_pane_b, "Logs", "/var", b""),
-                ],
-            ),
+            vec![
+                pane_snapshot(runtime_pane_a, "Shell", "/home", b""),
+                pane_snapshot(runtime_pane_b, "Logs", "/var", b""),
+            ],
         );
+        snap.tree = Some(pane_tree_split(
+            v3::PaneSplitAxis::Horizontal,
+            0.5,
+            pane_tree_leaf(uuid::Uuid::parse_str(runtime_pane_a).unwrap()),
+            pane_tree_leaf(uuid::Uuid::parse_str(runtime_pane_b).unwrap()),
+        ));
+        state.apply_managed_workspace_opened("workspace-1", runtime_id, &snap);
 
+        // Layout terminals ARE the server pane ids (identity).
         assert_eq!(
             state.runtime_pane_target(&RuntimeEndpoint::Local, runtime_pane_a),
-            Some(("workspace-1".into(), "left".into())),
+            Some(("workspace-1".into(), runtime_pane_a.into())),
         );
         assert_eq!(
             state.runtime_pane_target(&RuntimeEndpoint::Local, runtime_pane_b),
-            Some(("workspace-1".into(), "right".into())),
+            Some(("workspace-1".into(), runtime_pane_b.into())),
         );
     }
 
@@ -2556,15 +2134,14 @@ mod tests {
 
     #[test]
     fn reverse_index_not_serialized() {
-        let mut session = managed_session_with_runtime(
+        let session = managed_session_with_runtime(
             "ws-1",
             "Work",
-            term("t1"),
+            term("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
             RuntimeEndpoint::Local,
             WorkspacePolicy::Persistent,
             Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
         );
-        session.runtime.bind_runtime_pane("t1", "598b80fe-b96b-4fbf-8e2d-f2610b6f4f26");
         let state = window_state(vec![session]);
 
         let json = serde_json::to_string(&state).unwrap();
@@ -2586,35 +2163,34 @@ mod tests {
         let remote_pane = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
         let remote_endpoint = RuntimeEndpoint::remote("builder.example");
 
-        let mut local_session = managed_session_with_runtime(
+        // Layout terminal uuids ARE their server pane ids (identity).
+        let local_session = managed_session_with_runtime(
             "ws-local",
             "Local",
-            term("local-t1"),
+            term(local_pane),
             RuntimeEndpoint::Local,
             WorkspacePolicy::Persistent,
             Some("d7d04564-b2bf-4302-9495-e65c4df12ac6"),
         );
-        local_session.runtime.bind_runtime_pane("local-t1", local_pane);
 
-        let mut remote_session = managed_session_with_runtime(
+        let remote_session = managed_session_with_runtime(
             "ws-remote",
             "Remote",
-            term("remote-t1"),
+            term(remote_pane),
             remote_endpoint.clone(),
             WorkspacePolicy::Persistent,
             Some("598b80fe-b96b-4fbf-8e2d-f2610b6f4f26"),
         );
-        remote_session.runtime.bind_runtime_pane("remote-t1", remote_pane);
 
         let state = window_state(vec![local_session, remote_session]);
 
         assert_eq!(
             state.runtime_pane_target(&RuntimeEndpoint::Local, local_pane),
-            Some(("ws-local".into(), "local-t1".into())),
+            Some(("ws-local".into(), local_pane.into())),
         );
         assert_eq!(
             state.runtime_pane_target(&remote_endpoint, remote_pane),
-            Some(("ws-remote".into(), "remote-t1".into())),
+            Some(("ws-remote".into(), remote_pane.into())),
         );
         // Cross-endpoint lookup must not match.
         assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, remote_pane).is_none());

--- a/clients/rttx/tests/pane_reverse_index.rs
+++ b/clients/rttx/tests/pane_reverse_index.rs
@@ -5,7 +5,6 @@
 
 use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy, WorkspaceRuntime};
 use rttx::workspace::*;
-use std::collections::{BTreeMap, BTreeSet};
 
 fn term(id: &str) -> LayoutNode {
     LayoutNode::Terminal { uuid: id.to_string(), profile: None, cwd: None, custom_title: None }
@@ -32,7 +31,7 @@ fn managed_session(
     let terminal_recovery =
         terminal_uuids.iter().cloned().map(|uuid| (uuid, PaneRecovery::empty_shell())).collect();
     let active_terminal_uuid = terminal_uuids.first().cloned();
-    let mut session = WorkspaceState {
+    WorkspaceState {
         uuid: id.to_string(),
         name: name.to_string(),
         layout,
@@ -44,15 +43,11 @@ fn managed_session(
             endpoint,
             policy,
             runtime_id: runtime_id.map(str::to_string),
-            pane_bindings: BTreeMap::default(),
-            pending_layout_panes: BTreeSet::default(),
         },
         color: WorkspaceColor::default(),
         zoomed_terminal_uuid: None,
         user_renamed: false,
-    };
-    session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
-    session
+    }
 }
 
 fn window_state(workspaces: Vec<WorkspaceState>) -> WindowState {
@@ -107,73 +102,73 @@ fn lifecycle_create_bind_close_keeps_index_consistent() {
         None,
     )]);
 
-    // Before binding: no lookups should resolve.
+    // Before binding: no lookups should resolve to the server pane ids.
     assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, pane_a).is_none());
 
-    // Bind panes via apply_managed_pane_created.
+    // Bind panes via apply_managed_pane_created (re-keys layout to pane ids).
     state.apply_managed_pane_created("ws-1", "left", runtime_id, pane_a);
     state.apply_managed_pane_created("ws-1", "right", runtime_id, pane_b);
 
-    // Both panes should resolve.
+    // After the re-key each layout terminal IS its server pane id (identity).
     assert_eq!(
         state.runtime_pane_target(&RuntimeEndpoint::Local, pane_a),
-        Some(("ws-1".into(), "left".into())),
+        Some(("ws-1".into(), pane_a.into())),
     );
     assert_eq!(
         state.runtime_pane_target(&RuntimeEndpoint::Local, pane_b),
-        Some(("ws-1".into(), "right".into())),
+        Some(("ws-1".into(), pane_b.into())),
     );
 
-    // Close one pane.
-    state.apply_managed_pane_closed("ws-1", "left");
+    // Close one pane (identity: close by its server pane id).
+    state.apply_managed_pane_closed("ws-1", pane_a);
 
     // Closed pane should no longer resolve.
     assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, pane_a).is_none());
     // Remaining pane should still resolve.
     assert_eq!(
         state.runtime_pane_target(&RuntimeEndpoint::Local, pane_b),
-        Some(("ws-1".into(), "right".into())),
+        Some(("ws-1".into(), pane_b.into())),
     );
 }
 
-/// Reconciliation through `workspace_opened` replaces stale bindings and
-/// the index reflects the new state.
+/// A daemon restart delivers a new authoritative tree; the client adopts it
+/// and the index reflects the new (identity) pane ids.
 #[test]
 fn reconciliation_updates_index_after_daemon_restart() {
+    use rttx_proto::v3_tree::pane_tree_leaf;
+
     let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
     let old_pane = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
     let new_pane = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
-    let mut session = managed_session(
+    // The layout terminal IS the old server pane id (identity).
+    let session = managed_session(
         "ws-1",
         "Workspace",
-        term("t1"),
+        term(old_pane),
         RuntimeEndpoint::Local,
         WorkspacePolicy::Persistent,
         Some(runtime_id),
     );
-    session.runtime.bind_runtime_pane("t1", old_pane);
     let mut state = window_state(vec![session]);
 
     // Old pane resolves.
     assert_eq!(
         state.runtime_pane_target(&RuntimeEndpoint::Local, old_pane),
-        Some(("ws-1".into(), "t1".into())),
+        Some(("ws-1".into(), old_pane.into())),
     );
 
-    // Daemon restarts with a new pane ID.
-    state.apply_managed_workspace_opened(
-        "ws-1",
-        runtime_id,
-        &snapshot(runtime_id, vec![pane_snapshot(new_pane, "Shell", "/home")]),
-    );
+    // Daemon restarts and sends a new authoritative single-pane tree.
+    let mut snap = snapshot(runtime_id, vec![pane_snapshot(new_pane, "Shell", "/home")]);
+    snap.tree = Some(pane_tree_leaf(uuid::Uuid::parse_str(new_pane).unwrap()));
+    state.apply_managed_workspace_opened("ws-1", runtime_id, &snap);
 
     // Old pane should no longer resolve.
     assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, old_pane).is_none());
     // New pane should resolve.
     assert_eq!(
         state.runtime_pane_target(&RuntimeEndpoint::Local, new_pane),
-        Some(("ws-1".into(), "t1".into())),
+        Some(("ws-1".into(), new_pane.into())),
     );
 }
 
@@ -210,14 +205,14 @@ fn multi_endpoint_isolation_through_full_lifecycle() {
     // Bind remote pane.
     state.apply_managed_pane_created("ws-remote", "remote-t1", remote_runtime, remote_pane);
 
-    // Each pane resolves only on its own endpoint.
+    // Each pane resolves only on its own endpoint (identity: uuid == pane id).
     assert_eq!(
         state.runtime_pane_target(&RuntimeEndpoint::Local, local_pane),
-        Some(("ws-local".into(), "local-t1".into())),
+        Some(("ws-local".into(), local_pane.into())),
     );
     assert_eq!(
         state.runtime_pane_target(&remote_endpoint, remote_pane),
-        Some(("ws-remote".into(), "remote-t1".into())),
+        Some(("ws-remote".into(), remote_pane.into())),
     );
     assert!(state.runtime_pane_target(&RuntimeEndpoint::Local, remote_pane).is_none());
     assert!(state.runtime_pane_target(&remote_endpoint, local_pane).is_none());

--- a/clients/rttx/tests/reconnect_layout_stability.rs
+++ b/clients/rttx/tests/reconnect_layout_stability.rs
@@ -59,10 +59,7 @@ fn layout_stays_stable_across_reconnect_cycles_with_fresh_pane_ids() {
         WorkspaceState::new_managed_local("Home".into(), WorkspacePolicy::Persistent, None);
     session.uuid = "ws-1".into();
     session.layout = hsplit(term("left"), term("right"));
-    session.runtime = WorkspaceRuntime::managed_local(
-        WorkspacePolicy::Persistent,
-        &session.layout.terminal_uuids(),
-    );
+    session.runtime = WorkspaceRuntime::managed_local(WorkspacePolicy::Persistent);
     session.runtime.runtime_id = Some(runtime_id.into());
 
     let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };

--- a/clients/rttx/tests/render_from_server_tree.rs
+++ b/clients/rttx/tests/render_from_server_tree.rs
@@ -142,10 +142,7 @@ fn attach_adopts_server_tree_through_the_window_state_flow() {
         cwd: None,
         custom_title: None,
     };
-    session.runtime = WorkspaceRuntime::managed_local(
-        WorkspacePolicy::Persistent,
-        &session.layout.terminal_uuids(),
-    );
+    session.runtime = WorkspaceRuntime::managed_local(WorkspacePolicy::Persistent);
     session.runtime.runtime_id = Some(runtime_id.into());
 
     let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };
@@ -205,10 +202,7 @@ fn close_after_adopt_then_reconnect_keeps_single_pane() {
     let mut session =
         WorkspaceState::new_managed_local("Home".into(), WorkspacePolicy::Persistent, None);
     session.uuid = "ws-1".into();
-    session.runtime = WorkspaceRuntime::managed_local(
-        WorkspacePolicy::Persistent,
-        &session.layout.terminal_uuids(),
-    );
+    session.runtime = WorkspaceRuntime::managed_local(WorkspacePolicy::Persistent);
     session.runtime.runtime_id = Some(runtime_id.into());
     let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };
 

--- a/clients/rttx/tests/render_from_server_tree.rs
+++ b/clients/rttx/tests/render_from_server_tree.rs
@@ -259,3 +259,56 @@ fn close_after_adopt_then_reconnect_keeps_single_pane() {
         "still one pane after the second reconnect"
     );
 }
+
+/// A managed pane ack (the `CreatePane` bootstrap for a new workspace, or a
+/// `SplitPane` reply) carries the server-minted pane id. The client re-keys its
+/// optimistic, client-minted layout terminal onto that durable id so the
+/// invariant `layout uuid == server pane id` holds everywhere — with no
+/// binding table (RFC-031). The transition carries the re-key so the window
+/// can rename its widget maps, and downstream connect/recover target the new id.
+#[test]
+fn pane_ack_rekeys_client_layout_terminal_to_server_pane_id() {
+    use rttx::daemon_bridge::EndpointEvent;
+    use rttx::runtime::{WorkspacePolicy, WorkspaceRuntime};
+    use rttx::workspace::{WindowState, WorkspaceState};
+
+    let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
+
+    let mut session =
+        WorkspaceState::new_managed_local("Home".into(), WorkspacePolicy::Persistent, None);
+    session.uuid = "ws-1".into();
+    // The optimistic split (or new-workspace bootstrap) added a client-minted
+    // layout terminal that is not yet a server pane id.
+    session.layout = LayoutNode::Terminal {
+        uuid: "client-minted-pane".into(),
+        profile: None,
+        cwd: None,
+        custom_title: None,
+    };
+    session.active_terminal_uuid = Some("client-minted-pane".into());
+    session.runtime = WorkspaceRuntime::managed_local(WorkspacePolicy::Persistent);
+    session.runtime.runtime_id = Some(runtime_id.into());
+    let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };
+
+    let server_pane = Uuid::new_v4();
+    let transition = state.reconcile_endpoint_event(&EndpointEvent::PaneCreated {
+        workspace_id: "ws-1".into(),
+        layout_terminal_uuid: "client-minted-pane".into(),
+        runtime_id: runtime_id.into(),
+        runtime_pane_id: server_pane.to_string(),
+    });
+
+    // The layout terminal (and active pointer) are re-keyed to the server id.
+    assert_eq!(state.workspaces[0].layout.terminal_uuids(), vec![server_pane.to_string()]);
+    assert_eq!(
+        state.workspaces[0].active_terminal_uuid.as_deref(),
+        Some(server_pane.to_string().as_str())
+    );
+
+    // The transition reports the re-key (so the window renames its widget maps)
+    // and targets the new identity uuid downstream.
+    assert_eq!(transition.pane_rekeys.len(), 1);
+    assert_eq!(transition.pane_rekeys[0].old_uuid, "client-minted-pane");
+    assert_eq!(transition.pane_rekeys[0].new_uuid, server_pane.to_string());
+    assert_eq!(transition.connected_layout_terminals, vec![server_pane.to_string()]);
+}

--- a/clients/rttx/tests/stale_terminal_cleanup.rs
+++ b/clients/rttx/tests/stale_terminal_cleanup.rs
@@ -54,10 +54,7 @@ fn managed_session(layout: LayoutNode, runtime_id: &str) -> WorkspaceState {
         WorkspaceState::new_managed_local("Test".into(), WorkspacePolicy::Persistent, None);
     session.uuid = "ws-1".into();
     session.layout = layout;
-    session.runtime = WorkspaceRuntime::managed_local(
-        WorkspacePolicy::Persistent,
-        &session.layout.terminal_uuids(),
-    );
+    session.runtime = WorkspaceRuntime::managed_local(WorkspacePolicy::Persistent);
     session.runtime.runtime_id = Some(runtime_id.into());
     session
 }
@@ -78,13 +75,9 @@ fn stale_uuids_from_transition(transition: &EndpointEventTransition) -> Vec<Stri
 #[test]
 fn reconnect_cycles_never_leak_terminal_uuids() {
     let runtime_id = "d7d04564-b2bf-4302-9495-e65c4df12ac6";
-    let initial_pane = uuid::Uuid::new_v4().to_string();
 
     let session = managed_session(term("initial"), runtime_id);
     let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };
-
-    // Bind the initial terminal to a runtime pane.
-    state.workspaces[0].runtime.bind_runtime_pane("initial", &initial_pane);
 
     let mut all_ever_created: std::collections::BTreeSet<String> =
         state.workspaces[0].layout.terminal_uuids().into_iter().collect();
@@ -137,9 +130,7 @@ fn workspace_opened_transition_accounts_for_all_previous_terminals() {
     let pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
     let pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
 
-    let mut session = managed_session(hsplit(term("left"), term("right")), runtime_id);
-    session.runtime.bind_runtime_pane("left", pane_a);
-    session.runtime.bind_runtime_pane("right", pane_b);
+    let session = managed_session(hsplit(term("left"), term("right")), runtime_id);
     let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };
 
     let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
@@ -173,9 +164,7 @@ fn pane_closed_then_workspace_opened_does_not_double_remove() {
     let pane_a = "07fa83b4-9ae3-4354-a1c5-1f685ffab370";
     let pane_b = "0d88f17f-626d-40b8-a1d3-6a42af628ac9";
 
-    let mut session = managed_session(hsplit(term("left"), term("right")), runtime_id);
-    session.runtime.bind_runtime_pane("left", pane_a);
-    session.runtime.bind_runtime_pane("right", pane_b);
+    let session = managed_session(hsplit(term("left"), term("right")), runtime_id);
     let mut state = WindowState { workspaces: vec![session], ..WindowState::default() };
 
     // Close "left" pane.

--- a/clients/rttx/tests/stream_overflow_resync.rs
+++ b/clients/rttx/tests/stream_overflow_resync.rs
@@ -64,7 +64,7 @@ fn managed_workspace(id: &str, layout: LayoutNode, runtime_id: Option<&str>) -> 
         .map(|uuid| (uuid, rttx::workspace::PaneRecovery::empty_shell()))
         .collect();
     let active_terminal_uuid = terminal_uuids.first().cloned();
-    let mut session = WorkspaceState {
+    WorkspaceState {
         uuid: id.to_string(),
         name: id.to_string(),
         layout,
@@ -76,15 +76,11 @@ fn managed_workspace(id: &str, layout: LayoutNode, runtime_id: Option<&str>) -> 
             endpoint: RuntimeEndpoint::Local,
             policy: WorkspacePolicy::Persistent,
             runtime_id: runtime_id.map(str::to_string),
-            pane_bindings: std::collections::BTreeMap::default(),
-            pending_layout_panes: std::collections::BTreeSet::default(),
         },
         color: WorkspaceColor::default(),
         zoomed_terminal_uuid: None,
         user_renamed: false,
-    };
-    session.runtime.ensure_placeholder_bindings(&terminal_uuids);
-    session
+    }
 }
 
 /// Resync on a multi-pane workspace restores all bound panes without
@@ -191,7 +187,6 @@ fn repeated_resyncs_are_idempotent() {
         assert!(transition.rebuilt_workspaces.is_empty());
     }
 
-    // Layout and bindings unchanged after 5 resyncs.
+    // Layout unchanged after 5 resyncs.
     assert_eq!(state.workspaces[0].layout.terminal_uuids().len(), 1);
-    assert_eq!(state.workspaces[0].runtime.pane_bindings.len(), 1);
 }

--- a/clients/rttx/tests/workspace_lifecycle.rs
+++ b/clients/rttx/tests/workspace_lifecycle.rs
@@ -523,7 +523,6 @@ fn new_managed_remote_produces_remote_persistent_session() {
     assert!(session.runtime.is_managed());
     assert_eq!(session.runtime.endpoint, RuntimeEndpoint::remote("dev-box.internal"));
     assert!(!session.layout.terminal_uuids().is_empty());
-    assert!(!session.runtime.pending_layout_panes.is_empty());
 }
 
 /// Remote managed session must round-trip through serialization.
@@ -588,9 +587,9 @@ fn update_remote_endpoint_changes_host() {
 }
 
 /// Splitting a pane in a remote managed session must preserve the remote
-/// endpoint and add the new pane to pending bindings. Issue #246.
+/// endpoint and add the new pane to the layout. Issue #246.
 #[test]
-fn split_remote_session_preserves_endpoint_and_adds_pending_pane() {
+fn split_remote_session_preserves_endpoint_and_adds_pane() {
     use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
     use rttx::workspace::layout::SplitOrientation;
     use rttx::workspace::{PaneRecovery, WorkspaceState};
@@ -603,7 +602,7 @@ fn split_remote_session_preserves_endpoint_and_adds_pending_pane() {
     );
 
     let original_uuid = session.layout.terminal_uuids()[0].clone();
-    assert_eq!(session.runtime.pending_layout_panes.len(), 1);
+    assert_eq!(session.layout.terminal_count(), 1);
 
     // Split — mirrors the logic in window/mod.rs split_terminal().
     let (new_layout, new_uuid) = session
@@ -612,7 +611,6 @@ fn split_remote_session_preserves_endpoint_and_adds_pending_pane() {
         .unwrap();
     session.layout = new_layout;
     session.set_recovery(&new_uuid, PaneRecovery::empty_shell());
-    session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
 
     // Endpoint must still be remote.
     assert_eq!(
@@ -621,18 +619,15 @@ fn split_remote_session_preserves_endpoint_and_adds_pending_pane() {
         "split must not change the workspace endpoint"
     );
 
-    // Both panes must be in pending bindings.
-    assert!(
-        session.runtime.pending_layout_panes.contains(&new_uuid),
-        "new pane must be in pending_layout_panes"
-    );
+    // Both panes must be in the layout.
+    assert!(session.layout.contains_terminal(&new_uuid), "new pane must be in the layout");
     assert_eq!(session.layout.terminal_count(), 2);
     assert!(session.runtime.is_managed());
 }
 
-/// Splitting twice must keep all panes pending and endpoint unchanged.
+/// Splitting twice must keep all panes in the layout and endpoint unchanged.
 #[test]
-fn double_split_remote_session_keeps_all_panes_pending() {
+fn double_split_remote_session_keeps_all_panes() {
     use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
     use rttx::workspace::layout::SplitOrientation;
     use rttx::workspace::{PaneRecovery, WorkspaceState};
@@ -650,18 +645,16 @@ fn double_split_remote_session_keeps_all_panes_pending() {
         session.layout.split_terminal_with_new_uuid(&t1, SplitOrientation::Horizontal).unwrap();
     session.layout = layout;
     session.set_recovery(&t2, PaneRecovery::empty_shell());
-    session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
 
     let (layout, t3) =
         session.layout.split_terminal_with_new_uuid(&t2, SplitOrientation::Vertical).unwrap();
     session.layout = layout;
     session.set_recovery(&t3, PaneRecovery::empty_shell());
-    session.runtime.ensure_placeholder_bindings(&session.layout.terminal_uuids());
 
     assert_eq!(session.runtime.endpoint, RuntimeEndpoint::remote("gpu-box"));
     assert_eq!(session.layout.terminal_count(), 3);
-    assert!(session.runtime.pending_layout_panes.contains(&t2));
-    assert!(session.runtime.pending_layout_panes.contains(&t3));
+    assert!(session.layout.contains_terminal(&t2));
+    assert!(session.layout.contains_terminal(&t3));
 }
 
 /// Closing a remote workspace and then receiving inventory must not
@@ -725,7 +718,7 @@ fn remote_managed_session_is_ready_for_inventory_binding() {
     assert!(remote_session.runtime.is_managed());
     assert_eq!(remote_session.runtime.endpoint, endpoint);
     assert!(remote_session.runtime.runtime_id.is_none());
-    assert!(!remote_session.runtime.pending_layout_panes.is_empty());
+    assert!(!remote_session.layout.terminal_uuids().is_empty());
 }
 
 /// `active_workspace_index` must be clamped to valid range on restore.
@@ -893,29 +886,30 @@ fn ctrl_arrow_encodes_with_modifier_param() {
     );
 }
 
-/// Split pane CWD must propagate through reconciliation pane create requests. #297.
+/// Split pane CWD must propagate to a pane create request. #297.
+///
+/// Removed with RFC-031: the client no longer reconciles a tree-less snapshot
+/// into pane-create requests. Pane creation is bootstrapped by the daemon
+/// bridge and pane identity is assigned by the `PaneCreated` re-key.
 #[test]
-fn split_pane_cwd_propagates_through_reconciliation_create_request() {
-    use rttx::daemon_bridge::EndpointEvent;
+fn split_remote_session_cwd_survives_layout_round_trip() {
     use rttx::runtime::WorkspacePolicy;
     use rttx::workspace::*;
 
     let first_uuid = uuid::Uuid::new_v4().to_string();
     let second_uuid = uuid::Uuid::new_v4().to_string();
-    let runtime_id = uuid::Uuid::new_v4().to_string();
 
-    // Build a managed workspace with two panes, second has a CWD from a prior split.
     let layout = LayoutNode::Split {
         orientation: SplitOrientation::Horizontal,
         ratio: 0.5,
         first: Box::new(LayoutNode::Terminal {
-            uuid: first_uuid.clone(),
+            uuid: first_uuid,
             profile: None,
             cwd: None,
             custom_title: None,
         }),
         second: Box::new(LayoutNode::Terminal {
-            uuid: second_uuid,
+            uuid: second_uuid.clone(),
             profile: None,
             cwd: Some("/srv/project".into()),
             custom_title: None,
@@ -926,41 +920,9 @@ fn split_pane_cwd_propagates_through_reconciliation_create_request() {
         WorkspaceState::new_managed_local("Workspace".into(), WorkspacePolicy::Persistent, None);
     session.layout = layout;
 
-    let mut state = WindowState { workspaces: vec![session], ..Default::default() };
-
-    // Simulate daemon reporting only the first pane exists.
-    let transition = state.reconcile_endpoint_event(&EndpointEvent::WorkspaceOpened {
-        workspace_id: state.workspaces[0].uuid.clone(),
-        runtime_id: runtime_id.clone(),
-        snapshot: rttx_proto::v3::WorkspaceSnapshot {
-            tree: None,
-            default_active_pane_id: Vec::new(),
-            runtime_id: rttx_proto::uuid_to_bytes(runtime_id.parse().unwrap()),
-            panes: vec![rttx_proto::v3::PaneSnapshot {
-                pane_id: rttx_proto::uuid_to_bytes(first_uuid.parse().unwrap()),
-                pane_output_seq: 0,
-                title: "Shell".into(),
-                cwd: "/home".into(),
-                scrollback_tail: bytes::Bytes::new(),
-                cols: 80,
-                rows: 24,
-                exit_status: None,
-                terminal_modes: None,
-                total_scrollback_bytes: 0,
-                scrollback_complete: true,
-            }],
-            workspace_revision: 0,
-            client_role: 0,
-        },
-    });
-
-    // The second pane should be requested with the layout CWD.
-    assert_eq!(transition.pane_create_requests.len(), 1);
-    assert_eq!(
-        transition.pane_create_requests[0].cwd.as_deref(),
-        Some("/srv/project"),
-        "reconciliation must carry layout CWD to pane create request"
-    );
+    // The layout node carries the CWD for the second pane; this is what a
+    // subsequent CreatePane bootstrap reads to seed the daemon pane.
+    assert_eq!(session.layout.terminal_cwd(&second_uuid).as_deref(), Some("/srv/project"),);
 }
 
 // ── Zoom state ──────────────────────────────────────────────────
@@ -1173,7 +1135,6 @@ fn input_sync_fan_out_targets_all_bound_managed_siblings() {
     use rttx::runtime::{RuntimeEndpoint, WorkspacePolicy};
 
     let layout = hsplit(term("pane-1"), hsplit(term("pane-2"), term("pane-3")));
-    let terminal_uuids = layout.terminal_uuids();
     let mut session = WorkspaceState::new("Sync test".into());
     session.uuid = "ws-sync".into();
     session.layout = layout;
@@ -1183,13 +1144,7 @@ fn input_sync_fan_out_targets_all_bound_managed_siblings() {
         endpoint: RuntimeEndpoint::Local,
         policy: WorkspacePolicy::Persistent,
         runtime_id: Some("rt-1".into()),
-        pane_bindings: std::collections::BTreeMap::default(),
-        pending_layout_panes: std::collections::BTreeSet::default(),
     };
-    session.runtime.ensure_placeholder_bindings(&terminal_uuids);
-    session.runtime.bind_runtime_pane("pane-1", "daemon-1");
-    session.runtime.bind_runtime_pane("pane-2", "daemon-2");
-    session.runtime.bind_runtime_pane("pane-3", "daemon-3");
 
     let state = WindowState {
         active_workspace_index: 0,
@@ -1197,11 +1152,12 @@ fn input_sync_fan_out_targets_all_bound_managed_siblings() {
         ..WindowState::default()
     };
 
+    // Identity invariant: each sibling's runtime pane id IS its layout uuid.
     let targets = state.input_sync_targets("pane-1");
     assert_eq!(targets.len(), 2);
     let target_pane_ids: Vec<&str> = targets.iter().map(|t| t.runtime_pane_id.as_str()).collect();
-    assert!(target_pane_ids.contains(&"daemon-2"));
-    assert!(target_pane_ids.contains(&"daemon-3"));
+    assert!(target_pane_ids.contains(&"pane-2"));
+    assert!(target_pane_ids.contains(&"pane-3"));
 
     // Verify no targets when input sync is off.
     let mut state_off = state.clone();
@@ -1300,6 +1256,8 @@ fn default_window_state_has_reasonable_sidebar_widths() {
 
 #[test]
 fn v3_snapshot_terminal_modes_propagate_through_reconciliation() {
+    use rttx::workspace::LayoutNode;
+
     let runtime_id = uuid::Uuid::new_v4().to_string();
     let pane_id = uuid::Uuid::new_v4().to_string();
     let mut state = WindowState {
@@ -1310,10 +1268,17 @@ fn v3_snapshot_terminal_modes_propagate_through_reconciliation() {
         )],
         ..WindowState::default()
     };
+    // The layout terminal IS the server pane id (identity invariant).
+    state.workspaces[0].layout = LayoutNode::Terminal {
+        uuid: pane_id.clone(),
+        profile: None,
+        cwd: None,
+        custom_title: None,
+    };
     let ws_id = state.workspaces[0].uuid.clone();
 
     let snapshot = rttx_proto::v3::WorkspaceSnapshot {
-        tree: None,
+        tree: Some(rttx_proto::v3_tree::pane_tree_leaf(uuid::Uuid::parse_str(&pane_id).unwrap())),
         default_active_pane_id: Vec::new(),
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
         panes: vec![rttx_proto::v3::PaneSnapshot {
@@ -1367,7 +1332,7 @@ fn v3_snapshot_terminal_modes_propagate_through_reconciliation() {
 /// through reconciliation so the restore path can re-apply them. #765.
 #[test]
 fn v3_snapshot_focus_and_cursor_modes_propagate_through_reconciliation() {
-    use rttx::workspace::{WindowState, WorkspaceState};
+    use rttx::workspace::{LayoutNode, WindowState, WorkspaceState};
 
     let runtime_id = uuid::Uuid::new_v4().to_string();
     let pane_id = uuid::Uuid::new_v4().to_string();
@@ -1379,10 +1344,17 @@ fn v3_snapshot_focus_and_cursor_modes_propagate_through_reconciliation() {
         )],
         ..WindowState::default()
     };
+    // The layout terminal IS the server pane id (identity invariant).
+    state.workspaces[0].layout = LayoutNode::Terminal {
+        uuid: pane_id.clone(),
+        profile: None,
+        cwd: None,
+        custom_title: None,
+    };
     let ws_id = state.workspaces[0].uuid.clone();
 
     let snapshot = rttx_proto::v3::WorkspaceSnapshot {
-        tree: None,
+        tree: Some(rttx_proto::v3_tree::pane_tree_leaf(uuid::Uuid::parse_str(&pane_id).unwrap())),
         default_active_pane_id: Vec::new(),
         runtime_id: rttx_proto::uuid_to_bytes(uuid::Uuid::parse_str(&runtime_id).unwrap()),
         panes: vec![rttx_proto::v3::PaneSnapshot {


### PR DESCRIPTION
Completes the RFC-031 "complete legacy removal" mandate that epic #997 tracked. Establishes the invariant that **every client layout terminal's uuid IS its server pane id**, and deletes the client-side binding/translation layer entirely — **no leftovers**.

## Removed
`WorkspaceRuntime::pane_bindings` + `pending_layout_panes` fields; `ensure_placeholder_bindings`, `replace_layout_terminal_uuid`, `bind_runtime_pane`, `is_layout_pane_pending`, `rebind`; `BindingReconciliation` + `reconcile_bindings`; and the tree-less reconciliation fallback in `apply_managed_workspace_opened`.

## Mechanism (re-key on ack)
When the daemon acks a client-minted pane (the CreatePane bootstrap for a new workspace's first pane, or a SplitPane reply), `apply_managed_pane_created` **re-keys** the layout terminal — its recovery state, active-terminal pointer, and the GUI widget maps (`terminals`/`persistent_terminals`) — onto the server pane id. So `uuid == pane_id` holds everywhere and no binding table is needed. Pane-id lookups, input-sync targets, close, resync restores, and the reverse index all use the uuid directly. Attach/reconnect still adopts the server tree wholesale.

## Verification
- No-leftovers grep across `clients/rttx` (src + tests): **0 matches** for all removed symbols.
- Client builds clean (`--no-default-features --features vte-0_76`); `cargo test -p rttx ...`: **all pass, 0 failed**; strict clippy (`--all-targets -D warnings`, incl. pedantic/nursery): clean.
- Server + proto build/clippy: clean.
- Net **−695 lines**.

Refs #997 (will close the epic once merged, with a verification summary).