### PR TITLE
fix(server): reset terminal modes on daemon restart instead of restoring dead TUI state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Restarting the daemon no longer leaves panes that were running a full-screen
+  TUI (e.g. Claude, Codex, vim, htop) in a broken, garbage-spewing state. A
+  daemon restart kills the app that owned the terminal, so reconstruction now
+  resets the pane to a clean interactive baseline instead of restoring the dead
+  app's interaction modes. Previously the persisted mouse-tracking / alt-screen
+  modes were re-applied onto the freshly respawned shell, so every mouse
+  movement injected `\x1b[<btn;col;rowM` reports onto the prompt and the
+  replayed alt-screen frame scattered text across the buffer. The transient TUI
+  frame is now dropped (detected via alternate-screen or mouse-tracking state)
+  and only genuine shell scrollback is replayed.
+
 ### Removed
 - The `rttx-server salvage-history` subcommand and its one-time orphaned-history
   recovery scan — the last code that engaged with the previous iteration's

--- a/services/rttx-server/src/pane.rs
+++ b/services/rttx-server/src/pane.rs
@@ -300,6 +300,7 @@ impl Pane {
                 mouse_tracking_mode: self.screen.mouse_tracking_mode(),
                 sgr_mouse: self.screen.sgr_mouse_mode(),
                 focus_reporting: self.screen.focus_event_mode(),
+                alternate_screen: self.screen.alternate_screen(),
             },
             screen_bytes,
             confidential: self.no_persist,
@@ -308,16 +309,41 @@ impl Pane {
 
     /// Restore canonical pane state from a persisted screen snapshot.
     ///
-    /// Feeds `screen_bytes` through the parser, then overwrites mode flags,
-    /// cursor visibility, and output sequence from the snapshot metadata.
-    /// This ensures restart reconstruction is deterministic from the
-    /// persisted metadata rather than depending on mode-setting escape
-    /// sequences being present in the retained byte tail.
+    /// A daemon restart destroyed the process that owned this pane. Any
+    /// full-screen TUI (Claude, Codex, vim, htop, …) that had put the terminal
+    /// into alternate-screen / mouse-tracking / bracketed-paste mode is gone,
+    /// and the pane is about to be handed to a freshly respawned shell.
+    /// Faithfully restoring the dead app's modes leaves that shell in a broken
+    /// input state — most visibly, stuck mouse tracking makes every pointer
+    /// movement inject `\x1b[<btn;col;rowM` reports onto the command line, and a
+    /// replayed alt-screen frame scatters absolutely-positioned text across the
+    /// buffer. So reconstruction is treated like a clean process exit: the
+    /// transient app frame is dropped and the terminal is reset to an
+    /// interactive baseline via [`terminal_cleanup_bytes`].
+    ///
+    /// The reset is applied to the screen state itself, so it also propagates to
+    /// clients that attach after reconstruction — their snapshot is rebuilt from
+    /// this screen's live mode flags and byte tail.
+    ///
+    /// [`terminal_cleanup_bytes`]: crate::screen::terminal_cleanup_bytes
     pub fn restore_from_snapshot(&mut self, snap: &ScreenSnapshotV1) {
-        let clean = crate::screen::restart_safe_scrollback(&snap.screen_bytes);
-        self.screen.feed(clean);
-        self.screen.restore_modes(&snap.modes);
-        self.screen.restore_cursor_visible(snap.cursor_visible);
+        // A TUI owned the screen if it was in the alternate buffer or had mouse
+        // tracking enabled. Its on-screen content is transient app UI, not
+        // scrollback worth replaying.
+        let tui_owned_screen = snap.modes.alternate_screen || snap.modes.mouse_tracking_mode != 0;
+
+        if !tui_owned_screen {
+            // Normal shell: the retained tail is real scrollback worth showing.
+            let clean = crate::screen::restart_safe_scrollback(&snap.screen_bytes);
+            self.screen.feed(clean);
+        }
+
+        // Reset alt-screen, mouse tracking, bracketed paste, application cursor
+        // keys, and cursor visibility to a sane baseline. Feeding the cleanup
+        // bytes through the parser also clears the corresponding mode flags, so
+        // the reconstructed screen reports a clean state to attaching clients.
+        self.screen.feed(crate::screen::terminal_cleanup_bytes());
+
         self.output_seq = snap.pane_output_seq;
     }
 }
@@ -870,36 +896,60 @@ mod tests {
                 mouse_tracking_mode: 1003,
                 sgr_mouse: true,
                 focus_reporting: true,
+                alternate_screen: false,
             },
             screen_bytes: b"line1\r\nline2\r\n".to_vec(),
             confidential: false,
         }
     }
 
-    #[test]
-    fn restore_from_snapshot_restores_modes() {
-        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
-        let snap = snapshot_with_modes(pane.id);
-
-        pane.restore_from_snapshot(&snap);
-
-        assert!(pane.screen.bracketed_paste_mode());
-        assert!(pane.screen.application_cursor_keys());
-        assert!(pane.screen.application_keypad());
-        assert_eq!(pane.screen.mouse_tracking_mode(), 1003);
-        assert!(pane.screen.sgr_mouse_mode());
-        assert!(pane.screen.focus_event_mode());
+    /// Return a normal-shell snapshot: no alt-screen, no mouse tracking, with
+    /// real scrollback in `screen_bytes`.
+    fn normal_shell_snapshot(pane_id: Uuid, screen_bytes: &[u8]) -> ScreenSnapshotV1 {
+        let mut snap = snapshot_with_modes(pane_id);
+        snap.modes = TerminalModeSnapshot {
+            bracketed_paste: false,
+            application_cursor_keys: false,
+            application_keypad: false,
+            mouse_tracking_mode: 0,
+            sgr_mouse: false,
+            focus_reporting: false,
+            alternate_screen: false,
+        };
+        snap.screen_bytes = screen_bytes.to_vec();
+        snap
     }
 
     #[test]
-    fn restore_from_snapshot_restores_cursor_visibility() {
+    fn restore_from_snapshot_resets_tui_modes_to_baseline() {
+        // Regression: a daemon restart kills the TUI (Claude/Codex/vim) that
+        // enabled mouse tracking. Reconstruction must NOT restore those modes —
+        // otherwise the respawned shell inherits mouse tracking and every
+        // pointer movement injects `\x1b[<btn;col;rowM` reports onto the prompt.
         let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
-        assert!(pane.screen.cursor_visible());
+        let snap = snapshot_with_modes(pane.id); // mouse_tracking_mode: 1003
 
-        let snap = snapshot_with_modes(pane.id);
         pane.restore_from_snapshot(&snap);
 
-        assert!(!pane.screen.cursor_visible());
+        assert_eq!(pane.screen.mouse_tracking_mode(), 0, "mouse tracking must be reset");
+        assert!(!pane.screen.sgr_mouse_mode());
+        assert!(!pane.screen.bracketed_paste_mode());
+        assert!(!pane.screen.application_cursor_keys());
+        assert!(!pane.screen.application_keypad());
+        assert!(!pane.screen.focus_event_mode());
+        assert!(!pane.screen.alternate_screen());
+    }
+
+    #[test]
+    fn restore_from_snapshot_forces_cursor_visible() {
+        // TUI apps often hide the cursor; the reconstructed baseline shows it so
+        // the fresh shell prompt is usable.
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let snap = snapshot_with_modes(pane.id); // cursor_visible: false
+
+        pane.restore_from_snapshot(&snap);
+
+        assert!(pane.screen.cursor_visible());
     }
 
     #[test]
@@ -914,45 +964,60 @@ mod tests {
     }
 
     #[test]
-    fn restore_from_snapshot_feeds_screen_bytes() {
+    fn restore_from_snapshot_skips_transient_frame_for_tui_app() {
+        // The alt-screen / mouse-driven frame is transient app UI, not
+        // scrollback. Replaying its absolute-positioned redraw bytes would
+        // scatter text across the reconstructed buffer, so it must be dropped.
         let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
-        let snap = snapshot_with_modes(pane.id);
+        let snap = snapshot_with_modes(pane.id); // mouse 1003, bytes "line1\r\nline2\r\n"
 
         pane.restore_from_snapshot(&snap);
 
-        assert!(!pane.screen.raw_bytes().is_empty());
+        assert!(
+            !pane.screen.raw_bytes().windows(5).any(|w| w == b"line1"),
+            "transient TUI frame should not be replayed"
+        );
     }
 
     #[test]
-    fn restore_from_snapshot_modes_override_replay() {
+    fn restore_from_snapshot_detects_tui_via_alternate_screen() {
+        // A full-screen app with mouse tracking off but the alternate buffer
+        // active (e.g. `less`, `man`) is still transient — skip its frame.
         let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
-        // screen_bytes enable bracketed paste, but snapshot metadata says off.
-        let snap = ScreenSnapshotV1 {
-            schema_version: SCREEN_SNAPSHOT_SCHEMA_VERSION,
-            pane_id: pane.id,
-            cols: 80,
-            rows: 24,
-            cursor_row: 0,
-            cursor_col: 0,
-            cursor_visible: true,
-            title: None,
-            cwd: None,
-            pane_output_seq: 0,
-            modes: TerminalModeSnapshot {
-                bracketed_paste: false,
-                application_cursor_keys: false,
-                application_keypad: false,
-                mouse_tracking_mode: 0,
-                sgr_mouse: false,
-                focus_reporting: false,
-            },
-            screen_bytes: b"\x1b[?2004h\x1b[?1hsome text\r\n".to_vec(),
-            confidential: false,
-        };
+        let mut snap = snapshot_with_modes(pane.id);
+        snap.modes.mouse_tracking_mode = 0;
+        snap.modes.alternate_screen = true;
 
         pane.restore_from_snapshot(&snap);
 
-        // Metadata wins over replay-derived state.
+        assert!(!pane.screen.raw_bytes().windows(5).any(|w| w == b"line1"));
+    }
+
+    #[test]
+    fn restore_from_snapshot_replays_scrollback_for_normal_shell() {
+        // A normal shell (no alt-screen, no mouse) has real scrollback worth
+        // showing on reconnect.
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let snap = normal_shell_snapshot(pane.id, b"hello world\r\n$ \r\n");
+
+        pane.restore_from_snapshot(&snap);
+
+        assert!(
+            pane.screen.raw_bytes().windows(11).any(|w| w == b"hello world"),
+            "normal-shell scrollback should be replayed"
+        );
+    }
+
+    #[test]
+    fn restore_from_snapshot_resets_modes_left_by_replayed_bytes() {
+        // Even for a normal-shell replay, mode-setting sequences embedded in the
+        // retained bytes (bracketed paste, application cursor keys) must be
+        // neutralized so the reconstructed baseline is clean.
+        let mut pane = Pane::new(Uuid::new_v4(), 80, 24);
+        let snap = normal_shell_snapshot(pane.id, b"\x1b[?2004h\x1b[?1hsome text\r\n");
+
+        pane.restore_from_snapshot(&snap);
+
         assert!(!pane.screen.bracketed_paste_mode());
         assert!(!pane.screen.application_cursor_keys());
     }

--- a/services/rttx-server/src/screen.rs
+++ b/services/rttx-server/src/screen.rs
@@ -1422,6 +1422,7 @@ mod tests {
             mouse_tracking_mode: 1003,
             sgr_mouse: true,
             focus_reporting: true,
+            alternate_screen: false,
         });
 
         assert!(screen.bracketed_paste_mode());
@@ -1449,6 +1450,7 @@ mod tests {
             mouse_tracking_mode: 0,
             sgr_mouse: false,
             focus_reporting: false,
+            alternate_screen: false,
         });
 
         assert!(!screen.bracketed_paste_mode());

--- a/services/rttx-server/src/server.rs
+++ b/services/rttx-server/src/server.rs
@@ -337,7 +337,14 @@ impl Server {
                     if let Some(pane) = rt.panes.get_mut(&pane_id) {
                         match data {
                             ReplayData::Snapshot(snap) => pane.restore_from_snapshot(&snap),
-                            ReplayData::Scrollback { clean, .. } => pane.screen.feed(&clean),
+                            ReplayData::Scrollback { clean, .. } => {
+                                pane.screen.feed(&clean);
+                                // The app that owned this pane is gone. Reset any
+                                // TUI modes the captured scrollback left active
+                                // so the respawned shell starts from a clean,
+                                // interactive baseline (mirrors the snapshot path).
+                                pane.screen.feed(crate::screen::terminal_cleanup_bytes());
+                            }
                             ReplayData::None => {}
                         }
                     }

--- a/services/rttx-server/src/state/migrations.rs
+++ b/services/rttx-server/src/state/migrations.rs
@@ -142,6 +142,7 @@ mod tests {
                 mouse_tracking_mode: 0,
                 sgr_mouse: false,
                 focus_reporting: false,
+                alternate_screen: false,
             },
             screen_bytes: vec![],
             confidential: false,

--- a/services/rttx-server/src/state/persistence.rs
+++ b/services/rttx-server/src/state/persistence.rs
@@ -542,6 +542,7 @@ mod tests {
                 mouse_tracking_mode: 0,
                 sgr_mouse: false,
                 focus_reporting: false,
+                alternate_screen: false,
             },
             screen_bytes: b"hello world\r\n$ ".to_vec(),
             confidential: false,

--- a/services/rttx-server/src/state/types.rs
+++ b/services/rttx-server/src/state/types.rs
@@ -184,6 +184,11 @@ pub struct TerminalModeSnapshot {
     pub sgr_mouse: bool,
     /// Focus event reporting (DECSET 1004).
     pub focus_reporting: bool,
+    /// Alternate screen buffer (DECSET 1049/1047) active — a full-screen TUI
+    /// (e.g. Claude, Codex, vim, htop) owned the terminal at snapshot time.
+    /// Added after the initial schema; older snapshots default to `false`.
+    #[serde(default)]
+    pub alternate_screen: bool,
 }
 
 // ── Version envelope for dispatch ───────────────────────────────────
@@ -283,6 +288,7 @@ mod tests {
                 mouse_tracking_mode: 0,
                 sgr_mouse: false,
                 focus_reporting: false,
+                alternate_screen: false,
             },
             screen_bytes: b"hello world\r\n".to_vec(),
             confidential: false,
@@ -457,6 +463,7 @@ mod tests {
                 mouse_tracking_mode: 0,
                 sgr_mouse: false,
                 focus_reporting: false,
+                alternate_screen: false,
             },
             screen_bytes: vec![],
             confidential: false,
@@ -486,6 +493,7 @@ mod tests {
                 mouse_tracking_mode: 1003,
                 sgr_mouse: true,
                 focus_reporting: true,
+                alternate_screen: false,
             },
             screen_bytes: vec![0x1b, b'[', b'H'],
             confidential: false,

--- a/services/rttx-server/tests/property_robustness.rs
+++ b/services/rttx-server/tests/property_robustness.rs
@@ -156,6 +156,7 @@ proptest! {
                 mouse_tracking_mode: 0,
                 sgr_mouse: false,
                 focus_reporting: false,
+                alternate_screen: false,
             },
             screen_bytes: screen_bytes.clone(),
             confidential: false,

--- a/services/rttx-server/tests/snapshot_metadata_restore.rs
+++ b/services/rttx-server/tests/snapshot_metadata_restore.rs
@@ -1,5 +1,7 @@
-//! Integration test: daemon restart restores canonical pane state from
-//! snapshot metadata, not just from replaying `screen_bytes`.
+//! Integration test: a daemon restart persists terminal-mode metadata in the
+//! screen snapshot, but reconstructs the pane to a clean interactive baseline
+//! rather than restoring a dead TUI's interaction modes (mouse tracking,
+//! alt-screen, …) onto the freshly respawned shell.
 
 mod common;
 
@@ -11,11 +13,14 @@ use rttx_proto::{bytes_to_uuid, v3};
 use rttx_server::state::persistence;
 use std::time::Duration;
 
-/// After daemon restart, terminal modes persisted in the screen snapshot
-/// are restored even when the mode-enabling escape sequences are not
-/// present in the retained `screen_bytes` tail.
+/// The daemon persists the pane's terminal modes in the on-disk snapshot, but
+/// after a restart the process that set those modes is gone. Reconstruction
+/// must reset interaction modes (mouse tracking, SGR mouse, …) to a clean
+/// baseline instead of restoring them — otherwise the respawned shell inherits
+/// stuck mouse tracking and pointer movement injects `\x1b[<btn;col;rowM`
+/// reports onto the prompt (the reported "daemon spitting garbage" bug).
 #[tokio::test]
-async fn restart_restores_terminal_modes_from_snapshot_metadata() {
+async fn restart_resets_tui_modes_instead_of_restoring_them() {
     let tmp = tempfile::TempDir::new().unwrap();
 
     let runtime_id_bytes;
@@ -79,7 +84,84 @@ async fn restart_restores_terminal_modes_from_snapshot_metadata() {
         // The pane should have a live shell (not exited).
         assert!(pane.exit_status.is_none(), "reconstructed pane should have a live shell");
 
-        // Scrollback should not be empty (screen_bytes were fed).
-        assert!(!pane.scrollback_tail.is_empty(), "scrollback should be restored");
+        // The dead TUI's interaction modes must NOT be restored onto the fresh
+        // shell. A bare shell never enables mouse tracking, so a reset mouse
+        // mode proves reconstruction rebuilt a clean baseline rather than
+        // replaying the app's stuck-mouse state.
+        let modes = pane.terminal_modes.as_ref().expect("terminal modes present");
+        assert_eq!(
+            modes.mouse_mode,
+            v3::MouseMode::None as i32,
+            "mouse tracking must be reset after restart, not restored",
+        );
+        assert!(!modes.sgr_mouse, "SGR mouse must be reset after restart");
+    }
+}
+
+/// A normal shell (no alt-screen, no mouse tracking) keeps its scrollback across
+/// a daemon restart. The transient-frame skip that fixes the TUI garbage bug
+/// must not discard genuine shell history.
+#[tokio::test]
+async fn restart_preserves_normal_shell_scrollback() {
+    const MARKER: &str = "MARKER_ABC123";
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state/rttx/daemon");
+
+    let runtime_id_bytes;
+    let pane_id;
+    {
+        let (sock, handle) = start_test_server(tmp.path()).await;
+        let mut c = common::TestClient::connect(&sock).await;
+        c.handshake().await;
+
+        runtime_id_bytes =
+            create_workspace(&mut c, "scrollback-keep", v3::WorkspacePolicy::Persistent).await;
+        let pane_id_bytes = create_pane(&mut c, &runtime_id_bytes).await;
+        pane_id = bytes_to_uuid(&pane_id_bytes).unwrap();
+        attach_rw(&mut c, &runtime_id_bytes).await;
+
+        // Emit a unique marker as ordinary shell output — no TUI modes involved.
+        send_input(&mut c, &runtime_id_bytes, &pane_id_bytes, b"printf 'MARKER_ABC123\\n'\n").await;
+
+        // Wait until the marker is captured in the persisted screen snapshot so
+        // the restart below has it on disk to replay.
+        let runtime_id = bytes_to_uuid(&runtime_id_bytes).unwrap();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Some(snap) = persistence::load_screen_snapshot(&state_dir, runtime_id, pane_id)
+                && snap.screen_bytes.windows(MARKER.len()).any(|w| w == MARKER.as_bytes())
+            {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "marker never persisted to screen snapshot",
+            );
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+
+        handle.abort();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Phase 2: restart and confirm the normal-shell scrollback replays.
+    {
+        let (sock, _handle) = start_test_server(tmp.path()).await;
+        let mut c = common::TestClient::connect(&sock).await;
+        c.handshake().await;
+
+        let snapshot = attach_rw(&mut c, &runtime_id_bytes).await;
+        let pane = snapshot
+            .panes
+            .iter()
+            .find(|p| bytes_to_uuid(&p.pane_id).unwrap() == pane_id)
+            .expect("pane should be present after restart");
+
+        let tail = String::from_utf8_lossy(&pane.scrollback_tail);
+        assert!(
+            tail.contains(MARKER),
+            "normal-shell scrollback should survive restart, got: {tail:?}",
+        );
     }
 }

--- a/services/rttx-server/tests/v2_persisted_structs.rs
+++ b/services/rttx-server/tests/v2_persisted_structs.rs
@@ -65,6 +65,7 @@ fn screen_snapshot_persists_and_loads_via_migration_chain() {
             mouse_tracking_mode: 1000,
             sgr_mouse: true,
             focus_reporting: false,
+            alternate_screen: false,
         },
         screen_bytes: vec![0x1b, b'[', b'2', b'J'],
         confidential: false,


### PR DESCRIPTION
## Problem

Restarting the daemon left panes that had been running a full-screen TUI (Claude, Codex, vim, htop, …) **broken and spewing garbage**: the pane kept receiving stray mouse-report bytes (`35;135;28M…`) for as long as the pointer hovered it, and the previous app frame was scattered across the buffer.


## Root cause

A daemon restart **kills the app** that owned the terminal (the PTY child dies with the daemon). But `Pane::restore_from_snapshot` faithfully **restored that dead app's interaction modes** from the persisted snapshot:

```
restore_from_snapshot → restore_modes(&snap.modes)          // re-enables mouse_tracking_mode = 1003
   → client rebuilds modes from reconstructed screen
   → client restore_interaction_modes → vte.feed("\x1b[?1003h")   // mouse tracking ON in VTE
   → bare shell + mouse-tracking-on → every mouse move injects  ESC[<btn;col;rowM  onto the prompt
```

The scattered text was the app's **alt-screen frame** replayed as if it were scrollback. Prior mitigations (`restart_safe_scrollback`, `strip_client_queries`, `terminal_cleanup_bytes` on *normal* exit) patched adjacent symptoms but never the core: restoring a dead TUI's mouse/alt modes on restart.

## Fix

Treat reconstruction like a clean process exit — reset to a baseline instead of restoring the dead app's state:

- `restore_from_snapshot` feeds `terminal_cleanup_bytes()` (exits alt-screen, disables mouse tracking / bracketed paste / app-cursor keys, shows cursor) and **no longer restores** the snapshot's interaction modes.
- When the snapshot shows a TUI owned the screen (**alternate buffer active or mouse tracking on**), the transient frame is **dropped**, not replayed. Genuine shell scrollback still replays.
- The scrollback-only fallback path gets the same cleanup.
- Adds a persisted `alternate_screen` flag to `TerminalModeSnapshot` (`#[serde(default)]`, no schema bump) so non-mouse full-screen apps (less, man, vim) are detected too.

Server-side only; the client rebuilds its modes from the live reconstructed screen, so the reset propagates without a client change.

## Testing

- New integration test `restart_resets_tui_modes_instead_of_restoring_them`: enables mouse tracking → persists → **restarts the daemon** → attaches → asserts the reconstructed pane reports **mouse mode = None**. Fails on old code, passes on new.
- 7 new/updated unit tests (transient-frame skip, alt-screen detection, normal-shell scrollback replay, baseline reset, forced cursor-visible).
- All 531 lib tests + reconnect / screen_snapshot / gui_restore_flow / close_survives_restart integration tests pass; `fmt` and `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
